### PR TITLE
chore: audit quick wins (dead code, i18n, SSE listener, logging)

### DIFF
--- a/apps/backend/src/infrastructure/external/spotify.types.ts
+++ b/apps/backend/src/infrastructure/external/spotify.types.ts
@@ -70,9 +70,3 @@ export interface SpotifyFollowedArtistsResponse {
 export interface SpotifyArtistAlbumsResponse {
   items: SpotifyAlbum[];
 }
-
-export interface SpotifySearchResponse {
-  tracks?: { items: SpotifyTrack[] };
-  albums?: { items: SpotifyAlbum[] };
-  artists?: { items: SpotifyArtistFull[] };
-}

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const workerListeners: Record<string, (...args: unknown[]) => unknown> = {};
+
+const workerOn = vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
+  workerListeners[event] = cb;
+});
+
+const WorkerMock = vi.fn(() => ({
+  on: workerOn,
+}));
+
+const getSyncState = vi.fn();
+
+vi.mock("bullmq", () => ({
+  Worker: WorkerMock,
+}));
+
+vi.mock("@/container", () => ({
+  container: {
+    spotifyUserLibrarySyncService: {},
+    releaseFeedService: {},
+    feedRepository: {
+      getSyncState,
+      setSyncState: vi.fn(),
+    },
+    eventBus: {
+      emit: vi.fn(),
+    },
+    settingsService: {
+      getNumber: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../setup/environment", () => ({
+  getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
+}));
+
+vi.mock("../setup/queues", () => ({
+  FEED_SYNC_QUEUE: "feed-sync",
+}));
+
+describe("createFeedSyncWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(workerListeners).forEach((key) => {
+      delete workerListeners[key];
+    });
+    getSyncState.mockResolvedValue({ status: "idle" });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("logs non-fatal warning when failed-state sync check rejects", async () => {
+    const { createFeedSyncWorker } = await import("./feed-sync.worker");
+
+    createFeedSyncWorker();
+    getSyncState.mockRejectedValueOnce(new Error("read failure"));
+
+    const failedHandler = workerListeners.failed;
+    expect(failedHandler).toBeTypeOf("function");
+
+    await failedHandler?.({ id: "job-1" }, new Error("job failed"));
+    await Promise.resolve();
+
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -171,7 +171,11 @@ export function createFeedSyncWorker(): Worker {
           );
         }
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.warn("[feed-sync.worker] non-fatal error", {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
   });
 
   console.log("✅ Feed sync worker initialized");

--- a/apps/backend/src/presentation/routes/settings.routes.ts
+++ b/apps/backend/src/presentation/routes/settings.routes.ts
@@ -6,7 +6,6 @@ const router: ExpressRouter = Router();
 const { settingsController } = container;
 
 // GET /api/settings - Get all settings
-// GET /api/settings - Get all settings
 router.get("/", asyncHandler(settingsController.getSettings));
 
 // GET /api/settings/metadata - Get settings metadata

--- a/apps/frontend/src/components/molecules/SearchTopResultCard.test.tsx
+++ b/apps/frontend/src/components/molecules/SearchTopResultCard.test.tsx
@@ -1,0 +1,62 @@
+import { FollowedArtist } from "@spotiarr/shared";
+import { render, screen } from "@testing-library/react";
+import i18next, { i18n } from "i18next";
+import { initReactI18next, I18nextProvider } from "react-i18next";
+import { describe, expect, it, vi } from "vitest";
+import en from "@/locales/en.json";
+import es from "@/locales/es.json";
+import { SearchTopResultCard } from "./SearchTopResultCard";
+
+const artistItem: { type: "artist"; data: FollowedArtist } = {
+  type: "artist",
+  data: {
+    id: "artist-1",
+    name: "Daft Punk",
+    image: null,
+    spotifyUrl: "https://open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi",
+  },
+};
+
+const createI18nInstance = async (language: "en" | "es"): Promise<i18n> => {
+  const instance = i18next.createInstance();
+
+  await instance.use(initReactI18next).init({
+    lng: language,
+    fallbackLng: "en",
+    resources: {
+      en: { translation: en },
+      es: { translation: es },
+    },
+    interpolation: {
+      escapeValue: false,
+    },
+  });
+
+  return instance;
+};
+
+describe("SearchTopResultCard", () => {
+  it("renders Artist label for English locale", async () => {
+    const i18n = await createI18nInstance("en");
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SearchTopResultCard item={artistItem} onClick={vi.fn()} />
+      </I18nextProvider>,
+    );
+
+    expect(screen.getByText("Artist")).toBeDefined();
+  });
+
+  it("renders Artista label for Spanish locale", async () => {
+    const i18n = await createI18nInstance("es");
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <SearchTopResultCard item={artistItem} onClick={vi.fn()} />
+      </I18nextProvider>,
+    );
+
+    expect(screen.getByText("Artista")).toBeDefined();
+  });
+});

--- a/apps/frontend/src/components/molecules/SearchTopResultCard.tsx
+++ b/apps/frontend/src/components/molecules/SearchTopResultCard.tsx
@@ -29,7 +29,7 @@ const getConfig = (item: TopResultItem, t: TFunction): ResultConfig => {
       return {
         imageSrc: item.data.image ?? undefined,
         title: item.data.name,
-        typeLabel: t("common.cards.albumTypes.artist", "Artista"),
+        typeLabel: t("common.cards.albumTypes.artist"),
         isCircular: true,
         fallbackIcon: "user",
       };

--- a/apps/frontend/src/components/molecules/SettingItem.tsx
+++ b/apps/frontend/src/components/molecules/SettingItem.tsx
@@ -1,5 +1,7 @@
-import { APP_LOCALE_LABELS, AppLocale, SettingMetadata } from "@spotiarr/shared";
-import { ChangeEvent, FC, memo, MouseEvent, ReactNode } from "react";
+import { APP_LOCALE_LABELS } from "@spotiarr/shared";
+import type { AppLocale, SettingMetadata } from "@spotiarr/shared";
+import { memo } from "react";
+import type { ChangeEvent, FC, MouseEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { SettingInput } from "./SettingInput";
 import { SettingSelect } from "./SettingSelect";

--- a/apps/frontend/src/hooks/useServerEvents.test.tsx
+++ b/apps/frontend/src/hooks/useServerEvents.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/hooks/queryKeys";
+import { useServerEvents } from "@/hooks/useServerEvents";
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  readyState = 0;
+  listeners = new Map<string, ((event: MessageEvent) => void)[]>();
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, cb: (event: MessageEvent) => void) {
+    const list = this.listeners.get(type) ?? [];
+    list.push(cb);
+    this.listeners.set(type, list);
+  }
+
+  dispatch(type: string, data?: unknown) {
+    const list = this.listeners.get(type) ?? [];
+    for (const cb of list) {
+      cb(new MessageEvent(type, { data: JSON.stringify(data ?? {}) }));
+    }
+  }
+
+  close() {
+    this.readyState = 2;
+  }
+}
+
+describe("useServerEvents", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  it("invalidates releases and followed artists on catalog-updated", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useServerEvents(), { wrapper });
+
+    const source = MockEventSource.instances[0];
+    source.dispatch("catalog-updated");
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.releases });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.followedArtists });
+  });
+
+  it("invalidates expected queries on feed-updated and library-updated", () => {
+    const queryClient = new QueryClient();
+    const invalidateQueriesSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    renderHook(() => useServerEvents(), { wrapper });
+
+    const source = MockEventSource.instances[0];
+    source.dispatch("feed-updated");
+    source.dispatch("library-updated");
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.releases });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.followedArtists });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.libraryStats });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({ queryKey: queryKeys.libraryArtists });
+  });
+
+  it("closes EventSource on unmount", () => {
+    const queryClient = new QueryClient();
+
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { unmount } = renderHook(() => useServerEvents(), { wrapper });
+
+    unmount();
+
+    expect(MockEventSource.instances[0].readyState).toBe(2);
+  });
+});

--- a/apps/frontend/src/hooks/useServerEvents.ts
+++ b/apps/frontend/src/hooks/useServerEvents.ts
@@ -38,6 +38,11 @@ export const useServerEvents = () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.followedArtists });
     });
 
+    eventSource.addEventListener("catalog-updated", () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.releases });
+      queryClient.invalidateQueries({ queryKey: queryKeys.followedArtists });
+    });
+
     eventSource.onerror = (error) => {
       console.error("EventSource failed:", error);
     };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -52,6 +52,7 @@
     "cards": {
       "albumTypes": {
         "all": "All",
+        "artist": "Artist",
         "single": "Single",
         "ep": "EP",
         "singlesAndEps": "Singles & EPs",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -52,6 +52,7 @@
     "cards": {
       "albumTypes": {
         "all": "Todos",
+        "artist": "Artista",
         "single": "Sencillo",
         "ep": "EP",
         "singlesAndEps": "Sencillos y EPs",

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
   resolve: {
     alias: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -19,8 +19,6 @@ export const UI_SUPPORTED_AUDIO_FORMATS = [
   "m4a",
 ] as const satisfies readonly SupportedAudioFormat[];
 
-export type UiSupportedAudioFormat = (typeof UI_SUPPORTED_AUDIO_FORMATS)[number];
-
 export const APP_LOCALES = ["en", "es"] as const;
 export type AppLocale = (typeof APP_LOCALES)[number];
 
@@ -170,8 +168,6 @@ export interface ApiErrorShape {
 export interface ApiSuccess<T> {
   data: T;
 }
-
-export type ApiResponse<T> = ApiSuccess<T> | ApiErrorShape;
 
 export interface DownloadHistoryItem {
   id: string;


### PR DESCRIPTION
## Why
Limpieza de hallazgos de bajo riesgo del audit interno: código muerto, logging silencioso, key i18n faltante, listener SSE no consumido, e `import type` corregido. Ninguno justifica un SDD propio.

## What
- **QW1** Borra `ApiResponse` y `UiSupportedAudioFormat` de `@spotiarr/shared` (sin consumidores).
- **QW2** Borra `SpotifySearchResponse` del backend (sin consumidores).
- **QW3** Agrega `common.cards.albumTypes.artist` en `en.json` y `es.json`; remueve fallback hardcodeado en `SearchTopResultCard`.
- **QW4** Reemplaza `.catch(() => {})` en `feed-sync.worker` por `console.warn` estructurado + test.
- **QW5** `import type` en `SettingItem.tsx`.
- **QW6** Listener SSE `catalog-updated` invalida `releases` + `followedArtists` (mismo set que `feed-updated`).
- **QW7** Borra comentario duplicado en `settings.routes.ts:8-9`.

## Validation
- `pnpm --filter @spotiarr/shared run build` ✅
- `pnpm --filter backend run lint` ✅
- `pnpm --filter backend run test:run` ✅ 167/167
- `pnpm --filter backend run build` ✅
- `pnpm --filter frontend run lint` ✅
- `pnpm --filter frontend run test:run` ✅ 47/47
- `pnpm --filter frontend run build` ✅

## Audit trail
Hallazgos del audit del 2026-05-23 (Engram).