### PR TITLE
fix(frontend): F1 frontend bug fixes — SSE, Deezer nav, ApiErrorState, duplicate mutation

### DIFF
--- a/apps/frontend/src/components/molecules/ApiErrorState.tsx
+++ b/apps/frontend/src/components/molecules/ApiErrorState.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/utils/cn";
 import { ConnectSpotifyPrompt } from "./ConnectSpotifyPrompt";
 import { RateLimitedMessage } from "./RateLimitedMessage";
 
-interface SpotifyErrorStateProps {
+interface ApiErrorStateProps {
   error: ApiErrorCode | null;
   message?: string;
   className?: string;
@@ -32,7 +32,7 @@ const ERROR_RENDERERS: Partial<Record<ApiErrorCode, FC<ErrorRendererProps>>> = {
   ),
 };
 
-export const SpotifyErrorState: FC<SpotifyErrorStateProps> = ({
+export const ApiErrorState: FC<ApiErrorStateProps> = ({
   error,
   message = "Failed to load data.",
   className = "",

--- a/apps/frontend/src/components/molecules/ArtistLinks.tsx
+++ b/apps/frontend/src/components/molecules/ArtistLinks.tsx
@@ -1,7 +1,7 @@
 import { FC, memo, MouseEvent } from "react";
 import { Link } from "react-router-dom";
 import { Path } from "@/routes/routes";
-import { getSpotifyIdFromUrl } from "@/utils/spotify";
+import { getSpotifyIdFromUrl, isSpotifyUrl } from "@/utils/spotify";
 
 interface Artist {
   name: string;
@@ -23,7 +23,11 @@ interface ArtistLinkProps {
 }
 
 const ArtistLink: FC<ArtistLinkProps> = memo(({ artist, linkClassName, onLinkClick, isLast }) => {
-  const artistId = artist.url ? getSpotifyIdFromUrl(artist.url) : null;
+  const artistId = artist.url
+    ? isSpotifyUrl(artist.url)
+      ? getSpotifyIdFromUrl(artist.url)
+      : (artist.url.split("/").filter(Boolean).pop() ?? null)
+    : null;
 
   const handleClick = (e: MouseEvent) => {
     if (onLinkClick) onLinkClick(e);

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
@@ -4,7 +4,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useBulkTrackStatus } from "@/contexts/DownloadStatusContext";
 import { Path } from "@/routes/routes";
 import { PlaylistWithStats, Track } from "@/types";
-import { useCreatePlaylistMutation } from "../mutations/useCreatePlaylistMutation";
 import { useAlbumTracksQuery } from "../queries/useAlbumTracksQuery";
 import { useArtistAlbumsQuery } from "../queries/useArtistAlbumsQuery";
 import { usePlaylistController } from "./usePlaylistController";
@@ -127,8 +126,6 @@ export const useAlbumDetailController = () => {
     id: undefined,
   });
 
-  const createPlaylistMutation = useCreatePlaylistMutation();
-
   const handleDownload = useCallback(() => {
     if (!artistId || !albumId) return;
     createPlaylist.mutate({ kind: "album", artistId, albumId });
@@ -139,9 +136,9 @@ export const useAlbumDetailController = () => {
       const parts = track.id.split("-");
       const i = parseInt(parts[parts.length - 1]!, 10);
       if (isNaN(i) || i < 0) return;
-      createPlaylistMutation.mutate({ kind: "albumTrack", artistId, albumId, trackIndex: i });
+      createPlaylist.mutate({ kind: "albumTrack", artistId, albumId, trackIndex: i });
     },
-    [artistId, albumId, createPlaylistMutation],
+    [artistId, albumId, createPlaylist],
   );
 
   const isButtonLoading =

--- a/apps/frontend/src/hooks/queries/useArtistDetailQuery.ts
+++ b/apps/frontend/src/hooks/queries/useArtistDetailQuery.ts
@@ -2,7 +2,7 @@ import type { ApiErrorCode, ArtistDetail } from "@spotiarr/shared";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { artistService } from "@/services/artist.service";
-import { mapSpotifyError } from "@/utils/spotify";
+import { mapApiError } from "@/utils/spotify";
 import { queryKeys } from "../queryKeys";
 
 const MAX_CATALOG_REFRESH_REFETCHES = 2;
@@ -62,7 +62,7 @@ export const useArtistDetailQuery = (
     };
   }, [artistId, data, refetch]);
 
-  const mappedError = mapSpotifyError(error, "failed_to_fetch_artist_detail");
+  const mappedError = mapApiError(error, "failed_to_fetch_artist_detail");
 
   return {
     artist: data ?? null,

--- a/apps/frontend/src/hooks/queries/useFollowedArtistsQuery.ts
+++ b/apps/frontend/src/hooks/queries/useFollowedArtistsQuery.ts
@@ -2,7 +2,7 @@ import { ApiErrorCode } from "@spotiarr/shared";
 import { useQuery } from "@tanstack/react-query";
 import { artistService } from "@/services/artist.service";
 import { getSettingsCacheTimings } from "@/utils/cache";
-import { mapSpotifyError } from "@/utils/spotify";
+import { mapApiError } from "@/utils/spotify";
 import { queryKeys } from "../queryKeys";
 import { useSettingsQuery } from "./useSettingsQuery";
 
@@ -31,7 +31,7 @@ export const useFollowedArtistsQuery = (): UseFollowedArtistsState => {
     refetchOnWindowFocus: false,
   });
 
-  const mappedError = mapSpotifyError(error, "failed_to_fetch_followed_artists");
+  const mappedError = mapApiError(error, "failed_to_fetch_followed_artists");
 
   return {
     artists: data ?? null,

--- a/apps/frontend/src/hooks/queries/useReleasesQuery.ts
+++ b/apps/frontend/src/hooks/queries/useReleasesQuery.ts
@@ -2,7 +2,7 @@ import { ApiErrorCode, type ArtistRelease } from "@spotiarr/shared";
 import { useQuery } from "@tanstack/react-query";
 import { artistService } from "@/services/artist.service";
 import { getSettingsCacheTimings } from "@/utils/cache";
-import { mapSpotifyError } from "@/utils/spotify";
+import { mapApiError } from "@/utils/spotify";
 import { queryKeys } from "../queryKeys";
 import { useSettingsQuery } from "./useSettingsQuery";
 
@@ -24,7 +24,7 @@ export const useReleasesQuery = (): UseReleasesState => {
     refetchOnWindowFocus: false,
   });
 
-  const mappedError = mapSpotifyError(error, "failed_to_fetch_releases");
+  const mappedError = mapApiError(error, "failed_to_fetch_releases");
 
   return {
     releases: data ?? null,

--- a/apps/frontend/src/hooks/useServerEvents.ts
+++ b/apps/frontend/src/hooks/useServerEvents.ts
@@ -27,7 +27,9 @@ export const useServerEvents = () => {
       // Invalidate specifically the active artist view if they are viewing one
       queryClient.invalidateQueries({
         predicate: (query) =>
-          Array.isArray(query.queryKey) && query.queryKey[0] === "libraryArtist",
+          Array.isArray(query.queryKey) &&
+          query.queryKey[0] === "library" &&
+          query.queryKey[1] === "artist",
       });
     });
 

--- a/apps/frontend/src/utils/spotify.ts
+++ b/apps/frontend/src/utils/spotify.ts
@@ -29,7 +29,7 @@ export const normalizeSpotifyUrl = (value: string): string | null => {
   }
 };
 
-export const mapSpotifyError = (error: unknown, fallback: ApiErrorCode): ApiErrorCode | null => {
+export const mapApiError = (error: unknown, fallback: ApiErrorCode): ApiErrorCode | null => {
   if (!(error instanceof Error)) return null;
 
   const code = (error as { code?: string }).code;

--- a/apps/frontend/src/views/ArtistDetail.tsx
+++ b/apps/frontend/src/views/ArtistDetail.tsx
@@ -4,8 +4,8 @@ import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/atoms/Button";
 import { Loading } from "@/components/atoms/Loading";
+import { ApiErrorState } from "@/components/molecules/ApiErrorState";
 import { ArtistHeader } from "@/components/molecules/ArtistHeader";
-import { SpotifyErrorState } from "@/components/molecules/SpotifyErrorState";
 import { SpotifyLinkButton } from "@/components/molecules/SpotifyLinkButton";
 import { ArtistDiscography } from "@/components/organisms/ArtistDiscography";
 import { useArtistDetailController } from "@/hooks/controllers/useArtistDetailController";
@@ -45,7 +45,7 @@ export const ArtistDetail: FC = () => {
   if (error) {
     return (
       <div className="bg-background flex flex-1 items-center justify-center p-6 text-white">
-        <SpotifyErrorState error={error} message={t("artist.error")} />
+        <ApiErrorState error={error} message={t("artist.error")} />
       </div>
     );
   }

--- a/apps/frontend/src/views/Artists.tsx
+++ b/apps/frontend/src/views/Artists.tsx
@@ -1,9 +1,9 @@
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Loading } from "@/components/atoms/Loading";
+import { ApiErrorState } from "@/components/molecules/ApiErrorState";
 import { PageHeader } from "@/components/molecules/PageHeader";
 import { SearchInput } from "@/components/molecules/SearchInput";
-import { SpotifyErrorState } from "@/components/molecules/SpotifyErrorState";
 import { ArtistList } from "@/components/organisms/ArtistList";
 import { useArtistsController } from "@/hooks/controllers/useArtistsController";
 
@@ -15,7 +15,7 @@ export const Artists: FC = () => {
   if (error) {
     return (
       <section className="bg-background flex-1 px-4 py-6 md:px-8">
-        <SpotifyErrorState error={error} message={t("artists.error")} />
+        <ApiErrorState error={error} message={t("artists.error")} />
       </section>
     );
   }

--- a/apps/frontend/src/views/MyPlaylists.tsx
+++ b/apps/frontend/src/views/MyPlaylists.tsx
@@ -2,9 +2,9 @@ import { ApiErrorCode } from "@spotiarr/shared";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Loading } from "@/components/atoms/Loading";
+import { ApiErrorState } from "@/components/molecules/ApiErrorState";
 import { PageHeader } from "@/components/molecules/PageHeader";
 import { SearchInput } from "@/components/molecules/SearchInput";
-import { SpotifyErrorState } from "@/components/molecules/SpotifyErrorState";
 import { SpotifyPlaylistList } from "@/components/organisms/SpotifyPlaylistList";
 import { useMyPlaylistsController } from "@/hooks/controllers/useMyPlaylistsController";
 import { ApiError } from "@/services/httpClient";
@@ -20,7 +20,7 @@ export const MyPlaylists: FC = () => {
 
     return (
       <section className="bg-background flex-1 px-4 py-6 md:px-8">
-        <SpotifyErrorState error={errorCode} message={t("myPlaylists.error")} />
+        <ApiErrorState error={errorCode} message={t("myPlaylists.error")} />
       </section>
     );
   }

--- a/apps/frontend/src/views/Releases.tsx
+++ b/apps/frontend/src/views/Releases.tsx
@@ -2,9 +2,9 @@ import { faCompactDisc } from "@fortawesome/free-solid-svg-icons";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Loading } from "@/components/atoms/Loading";
+import { ApiErrorState } from "@/components/molecules/ApiErrorState";
 import { EmptyState } from "@/components/molecules/EmptyState";
 import { PageHeader } from "@/components/molecules/PageHeader";
-import { SpotifyErrorState } from "@/components/molecules/SpotifyErrorState";
 import { ReleasesList } from "@/components/organisms/ReleasesList";
 import { useReleasesController } from "@/hooks/controllers/useReleasesController";
 
@@ -22,7 +22,7 @@ export const Releases: FC = () => {
   if (error) {
     return (
       <section className="bg-background flex-1 px-4 py-6 md:px-8">
-        <SpotifyErrorState error={error} message={t("releases.error")} />
+        <ApiErrorState error={error} message={t("releases.error")} />
       </section>
     );
   }


### PR DESCRIPTION
## Summary

4 bug fixes, each in its own commit:

- **SSE library-updated predicate** (`useServerEvents.ts`): predicate used `queryKey[0] === "libraryArtist"` but `libraryArtistDetail(name)` produces `["library", "artist", name]` — individual artist queries were never invalidated on sync
- **Deezer artist navigation** (`ArtistLinks.tsx`): `getSpotifyIdFromUrl` only parses Spotify URLs — Deezer artists had no clickable link; now falls back to last URL path segment for non-Spotify providers
- **ApiErrorState rename** (`SpotifyErrorState.tsx` → `ApiErrorState.tsx`, `mapSpotifyError` → `mapApiError`): component and helper are provider-agnostic; Spotify-specific names were misleading after Deezer integration
- **Duplicate mutation** (`useAlbumDetailController.ts`): `handleDownloadTrack` called a separate `useCreatePlaylistMutation()` instead of reusing `createPlaylist` from `usePlaylistController` — removes duplicate hook instance and unifies pending state

## Test plan

- [ ] `pnpm --filter frontend run build` — no new TS errors (pre-existing ones on `CreatePlaylistRequest`/`catalogRefreshPending` are unrelated)
- [ ] `pnpm --filter frontend run lint` — 0 errors
- [ ] SSE: after library sync, open artist detail page and verify it auto-refreshes
- [ ] Deezer artist in track list → artist link is clickable and navigates correctly
- [ ] Error states render correctly in Releases, Artists, ArtistDetail, MyPlaylists views

> Part of `sdd/dup-dead-code-audit` — PR-2b of 4 (independent of B3, targets `main` directly).