### PR TITLE
test(frontend): add Vitest utility coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  build-and-lint:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     steps:
@@ -31,14 +32,61 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Build shared package
         run: pnpm --filter @spotiarr/shared run build
 
       - name: Generate Prisma client
         run: pnpm --filter backend run prisma:generate
 
-      - name: Test backend
-        run: pnpm --filter backend run test:run
+      - name: Run tests
+        run: pnpm test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm --filter backend run prisma:generate
 
       - name: Build
         run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,12 +167,12 @@ Pre-commit hooks run lint + format automatically via `lint-staged` + Husky. Neve
 
 Run targeted first, broad only for cross-workspace changes.
 
-| Scope                   | Commands                                                                               |
-| ----------------------- | -------------------------------------------------------------------------------------- |
-| Frontend only           | `pnpm --filter frontend run lint` → `pnpm --filter frontend run build`                 |
-| Backend only            | `pnpm --filter backend run lint` → `pnpm --filter backend run build`                   |
-| Shared package          | `pnpm --filter @spotiarr/shared run lint` → `pnpm --filter @spotiarr/shared run build` |
-| Broad / cross-workspace | `pnpm lint` → `pnpm build`                                                             |
+| Scope                   | Commands                                                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Frontend only           | `pnpm --filter frontend run lint` → `pnpm --filter frontend run test:run` → `pnpm --filter frontend run build` |
+| Backend only            | `pnpm --filter backend run lint` → `pnpm --filter backend run test:run` → `pnpm --filter backend run build`    |
+| Shared package          | `pnpm --filter @spotiarr/shared run lint` → `pnpm --filter @spotiarr/shared run build`                         |
+| Broad / cross-workspace | `pnpm lint` → `pnpm test` → `pnpm build`                                                                       |
 
 ---
 

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -47,6 +47,7 @@ src/
 
 ```bash
 pnpm --filter frontend run lint
+pnpm --filter frontend run test:run
 pnpm --filter frontend run build
 ```
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,7 +9,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "spotiarr-lint src",
-    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\""
+    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
@@ -37,14 +39,18 @@
     "@spotiarr/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4.1.17",
     "@tanstack/react-query-devtools": "^5.91.1",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "jsdom": "^29.1.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.1.17",
-    "vite": "^7.2.7"
+    "vite": "^7.2.7",
+    "vitest": "^3.2.4"
   }
 }

--- a/apps/frontend/src/utils/cache.test.ts
+++ b/apps/frontend/src/utils/cache.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStaleWhileRevalidateTimings,
+  getCacheMinutesFromSettings,
+  getSettingsCacheTimings,
+  STALE_TIME_AUTH,
+  STALE_TIME_LONG,
+  STALE_TIME_MEDIUM,
+} from "./cache";
+
+describe("getCacheMinutesFromSettings", () => {
+  it("returns fallback when key is missing", () => {
+    const settings = [{ key: "other", value: "10" }];
+    expect(getCacheMinutesFromSettings(settings, "RELEASES_CACHE_MINUTES", 5)).toBe(5);
+  });
+
+  it("parses a valid setting value", () => {
+    const settings = [{ key: "RELEASES_CACHE_MINUTES", value: "60" }];
+    expect(getCacheMinutesFromSettings(settings, "RELEASES_CACHE_MINUTES", 5)).toBe(60);
+  });
+
+  it("returns fallback when value is not a number", () => {
+    const settings = [{ key: "RELEASES_CACHE_MINUTES", value: "invalid" }];
+    expect(getCacheMinutesFromSettings(settings, "RELEASES_CACHE_MINUTES", 5)).toBe(5);
+  });
+});
+
+describe("buildStaleWhileRevalidateTimings", () => {
+  it("calculates gcTime and staleTime from cache minutes", () => {
+    const result = buildStaleWhileRevalidateTimings(10);
+    expect(result.gcTime).toBe(10 * 60 * 1000);
+    expect(result.staleTime).toBe(5 * 60 * 1000);
+  });
+
+  it("enforces a minimum staleTime of one minute", () => {
+    const result = buildStaleWhileRevalidateTimings(1);
+    expect(result.gcTime).toBe(60 * 1000);
+    expect(result.staleTime).toBe(60 * 1000);
+  });
+});
+
+describe("getSettingsCacheTimings", () => {
+  it("combines parsing and timing building", () => {
+    const settings = [{ key: "RELEASES_CACHE_MINUTES", value: "20" }];
+    const result = getSettingsCacheTimings(settings, "RELEASES_CACHE_MINUTES", 5);
+    expect(result.gcTime).toBe(20 * 60 * 1000);
+    expect(result.staleTime).toBe(10 * 60 * 1000);
+  });
+});
+
+describe("cache constants", () => {
+  it("exports expected constant values", () => {
+    expect(STALE_TIME_LONG).toBe(5 * 60 * 1000);
+    expect(STALE_TIME_MEDIUM).toBe(60 * 1000);
+    expect(STALE_TIME_AUTH).toBe(30 * 1000);
+  });
+});

--- a/apps/frontend/src/utils/cn.test.ts
+++ b/apps/frontend/src/utils/cn.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { cn } from "./cn";
+
+describe("cn", () => {
+  it("merges plain class strings", () => {
+    expect(cn("foo", "bar")).toBe("foo bar");
+  });
+
+  it("resolves Tailwind conflicting utilities to the last value", () => {
+    expect(cn("px-2", "px-4")).toBe("px-4");
+  });
+
+  it("ignores falsy values", () => {
+    expect(cn("foo", undefined, "baz", null, "")).toBe("foo baz");
+  });
+
+  it("handles conditional object syntax", () => {
+    expect(cn("base", { active: true, disabled: false })).toBe("base active");
+  });
+
+  it("resolves complex Tailwind conflicts", () => {
+    expect(cn("text-sm text-red-500", "text-lg text-blue-500")).toBe("text-lg text-blue-500");
+  });
+});

--- a/apps/frontend/src/utils/date.test.ts
+++ b/apps/frontend/src/utils/date.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { formatDuration } from "./date";
+
+describe("formatDuration", () => {
+  it("formats zero milliseconds", () => {
+    expect(formatDuration(0)).toBe("0:00");
+  });
+
+  it("formats seconds under one minute", () => {
+    expect(formatDuration(30_000)).toBe("0:30");
+  });
+
+  it("formats exact minutes", () => {
+    expect(formatDuration(120_000)).toBe("2:00");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(185_000)).toBe("3:05");
+  });
+
+  it("formats hours as large minutes", () => {
+    expect(formatDuration(3_600_000)).toBe("60:00");
+  });
+});

--- a/apps/frontend/src/utils/playlist.test.ts
+++ b/apps/frontend/src/utils/playlist.test.ts
@@ -1,0 +1,122 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { describe, expect, it } from "vitest";
+import type { Playlist, Track } from "@/types";
+import { buildZeroStats, calculatePlaylistStats, formatPlaylistTitle } from "./playlist";
+
+const makeTrack = (status: TrackStatusEnum, overrides: Partial<Track> = {}): Track => ({
+  id: "t1",
+  name: "Song",
+  artist: "Artist",
+  album: "Album",
+  durationMs: 180000,
+  status,
+  ...overrides,
+});
+
+describe("buildZeroStats", () => {
+  it("returns all-zero stats for a given total count", () => {
+    const stats = buildZeroStats(5);
+    expect(stats).toEqual({
+      completedCount: 0,
+      downloadingCount: 0,
+      searchingCount: 0,
+      queuedCount: 0,
+      activeCount: 0,
+      errorCount: 0,
+      totalCount: 5,
+      progress: 0,
+      isDownloading: false,
+      hasErrors: false,
+      isCompleted: false,
+    });
+  });
+});
+
+describe("calculatePlaylistStats", () => {
+  it("handles an empty track list", () => {
+    const playlist: Playlist = {
+      id: "p1",
+      name: "Test",
+      spotifyUrl: "https://open.spotify.com/playlist/s1",
+      type: PlaylistTypeEnum.Playlist,
+      tracks: [],
+    };
+    const stats = calculatePlaylistStats(playlist);
+    expect(stats.totalCount).toBe(0);
+    expect(stats.progress).toBe(0);
+    expect(stats.isCompleted).toBe(false);
+    expect(stats.isDownloading).toBe(false);
+    expect(stats.hasErrors).toBe(false);
+  });
+
+  it("calculates progress and flags for mixed statuses", () => {
+    const playlist: Playlist = {
+      id: "p1",
+      name: "Test",
+      spotifyUrl: "https://open.spotify.com/playlist/s1",
+      type: PlaylistTypeEnum.Playlist,
+      tracks: [
+        makeTrack(TrackStatusEnum.Completed),
+        makeTrack(TrackStatusEnum.Downloading),
+        makeTrack(TrackStatusEnum.Searching),
+        makeTrack(TrackStatusEnum.Queued),
+        makeTrack(TrackStatusEnum.Error),
+      ],
+    };
+    const stats = calculatePlaylistStats(playlist);
+    expect(stats.completedCount).toBe(1);
+    expect(stats.downloadingCount).toBe(1);
+    expect(stats.searchingCount).toBe(1);
+    expect(stats.queuedCount).toBe(1);
+    expect(stats.errorCount).toBe(1);
+    expect(stats.activeCount).toBe(3);
+    expect(stats.totalCount).toBe(5);
+    expect(stats.progress).toBe(20);
+    expect(stats.isDownloading).toBe(true);
+    expect(stats.hasErrors).toBe(true);
+    expect(stats.isCompleted).toBe(false);
+  });
+
+  it("marks completed when all tracks are completed", () => {
+    const playlist: Playlist = {
+      id: "p1",
+      name: "Test",
+      spotifyUrl: "https://open.spotify.com/playlist/s1",
+      type: PlaylistTypeEnum.Playlist,
+      tracks: [makeTrack(TrackStatusEnum.Completed), makeTrack(TrackStatusEnum.Completed)],
+    };
+    const stats = calculatePlaylistStats(playlist);
+    expect(stats.isCompleted).toBe(true);
+    expect(stats.progress).toBe(100);
+    expect(stats.hasErrors).toBe(false);
+    expect(stats.isDownloading).toBe(false);
+  });
+});
+
+describe("formatPlaylistTitle", () => {
+  it("returns 'Unnamed Playlist' for empty title", () => {
+    expect(formatPlaylistTitle("", "playlist", [])).toBe("Unnamed Playlist");
+  });
+
+  it("returns raw title for plain playlist type", () => {
+    expect(formatPlaylistTitle("My Playlist", "playlist", [])).toBe("My Playlist");
+  });
+
+  it("extracts album name from first track for album type", () => {
+    const tracks = [makeTrack(TrackStatusEnum.New, { album: "Dark Side" })];
+    expect(formatPlaylistTitle("Artist - Dark Side", "album", tracks)).toBe("Dark Side");
+  });
+
+  it("falls back to splitting raw title for album when no track album", () => {
+    expect(formatPlaylistTitle("Artist - Dark Side", "album", [])).toBe("Dark Side");
+  });
+
+  it("extracts track name from first track for track type", () => {
+    const tracks = [makeTrack(TrackStatusEnum.New, { name: "Money" })];
+    expect(formatPlaylistTitle("Artist - Money", "track", tracks)).toBe("Money");
+  });
+
+  it("returns raw title when splitting yields no dash for track type", () => {
+    expect(formatPlaylistTitle("Single", "track", [])).toBe("Single");
+  });
+});

--- a/apps/frontend/src/utils/spotify.test.ts
+++ b/apps/frontend/src/utils/spotify.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { getSpotifyIdFromUrl, isSpotifyUrl, mapApiError, normalizeSpotifyUrl } from "./spotify";
+
+describe("normalizeSpotifyUrl", () => {
+  it("normalizes a valid open.spotify.com URL", () => {
+    expect(normalizeSpotifyUrl("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")).toBe(
+      "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M",
+    );
+  });
+
+  it("normalizes a URL with extra path segments", () => {
+    expect(
+      normalizeSpotifyUrl("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M/tracks"),
+    ).toBe("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M");
+  });
+
+  it("normalizes an album URL", () => {
+    expect(normalizeSpotifyUrl("https://open.spotify.com/album/4yP0hdKOZPNsh8gydrB7Jb")).toBe(
+      "https://open.spotify.com/album/4yP0hdKOZPNsh8gydrB7Jb",
+    );
+  });
+
+  it("rejects non-spotify host", () => {
+    expect(normalizeSpotifyUrl("https://example.com/playlist/abc")).toBeNull();
+  });
+
+  it("rejects empty input", () => {
+    expect(normalizeSpotifyUrl("  ")).toBeNull();
+    expect(normalizeSpotifyUrl("")).toBeNull();
+  });
+
+  it("rejects malformed URL", () => {
+    expect(normalizeSpotifyUrl("not-a-url")).toBeNull();
+  });
+
+  it("rejects URL with missing ID", () => {
+    expect(normalizeSpotifyUrl("https://open.spotify.com/playlist/")).toBeNull();
+  });
+});
+
+describe("isSpotifyUrl", () => {
+  it("returns true for open.spotify.com", () => {
+    expect(isSpotifyUrl("https://open.spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns true for spotify.com", () => {
+    expect(isSpotifyUrl("https://spotify.com/track/abc")).toBe(true);
+  });
+
+  it("returns true for spoti.fi", () => {
+    expect(isSpotifyUrl("https://spoti.fi/abc")).toBe(true);
+  });
+
+  it("returns false for non-spotify URLs", () => {
+    expect(isSpotifyUrl("https://youtube.com/watch")).toBe(false);
+  });
+
+  it("returns false for null/undefined/empty", () => {
+    expect(isSpotifyUrl(null)).toBe(false);
+    expect(isSpotifyUrl(undefined)).toBe(false);
+    expect(isSpotifyUrl("")).toBe(false);
+  });
+});
+
+describe("getSpotifyIdFromUrl", () => {
+  it("extracts the ID from a standard URL", () => {
+    expect(getSpotifyIdFromUrl("https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M")).toBe(
+      "37i9dQZF1DXcBWIGoYBM5M",
+    );
+  });
+
+  it("returns null for malformed URLs", () => {
+    expect(getSpotifyIdFromUrl("not-a-url")).toBeNull();
+  });
+
+  it("returns null when path has fewer than 3 segments", () => {
+    expect(getSpotifyIdFromUrl("https://open.spotify.com/playlist")).toBeNull();
+  });
+});
+
+describe("mapApiError", () => {
+  it("maps missing_user_access_token from code", () => {
+    const error = new Error("something");
+    (error as { code?: string }).code = "missing_user_access_token";
+    expect(mapApiError(error, "spotify_rate_limited")).toBe("missing_user_access_token");
+  });
+
+  it("maps missing_user_access_token from message", () => {
+    const error = new Error("missing_user_access_token");
+    expect(mapApiError(error, "spotify_rate_limited")).toBe("missing_user_access_token");
+  });
+
+  it("maps spotify_rate_limited from code", () => {
+    const error = new Error("rate limited");
+    (error as { code?: string }).code = "spotify_rate_limited";
+    expect(mapApiError(error, "missing_user_access_token")).toBe("spotify_rate_limited");
+  });
+
+  it("returns null for non-Error input", () => {
+    expect(mapApiError("string error", "spotify_rate_limited")).toBeNull();
+  });
+
+  it("returns fallback for unmatched errors", () => {
+    const error = new Error("unknown");
+    expect(mapApiError(error, "spotify_rate_limited")).toBe("spotify_rate_limited");
+  });
+});

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    include: ["src/**/*.test.ts"],
+  },
+  resolve: {
+    alias: {
+      "@spotiarr/shared": path.resolve(__dirname, "../../packages/shared/src/index.ts"),
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "db:generate": "pnpm --filter backend run prisma:generate",
     "build": "pnpm -r run build",
     "start": "node apps/backend/dist/index.js",
+    "test": "pnpm -r --if-present run test:run",
     "lint": "pnpm -r --if-present run lint",
     "format": "pnpm -r --if-present run format",
     "clean": "pnpm -r --if-present run clean && rm -rf apps/*/dist packages/*/dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,7 +94,7 @@ importers:
         version: 4.20.6
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   apps/frontend:
     dependencies:
@@ -168,6 +168,12 @@ importers:
       "@tanstack/react-query-devtools":
         specifier: ^5.91.1
         version: 5.91.1(@tanstack/react-query@5.90.12(react@19.2.1))(react@19.2.1)
+      "@testing-library/dom":
+        specifier: ^10.4.1
+        version: 10.4.1
+      "@testing-library/react":
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@types/react":
         specifier: ^19.2.7
         version: 19.2.7
@@ -186,6 +192,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.1(jiti@2.6.1))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       prettier-plugin-tailwindcss:
         specifier: ^0.7.2
         version: 0.7.2(@trivago/prettier-plugin-sort-imports@6.0.0(prettier@3.7.4))(prettier@3.7.4)
@@ -195,6 +204,9 @@ importers:
       vite:
         specifier: ^7.2.7
         version: 7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/eslint-config:
     dependencies:
@@ -239,6 +251,33 @@ importers:
         version: 5.9.3
 
 packages:
+  "@asamuzakjp/css-color@5.1.11":
+    resolution:
+      {
+        integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
+  "@asamuzakjp/dom-selector@7.1.1":
+    resolution:
+      {
+        integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
+  "@asamuzakjp/generational-cache@1.0.1":
+    resolution:
+      {
+        integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
+  "@asamuzakjp/nwsapi@2.3.9":
+    resolution:
+      {
+        integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==,
+      }
+
   "@babel/code-frame@7.27.1":
     resolution:
       {
@@ -391,6 +430,67 @@ packages:
       {
         integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==,
       }
+
+  "@bramus/specificity@2.4.2":
+    resolution:
+      {
+        integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==,
+      }
+    hasBin: true
+
+  "@csstools/color-helpers@6.0.2":
+    resolution:
+      {
+        integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==,
+      }
+    engines: { node: ">=20.19.0" }
+
+  "@csstools/css-calc@3.2.1":
+    resolution:
+      {
+        integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==,
+      }
+    engines: { node: ">=20.19.0" }
+    peerDependencies:
+      "@csstools/css-parser-algorithms": ^4.0.0
+      "@csstools/css-tokenizer": ^4.0.0
+
+  "@csstools/css-color-parser@4.1.1":
+    resolution:
+      {
+        integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==,
+      }
+    engines: { node: ">=20.19.0" }
+    peerDependencies:
+      "@csstools/css-parser-algorithms": ^4.0.0
+      "@csstools/css-tokenizer": ^4.0.0
+
+  "@csstools/css-parser-algorithms@4.0.0":
+    resolution:
+      {
+        integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==,
+      }
+    engines: { node: ">=20.19.0" }
+    peerDependencies:
+      "@csstools/css-tokenizer": ^4.0.0
+
+  "@csstools/css-syntax-patches-for-csstree@1.1.4":
+    resolution:
+      {
+        integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==,
+      }
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  "@csstools/css-tokenizer@4.0.0":
+    resolution:
+      {
+        integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==,
+      }
+    engines: { node: ">=20.19.0" }
 
   "@esbuild/aix-ppc64@0.25.12":
     resolution:
@@ -690,6 +790,18 @@ packages:
         integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@exodus/bytes@1.15.1":
+    resolution:
+      {
+        integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+    peerDependencies:
+      "@noble/hashes": ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      "@noble/hashes":
+        optional: true
 
   "@fortawesome/fontawesome-common-types@7.1.0":
     resolution:
@@ -1270,6 +1382,31 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  "@testing-library/dom@10.4.1":
+    resolution:
+      {
+        integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==,
+      }
+    engines: { node: ">=18" }
+
+  "@testing-library/react@16.3.2":
+    resolution:
+      {
+        integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      "@testing-library/dom": ^10.0.0
+      "@types/react": ^18.0.0 || ^19.0.0
+      "@types/react-dom": ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      "@types/react-dom":
+        optional: true
+
   "@tokenizer/inflate@0.4.1":
     resolution:
       {
@@ -1304,6 +1441,12 @@ packages:
         optional: true
       svelte:
         optional: true
+
+  "@types/aria-query@5.0.4":
+    resolution:
+      {
+        integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
+      }
 
   "@types/babel__core@7.20.5":
     resolution:
@@ -1662,6 +1805,13 @@ packages:
       }
     engines: { node: ">=8" }
 
+  ansi-styles@5.2.0:
+    resolution:
+      {
+        integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
+      }
+    engines: { node: ">=10" }
+
   ansi-styles@6.2.3:
     resolution:
       {
@@ -1680,6 +1830,12 @@ packages:
     resolution:
       {
         integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
+
+  aria-query@5.3.0:
+    resolution:
+      {
+        integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
       }
 
   array-buffer-byte-length@1.0.2:
@@ -1778,6 +1934,12 @@ packages:
         integrity: sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==,
       }
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution:
+      {
+        integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==,
+      }
 
   binary-extensions@2.3.0:
     resolution:
@@ -2058,11 +2220,25 @@ packages:
       }
     engines: { node: ">= 8" }
 
+  css-tree@3.2.1:
+    resolution:
+      {
+        integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
+      }
+    engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
+
   csstype@3.2.3:
     resolution:
       {
         integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
       }
+
+  data-urls@7.0.0:
+    resolution:
+      {
+        integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
 
   data-view-buffer@1.0.2:
     resolution:
@@ -2108,6 +2284,12 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution:
+      {
+        integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==,
+      }
+
   deep-eql@5.0.2:
     resolution:
       {
@@ -2149,6 +2331,13 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  dequal@2.0.3:
+    resolution:
+      {
+        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
+      }
+    engines: { node: ">=6" }
+
   detect-libc@2.1.2:
     resolution:
       {
@@ -2169,6 +2358,12 @@ packages:
         integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==,
       }
     engines: { node: ">=0.10.0" }
+
+  dom-accessibility-api@0.5.16:
+    resolution:
+      {
+        integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
+      }
 
   dotenv@17.2.3:
     resolution:
@@ -2221,6 +2416,13 @@ packages:
         integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==,
       }
     engines: { node: ">=10.13.0" }
+
+  entities@8.0.0:
+    resolution:
+      {
+        integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==,
+      }
+    engines: { node: ">=20.19.0" }
 
   environment@1.1.0:
     resolution:
@@ -2800,6 +3002,13 @@ packages:
         integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==,
       }
 
+  html-encoding-sniffer@6.0.0:
+    resolution:
+      {
+        integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
   html-parse-stringify@3.0.1:
     resolution:
       {
@@ -3046,6 +3255,12 @@ packages:
       }
     engines: { node: ">=0.12.0" }
 
+  is-potential-custom-element-name@1.0.1:
+    resolution:
+      {
+        integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==,
+      }
+
   is-promise@4.0.0:
     resolution:
       {
@@ -3165,6 +3380,18 @@ packages:
         integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
       }
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution:
+      {
+        integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==,
+      }
+    engines: { node: ^20.19.0 || ^22.13.0 || >=24.0.0 }
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution:
@@ -3399,6 +3626,13 @@ packages:
         integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
       }
 
+  lru-cache@11.5.0:
+    resolution:
+      {
+        integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==,
+      }
+    engines: { node: 20 || >=22 }
+
   lru-cache@5.1.1:
     resolution:
       {
@@ -3412,6 +3646,13 @@ packages:
       }
     engines: { node: ">=12" }
 
+  lz-string@1.5.0:
+    resolution:
+      {
+        integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==,
+      }
+    hasBin: true
+
   magic-string@0.30.21:
     resolution:
       {
@@ -3424,6 +3665,12 @@ packages:
         integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
       }
     engines: { node: ">= 0.4" }
+
+  mdn-data@2.27.1:
+    resolution:
+      {
+        integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
+      }
 
   media-typer@1.1.0:
     resolution:
@@ -3716,6 +3963,12 @@ packages:
         integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==,
       }
 
+  parse5@8.0.1:
+    resolution:
+      {
+        integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==,
+      }
+
   parseurl@1.3.3:
     resolution:
       {
@@ -3891,6 +4144,13 @@ packages:
     engines: { node: ">=14" }
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution:
+      {
+        integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
   prisma@5.22.0:
     resolution:
       {
@@ -3986,6 +4246,12 @@ packages:
         integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==,
       }
 
+  react-is@17.0.2:
+    resolution:
+      {
+        integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
+      }
+
   react-refresh@0.18.0:
     resolution:
       {
@@ -4071,6 +4337,13 @@ packages:
     resolution:
       {
         integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  require-from-string@2.0.2:
+    resolution:
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
       }
     engines: { node: ">=0.10.0" }
 
@@ -4175,6 +4448,13 @@ packages:
       {
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
+
+  saxes@6.0.0:
+    resolution:
+      {
+        integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==,
+      }
+    engines: { node: ">=v12.22.7" }
 
   scheduler@0.27.0:
     resolution:
@@ -4496,6 +4776,12 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  symbol-tree@3.2.4:
+    resolution:
+      {
+        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
+      }
+
   tailwind-merge@3.4.0:
     resolution:
       {
@@ -4563,6 +4849,19 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
+  tldts-core@7.0.30:
+    resolution:
+      {
+        integrity: sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==,
+      }
+
+  tldts@7.0.30:
+    resolution:
+      {
+        integrity: sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==,
+      }
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution:
       {
@@ -4583,6 +4882,20 @@ packages:
         integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==,
       }
     engines: { node: ">=14.16" }
+
+  tough-cookie@6.0.1:
+    resolution:
+      {
+        integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==,
+      }
+    engines: { node: ">=16" }
+
+  tr46@6.0.0:
+    resolution:
+      {
+        integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==,
+      }
+    engines: { node: ">=20" }
 
   tree-kill@1.2.2:
     resolution:
@@ -4707,6 +5020,13 @@ packages:
       {
         integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==,
       }
+
+  undici@7.25.0:
+    resolution:
+      {
+        integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==,
+      }
+    engines: { node: ">=20.18.1" }
 
   unpipe@1.0.0:
     resolution:
@@ -4848,6 +5168,34 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  w3c-xmlserializer@5.0.0:
+    resolution:
+      {
+        integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==,
+      }
+    engines: { node: ">=18" }
+
+  webidl-conversions@8.0.1:
+    resolution:
+      {
+        integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==,
+      }
+    engines: { node: ">=20" }
+
+  whatwg-mimetype@5.0.0:
+    resolution:
+      {
+        integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==,
+      }
+    engines: { node: ">=20" }
+
+  whatwg-url@16.0.1:
+    resolution:
+      {
+        integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
   which-boxed-primitive@1.1.1:
     resolution:
       {
@@ -4923,6 +5271,19 @@ packages:
     resolution:
       {
         integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
+
+  xml-name-validator@5.0.0:
+    resolution:
+      {
+        integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
+      }
+    engines: { node: ">=18" }
+
+  xmlchars@2.2.0:
+    resolution:
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
       }
 
   y18n@5.0.8:
@@ -5012,6 +5373,26 @@ packages:
         optional: true
 
 snapshots:
+  "@asamuzakjp/css-color@5.1.11":
+    dependencies:
+      "@asamuzakjp/generational-cache": 1.0.1
+      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-color-parser": 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-tokenizer": 4.0.0
+
+  "@asamuzakjp/dom-selector@7.1.1":
+    dependencies:
+      "@asamuzakjp/generational-cache": 1.0.1
+      "@asamuzakjp/nwsapi": 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  "@asamuzakjp/generational-cache@1.0.1": {}
+
+  "@asamuzakjp/nwsapi@2.3.9": {}
+
   "@babel/code-frame@7.27.1":
     dependencies:
       "@babel/helper-validator-identifier": 7.28.5
@@ -5127,6 +5508,34 @@ snapshots:
       "@babel/helper-validator-identifier": 7.28.5
 
   "@borewit/text-codec@0.2.1": {}
+
+  "@bramus/specificity@2.4.2":
+    dependencies:
+      css-tree: 3.2.1
+
+  "@csstools/color-helpers@6.0.2": {}
+
+  "@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
+    dependencies:
+      "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-tokenizer": 4.0.0
+
+  "@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
+    dependencies:
+      "@csstools/color-helpers": 6.0.2
+      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-tokenizer": 4.0.0
+
+  "@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)":
+    dependencies:
+      "@csstools/css-tokenizer": 4.0.0
+
+  "@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)":
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  "@csstools/css-tokenizer@4.0.0": {}
 
   "@esbuild/aix-ppc64@0.25.12":
     optional: true
@@ -5251,6 +5660,8 @@ snapshots:
     dependencies:
       "@eslint/core": 0.17.0
       levn: 0.4.1
+
+  "@exodus/bytes@1.15.1": {}
 
   "@fortawesome/fontawesome-common-types@7.1.0": {}
 
@@ -5522,6 +5933,27 @@ snapshots:
       "@tanstack/query-core": 5.90.12
       react: 19.2.1
 
+  "@testing-library/dom@10.4.1":
+    dependencies:
+      "@babel/code-frame": 7.27.1
+      "@babel/runtime": 7.28.4
+      "@types/aria-query": 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  "@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+    dependencies:
+      "@babel/runtime": 7.28.4
+      "@testing-library/dom": 10.4.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+    optionalDependencies:
+      "@types/react": 19.2.7
+      "@types/react-dom": 19.2.3(@types/react@19.2.7)
+
   "@tokenizer/inflate@0.4.1":
     dependencies:
       debug: 4.4.3
@@ -5544,6 +5976,8 @@ snapshots:
       prettier: 3.7.4
     transitivePeerDependencies:
       - supports-color
+
+  "@types/aria-query@5.0.4": {}
 
   "@types/babel__core@7.20.5":
     dependencies:
@@ -5817,6 +6251,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   anymatch@3.1.3:
@@ -5825,6 +6261,10 @@ snapshots:
       picomatch: 2.3.1
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -5906,6 +6346,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   baseline-browser-mapping@2.8.30: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-extensions@2.3.0: {}
 
@@ -6083,7 +6527,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - "@noble/hashes"
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -6111,6 +6567,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -6131,6 +6589,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
 
   dir-glob@3.0.1:
@@ -6140,6 +6600,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dotenv@17.2.3: {}
 
@@ -6163,6 +6625,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -6676,6 +7140,12 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      "@exodus/bytes": 1.15.1
+    transitivePeerDependencies:
+      - "@noble/hashes"
+
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
@@ -6824,6 +7294,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regex@1.2.1:
@@ -6889,6 +7361,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      "@asamuzakjp/css-color": 5.1.11
+      "@asamuzakjp/dom-selector": 7.1.1
+      "@bramus/specificity": 2.4.2
+      "@csstools/css-syntax-patches-for-csstree": 1.1.4(css-tree@3.2.1)
+      "@exodus/bytes": 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.0
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - "@noble/hashes"
 
   jsesc@3.1.0: {}
 
@@ -7014,17 +7512,23 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.5.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
   luxon@3.7.2: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -7202,6 +7706,10 @@ snapshots:
 
   parse-statements@1.0.11: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
@@ -7247,6 +7755,12 @@ snapshots:
       "@trivago/prettier-plugin-sort-imports": 6.0.0(prettier@3.7.4)
 
   prettier@3.7.4: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   prisma@5.22.0:
     dependencies:
@@ -7302,6 +7816,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-refresh@0.18.0: {}
 
   react-router-dom@7.10.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
@@ -7356,6 +7872,8 @@ snapshots:
       set-function-name: 2.0.2
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
 
@@ -7448,6 +7966,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -7670,6 +8192,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.4.0: {}
 
   tailwindcss@4.1.17: {}
@@ -7699,6 +8223,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.30: {}
+
+  tldts@7.0.30:
+    dependencies:
+      tldts-core: 7.0.30
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -7710,6 +8240,14 @@ snapshots:
       "@borewit/text-codec": 0.2.1
       "@tokenizer/token": 0.3.0
       ieee754: 1.2.1
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.30
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -7810,6 +8348,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  undici@7.25.0: {}
+
   unpipe@1.0.0: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
@@ -7870,7 +8410,7 @@ snapshots:
       tsx: 4.20.6
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
       "@types/chai": 5.2.3
       "@vitest/expect": 3.2.4
@@ -7897,6 +8437,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 24.10.1
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - jiti
       - less
@@ -7912,6 +8453,22 @@ snapshots:
       - yaml
 
   void-elements@3.1.0: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      "@exodus/bytes": 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - "@noble/hashes"
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -7980,6 +8537,10 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/skills/spotiarr-workflow/SKILL.md
+++ b/skills/spotiarr-workflow/SKILL.md
@@ -13,18 +13,18 @@ Load when running commands, validating changes, creating PRs, managing branches,
 
 ## Hard Rules
 
-- No automated test suite — CI runs lint + build only. Human verification required for behaviour changes.
+- CI runs lint, tests, and build as separate jobs. Automated tests cover backend and frontend utilities.
 - Never commit `.env`, tokens, or credentials. Use `.env.example` as source of truth.
 - Never bypass pre-commit hooks (`--no-verify` is forbidden).
 - External services required locally: **Redis**, **FFmpeg**, **yt-dlp**, **Python 3.11/3.12**.
 
 ## Decision Gates
 
-| Scope                     | Validate with                                                          |
-| ------------------------- | ---------------------------------------------------------------------- |
-| Frontend only             | `pnpm --filter frontend run lint` → `pnpm --filter frontend run build` |
-| Backend only              | `pnpm --filter backend run lint` → `pnpm --filter backend run build`   |
-| Shared or cross-workspace | `pnpm lint` → `pnpm build`                                             |
+| Scope                     | Validate with                                                                                                  |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Frontend only             | `pnpm --filter frontend run lint` → `pnpm --filter frontend run test:run` → `pnpm --filter frontend run build` |
+| Backend only              | `pnpm --filter backend run lint` → `pnpm --filter backend run test:run` → `pnpm --filter backend run build`    |
+| Shared or cross-workspace | `pnpm lint` → `pnpm test` → `pnpm build`                                                                       |
 
 ## Execution Steps
 
@@ -44,7 +44,10 @@ Load when running commands, validating changes, creating PRs, managing branches,
 
 ```bash
 pnpm dev                                    # full dev stack
-pnpm lint && pnpm build                     # broad validation
+pnpm lint && pnpm test && pnpm build        # broad validation
+pnpm test                                   # all workspace tests
+pnpm --filter frontend run test:run         # frontend unit tests
+pnpm --filter backend run test:run          # backend unit tests
 pnpm --filter backend run prisma:migrate:deploy
 gh pr create                                # title must follow Conventional Commits
 ```


### PR DESCRIPTION
## What

Adds frontend Vitest test infrastructure, initial utility coverage, and a root monorepo test command. CI now runs lint, tests, and build as separate jobs, with the test job using `pnpm test` from the repo root.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / chore

## Scope

- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [x] Cross-workspace

## Checklist

- [x] Lint + build pass for affected scope (`pnpm test`, `pnpm lint`, `pnpm build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [x] Screenshots / GIF attached for UI changes — N/A
- [x] `CHANGELOG.md` updated if this is a user-facing change — N/A

## Verification

- `pnpm test` — 183 passing tests
- `pnpm lint` — passes with 2 pre-existing backend warnings
- `pnpm build` — passes