### PR TITLE
refactor(frontend): F3 optional polish — deduplicate helpers and hooks

### DIFF
--- a/apps/frontend/src/components/organisms/ArtistDiscography.tsx
+++ b/apps/frontend/src/components/organisms/ArtistDiscography.tsx
@@ -1,7 +1,7 @@
 import { ArtistRelease, NormalizedTrack } from "@spotiarr/shared";
 import { FC, memo, MouseEvent, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useBulkPlaylistStatus } from "@/contexts/DownloadStatusContext";
+import { useAlbumListDownloadStates } from "@/hooks/useAlbumListDownloadStates";
 import { Button } from "../atoms/Button";
 import { AlbumCard } from "../molecules/AlbumCard";
 import { ArtistDiscographyFilters, DiscographyFilter } from "../molecules/ArtistDiscographyFilters";
@@ -115,16 +115,7 @@ export const ArtistDiscography: FC<ArtistDiscographyProps> = ({
     [filteredAlbums, visibleItems],
   );
 
-  const albumStatusItems = useMemo(
-    () =>
-      displayedItems.map((album) => ({
-        url: album.spotifyUrl,
-        totalTracks: album.totalTracks,
-      })),
-    [displayedItems],
-  );
-
-  const downloadStatesMap = useBulkPlaylistStatus(albumStatusItems);
+  const downloadStatesMap = useAlbumListDownloadStates(displayedItems);
 
   const renderDiscographyItem = useCallback(
     (album: ArtistRelease) => {

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -30,7 +30,7 @@ interface PlaylistProps {
   onConfirmDelete: (() => void) | undefined;
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
-  onDownload: () => void;
+  onDownloadOrRetry: () => void;
 }
 
 export const Playlist: FC<PlaylistProps> = ({
@@ -51,7 +51,7 @@ export const Playlist: FC<PlaylistProps> = ({
   onConfirmDelete,
   onRetryFailed,
   onToggleSubscription,
-  onDownload,
+  onDownloadOrRetry,
 }) => {
   const { t } = useTranslation();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -109,7 +109,7 @@ export const Playlist: FC<PlaylistProps> = ({
             onToggleSubscription={onToggleSubscription}
             onRetryFailed={onRetryFailed}
             onDelete={handleDelete}
-            onDownload={onDownload}
+            onDownload={onDownloadOrRetry}
             spotifyUrl={
               playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")
                 ? playlist.spotifyUrl

--- a/apps/frontend/src/components/organisms/ReleasesList.tsx
+++ b/apps/frontend/src/components/organisms/ReleasesList.tsx
@@ -1,6 +1,6 @@
 import { ArtistRelease } from "@spotiarr/shared";
-import { FC, memo, MouseEvent, useCallback, useMemo } from "react";
-import { useBulkPlaylistStatus } from "@/contexts/DownloadStatusContext";
+import { FC, memo, MouseEvent, useCallback } from "react";
+import { useAlbumListDownloadStates } from "@/hooks/useAlbumListDownloadStates";
 import { AlbumCard } from "../molecules/AlbumCard";
 import { VirtualGrid } from "../molecules/VirtualGrid";
 
@@ -61,16 +61,7 @@ export const ReleasesList: FC<ReleasesListProps> = ({
   onDownloadRelease,
   onArtistClick,
 }) => {
-  const releaseStatusItems = useMemo(
-    () =>
-      releases.map((release) => ({
-        url: release.spotifyUrl,
-        totalTracks: release.totalTracks,
-      })),
-    [releases],
-  );
-
-  const downloadStatesMap = useBulkPlaylistStatus(releaseStatusItems);
+  const downloadStatesMap = useAlbumListDownloadStates(releases);
 
   const renderItem = useCallback(
     (release: ArtistRelease) => {

--- a/apps/frontend/src/components/organisms/SearchAlbumGrid.tsx
+++ b/apps/frontend/src/components/organisms/SearchAlbumGrid.tsx
@@ -1,6 +1,6 @@
 import { ArtistRelease } from "@spotiarr/shared";
-import { FC, memo, MouseEvent, useCallback, useMemo } from "react";
-import { useBulkPlaylistStatus } from "@/contexts/DownloadStatusContext";
+import { FC, memo, MouseEvent, useCallback } from "react";
+import { useAlbumListDownloadStates } from "@/hooks/useAlbumListDownloadStates";
 import { AlbumCard } from "../molecules/AlbumCard";
 import { VirtualGrid } from "../molecules/VirtualGrid";
 
@@ -60,16 +60,7 @@ export const SearchAlbumGrid: FC<SearchAlbumGridProps> = ({
   onArtistClick,
   onDownload,
 }) => {
-  const albumStatusItems = useMemo(
-    () =>
-      albums.map((album) => ({
-        url: album.spotifyUrl,
-        totalTracks: album.totalTracks,
-      })),
-    [albums],
-  );
-
-  const downloadStatesMap = useBulkPlaylistStatus(albumStatusItems);
+  const downloadStatesMap = useAlbumListDownloadStates(albums);
 
   const renderItem = useCallback(
     (album: ArtistRelease) => {

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
@@ -5,6 +5,7 @@ import { APP_CONFIG } from "@/config/app";
 import { useBulkTrackStatus } from "@/contexts/DownloadStatusContext";
 import { Path } from "@/routes/routes";
 import { PlaylistWithStats, Track } from "@/types";
+import { buildZeroStats } from "@/utils/playlist";
 import { useAlbumTracksQuery } from "../queries/useAlbumTracksQuery";
 import { useArtistAlbumsQuery } from "../queries/useArtistAlbumsQuery";
 import { usePlaylistController } from "./usePlaylistController";
@@ -84,19 +85,7 @@ export const useAlbumDetailController = () => {
       createdAt: Date.now(),
       owner,
       ownerUrl: undefined,
-      stats: {
-        completedCount: 0,
-        downloadingCount: 0,
-        searchingCount: 0,
-        queuedCount: 0,
-        activeCount: 0,
-        errorCount: 0,
-        totalCount: tracks.length,
-        progress: 0,
-        isDownloading: false,
-        hasErrors: false,
-        isCompleted: false,
-      },
+      stats: buildZeroStats(tracks.length),
     };
   }, [album, albumId, rawTracks, tracks.length]);
 

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
@@ -96,7 +96,6 @@ export const useAlbumDetailController = () => {
   }, [album?.spotifyUrl, artistId, albumId]);
 
   const {
-    isDownloading,
     isDownloaded,
     isButtonLoading,
     hasFailed,

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
@@ -98,6 +98,7 @@ export const useAlbumDetailController = () => {
   const {
     isDownloading,
     isDownloaded,
+    isButtonLoading,
     hasFailed,
     completedCount,
     displayTitle,
@@ -127,11 +128,6 @@ export const useAlbumDetailController = () => {
     },
     [artistId, albumId, createPlaylist],
   );
-
-  const isButtonLoading =
-    createPlaylist.isPending ||
-    isDownloading ||
-    (createPlaylist.isSuccess && !isDownloading && !isDownloaded);
 
   const isSaved = tracks.some((t) => t.status === TrackStatusEnum.Completed);
 

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.ts
@@ -1,18 +1,18 @@
 import { NormalizedTrack, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
 import { useMemo, useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { APP_CONFIG } from "@/config/app";
 import { useBulkTrackStatus } from "@/contexts/DownloadStatusContext";
-import { Path } from "@/routes/routes";
 import { PlaylistWithStats, Track } from "@/types";
 import { buildZeroStats } from "@/utils/playlist";
 import { useAlbumTracksQuery } from "../queries/useAlbumTracksQuery";
 import { useArtistAlbumsQuery } from "../queries/useArtistAlbumsQuery";
+import { useNavigationHelpers } from "../useNavigationHelpers";
 import { usePlaylistController } from "./usePlaylistController";
 
 export const useAlbumDetailController = () => {
   const { artistId = "", albumId = "" } = useParams<{ artistId: string; albumId: string }>();
-  const navigate = useNavigate();
+  const { handleGoBack, handleGoHome } = useNavigationHelpers();
 
   // Fetch album tracks
   const {
@@ -130,14 +130,6 @@ export const useAlbumDetailController = () => {
   );
 
   const isSaved = tracks.some((t) => t.status === TrackStatusEnum.Completed);
-
-  const handleGoBack = useCallback(() => {
-    navigate(-1);
-  }, [navigate]);
-
-  const handleGoHome = useCallback(() => {
-    navigate(Path.HOME);
-  }, [navigate]);
 
   return {
     playlist,

--- a/apps/frontend/src/hooks/controllers/usePlaylistController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistController.ts
@@ -121,9 +121,15 @@ export const usePlaylistController = ({
     [playlist?.name, playlist?.type, tracks],
   );
 
+  const isButtonLoading =
+    createPlaylist.isPending ||
+    isDownloading ||
+    (createPlaylist.isSuccess && !isDownloading && !isDownloaded);
+
   return {
     isDownloading,
     isDownloaded,
+    isButtonLoading,
     hasFailed,
     completedCount,
     displayTitle,

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -1,12 +1,12 @@
-import { useCallback, useMemo } from "react";
-import { useNavigate, useParams } from "react-router-dom";
-import { Path } from "@/routes/routes";
+import { useMemo } from "react";
+import { useParams } from "react-router-dom";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useTracksQuery } from "../queries/useTracksQuery";
+import { useNavigationHelpers } from "../useNavigationHelpers";
 import { usePlaylistController } from "./usePlaylistController";
 
 export const usePlaylistDetailController = () => {
-  const navigate = useNavigate();
+  const { handleGoHome } = useNavigationHelpers();
   const { id } = useParams<{ id: string }>();
 
   const { data: playlists = [], isLoading: isPlaylistsLoading } = usePlaylistsQuery();
@@ -31,10 +31,6 @@ export const usePlaylistDetailController = () => {
     spotifyUrl: playlist?.spotifyUrl,
     id,
   });
-
-  const handleGoHome = useCallback(() => {
-    navigate(Path.HOME);
-  }, [navigate]);
 
   return {
     playlist,

--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
@@ -162,6 +162,7 @@ export const usePlaylistPreviewController = () => {
   const {
     isDownloading,
     isDownloaded,
+    isButtonLoading,
     hasFailed,
     completedCount,
     displayTitle,
@@ -170,18 +171,12 @@ export const usePlaylistPreviewController = () => {
     handleDelete,
     handleRetryFailed,
     handleRetryTrack,
-    mutations: { createPlaylist },
   } = usePlaylistController({
     playlist,
     tracks,
     spotifyUrl,
     id: savedPlaylistId,
   });
-
-  const isButtonLoading =
-    createPlaylist.isPending ||
-    isDownloading ||
-    (createPlaylist.isSuccess && !isDownloading && !isDownloaded);
 
   const isSaved = !!savedPlaylistId || tracks.some((t) => t.status === TrackStatusEnum.Completed);
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
@@ -1,14 +1,14 @@
 import { PlaylistPreview, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useBulkTrackStatus } from "@/contexts/DownloadStatusContext";
-import { Path } from "@/routes/routes";
 import { playlistService } from "@/services/playlist.service";
 import { PlaylistWithStats } from "@/types";
 import { Track } from "@/types";
 import { buildZeroStats } from "@/utils/playlist";
 import { usePlaylistPreviewQuery } from "../queries/usePlaylistPreviewQuery";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
+import { useNavigationHelpers } from "../useNavigationHelpers";
 import { usePlaylistController } from "./usePlaylistController";
 
 const PLAYLIST_PREVIEW_PAGE_SIZE = 100;
@@ -34,7 +34,7 @@ const mergeUniquePreviewTracks = (tracks: PlaylistPreviewTrack[]): PlaylistPrevi
 };
 
 export const usePlaylistPreviewController = () => {
-  const navigate = useNavigate();
+  const { handleGoBack, handleGoHome } = useNavigationHelpers();
   const [searchParams] = useSearchParams();
   const spotifyUrl = searchParams.get("url");
 
@@ -179,14 +179,6 @@ export const usePlaylistPreviewController = () => {
   });
 
   const isSaved = !!savedPlaylistId || tracks.some((t) => t.status === TrackStatusEnum.Completed);
-
-  const handleGoBack = () => {
-    navigate(-1);
-  };
-
-  const handleGoHome = useCallback(() => {
-    navigate(Path.HOME);
-  }, [navigate]);
 
   return {
     playlist,

--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
@@ -160,7 +160,6 @@ export const usePlaylistPreviewController = () => {
   }, [accumulatedPreviewTracks, trackStatusesMap]);
 
   const {
-    isDownloading,
     isDownloaded,
     isButtonLoading,
     hasFailed,

--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
@@ -6,6 +6,7 @@ import { Path } from "@/routes/routes";
 import { playlistService } from "@/services/playlist.service";
 import { PlaylistWithStats } from "@/types";
 import { Track } from "@/types";
+import { buildZeroStats } from "@/utils/playlist";
 import { usePlaylistPreviewQuery } from "../queries/usePlaylistPreviewQuery";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { usePlaylistController } from "./usePlaylistController";
@@ -133,19 +134,7 @@ export const usePlaylistPreviewController = () => {
       createdAt: Date.now(),
       owner: previewData.owner,
       ownerUrl: previewData.ownerUrl,
-      stats: {
-        completedCount: 0,
-        downloadingCount: 0,
-        searchingCount: 0,
-        queuedCount: 0,
-        activeCount: 0,
-        errorCount: 0,
-        totalCount: accumulatedPreviewTracks.length,
-        progress: 0,
-        isDownloading: false,
-        hasErrors: false,
-        isCompleted: false,
-      },
+      stats: buildZeroStats(accumulatedPreviewTracks.length),
     };
   }, [accumulatedPreviewTracks.length, previewData, spotifyUrl, savedPlaylist?.subscribed]);
 

--- a/apps/frontend/src/hooks/useAlbumListDownloadStates.ts
+++ b/apps/frontend/src/hooks/useAlbumListDownloadStates.ts
@@ -1,0 +1,28 @@
+import { ArtistRelease } from "@spotiarr/shared";
+import { useMemo } from "react";
+import { useBulkPlaylistStatus } from "@/contexts/DownloadStatusContext";
+
+export interface AlbumDownloadState {
+  isDownloaded: boolean;
+  isDownloading: boolean;
+}
+
+/**
+ * Centralizes the download-status Map pattern for album list components.
+ * Wraps useBulkPlaylistStatus with ArtistRelease[] mapping.
+ * Returns a Map<spotifyUrl, AlbumDownloadState>.
+ */
+export function useAlbumListDownloadStates(
+  albums: ArtistRelease[],
+): Map<string, AlbumDownloadState> {
+  const statusItems = useMemo(
+    () =>
+      albums.map((album) => ({
+        url: album.spotifyUrl,
+        totalTracks: album.totalTracks,
+      })),
+    [albums],
+  );
+
+  return useBulkPlaylistStatus(statusItems);
+}

--- a/apps/frontend/src/hooks/useNavigationHelpers.ts
+++ b/apps/frontend/src/hooks/useNavigationHelpers.ts
@@ -1,0 +1,27 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Path } from "@/routes/routes";
+
+export interface NavigationHelpers {
+  handleGoBack: () => void;
+  handleGoHome: () => void;
+}
+
+/**
+ * Shared memoized navigation helpers.
+ * Centralizes handleGoBack (navigate(-1)) and handleGoHome (navigate to HOME)
+ * so controllers don't redefine them inline.
+ */
+export function useNavigationHelpers(): NavigationHelpers {
+  const navigate = useNavigate();
+
+  const handleGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  const handleGoHome = useCallback(() => {
+    navigate(Path.HOME);
+  }, [navigate]);
+
+  return { handleGoBack, handleGoHome };
+}

--- a/apps/frontend/src/utils/playlist.ts
+++ b/apps/frontend/src/utils/playlist.ts
@@ -1,6 +1,20 @@
 import { TrackStatusEnum } from "@spotiarr/shared";
 import { type Playlist, PlaylistStats, type Track } from "@/types";
 
+export const buildZeroStats = (totalCount: number): PlaylistStats => ({
+  completedCount: 0,
+  downloadingCount: 0,
+  searchingCount: 0,
+  queuedCount: 0,
+  activeCount: 0,
+  errorCount: 0,
+  totalCount,
+  progress: 0,
+  isDownloading: false,
+  hasErrors: false,
+  isCompleted: false,
+});
+
 export const calculatePlaylistStats = (playlist: Playlist): PlaylistStats => {
   const tracks = playlist.tracks || [];
   const completed = tracks.filter((t: Track) => t.status === TrackStatusEnum.Completed).length;

--- a/apps/frontend/src/views/AlbumDetail.tsx
+++ b/apps/frontend/src/views/AlbumDetail.tsx
@@ -54,7 +54,7 @@ export const AlbumDetail: FC = () => {
       completedCount={completedCount}
       hasMoreTracks={hasMoreTracks}
       isLoadingMoreTracks={isLoadingMoreTracks}
-      onDownload={handleDownload}
+      onDownloadOrRetry={handleDownload}
       onDownloadTrack={handleDownloadTrack}
       onRetryTrack={(trackId) => {
         const track = tracks.find((t) => t.id === trackId);

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -49,7 +49,7 @@ export const PlaylistDetail: FC = () => {
       isRetrying={retryFailedTracks.isPending}
       onToggleSubscription={handleToggleSubscription}
       onDownloadTrack={(track) => handleRetryTrack(track)}
-      onDownload={handleRetryFailed}
+      onDownloadOrRetry={handleRetryFailed}
     />
   );
 };

--- a/apps/frontend/src/views/PlaylistPreview.tsx
+++ b/apps/frontend/src/views/PlaylistPreview.tsx
@@ -55,7 +55,7 @@ export const PlaylistPreview: FC = () => {
       hasMoreTracks={hasMoreTracks}
       isLoadingMoreTracks={isLoadingMoreTracks}
       onDownloadTrack={handleRetryTrack}
-      onDownload={handleDownload}
+      onDownloadOrRetry={handleDownload}
       onLoadMoreTracks={handleLoadMoreTracks}
       onRetryTrack={(trackId) => {
         const track = tracks.find((t) => t.id === trackId);


### PR DESCRIPTION
## Summary

- Extracts `buildZeroStats` factory to `utils/playlist.ts` — removes two inline zero-stats constructions in `useAlbumDetailController` and `usePlaylistPreviewController`
- Consolidates `isButtonLoading` derived value into `usePlaylistController` — consumers destructure it instead of redefining the expression
- Creates `useAlbumListDownloadStates` hook wrapping `useBulkPlaylistStatus` — centralizes the `Map<url, DownloadState>` pattern; wired into `ReleasesList`, `ArtistDiscography`, `SearchAlbumGrid`
- Creates `useNavigationHelpers` hook with memoized `handleGoBack`/`handleGoHome` — wired into `useAlbumDetailController`, `usePlaylistPreviewController`, `usePlaylistDetailController`
- Renames `onDownload` → `onDownloadOrRetry` prop in `Playlist` organism and all callsites (`AlbumDetail`, `PlaylistDetail`, `PlaylistPreview`) to document that the handler covers both download and retry flows

## Notes

- Batch F3 is optional per SDD `dup-dead-code-audit` — deferred here from PR-3 to stay within 400-line budget
- `useAlbumListDownloadStates` keys by URL (mirrors `useBulkPlaylistStatus` key shape) — no behavioral change
- 7 pre-existing TS errors remain from parent branch (`CreatePlaylistRequest`, `catalogRefreshPending`, `spotifyUrl` mismatch) — none introduced by this batch

## Test plan

- [ ] Playlist download + retry flow works in `PlaylistDetail` and `PlaylistPreview`
- [ ] Album list download states render correctly in `ReleasesList`, `ArtistDiscography`, `SearchAlbumGrid`
- [ ] Back/home navigation works in album detail and playlist preview
- [ ] `pnpm --filter frontend run lint` passes