### PR TITLE
fix(backend): close path traversal in GET /api/library/image

### DIFF
--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -54,7 +54,9 @@ import { BullMqTrackQueueService } from "./infrastructure/messaging/bullmq-track
 import { FileSystemM3uService } from "./infrastructure/services/file-system-m3u.service";
 import { FileSystemScannerService } from "./infrastructure/services/file-system-scanner.service";
 import { FileSystemTrackPathService } from "./infrastructure/services/file-system-track-path.service";
+import { FileSystemLibraryImageService } from "./infrastructure/services/library-image.service";
 import { MetadataService } from "./infrastructure/services/metadata.service";
+import { getEnv } from "./infrastructure/setup/environment";
 import { prisma } from "./infrastructure/setup/prisma";
 import { ArtistController } from "./presentation/controllers/artist.controller";
 import { AuthController } from "./presentation/controllers/auth.controller";
@@ -67,6 +69,16 @@ import { PlaylistController } from "./presentation/controllers/playlist.controll
 import { SearchController } from "./presentation/controllers/search.controller";
 import { SettingsController } from "./presentation/controllers/settings.controller";
 import { TrackController } from "./presentation/controllers/track.controller";
+
+function resolveDownloadsRoot(): string {
+  try {
+    return getEnv().DOWNLOADS;
+  } catch {
+    // Test suites can import the container before environment validation bootstraps.
+    // TODO(secure-library-image-serving): Remove this fallback after `getEnv()` becomes lazily initialized.
+    return process.env.DOWNLOADS ?? ".";
+  }
+}
 
 // Repositories
 const playlistRepository = new PrismaPlaylistRepository();
@@ -262,8 +274,9 @@ const scanLibraryUseCase = new ScanLibraryUseCase(
   trackRepository,
 );
 const libraryService = new LibraryService(scanLibraryUseCase);
+const libraryImageService = new FileSystemLibraryImageService(resolveDownloadsRoot());
 
-const libraryController = new LibraryController(libraryService);
+const libraryController = new LibraryController(libraryService, libraryImageService);
 
 const getArtistDetailUseCase = new GetArtistDetailUseCase(
   feedRepository,

--- a/apps/backend/src/infrastructure/services/library-image.service.test.ts
+++ b/apps/backend/src/infrastructure/services/library-image.service.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSystemLibraryImageService } from "./library-image.service";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FileSystemLibraryImageService", () => {
+  it("returns ok for image files inside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const artistDir = path.join(downloadsRoot, "Artist");
+    const coverPath = path.join(artistDir, "cover.jpg");
+
+    await fs.mkdir(artistDir, { recursive: true });
+    await fs.writeFile(coverPath, "img");
+
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(coverPath);
+    const expectedRealPath = await fs.realpath(coverPath);
+
+    expect(result).toEqual({
+      kind: "ok",
+      absolutePath: expectedRealPath,
+      contentType: "image/jpeg",
+    });
+  });
+
+  it("rejects paths outside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const outsideRoot = await makeTempDir("lib-img-out-");
+    const outsideFile = path.join(outsideRoot, "outside.png");
+
+    await fs.writeFile(outsideFile, "img");
+
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(outsideFile);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects path traversal attempts", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const outsideRoot = await makeTempDir("lib-img-out-");
+    const outsideFile = path.join(outsideRoot, "outside.png");
+
+    await fs.writeFile(outsideFile, "img");
+
+    const traversalPath = path.join(downloadsRoot, "..", path.basename(outsideRoot), "outside.png");
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(traversalPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects symlink escapes", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const outsideRoot = await makeTempDir("lib-img-out-");
+    const outsideFile = path.join(outsideRoot, "outside.webp");
+    const symlinkPath = path.join(downloadsRoot, "escape.webp");
+
+    await fs.writeFile(outsideFile, "img");
+    await fs.symlink(outsideFile, symlinkPath);
+
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(symlinkPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects non-image extension", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const filePath = path.join(downloadsRoot, "cover.txt");
+
+    await fs.writeFile(filePath, "txt");
+
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(filePath);
+
+    expect(result).toEqual({ kind: "reject", reason: "bad-extension" });
+  });
+
+  it("rejects missing path", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(undefined);
+
+    expect(result).toEqual({ kind: "reject", reason: "missing-path" });
+  });
+
+  it("rejects files that do not exist", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const missingPath = path.join(downloadsRoot, "missing.png");
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(missingPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "not-found" });
+  });
+
+  it("logs warning with reason category for rejected requests", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+
+    const result = await service.resolveImage(undefined);
+
+    expect(result).toEqual({ kind: "reject", reason: "missing-path" });
+    expect(warnSpy).toHaveBeenCalledWith("[LibraryImageService] Request rejected", {
+      reason: "missing-path",
+    });
+    expect(JSON.stringify(warnSpy.mock.calls[0])).not.toContain(downloadsRoot);
+  });
+});

--- a/apps/backend/src/infrastructure/services/library-image.service.ts
+++ b/apps/backend/src/infrastructure/services/library-image.service.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export type RejectReason = "outside-root" | "bad-extension" | "not-found" | "missing-path";
+
+export type ResolveImageResult =
+  | { kind: "ok"; absolutePath: string; contentType: string }
+  | { kind: "reject"; reason: RejectReason };
+
+export interface LibraryImageService {
+  resolveImage(rawPath: string | undefined): Promise<ResolveImageResult>;
+}
+
+const IMAGE_CONTENT_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
+export class FileSystemLibraryImageService implements LibraryImageService {
+  constructor(private readonly downloadsRoot: string) {}
+
+  private logRejection(reason: RejectReason): void {
+    console.warn("[LibraryImageService] Request rejected", { reason });
+  }
+
+  async resolveImage(rawPath: string | undefined): Promise<ResolveImageResult> {
+    if (!rawPath) {
+      this.logRejection("missing-path");
+      return { kind: "reject", reason: "missing-path" };
+    }
+
+    let rootRealPath: string;
+    let candidateRealPath: string;
+
+    try {
+      rootRealPath = await fs.realpath(this.downloadsRoot);
+      candidateRealPath = await fs.realpath(rawPath);
+    } catch {
+      this.logRejection("not-found");
+      return { kind: "reject", reason: "not-found" };
+    }
+    const extension = path.extname(candidateRealPath).toLowerCase();
+
+    if (!Object.hasOwn(IMAGE_CONTENT_TYPES, extension)) {
+      this.logRejection("bad-extension");
+      return { kind: "reject", reason: "bad-extension" };
+    }
+
+    const relativePath = path.relative(rootRealPath, candidateRealPath);
+    const isInsideRoot =
+      relativePath.length > 0 && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+
+    if (!isInsideRoot) {
+      this.logRejection("outside-root");
+      return { kind: "reject", reason: "outside-root" };
+    }
+
+    return {
+      kind: "ok",
+      absolutePath: candidateRealPath,
+      contentType: IMAGE_CONTENT_TYPES[extension],
+    };
+  }
+}

--- a/apps/backend/src/presentation/controllers/library.controller.ts
+++ b/apps/backend/src/presentation/controllers/library.controller.ts
@@ -1,8 +1,12 @@
 import { Request, Response } from "express";
 import { LibraryService } from "@/application/services/library.service";
+import { LibraryImageService } from "@/infrastructure/services/library-image.service";
 
 export class LibraryController {
-  constructor(private readonly libraryService: LibraryService) {}
+  constructor(
+    private readonly libraryService: LibraryService,
+    private readonly libraryImageService: LibraryImageService,
+  ) {}
 
   getStats = async (req: Request, res: Response) => {
     try {
@@ -55,26 +59,34 @@ export class LibraryController {
 
   getImage = async (req: Request, res: Response) => {
     try {
-      const imagePath = req.query.path as string;
+      const imagePath = typeof req.query.path === "string" ? req.query.path : undefined;
+      const result = await this.libraryImageService.resolveImage(imagePath);
 
-      if (!imagePath) {
-        res.status(400).json({
-          error: "invalid_request",
-          message: "Image path is required",
+      if (result.kind === "reject") {
+        if (result.reason === "missing-path") {
+          res.status(400).json({
+            error: "invalid_request",
+            message: "Image path is required",
+          });
+          return;
+        }
+
+        res.status(404).json({
+          error: "file_not_found",
+          message: "File not found",
         });
         return;
       }
 
-      res.sendFile(imagePath, (err) => {
-        if (err) {
-          console.error(`Error sending file ${imagePath}:`, err);
-          if (!res.headersSent) {
-            res.status(404).json({
-              error: "file_not_found",
-              message: "File not found",
-            });
-          }
+      res.type(result.contentType).sendFile(result.absolutePath, (err) => {
+        if (!err || res.headersSent) {
+          return;
         }
+
+        res.status(404).json({
+          error: "file_not_found",
+          message: "File not found",
+        });
       });
     } catch (error) {
       console.error("Error serving image:", error);

--- a/apps/backend/src/presentation/routes/library.routes.test.ts
+++ b/apps/backend/src/presentation/routes/library.routes.test.ts
@@ -1,0 +1,186 @@
+import express from "express";
+import fs from "node:fs/promises";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LibraryService } from "@/application/services/library.service";
+import { FileSystemLibraryImageService } from "@/infrastructure/services/library-image.service";
+import { LibraryController } from "@/presentation/controllers/library.controller";
+import { asyncHandler } from "../middleware/async-handler";
+
+const tempDirs: string[] = [];
+const servers: http.Server[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function startTestServer(downloadsRoot: string): Promise<string> {
+  const libraryController = new LibraryController(
+    {} as LibraryService,
+    new FileSystemLibraryImageService(downloadsRoot),
+  );
+
+  const app = express();
+  app.get("/image", asyncHandler(libraryController.getImage));
+
+  const server = await new Promise<http.Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+  servers.push(server);
+  const address = server.address();
+
+  if (address && typeof address === "object") {
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  throw new Error("Unable to resolve server address");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("GET /image integration", () => {
+  it("serves image inside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "cover.jpg");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "image-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/jpeg");
+    expect(await response.text()).toBe("image-content");
+  });
+
+  it("returns 404 for absolute path outside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const outsideRoot = await makeTempDir("lib-route-out-");
+    const outsideFile = path.join(outsideRoot, "cover.jpg");
+
+    await fs.writeFile(outsideFile, "image-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(outsideFile)}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+
+  it("returns 404 for traversal path", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const baseUrl = await startTestServer(downloadsRoot);
+    const traversalPath = `..${path.sep}outside.jpg`;
+
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(traversalPath)}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+
+  it("returns 404 for symlink escape", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const outsideRoot = await makeTempDir("lib-route-out-");
+    const outsideFile = path.join(outsideRoot, "cover.webp");
+    const symlinkPath = path.join(downloadsRoot, "link.webp");
+
+    await fs.writeFile(outsideFile, "image-content");
+    await fs.symlink(outsideFile, symlinkPath);
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(symlinkPath)}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+
+  it("returns 404 for non-image extension", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "cover.txt");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "not-image");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+
+  it("returns 400 for missing path query", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const baseUrl = await startTestServer(downloadsRoot);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await fetch(`${baseUrl}/image`);
+    const body = (await response.json()) as { error: string; message: string };
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "invalid_request",
+      message: "Image path is required",
+    });
+    expect(warnSpy).toHaveBeenCalledWith("[LibraryImageService] Request rejected", {
+      reason: "missing-path",
+    });
+  });
+
+  it("returns 400 for non-string path query", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const baseUrl = await startTestServer(downloadsRoot);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await fetch(`${baseUrl}/image?path=a&path=b`);
+    const body = (await response.json()) as { error: string; message: string };
+
+    expect(response.status).toBe(400);
+    expect(body).toEqual({
+      error: "invalid_request",
+      message: "Image path is required",
+    });
+    expect(warnSpy).toHaveBeenCalledWith("[LibraryImageService] Request rejected", {
+      reason: "missing-path",
+    });
+  });
+
+  it("returns 404 for non-existent image path inside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const missingInsideDownloads = path.join(downloadsRoot, "Artist", "missing-cover.png");
+    const baseUrl = await startTestServer(downloadsRoot);
+
+    const response = await fetch(
+      `${baseUrl}/image?path=${encodeURIComponent(missingInsideDownloads)}`,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+
+  it("returns 404 for URL-encoded traversal", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const baseUrl = await startTestServer(downloadsRoot);
+
+    const response = await fetch(`${baseUrl}/image?path=%2e%2e%2fescape.jpg`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
+  });
+});

--- a/apps/backend/src/presentation/routes/schemas/library.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/library.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const libraryImageQuerySchema = z.object({
+  path: z.string().min(1, "path query parameter is required"),
+});
+
+export const libraryImageRequestSchema = z.object({
+  query: libraryImageQuerySchema,
+});


### PR DESCRIPTION
## 🚨 CRITICAL Security Severity
Este cambio corrige una vulnerabilidad de **path traversal** explotable en un endpoint público de imágenes.

## Why
`GET /api/library/image?path=<X>` aceptaba paths arbitrarios y los pasaba a `res.sendFile`, permitiendo lectura de cualquier archivo legible por el proceso (path traversal). Ejemplo: `?path=/etc/passwd`.

## What
- Nuevo `LibraryImageService` que valida:
  - `realpath(DOWNLOADS)` + `realpath(candidate)` + `path.relative` containment
  - whitelist de extensiones: `.jpg`, `.jpeg`, `.png`, `.webp`
  - manejo explícito de `missing-path`, `outside-root`, `bad-extension`, `not-found`
- Logging estructurado `warn` por categoría de rechazo
- Validación + logging centralizados en el servicio (single source of truth)
- Contrato `?path=` del frontend preservado

## Validation
- `pnpm --filter backend run lint` ✅
- `pnpm --filter backend run test:run` ✅ 166/166
- `pnpm --filter backend run build` ✅
- 16 nuevos tests (8 unit + 8 integration) cubriendo R1..R6 y los 8 escenarios del spec, incluyendo symlink escape y traversal URL-encoded.

## Test scenarios
- happy path dentro de DOWNLOADS → 200
- path absoluto fuera de DOWNLOADS → 404
- traversal `../` → 404
- symlink escape → 404
- extensión no permitida → 404
- `path` faltante → 400 + warn log `missing-path`
- archivo inexistente dentro de DOWNLOADS → 404
- traversal URL-encoded → 404

## SDD trail (Engram)
- `sdd/secure-library-image-serving/explore`
- `sdd/secure-library-image-serving/proposal`
- `sdd/secure-library-image-serving/spec`
- `sdd/secure-library-image-serving/design`
- `sdd/secure-library-image-serving/tasks`
- `sdd/secure-library-image-serving/apply-progress`
- `sdd/secure-library-image-serving/verify-report` (✅ APPROVED, 0 critical, 0 warning)

Closes #28