### PR TITLE
Fix permissions for cache and prisma engines directories

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,6 +24,13 @@ USER_NAME=$(getent passwd "$PUID" | cut -d: -f1)
 echo "🔧 Fixing permissions..."
 mkdir -p /spotiarr/config
 chown -R "$PUID:$PGID" /spotiarr/config
+
+mkdir -p /spotiarr/.cache
+chown -R "$PUID:$PGID" /spotiarr/.cache
+
+# This is needed for `prisma migrate deploy` to run correctly
+chown -R "$PUID:$PGID" /spotiarr/node_modules/.pnpm/@prisma+engines*
+
 # Note: /spotiarr code is already owned by node:node from build, 
 # but if PUID!=1000 we might need to adjust, though usually read-only is fine for code.
 


### PR DESCRIPTION
#### Description
The application fails to start when using PUID and PGID other than 1000 due to permissions left from the build step.

The cache directory is owned by `1000:1000` and results in the following error:
```
spotiarr    | Error: EACCES: permission denied, mkdir '/spotiarr/.cache/node/corepack/v1'
spotiarr    |     at mkdirSync (node:fs:1377:26)
spotiarr    |     at getTemporaryFolder (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21916:27)
spotiarr    |     at download (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22206:21)
spotiarr    |     at installVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22300:61)
spotiarr    |     at async Engine.ensurePackageManager (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22851:32)
spotiarr    |     at async Engine.executePackageManagerRequest (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22962:25)
spotiarr    |     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23660:7) {
spotiarr    |   errno: -13,
spotiarr    |   code: 'EACCES',
spotiarr    |   syscall: 'mkdir',
spotiarr    |   path: '/spotiarr/.cache/node/corepack/v1'
spotiarr    | }
```

After fixing permissions for the cache directory, the application fails to run database migrations with the following error:
```
spotiarr    | > backend@0.0.0 prisma:migrate:deploy /spotiarr/apps/backend
spotiarr    | > prisma migrate deploy
spotiarr    |
spotiarr    | Error: Can't write to /spotiarr/node_modules/.pnpm/@prisma+engines@5.22.0/node_modules/@prisma/engines please make sure you install "prisma" with the right permissions.
spotiarr    | /spotiarr/apps/backend:
spotiarr    |  ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  backend@0.0.0 prisma:migrate:deploy: `prisma migrate deploy`
spotiarr    | Exit status 1
```

#### Changes

- Change permission of `/spotiarr/.cache` to provided PUID and PGID during startup
- Change permission of `/spotiarr/node_modules/.pnpm/@prisma+engines*` to provided PUID and PGID during startup

#### Issues

- Fixes: https://github.com/mralexsaavedra/spotiarr/issues/7