### PR TITLE
refactor(backend): extract GetRecentReleasesUseCase from FeedController

### DIFF
--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
@@ -1,0 +1,127 @@
+import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import type { FeedRepository } from "@/infrastructure/database/feed.repository";
+import type { ReleaseFeedService } from "@/infrastructure/external/release-feed.service";
+import type { SpotifyUserLibraryService } from "@/infrastructure/external/spotify-user-library.service";
+import { GetRecentReleasesUseCase } from "./get-recent-releases.use-case";
+
+function makeArtist(overrides: Partial<FollowedArtist> = {}): FollowedArtist {
+  return {
+    id: "a1",
+    name: "Artist One",
+    image: "https://img/1.jpg",
+    spotifyUrl: "https://spotify/a1",
+    ...overrides,
+  };
+}
+
+function makeRelease(overrides: Partial<ArtistRelease> = {}): ArtistRelease {
+  return {
+    artistId: "a1",
+    artistName: "Artist One",
+    artistImageUrl: null,
+    albumId: "al1",
+    albumName: "Album One",
+    albumType: "album",
+    releaseDate: "2026-01-01",
+    coverUrl: null,
+    ...overrides,
+  };
+}
+
+function makeDeps() {
+  const feedRepository = {
+    getReleases: vi.fn().mockResolvedValue([]),
+    upsertArtists: vi.fn().mockResolvedValue(undefined),
+    upsertReleases: vi.fn().mockResolvedValue(undefined),
+  } as unknown as FeedRepository;
+
+  const spotifyUserLibraryService = {
+    getFollowedArtists: vi.fn().mockResolvedValue([makeArtist()]),
+  } as unknown as SpotifyUserLibraryService;
+
+  const releaseFeedService = {
+    getActiveArtistReleases: vi.fn().mockResolvedValue({ releases: [], decisions: [] }),
+  } as unknown as ReleaseFeedService;
+
+  const settingsService = {
+    getNumber: vi.fn().mockResolvedValue(30),
+  } as unknown as SettingsService;
+
+  return { feedRepository, spotifyUserLibraryService, releaseFeedService, settingsService };
+}
+
+describe("GetRecentReleasesUseCase", () => {
+  let useCase: GetRecentReleasesUseCase;
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    useCase = new GetRecentReleasesUseCase(
+      deps.feedRepository,
+      deps.spotifyUserLibraryService,
+      deps.releaseFeedService,
+      deps.settingsService,
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  it("returns cached releases without triggering warm when cache is fresh", async () => {
+    const cached = [makeRelease({ albumId: "cached-1" })];
+    vi.mocked(deps.feedRepository.getReleases).mockResolvedValue(cached);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual(cached);
+    expect(deps.spotifyUserLibraryService.getFollowedArtists).not.toHaveBeenCalled();
+    expect(deps.releaseFeedService.getActiveArtistReleases).not.toHaveBeenCalled();
+    expect(deps.feedRepository.upsertArtists).not.toHaveBeenCalled();
+  });
+
+  it("warms cache and returns fallback releases when cache is empty and artists exist", async () => {
+    const artists = [makeArtist({ id: "a1" }), makeArtist({ id: "a2" })];
+    const fallback = [makeRelease({ albumId: "r1" }), makeRelease({ albumId: "r2" })];
+    vi.mocked(deps.feedRepository.getReleases).mockResolvedValue([]);
+    vi.mocked(deps.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue(artists);
+    vi.mocked(deps.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
+      releases: fallback,
+      decisions: [],
+    });
+
+    const result = await useCase.execute();
+
+    expect(deps.feedRepository.upsertArtists).toHaveBeenCalledWith(artists);
+    expect(deps.feedRepository.upsertReleases).toHaveBeenCalledWith(fallback);
+    expect(result).toEqual(fallback);
+  });
+
+  it("upserts artists but skips upsertReleases and returns empty when warm yields 0 releases", async () => {
+    const artists = [makeArtist()];
+    vi.mocked(deps.feedRepository.getReleases).mockResolvedValue([]);
+    vi.mocked(deps.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue(artists);
+    vi.mocked(deps.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
+      releases: [],
+      decisions: [],
+    });
+
+    const result = await useCase.execute();
+
+    expect(deps.feedRepository.upsertArtists).toHaveBeenCalledWith(artists);
+    expect(deps.feedRepository.upsertReleases).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it("propagates error from getFollowedArtists without calling upserts", async () => {
+    vi.mocked(deps.feedRepository.getReleases).mockResolvedValue([]);
+    vi.mocked(deps.spotifyUserLibraryService.getFollowedArtists).mockRejectedValue(
+      new Error("token expired"),
+    );
+
+    await expect(useCase.execute()).rejects.toThrow("token expired");
+
+    expect(deps.feedRepository.upsertArtists).not.toHaveBeenCalled();
+    expect(deps.feedRepository.upsertReleases).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
@@ -1,0 +1,52 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import type { SettingsService } from "@/application/services/settings.service";
+import type { FeedRepository } from "@/infrastructure/database/feed.repository";
+import type { ReleaseFeedService } from "@/infrastructure/external/release-feed.service";
+import type { SpotifyUserLibraryService } from "@/infrastructure/external/spotify-user-library.service";
+
+export class GetRecentReleasesUseCase {
+  constructor(
+    private readonly feedRepository: FeedRepository,
+    private readonly spotifyUserLibraryService: SpotifyUserLibraryService,
+    private readonly releaseFeedService: ReleaseFeedService,
+    private readonly settingsService: SettingsService,
+  ) {}
+
+  async execute(): Promise<ArtistRelease[]> {
+    const lookbackDays = await this.settingsService.getNumber("RELEASES_LOOKBACK_DAYS", 30);
+    let releases = await this.feedRepository.getReleases(lookbackDays);
+
+    if (releases.length === 0) {
+      console.log("[GetRecentReleasesUseCase] Empty release cache — running Deezer-first fallback");
+
+      const artists = await this.spotifyUserLibraryService.getFollowedArtists();
+      const catalogArtists = artists.map((a) => ({
+        id: a.id,
+        name: a.name,
+        imageUrl: a.image,
+      }));
+
+      const { releases: fallbackReleases } = await this.releaseFeedService.getActiveArtistReleases(
+        catalogArtists,
+        { lookbackDays },
+      );
+
+      await this.feedRepository.upsertArtists(artists);
+
+      if (fallbackReleases.length > 0) {
+        await this.feedRepository.upsertReleases(fallbackReleases);
+        console.log(
+          `[GetRecentReleasesUseCase] Fallback warmed cache with ${fallbackReleases.length} releases for ${artists.length} artists`,
+        );
+      } else {
+        console.warn(
+          "[GetRecentReleasesUseCase] Fallback resolved 0 releases — DB warming skipped",
+        );
+      }
+
+      releases = fallbackReleases;
+    }
+
+    return releases;
+  }
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -6,6 +6,7 @@ import { TrackService } from "./application/services/track.service";
 import { GetAlbumTracksUseCase } from "./application/use-cases/artists/get-album-tracks.use-case";
 import { GetArtistAlbumsUseCase } from "./application/use-cases/artists/get-artist-albums.use-case";
 import { GetArtistDetailUseCase } from "./application/use-cases/artists/get-artist-detail.use-case";
+import { GetRecentReleasesUseCase } from "./application/use-cases/feed/get-recent-releases.use-case";
 import { HistoryUseCases } from "./application/use-cases/history/history.use-cases";
 import { ScanLibraryUseCase } from "./application/use-cases/library/scan-library.use-case";
 import { CreatePlaylistUseCase } from "./application/use-cases/playlists/create-playlist.use-case";
@@ -327,11 +328,16 @@ const settingsController = new SettingsController(getSettingsUseCase, updateSett
 const historyUseCases = new HistoryUseCases({ repository: historyRepository });
 const historyController = new HistoryController(historyUseCases);
 
+const getRecentReleasesUseCase = new GetRecentReleasesUseCase(
+  feedRepository,
+  spotifyUserLibraryService,
+  releaseFeedService,
+  settingsService,
+);
 const feedController = new FeedController(
   spotifyUserLibraryService,
   feedRepository,
-  settingsService,
-  releaseFeedService,
+  getRecentReleasesUseCase,
 );
 const authController = new AuthController(spotifyAuthService, settingsService);
 const healthController = new HealthController();

--- a/apps/backend/src/presentation/controllers/feed.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/feed.controller.test.ts
@@ -1,9 +1,8 @@
 import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 import type { Request, Response } from "express";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { GetRecentReleasesUseCase } from "@/application/use-cases/feed/get-recent-releases.use-case";
 import type { FeedRepository } from "@/infrastructure/database/feed.repository";
-import type { ReleaseFeedService } from "@/infrastructure/external/release-feed.service";
 import type { SpotifyUserLibraryService } from "@/infrastructure/external/spotify-user-library.service";
 import { FeedController } from "./feed.controller";
 
@@ -32,9 +31,7 @@ function makeRelease(overrides: Partial<ArtistRelease> = {}): ArtistRelease {
 }
 
 function mockRes(): Response {
-  return {
-    json: vi.fn(),
-  } as unknown as Response;
+  return { json: vi.fn() } as unknown as Response;
 }
 
 function mockReq(): Request {
@@ -47,23 +44,17 @@ function makeMocks() {
   } as unknown as SpotifyUserLibraryService;
 
   const feedRepository = {
-    getReleases: vi.fn().mockResolvedValue([]),
-    upsertArtists: vi.fn().mockResolvedValue(undefined),
-    upsertReleases: vi.fn().mockResolvedValue(undefined),
+    getArtists: vi.fn().mockResolvedValue([]),
   } as unknown as FeedRepository;
 
-  const settingsService = {
-    getNumber: vi.fn().mockResolvedValue(30),
-  } as unknown as SettingsService;
+  const getRecentReleasesUseCase = {
+    execute: vi.fn().mockResolvedValue([]),
+  } as unknown as GetRecentReleasesUseCase;
 
-  const releaseFeedService = {
-    getActiveArtistReleases: vi.fn().mockResolvedValue({ releases: [], decisions: [] }),
-  } as unknown as ReleaseFeedService;
-
-  return { spotifyUserLibraryService, feedRepository, settingsService, releaseFeedService };
+  return { spotifyUserLibraryService, feedRepository, getRecentReleasesUseCase };
 }
 
-describe("FeedController — getRecentReleases", () => {
+describe("FeedController", () => {
   let controller: FeedController;
   let mocks: ReturnType<typeof makeMocks>;
 
@@ -72,127 +63,29 @@ describe("FeedController — getRecentReleases", () => {
     controller = new FeedController(
       mocks.spotifyUserLibraryService,
       mocks.feedRepository,
-      mocks.settingsService,
-      mocks.releaseFeedService,
+      mocks.getRecentReleasesUseCase,
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
-  describe("Scenario: Warm cache — no fallback", () => {
-    it("SHALL serve from DB cache and NOT invoke fallback collaborators", async () => {
-      const cachedReleases = [makeRelease({ albumId: "cached-1" })];
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue(cachedReleases);
-
-      const res = mockRes();
-      await controller.getRecentReleases(mockReq(), res);
-
-      expect(res.json).toHaveBeenCalledWith(cachedReleases);
-      expect(mocks.spotifyUserLibraryService.getFollowedArtists).not.toHaveBeenCalled();
-      expect(mocks.releaseFeedService.getActiveArtistReleases).not.toHaveBeenCalled();
-      expect(mocks.feedRepository.upsertArtists).not.toHaveBeenCalled();
-      expect(mocks.feedRepository.upsertReleases).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("Scenario: Empty cache — happy path", () => {
-    it("SHALL call getFollowedArtists then getActiveArtistReleases and warm the DB before responding", async () => {
-      const artists = [makeFollowedArtist({ id: "a1" }), makeFollowedArtist({ id: "a2" })];
+  describe("getRecentReleases", () => {
+    it("delegates to use case and responds with its result", async () => {
       const releases = [makeRelease({ albumId: "r1" }), makeRelease({ albumId: "r2" })];
-
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue([]);
-      vi.mocked(mocks.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue(artists);
-      vi.mocked(mocks.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
-        releases,
-        decisions: [],
-      });
+      vi.mocked(mocks.getRecentReleasesUseCase.execute).mockResolvedValue(releases);
 
       const res = mockRes();
       await controller.getRecentReleases(mockReq(), res);
 
-      expect(mocks.spotifyUserLibraryService.getFollowedArtists).toHaveBeenCalledTimes(1);
-      expect(mocks.releaseFeedService.getActiveArtistReleases).toHaveBeenCalledWith(
-        [
-          { id: "a1", name: "Test Artist", imageUrl: "https://image.test/1.jpg" },
-          { id: "a2", name: "Test Artist", imageUrl: "https://image.test/1.jpg" },
-        ],
-        { lookbackDays: 30 },
-      );
-      expect(mocks.feedRepository.upsertArtists).toHaveBeenCalledWith(artists);
-      expect(mocks.feedRepository.upsertReleases).toHaveBeenCalledWith(releases);
+      expect(mocks.getRecentReleasesUseCase.execute).toHaveBeenCalledTimes(1);
       expect(res.json).toHaveBeenCalledWith(releases);
     });
 
-    it("SHALL call upsertArtists before upsertReleases (ADR-002 write order)", async () => {
-      const callOrder: string[] = [];
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue([]);
-      vi.mocked(mocks.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
-        releases: [makeRelease()],
-        decisions: [],
-      });
-      vi.mocked(mocks.feedRepository.upsertArtists).mockImplementation(async () => {
-        callOrder.push("upsertArtists");
-      });
-      vi.mocked(mocks.feedRepository.upsertReleases).mockImplementation(async () => {
-        callOrder.push("upsertReleases");
-      });
-
-      await controller.getRecentReleases(mockReq(), mockRes());
-
-      expect(callOrder).toEqual(["upsertArtists", "upsertReleases"]);
-    });
-  });
-
-  describe("Scenario: Empty cache + empty cascade (ADR-003)", () => {
-    it("SHALL call upsertArtists but NOT upsertReleases, and respond with empty array", async () => {
-      const artists = [makeFollowedArtist()];
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue([]);
-      vi.mocked(mocks.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue(artists);
-      vi.mocked(mocks.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
-        releases: [],
-        decisions: [],
-      });
+    it("responds with empty array when use case returns no releases", async () => {
+      vi.mocked(mocks.getRecentReleasesUseCase.execute).mockResolvedValue([]);
 
       const res = mockRes();
       await controller.getRecentReleases(mockReq(), res);
 
-      expect(mocks.feedRepository.upsertArtists).toHaveBeenCalledWith(artists);
-      expect(mocks.feedRepository.upsertReleases).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith([]);
-    });
-  });
-
-  describe("Scenario: Missing or expired token (ADR-004)", () => {
-    it("SHALL propagate error from getFollowedArtists without calling upserts", async () => {
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue([]);
-      vi.mocked(mocks.spotifyUserLibraryService.getFollowedArtists).mockRejectedValue(
-        new Error("Spotify user token expired or invalid"),
-      );
-
-      await expect(controller.getRecentReleases(mockReq(), mockRes())).rejects.toThrow(
-        "Spotify user token expired or invalid",
-      );
-
-      expect(mocks.feedRepository.upsertArtists).not.toHaveBeenCalled();
-      expect(mocks.feedRepository.upsertReleases).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("Scenario: lookbackDays forwarded correctly", () => {
-    it("SHALL pass lookbackDays from settings to releaseFeedService.getActiveArtistReleases", async () => {
-      vi.mocked(mocks.settingsService.getNumber).mockResolvedValue(7);
-      vi.mocked(mocks.feedRepository.getReleases).mockResolvedValue([]);
-      vi.mocked(mocks.releaseFeedService.getActiveArtistReleases).mockResolvedValue({
-        releases: [],
-        decisions: [],
-      });
-
-      await controller.getRecentReleases(mockReq(), mockRes());
-
-      expect(mocks.releaseFeedService.getActiveArtistReleases).toHaveBeenCalledWith(
-        expect.any(Array),
-        { lookbackDays: 7 },
-      );
     });
   });
 });

--- a/apps/backend/src/presentation/controllers/feed.controller.ts
+++ b/apps/backend/src/presentation/controllers/feed.controller.ts
@@ -1,50 +1,17 @@
 import { Request, Response } from "express";
-import { SettingsService } from "@/application/services/settings.service";
+import { GetRecentReleasesUseCase } from "@/application/use-cases/feed/get-recent-releases.use-case";
 import { FeedRepository } from "@/infrastructure/database/feed.repository";
-import { ReleaseFeedService } from "@/infrastructure/external/release-feed.service";
 import { SpotifyUserLibraryService } from "@/infrastructure/external/spotify-user-library.service";
 
 export class FeedController {
   constructor(
     private readonly spotifyUserLibraryService: SpotifyUserLibraryService,
     private readonly feedRepository: FeedRepository,
-    private readonly settingsService: SettingsService,
-    private readonly releaseFeedService: ReleaseFeedService,
+    private readonly getRecentReleasesUseCase: GetRecentReleasesUseCase,
   ) {}
 
   getRecentReleases = async (_req: Request, res: Response) => {
-    const lookbackDays = await this.settingsService.getNumber("RELEASES_LOOKBACK_DAYS", 30);
-    let releases = await this.feedRepository.getReleases(lookbackDays);
-
-    if (releases.length === 0) {
-      console.log("[FeedController] Empty release cache — running Deezer-first fallback");
-
-      const artists = await this.spotifyUserLibraryService.getFollowedArtists();
-      const catalogArtists = artists.map((a) => ({
-        id: a.id,
-        name: a.name,
-        imageUrl: a.image,
-      }));
-
-      const { releases: fallbackReleases } = await this.releaseFeedService.getActiveArtistReleases(
-        catalogArtists,
-        { lookbackDays },
-      );
-
-      if (fallbackReleases.length > 0) {
-        await this.feedRepository.upsertArtists(artists);
-        await this.feedRepository.upsertReleases(fallbackReleases);
-        console.log(
-          `[FeedController] Fallback warmed cache with ${fallbackReleases.length} releases for ${artists.length} artists`,
-        );
-      } else {
-        await this.feedRepository.upsertArtists(artists);
-        console.warn("[FeedController] Fallback resolved 0 releases — DB warming skipped");
-      }
-
-      releases = fallbackReleases;
-    }
-
+    const releases = await this.getRecentReleasesUseCase.execute();
     res.json(releases);
   };
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -24,10 +24,9 @@ export default defineConfig(({ mode }) => {
     },
     envDir,
     server: {
-      host: env.PUBLIC_HOST || "localhost",
       proxy: {
         "/api": {
-          target: `http://${env.PUBLIC_HOST || "localhost"}:3000`,
+          target: "http://localhost:3000",
           changeOrigin: true,
         },
       },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -24,9 +24,10 @@ export default defineConfig(({ mode }) => {
     },
     envDir,
     server: {
+      host: env.PUBLIC_HOST || "localhost",
       proxy: {
         "/api": {
-          target: "http://localhost:3000",
+          target: `http://${env.PUBLIC_HOST || "localhost"}:3000`,
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
## Summary

- Extract feed-warming orchestration from `FeedController.getRecentReleases` into `GetRecentReleasesUseCase`
- `FeedController` is now a thin HTTP adapter: calls `getRecentReleasesUseCase.execute()` and responds
- Constructor slimmed from 4 dependencies to 3 (`spotifyUserLibraryService`, `feedRepository`, `getRecentReleasesUseCase`)
- Replaced 6 internal-orchestration assertions in `feed.controller.test.ts` with 2 HTTP contract tests
- Added 4 use-case tests covering: cache hit, warm success, warm yields 0 releases, error propagation

## Test plan

- [ ] `pnpm --filter backend run test` — 136 tests pass
- [ ] `pnpm --filter backend run lint` — 0 errors

> Part of `sdd/dup-dead-code-audit` — PR-2a of 4 (stacked on PR-1).
> Stacks on: #15 — merge PR-1 first, then rebase this branch to `main`.