### PR TITLE
refactor(backend): split feed.repository into bucketed persistence (PR 1/3)

### DIFF
--- a/apps/backend/src/application/ports/feed-repository.port.ts
+++ b/apps/backend/src/application/ports/feed-repository.port.ts
@@ -1,5 +1,48 @@
 import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 
+export interface CatalogIdentity {
+  spotifyId: string;
+  deezerId: string | null;
+  mbid: string | null;
+}
+
+export interface CatalogIdentityInput {
+  spotifyId: string;
+  deezerId?: string | null;
+  mbid?: string | null;
+}
+
+export interface ArtistAlbumSpotifyUrlInput {
+  artistId: string;
+  albumId: string;
+  albumName: string;
+  albumType?: string | null;
+  releaseDate?: string | null;
+  coverUrl?: string | null;
+  spotifyUrl: string;
+  totalTracks?: number | null;
+}
+
+export interface AlbumIdentityInput {
+  deezerAlbumId?: string | null;
+  mbAlbumId?: string | null;
+}
+
+export const SYNC_STATUS = {
+  Idle: "idle",
+  Running: "running",
+  Error: "error",
+} as const;
+
+export type SyncStatus = (typeof SYNC_STATUS)[keyof typeof SYNC_STATUS];
+
+export interface SyncStateRecord {
+  id: number;
+  lastSyncAt: Date | null;
+  status: string;
+  error: string | null;
+}
+
 export interface ArtistAlbumCacheWithArtist {
   id: string;
   spotifyArtistId: string;
@@ -29,6 +72,8 @@ export interface ArtistReleaseCacheWithArtist {
 
 export interface FeedRepositoryPort {
   getArtistBySpotifyId(spotifyId: string): Promise<FollowedArtist | null>;
+  getArtistCatalogIdentities(spotifyIds: string[]): Promise<CatalogIdentity[]>;
+  updateArtistCatalogIdentities(identities: CatalogIdentityInput[]): Promise<void>;
   getReleases(lookbackDays: number): Promise<ArtistRelease[]>;
   getArtists(): Promise<FollowedArtist[]>;
   upsertArtists(artists: FollowedArtist[]): Promise<void>;
@@ -41,15 +86,35 @@ export interface FeedRepositoryPort {
     artistId: string,
     albumId: string,
   ): Promise<ArtistReleaseCacheWithArtist | null>;
-  updateArtistAlbumIdentities(
-    id: string,
-    identities: { deezerAlbumId?: string | null; mbAlbumId?: string | null },
+  updateArtistAlbumIdentities(id: string, identities: AlbumIdentityInput): Promise<void>;
+  upsertArtistAlbumSpotifyUrl(input: ArtistAlbumSpotifyUrlInput): Promise<void>;
+  updateArtistReleaseSpotifyUrl(
+    artistId: string,
+    albumId: string,
+    spotifyUrl: string,
   ): Promise<void>;
+  getArtistAlbumCount(spotifyArtistId: string): Promise<number>;
   getArtistAlbumsFreshness(spotifyArtistId: string): Promise<Date | null>;
+  getArtistIdsWithNoAlbums(): Promise<Set<string>>;
+  getArtistIdsWithFreshAlbums(cutoffDate: Date): Promise<Set<string>>;
+  getArtistIdsWithFreshReleases(cutoffDate: Date): Promise<Set<string>>;
   getArtistAlbums(
     spotifyArtistId: string,
     limit: number,
     offset?: number,
   ): Promise<ArtistRelease[]>;
   upsertArtistAlbums(albums: ArtistRelease[]): Promise<void>;
+  evictStaleFeedCache(artistIds: string[], cutoffDays?: number): Promise<void>;
+  getArtistIdsNeedingCatalogSync(cutoffDate: Date, limit: number): Promise<string[]>;
+  getActiveArtistIdsForReleasesSync(
+    releaseCutoff: Date,
+    activityWindowDate: Date,
+    limit: number,
+  ): Promise<string[]>;
+  updateArtistCatalogSyncedAt(artistIds: string[]): Promise<void>;
+  updateArtistReleasesSyncedAt(artistIds: string[]): Promise<void>;
+  getSyncState(): Promise<SyncStateRecord>;
+  setSyncState(status: SyncStatus, error?: string): Promise<void>;
+  getCatalogSyncState(): Promise<SyncStateRecord>;
+  setCatalogSyncState(status: SyncStatus, error?: string): Promise<void>;
 }

--- a/apps/backend/src/application/services/feed-cache-eviction.service.test.ts
+++ b/apps/backend/src/application/services/feed-cache-eviction.service.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { FeedCacheEvictionService } from "./feed-cache-eviction.service";
+
+describe("FeedCacheEvictionService", () => {
+  it("delegates eviction with default cutoff", async () => {
+    const port = { evictStaleFeedCache: vi.fn().mockResolvedValue(undefined) };
+    const service = new FeedCacheEvictionService(port);
+
+    await service.evictStaleFeedCache(["a1"]);
+
+    expect(port.evictStaleFeedCache).toHaveBeenCalledWith(["a1"], 90);
+  });
+
+  it("delegates eviction with explicit cutoff", async () => {
+    const port = { evictStaleFeedCache: vi.fn().mockResolvedValue(undefined) };
+    const service = new FeedCacheEvictionService(port);
+
+    await service.evictStaleFeedCache([], 30);
+
+    expect(port.evictStaleFeedCache).toHaveBeenCalledWith([], 30);
+  });
+});

--- a/apps/backend/src/application/services/feed-cache-eviction.service.ts
+++ b/apps/backend/src/application/services/feed-cache-eviction.service.ts
@@ -1,0 +1,11 @@
+export interface FeedCacheEvictionPort {
+  evictStaleFeedCache(artistIds: string[], cutoffDays: number): Promise<void>;
+}
+
+export class FeedCacheEvictionService {
+  constructor(private readonly feedCacheEvictionPort: FeedCacheEvictionPort) {}
+
+  async evictStaleFeedCache(artistIds: string[], cutoffDays = 90): Promise<void> {
+    await this.feedCacheEvictionPort.evictStaleFeedCache(artistIds, cutoffDays);
+  }
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -1,3 +1,4 @@
+import { FeedCacheEvictionService } from "./application/services/feed-cache-eviction.service";
 import { HealthService } from "./application/services/health.service";
 import { LibraryService } from "./application/services/library.service";
 import { PlaylistService } from "./application/services/playlist.service";
@@ -32,7 +33,12 @@ import { RetryTrackDownloadUseCase } from "./application/use-cases/tracks/retry-
 import { SearchTrackOnYoutubeUseCase } from "./application/use-cases/tracks/search-track-on-youtube.use-case";
 import { UpdateTrackUseCase } from "./application/use-cases/tracks/update-track.use-case";
 import { NoopAlbumTracksCache } from "./infrastructure/cache/noop-album-tracks-cache";
+import { ArtistAlbumCacheRepository } from "./infrastructure/database/artist-album-cache.repository";
+import { ArtistReleaseCacheRepository } from "./infrastructure/database/artist-release-cache.repository";
+import { FeedCacheEvictionRepository } from "./infrastructure/database/feed-cache-eviction.repository";
+import { FeedSyncStateRepository } from "./infrastructure/database/feed-sync-state.repository";
 import { FeedRepository } from "./infrastructure/database/feed.repository";
+import { FollowedArtistRepository } from "./infrastructure/database/followed-artist.repository";
 import { PrismaConnectivityAdapter } from "./infrastructure/database/prisma-connectivity.adapter";
 import { PrismaHistoryRepository } from "./infrastructure/database/prisma-history.repository";
 import { PrismaPlaylistRepository } from "./infrastructure/database/prisma-playlist.repository";
@@ -96,7 +102,19 @@ const playlistRepository = new PrismaPlaylistRepository();
 const trackRepository = new PrismaTrackRepository();
 const historyRepository = new PrismaHistoryRepository();
 const settingsRepository = new PrismaSettingsRepository();
-const feedRepository = new FeedRepository(prisma);
+const followedArtistRepository = new FollowedArtistRepository(prisma);
+const artistAlbumCacheRepository = new ArtistAlbumCacheRepository(prisma);
+const artistReleaseCacheRepository = new ArtistReleaseCacheRepository(prisma);
+const feedSyncStateRepository = new FeedSyncStateRepository(prisma);
+const feedCacheEvictionRepository = new FeedCacheEvictionRepository(prisma);
+const feedCacheEvictionService = new FeedCacheEvictionService(feedCacheEvictionRepository);
+const feedRepository = new FeedRepository(
+  followedArtistRepository,
+  artistAlbumCacheRepository,
+  artistReleaseCacheRepository,
+  feedSyncStateRepository,
+  feedCacheEvictionService,
+);
 const connectivityAdapter = new PrismaConnectivityAdapter();
 
 const internalizedNumericSettingMap: Record<string, () => number> = {

--- a/apps/backend/src/infrastructure/database/artist-album-cache.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/artist-album-cache.repository.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+import { ArtistAlbumCacheRepository } from "./artist-album-cache.repository";
+
+describe("ArtistAlbumCacheRepository", () => {
+  it("returns freshness date when found", async () => {
+    const now = new Date();
+    const prisma = {
+      artistAlbumCache: { findFirst: vi.fn().mockResolvedValue({ syncedAt: now }) },
+    } as any;
+    const repo = new ArtistAlbumCacheRepository(prisma);
+    await expect(repo.getArtistAlbumsFreshness("a1")).resolves.toEqual(now);
+  });
+
+  it("short-circuits empty album upserts", async () => {
+    const prisma = { $transaction: vi.fn() } as any;
+    const repo = new ArtistAlbumCacheRepository(prisma);
+    await repo.upsertArtistAlbums([]);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/infrastructure/database/artist-album-cache.repository.ts
+++ b/apps/backend/src/infrastructure/database/artist-album-cache.repository.ts
@@ -1,0 +1,146 @@
+import type { PrismaClient } from "@prisma/client";
+import type { ArtistRelease } from "@spotiarr/shared";
+import type {
+  AlbumIdentityInput,
+  ArtistAlbumCacheWithArtist,
+  ArtistAlbumSpotifyUrlInput,
+} from "@/application/ports/feed-repository.port";
+import { mapArtistAlbumRowToRelease } from "./feed-row-mappers";
+
+export class ArtistAlbumCacheRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getArtistAlbumWithArtist(
+    spotifyArtistId: string,
+    albumId: string,
+  ): Promise<ArtistAlbumCacheWithArtist | null> {
+    const row = await this.prisma.artistAlbumCache.findUnique({
+      where: { id: `${spotifyArtistId}:${albumId}` },
+    });
+    if (!row) return null;
+    const artistRow = await this.prisma.followedArtistCache.findUnique({
+      where: { spotifyId: spotifyArtistId },
+      select: { name: true },
+    });
+    return { ...row, artistName: artistRow?.name ?? "Unknown Artist" };
+  }
+
+  async upsertArtistAlbumSpotifyUrl(input: ArtistAlbumSpotifyUrlInput): Promise<void> {
+    const now = new Date();
+    const id = `${input.artistId}:${input.albumId}`;
+    await this.prisma.artistAlbumCache.upsert({
+      where: { id },
+      update: {
+        spotifyUrl: input.spotifyUrl,
+        albumName: input.albumName,
+        albumType: input.albumType,
+        releaseDate: input.releaseDate,
+        coverUrl: input.coverUrl,
+        totalTracks: input.totalTracks ?? undefined,
+        syncedAt: now,
+      },
+      create: {
+        id,
+        spotifyArtistId: input.artistId,
+        albumId: input.albumId,
+        albumName: input.albumName,
+        albumType: input.albumType,
+        releaseDate: input.releaseDate,
+        coverUrl: input.coverUrl,
+        spotifyUrl: input.spotifyUrl,
+        totalTracks: input.totalTracks ?? null,
+        syncedAt: now,
+      },
+    });
+  }
+
+  async updateArtistAlbumIdentities(id: string, identities: AlbumIdentityInput): Promise<void> {
+    await this.prisma.artistAlbumCache.update({
+      where: { id },
+      data: {
+        ...(identities.deezerAlbumId !== undefined
+          ? { deezerAlbumId: identities.deezerAlbumId }
+          : {}),
+        ...(identities.mbAlbumId !== undefined ? { mbAlbumId: identities.mbAlbumId } : {}),
+      },
+    });
+  }
+
+  async getArtistAlbumCount(spotifyArtistId: string): Promise<number> {
+    return this.prisma.artistAlbumCache.count({ where: { spotifyArtistId } });
+  }
+
+  async getArtistAlbumsFreshness(spotifyArtistId: string): Promise<Date | null> {
+    const row = await this.prisma.artistAlbumCache.findFirst({
+      where: { spotifyArtistId },
+      orderBy: { syncedAt: "desc" },
+      select: { syncedAt: true },
+    });
+    return row?.syncedAt ?? null;
+  }
+
+  async getArtistIdsWithFreshAlbums(cutoffDate: Date): Promise<Set<string>> {
+    const rows = await this.prisma.artistAlbumCache.findMany({
+      where: { syncedAt: { gte: cutoffDate } },
+      select: { spotifyArtistId: true },
+      distinct: ["spotifyArtistId"],
+    });
+    return new Set(rows.map((r) => r.spotifyArtistId));
+  }
+
+  async getArtistAlbums(
+    spotifyArtistId: string,
+    limit: number,
+    offset = 0,
+  ): Promise<ArtistRelease[]> {
+    const rows = await this.prisma.artistAlbumCache.findMany({
+      where: { spotifyArtistId },
+      orderBy: [{ releaseDate: "desc" }, { albumId: "asc" }],
+      skip: offset,
+      take: limit,
+    });
+    const artistRow = await this.prisma.followedArtistCache.findUnique({
+      where: { spotifyId: spotifyArtistId },
+    });
+    const artistMeta = artistRow
+      ? { name: artistRow.name, imageUrl: artistRow.imageUrl }
+      : undefined;
+    return rows.map((row) => mapArtistAlbumRowToRelease(row, artistMeta));
+  }
+
+  async upsertArtistAlbums(albums: ArtistRelease[]): Promise<void> {
+    if (albums.length === 0) return;
+    const now = new Date();
+    await this.prisma.$transaction(
+      albums.map((album) => {
+        const id = `${album.artistId}:${album.albumId}`;
+        return this.prisma.artistAlbumCache.upsert({
+          where: { id },
+          update: {
+            spotifyArtistId: album.artistId,
+            albumId: album.albumId,
+            albumName: album.albumName,
+            albumType: album.albumType,
+            releaseDate: album.releaseDate,
+            coverUrl: album.coverUrl,
+            spotifyUrl: album.spotifyUrl,
+            totalTracks: album.totalTracks ?? null,
+            syncedAt: now,
+          },
+          create: {
+            id,
+            spotifyArtistId: album.artistId,
+            albumId: album.albumId,
+            albumName: album.albumName,
+            albumType: album.albumType,
+            releaseDate: album.releaseDate,
+            coverUrl: album.coverUrl,
+            spotifyUrl: album.spotifyUrl,
+            totalTracks: album.totalTracks ?? null,
+            syncedAt: now,
+          },
+        });
+      }),
+    );
+  }
+}

--- a/apps/backend/src/infrastructure/database/artist-release-cache.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/artist-release-cache.repository.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+import { ArtistReleaseCacheRepository } from "./artist-release-cache.repository";
+
+describe("ArtistReleaseCacheRepository", () => {
+  it("uses default lookback when input is invalid", async () => {
+    const prisma = {
+      artistReleaseCache: { findMany: vi.fn().mockResolvedValue([]) },
+    } as any;
+    const repo = new ArtistReleaseCacheRepository(prisma);
+    await repo.getReleases(Number.NaN);
+    expect(prisma.artistReleaseCache.findMany).toHaveBeenCalledOnce();
+  });
+
+  it("returns null when release is not found", async () => {
+    const prisma = { artistReleaseCache: { findUnique: vi.fn().mockResolvedValue(null) } } as any;
+    const repo = new ArtistReleaseCacheRepository(prisma);
+    await expect(repo.getArtistReleaseWithArtist("a", "b")).resolves.toBeNull();
+  });
+});

--- a/apps/backend/src/infrastructure/database/artist-release-cache.repository.ts
+++ b/apps/backend/src/infrastructure/database/artist-release-cache.repository.ts
@@ -1,0 +1,98 @@
+import type { PrismaClient } from "@prisma/client";
+import type { ArtistRelease } from "@spotiarr/shared";
+import type { ArtistReleaseCacheWithArtist } from "@/application/ports/feed-repository.port";
+import { mapArtistReleaseRow } from "./feed-row-mappers";
+
+export class ArtistReleaseCacheRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getReleases(lookbackDays: number): Promise<ArtistRelease[]> {
+    const safeDays = Number.isFinite(lookbackDays) && lookbackDays > 0 ? lookbackDays : 30;
+    const cutoff = new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const today = new Date().toISOString().slice(0, 10);
+    const rows = await this.prisma.artistReleaseCache.findMany({
+      where: { releaseDate: { not: null, gte: cutoff, lte: today } },
+      include: { artist: true },
+      orderBy: { releaseDate: "desc" },
+    });
+    return rows
+      .map((row) => mapArtistReleaseRow(row))
+      .sort((a, b) => (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""));
+  }
+
+  async upsertReleases(releases: ArtistRelease[]): Promise<void> {
+    const now = new Date();
+    await this.prisma.$transaction(
+      releases.map((release) => {
+        const id = `${release.artistId}:${release.albumId}`;
+        return this.prisma.artistReleaseCache.upsert({
+          where: { id },
+          update: {
+            artistId: release.artistId,
+            albumId: release.albumId,
+            albumName: release.albumName,
+            albumType: release.albumType,
+            releaseDate: release.releaseDate,
+            coverUrl: release.coverUrl,
+            spotifyUrl: release.spotifyUrl,
+            syncedAt: now,
+          },
+          create: {
+            id,
+            artistId: release.artistId,
+            albumId: release.albumId,
+            albumName: release.albumName,
+            albumType: release.albumType,
+            releaseDate: release.releaseDate,
+            coverUrl: release.coverUrl,
+            spotifyUrl: release.spotifyUrl,
+            syncedAt: now,
+          },
+        });
+      }),
+    );
+  }
+
+  async getArtistReleaseWithArtist(
+    artistId: string,
+    albumId: string,
+  ): Promise<ArtistReleaseCacheWithArtist | null> {
+    const row = await this.prisma.artistReleaseCache.findUnique({
+      where: { id: `${artistId}:${albumId}` },
+      include: { artist: true },
+    });
+    if (!row) return null;
+    const mapped = mapArtistReleaseRow(row);
+    return {
+      id: row.id,
+      artistId: mapped.artistId,
+      albumId: mapped.albumId,
+      albumName: mapped.albumName,
+      albumType: row.albumType,
+      releaseDate: row.releaseDate,
+      coverUrl: mapped.coverUrl ?? null,
+      spotifyUrl: row.spotifyUrl,
+      artistName: row.artist.name,
+    };
+  }
+
+  async updateArtistReleaseSpotifyUrl(
+    artistId: string,
+    albumId: string,
+    spotifyUrl: string,
+  ): Promise<void> {
+    await this.prisma.artistReleaseCache.updateMany({
+      where: { id: `${artistId}:${albumId}` },
+      data: { spotifyUrl, syncedAt: new Date() },
+    });
+  }
+
+  async getArtistIdsWithFreshReleases(cutoffDate: Date): Promise<Set<string>> {
+    const rows = await this.prisma.artistReleaseCache.findMany({
+      where: { syncedAt: { gte: cutoffDate } },
+      select: { artistId: true },
+      distinct: ["artistId"],
+    });
+    return new Set(rows.map((r) => r.artistId));
+  }
+}

--- a/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { FeedCacheEvictionRepository } from "./feed-cache-eviction.repository";
+
+describe("FeedCacheEvictionRepository", () => {
+  it("evicts all tables when artistIds is empty", async () => {
+    const prisma = {
+      $transaction: vi.fn().mockResolvedValue(undefined),
+      followedArtistCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
+      artistAlbumCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
+      artistReleaseCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
+    } as any;
+
+    const repo = new FeedCacheEvictionRepository(prisma);
+    await repo.evictStaleFeedCache([], 90);
+
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.test.ts
@@ -3,16 +3,27 @@ import { FeedCacheEvictionRepository } from "./feed-cache-eviction.repository";
 
 describe("FeedCacheEvictionRepository", () => {
   it("evicts all tables when artistIds is empty", async () => {
+    const deleteFollowedResult = Promise.resolve({ count: 1 });
+    const deleteAlbumResult = Promise.resolve({ count: 2 });
+    const deleteReleaseResult = Promise.resolve({ count: 3 });
     const prisma = {
       $transaction: vi.fn().mockResolvedValue(undefined),
-      followedArtistCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
-      artistAlbumCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
-      artistReleaseCache: { deleteMany: vi.fn().mockReturnValue(Promise.resolve()) },
+      followedArtistCache: { deleteMany: vi.fn().mockReturnValue(deleteFollowedResult) },
+      artistAlbumCache: { deleteMany: vi.fn().mockReturnValue(deleteAlbumResult) },
+      artistReleaseCache: { deleteMany: vi.fn().mockReturnValue(deleteReleaseResult) },
     } as any;
 
     const repo = new FeedCacheEvictionRepository(prisma);
     await repo.evictStaleFeedCache([], 90);
 
     expect(prisma.$transaction).toHaveBeenCalledOnce();
+    expect(prisma.$transaction).toHaveBeenCalledWith([
+      deleteFollowedResult,
+      deleteAlbumResult,
+      deleteReleaseResult,
+    ]);
+    expect(prisma.followedArtistCache.deleteMany).toHaveBeenCalledWith({});
+    expect(prisma.artistAlbumCache.deleteMany).toHaveBeenCalledWith({});
+    expect(prisma.artistReleaseCache.deleteMany).toHaveBeenCalledWith({});
   });
 });

--- a/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.ts
+++ b/apps/backend/src/infrastructure/database/feed-cache-eviction.repository.ts
@@ -1,0 +1,27 @@
+import type { PrismaClient } from "@prisma/client";
+
+export class FeedCacheEvictionRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async evictStaleFeedCache(artistIds: string[], cutoffDays: number): Promise<void> {
+    if (artistIds.length === 0) {
+      await this.prisma.$transaction([
+        this.prisma.followedArtistCache.deleteMany({}),
+        this.prisma.artistAlbumCache.deleteMany({}),
+        this.prisma.artistReleaseCache.deleteMany({}),
+      ]);
+      return;
+    }
+
+    const cutoff = new Date(Date.now() - cutoffDays * 24 * 60 * 60 * 1000);
+    await this.prisma.$transaction([
+      this.prisma.followedArtistCache.deleteMany({ where: { spotifyId: { notIn: artistIds } } }),
+      this.prisma.artistAlbumCache.deleteMany({
+        where: { OR: [{ syncedAt: { lt: cutoff } }, { spotifyArtistId: { notIn: artistIds } }] },
+      }),
+      this.prisma.artistReleaseCache.deleteMany({
+        where: { OR: [{ syncedAt: { lt: cutoff } }, { artistId: { notIn: artistIds } }] },
+      }),
+    ]);
+  }
+}

--- a/apps/backend/src/infrastructure/database/feed-row-mappers.test.ts
+++ b/apps/backend/src/infrastructure/database/feed-row-mappers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { mapArtistAlbumRowToRelease, mapArtistReleaseRow } from "./feed-row-mappers";
+
+describe("feed-row-mappers", () => {
+  it("maps artist release rows with artist relation", () => {
+    const result = mapArtistReleaseRow({
+      artistId: "a1",
+      albumId: "al1",
+      albumName: "Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: "https://e-cdns-images.dzcdn.net/images/cover/abc/250x250-000000-80-0-0.jpg",
+      spotifyUrl: "https://spotify/album/1",
+      artist: { name: "Artist", imageUrl: "img" },
+    });
+
+    expect(result.artistName).toBe("Artist");
+    expect(result.coverUrl).toContain("1000x1000");
+  });
+
+  it("maps artist album rows with fallback artist metadata", () => {
+    const result = mapArtistAlbumRowToRelease(
+      {
+        spotifyArtistId: "a1",
+        albumId: "al1",
+        albumName: "Album",
+        albumType: "album",
+        releaseDate: "2024-01-01",
+        coverUrl: null,
+        spotifyUrl: null,
+        totalTracks: 10,
+      },
+      { name: "Artist", imageUrl: null },
+    );
+
+    expect(result.artistId).toBe("a1");
+    expect(result.totalTracks).toBe(10);
+  });
+});

--- a/apps/backend/src/infrastructure/database/feed-row-mappers.ts
+++ b/apps/backend/src/infrastructure/database/feed-row-mappers.ts
@@ -1,0 +1,58 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import { upgradeDeezerCoverUrl } from "@/infrastructure/external/providers/deezer/cover-url";
+
+export interface ArtistReleaseRow {
+  artistId: string;
+  albumId: string;
+  albumName: string;
+  albumType: string | null;
+  releaseDate: string | null;
+  coverUrl: string | null;
+  spotifyUrl: string | null;
+  artist?: { name: string; imageUrl: string | null };
+  artistName?: string;
+  artistImageUrl?: string | null;
+}
+
+export interface ArtistAlbumRow {
+  spotifyArtistId: string;
+  albumId: string;
+  albumName: string;
+  albumType: string | null;
+  releaseDate: string | null;
+  coverUrl: string | null;
+  spotifyUrl: string | null;
+  totalTracks: number | null;
+}
+
+export function mapArtistReleaseRow(row: ArtistReleaseRow): ArtistRelease {
+  return {
+    artistId: row.artistId,
+    artistName: row.artist?.name ?? row.artistName ?? "Unknown Artist",
+    artistImageUrl: row.artist?.imageUrl ?? row.artistImageUrl ?? null,
+    albumId: row.albumId,
+    albumName: row.albumName,
+    albumType: row.albumType as ArtistRelease["albumType"],
+    releaseDate: row.releaseDate ?? undefined,
+    coverUrl: upgradeDeezerCoverUrl(row.coverUrl),
+    spotifyUrl: row.spotifyUrl ?? undefined,
+  };
+}
+
+export function mapArtistAlbumRowToRelease(
+  row: ArtistAlbumRow,
+  artistMeta?: { name?: string | null; imageUrl?: string | null },
+): ArtistRelease {
+  return {
+    artistId: row.spotifyArtistId,
+    artistName: artistMeta?.name ?? "Unknown Artist",
+    artistImageUrl: artistMeta?.imageUrl ?? null,
+    albumId: row.albumId,
+    albumName: row.albumName,
+    albumType: row.albumType as ArtistRelease["albumType"],
+    releaseDate: row.releaseDate ?? undefined,
+    coverUrl: upgradeDeezerCoverUrl(row.coverUrl),
+    spotifyUrl: row.spotifyUrl ?? undefined,
+    totalTracks: row.totalTracks ?? undefined,
+  };
+}

--- a/apps/backend/src/infrastructure/database/feed-sync-state.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/feed-sync-state.repository.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
+import { FeedSyncStateRepository } from "./feed-sync-state.repository";
+
+describe("FeedSyncStateRepository", () => {
+  it("creates default sync state when missing", async () => {
+    const prisma = {
+      syncState: { upsert: vi.fn().mockResolvedValue({ id: 1, status: SYNC_STATUS.Idle }) },
+    } as any;
+    const repo = new FeedSyncStateRepository(prisma);
+    await repo.getSyncState();
+    expect(prisma.syncState.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("sets sync state with optional error", async () => {
+    const prisma = { syncState: { upsert: vi.fn().mockResolvedValue(undefined) } } as any;
+    const repo = new FeedSyncStateRepository(prisma);
+    await repo.setSyncState(SYNC_STATUS.Error, "boom");
+    expect(prisma.syncState.upsert).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/infrastructure/database/feed-sync-state.repository.ts
+++ b/apps/backend/src/infrastructure/database/feed-sync-state.repository.ts
@@ -1,0 +1,62 @@
+import type { PrismaClient } from "@prisma/client";
+import {
+  SYNC_STATUS,
+  type SyncStateRecord,
+  type SyncStatus,
+} from "@/application/ports/feed-repository.port";
+
+const SyncStateId = { Feed: 1, Catalog: 2 } as const;
+
+export class FeedSyncStateRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getSyncState(): Promise<SyncStateRecord> {
+    return this.prisma.syncState.upsert({
+      where: { id: SyncStateId.Feed },
+      update: {},
+      create: { id: SyncStateId.Feed, status: SYNC_STATUS.Idle },
+    });
+  }
+
+  async setSyncState(status: SyncStatus, error?: string): Promise<void> {
+    await this.prisma.syncState.upsert({
+      where: { id: SyncStateId.Feed },
+      update: {
+        status,
+        error: error ?? null,
+        lastSyncAt: status === SYNC_STATUS.Running ? undefined : new Date(),
+      },
+      create: {
+        id: SyncStateId.Feed,
+        status,
+        error: error ?? null,
+        lastSyncAt: status === SYNC_STATUS.Running ? null : new Date(),
+      },
+    });
+  }
+
+  async getCatalogSyncState(): Promise<SyncStateRecord> {
+    return this.prisma.syncState.upsert({
+      where: { id: SyncStateId.Catalog },
+      update: {},
+      create: { id: SyncStateId.Catalog, status: SYNC_STATUS.Idle },
+    });
+  }
+
+  async setCatalogSyncState(status: SyncStatus, error?: string): Promise<void> {
+    await this.prisma.syncState.upsert({
+      where: { id: SyncStateId.Catalog },
+      update: {
+        status,
+        error: error ?? null,
+        lastSyncAt: status === SYNC_STATUS.Running ? undefined : new Date(),
+      },
+      create: {
+        id: SyncStateId.Catalog,
+        status,
+        error: error ?? null,
+        lastSyncAt: status === SYNC_STATUS.Running ? null : new Date(),
+      },
+    });
+  }
+}

--- a/apps/backend/src/infrastructure/database/feed.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/feed.repository.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { SYNC_STATUS, FeedRepository } from "./feed.repository";
+
+describe("FeedRepository facade", () => {
+  it("delegates to split repositories", async () => {
+    const followed = {
+      getArtists: vi.fn().mockResolvedValue([]),
+      getArtistBySpotifyId: vi.fn(),
+      getArtistCatalogIdentities: vi.fn(),
+      updateArtistCatalogIdentities: vi.fn(),
+      upsertArtists: vi.fn(),
+      getArtistIdsWithNoAlbums: vi.fn(),
+      getArtistIdsNeedingCatalogSync: vi.fn(),
+      updateArtistCatalogSyncedAt: vi.fn(),
+      updateArtistReleasesSyncedAt: vi.fn(),
+      getActiveArtistIdsForReleasesSync: vi.fn(),
+    } as any;
+    const album = { getArtistAlbumsFreshness: vi.fn().mockResolvedValue(null) } as any;
+    const release = { getReleases: vi.fn().mockResolvedValue([]) } as any;
+    const sync = {
+      getSyncState: vi
+        .fn()
+        .mockResolvedValue({ id: 1, status: SYNC_STATUS.Idle, lastSyncAt: null, error: null }),
+    } as any;
+    const eviction = { evictStaleFeedCache: vi.fn().mockResolvedValue(undefined) } as any;
+
+    const repo = new FeedRepository(followed, album, release, sync, eviction);
+
+    await repo.getArtists();
+    await repo.getReleases(30);
+    await repo.getSyncState();
+
+    expect(followed.getArtists).toHaveBeenCalledOnce();
+    expect(release.getReleases).toHaveBeenCalledWith(30);
+    expect(sync.getSyncState).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/infrastructure/database/feed.repository.ts
+++ b/apps/backend/src/infrastructure/database/feed.repository.ts
@@ -1,659 +1,142 @@
-import type { PrismaClient } from "@prisma/client";
 import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
-import { upgradeDeezerCoverUrl } from "@/infrastructure/external/providers/deezer/cover-url";
+import type {
+  AlbumIdentityInput,
+  ArtistAlbumCacheWithArtist,
+  ArtistAlbumSpotifyUrlInput,
+  ArtistReleaseCacheWithArtist,
+  CatalogIdentity,
+  CatalogIdentityInput,
+  FeedRepositoryPort,
+  SyncStateRecord,
+  SyncStatus,
+} from "@/application/ports/feed-repository.port";
+import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
+import type { FeedCacheEvictionService } from "@/application/services/feed-cache-eviction.service";
+import type { ArtistAlbumCacheRepository } from "./artist-album-cache.repository";
+import type { ArtistReleaseCacheRepository } from "./artist-release-cache.repository";
+import type { FeedSyncStateRepository } from "./feed-sync-state.repository";
+import type { FollowedArtistRepository } from "./followed-artist.repository";
 
-export interface CatalogIdentity {
-  spotifyId: string;
-  deezerId: string | null;
-  mbid: string | null;
-}
+export { SYNC_STATUS };
+export type { CatalogIdentity, SyncStatus };
 
-export const SYNC_STATUS = {
-  Idle: "idle",
-  Running: "running",
-  Error: "error",
-} as const;
+export class FeedRepository implements FeedRepositoryPort {
+  constructor(
+    private readonly followedArtistRepository: FollowedArtistRepository,
+    private readonly artistAlbumCacheRepository: ArtistAlbumCacheRepository,
+    private readonly artistReleaseCacheRepository: ArtistReleaseCacheRepository,
+    private readonly feedSyncStateRepository: FeedSyncStateRepository,
+    private readonly feedCacheEvictionService: FeedCacheEvictionService,
+  ) {}
 
-const SyncStateId = { Feed: 1, Catalog: 2 } as const;
-
-export type SyncStatus = (typeof SYNC_STATUS)[keyof typeof SYNC_STATUS];
-
-interface SyncStateRecord {
-  id: number;
-  lastSyncAt: Date | null;
-  status: string;
-  error: string | null;
-}
-
-export class FeedRepository {
-  constructor(private readonly prisma: PrismaClient) {}
-
-  /**
-   * Maps an artistReleaseCache row (with joined artist) to an ArtistRelease.
-   * Centralizes cover URL upgrade so it happens exactly once.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private mapRow(row: any): ArtistRelease {
-    return {
-      artistId: row.artistId,
-      artistName: row.artist?.name ?? row.artistName ?? "Unknown Artist",
-      artistImageUrl: row.artist?.imageUrl ?? row.artistImageUrl ?? null,
-      albumId: row.albumId,
-      albumName: row.albumName,
-      albumType: row.albumType as ArtistRelease["albumType"],
-      releaseDate: row.releaseDate ?? undefined,
-      coverUrl: upgradeDeezerCoverUrl(row.coverUrl),
-      spotifyUrl: row.spotifyUrl ?? undefined,
-    };
+  getArtistBySpotifyId(spotifyId: string): Promise<FollowedArtist | null> {
+    return this.followedArtistRepository.getArtistBySpotifyId(spotifyId);
   }
-
-  private mapArtistAlbumRowToRelease(
-    row: {
-      spotifyArtistId: string;
-      albumId: string;
-      albumName: string;
-      albumType: string | null;
-      releaseDate: string | null;
-      coverUrl: string | null;
-      spotifyUrl: string | null;
-      totalTracks: number | null;
-    },
-    artistMeta?: { name?: string | null; imageUrl?: string | null },
-  ): ArtistRelease {
-    return {
-      artistId: row.spotifyArtistId,
-      artistName: artistMeta?.name ?? "Unknown Artist",
-      artistImageUrl: artistMeta?.imageUrl ?? null,
-      albumId: row.albumId,
-      albumName: row.albumName,
-      albumType: row.albumType as ArtistRelease["albumType"],
-      releaseDate: row.releaseDate ?? undefined,
-      coverUrl: this.mapRow({ artistId: row.spotifyArtistId, ...row }).coverUrl,
-      spotifyUrl: row.spotifyUrl ?? undefined,
-      totalTracks: row.totalTracks ?? undefined,
-    };
+  getArtistCatalogIdentities(spotifyIds: string[]): Promise<CatalogIdentity[]> {
+    return this.followedArtistRepository.getArtistCatalogIdentities(spotifyIds);
   }
-
-  async getArtistBySpotifyId(spotifyId: string): Promise<FollowedArtist | null> {
-    const row = await this.prisma.followedArtistCache.findUnique({
-      where: { spotifyId },
-    });
-
-    if (!row) {
-      return null;
-    }
-
-    return {
-      id: row.spotifyId,
-      name: row.name,
-      image: row.imageUrl ?? null,
-      spotifyUrl: row.spotifyUrl ?? null,
-    };
+  updateArtistCatalogIdentities(identities: CatalogIdentityInput[]): Promise<void> {
+    return this.followedArtistRepository.updateArtistCatalogIdentities(identities);
   }
-
-  async getArtistCatalogIdentities(spotifyIds: string[]): Promise<CatalogIdentity[]> {
-    if (spotifyIds.length === 0) {
-      return [];
-    }
-
-    const rows = await this.prisma.followedArtistCache.findMany({
-      where: { spotifyId: { in: spotifyIds } },
-      select: { spotifyId: true, deezerId: true, mbid: true },
-    });
-
-    const rowMap = new Map(rows.map((r) => [r.spotifyId, r]));
-
-    return spotifyIds.map((id) => ({
-      spotifyId: id,
-      deezerId: rowMap.get(id)?.deezerId ?? null,
-      mbid: rowMap.get(id)?.mbid ?? null,
-    }));
+  getReleases(lookbackDays: number): Promise<ArtistRelease[]> {
+    return this.artistReleaseCacheRepository.getReleases(lookbackDays);
   }
-
-  async updateArtistCatalogIdentities(
-    identities: Array<{ spotifyId: string; deezerId?: string | null; mbid?: string | null }>,
-  ): Promise<void> {
-    if (identities.length === 0) {
-      return;
-    }
-
-    await this.prisma.$transaction(
-      identities.map(({ spotifyId, deezerId, mbid }) =>
-        this.prisma.followedArtistCache.update({
-          where: { spotifyId },
-          data: {
-            ...(deezerId !== undefined ? { deezerId } : {}),
-            ...(mbid !== undefined ? { mbid } : {}),
-          },
-        }),
-      ),
-    );
+  getArtists(): Promise<FollowedArtist[]> {
+    return this.followedArtistRepository.getArtists();
   }
-
-  async getReleases(lookbackDays: number): Promise<ArtistRelease[]> {
-    const safeDays = Number.isFinite(lookbackDays) && lookbackDays > 0 ? lookbackDays : 30;
-    const cutoff = new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
-    const today = new Date().toISOString().slice(0, 10);
-
-    const rows = await this.prisma.artistReleaseCache.findMany({
-      where: { releaseDate: { not: null, gte: cutoff, lte: today } },
-      include: { artist: true },
-      orderBy: { releaseDate: "desc" },
-    });
-
-    return rows
-      .map((row) => this.mapRow(row))
-      .sort((a, b) => (b.releaseDate ?? "").localeCompare(a.releaseDate ?? ""));
+  upsertArtists(artists: FollowedArtist[]): Promise<void> {
+    return this.followedArtistRepository.upsertArtists(artists);
   }
-
-  async getArtists(): Promise<FollowedArtist[]> {
-    const rows = await this.prisma.followedArtistCache.findMany({
-      orderBy: { name: "asc" },
-    });
-
-    return rows.map((row) => ({
-      id: row.spotifyId,
-      name: row.name,
-      image: row.imageUrl ?? null,
-      spotifyUrl: row.spotifyUrl ?? null,
-    }));
+  upsertReleases(releases: ArtistRelease[]): Promise<void> {
+    return this.artistReleaseCacheRepository.upsertReleases(releases);
   }
-
-  async upsertArtists(artists: FollowedArtist[]): Promise<void> {
-    const now = new Date();
-
-    await this.prisma.$transaction(
-      artists.map((artist) =>
-        this.prisma.followedArtistCache.upsert({
-          where: { spotifyId: artist.id },
-          update: {
-            name: artist.name,
-            imageUrl: artist.image,
-            spotifyUrl: artist.spotifyUrl,
-            syncedAt: now,
-          },
-          create: {
-            spotifyId: artist.id,
-            name: artist.name,
-            imageUrl: artist.image,
-            spotifyUrl: artist.spotifyUrl,
-            syncedAt: now,
-          },
-        }),
-      ),
-    );
-  }
-
-  async upsertReleases(releases: ArtistRelease[]): Promise<void> {
-    const now = new Date();
-
-    await this.prisma.$transaction(
-      releases.map((release) => {
-        const id = `${release.artistId}:${release.albumId}`;
-
-        return this.prisma.artistReleaseCache.upsert({
-          where: { id },
-          update: {
-            artistId: release.artistId,
-            albumId: release.albumId,
-            albumName: release.albumName,
-            albumType: release.albumType,
-            releaseDate: release.releaseDate,
-            coverUrl: release.coverUrl,
-            spotifyUrl: release.spotifyUrl,
-            syncedAt: now,
-          },
-          create: {
-            id,
-            artistId: release.artistId,
-            albumId: release.albumId,
-            albumName: release.albumName,
-            albumType: release.albumType,
-            releaseDate: release.releaseDate,
-            coverUrl: release.coverUrl,
-            spotifyUrl: release.spotifyUrl,
-            syncedAt: now,
-          },
-        });
-      }),
-    );
-  }
-
-  async getArtistAlbumWithArtist(
+  getArtistAlbumWithArtist(
     spotifyArtistId: string,
     albumId: string,
-  ): Promise<
-    | ({
-        id: string;
-        spotifyArtistId: string;
-        albumId: string;
-        albumName: string;
-        albumType: string | null;
-        releaseDate: string | null;
-        coverUrl: string | null;
-        spotifyUrl: string | null;
-        totalTracks: number | null;
-        deezerAlbumId: string | null;
-        mbAlbumId: string | null;
-      } & {
-        artistName: string;
-      })
-    | null
-  > {
-    const row = await this.prisma.artistAlbumCache.findUnique({
-      where: {
-        id: `${spotifyArtistId}:${albumId}`,
-      },
-    });
-
-    if (!row) {
-      return null;
-    }
-
-    const artistRow = await this.prisma.followedArtistCache.findUnique({
-      where: { spotifyId: spotifyArtistId },
-      select: { name: true },
-    });
-
-    return {
-      ...row,
-      coverUrl: this.mapRow({ artistId: row.spotifyArtistId, ...row }).coverUrl,
-      artistName: artistRow?.name ?? "Unknown Artist",
-    };
+  ): Promise<ArtistAlbumCacheWithArtist | null> {
+    return this.artistAlbumCacheRepository.getArtistAlbumWithArtist(spotifyArtistId, albumId);
   }
-
-  async getArtistReleaseWithArtist(
+  getArtistReleaseWithArtist(
     artistId: string,
     albumId: string,
-  ): Promise<{
-    id: string;
-    artistId: string;
-    albumId: string;
-    albumName: string;
-    albumType: string | null;
-    releaseDate: string | null;
-    coverUrl: string | null;
-    spotifyUrl: string | null;
-    artistName: string;
-  } | null> {
-    const row = await this.prisma.artistReleaseCache.findUnique({
-      where: { id: `${artistId}:${albumId}` },
-      include: { artist: true },
-    });
-
-    if (!row) {
-      return null;
-    }
-
-    const mapped = this.mapRow(row);
-    return {
-      id: row.id,
-      artistId: mapped.artistId,
-      albumId: mapped.albumId,
-      albumName: mapped.albumName,
-      albumType: row.albumType,
-      releaseDate: row.releaseDate,
-      coverUrl: mapped.coverUrl,
-      spotifyUrl: row.spotifyUrl,
-      artistName: row.artist.name,
-    };
+  ): Promise<ArtistReleaseCacheWithArtist | null> {
+    return this.artistReleaseCacheRepository.getArtistReleaseWithArtist(artistId, albumId);
   }
-
-  async upsertArtistAlbumSpotifyUrl(input: {
-    artistId: string;
-    albumId: string;
-    albumName: string;
-    albumType?: string | null;
-    releaseDate?: string | null;
-    coverUrl?: string | null;
-    spotifyUrl: string;
-    totalTracks?: number | null;
-  }): Promise<void> {
-    const now = new Date();
-    const id = `${input.artistId}:${input.albumId}`;
-
-    await this.prisma.artistAlbumCache.upsert({
-      where: { id },
-      update: {
-        spotifyUrl: input.spotifyUrl,
-        albumName: input.albumName,
-        albumType: input.albumType,
-        releaseDate: input.releaseDate,
-        coverUrl: input.coverUrl,
-        totalTracks: input.totalTracks ?? undefined,
-        syncedAt: now,
-      },
-      create: {
-        id,
-        spotifyArtistId: input.artistId,
-        albumId: input.albumId,
-        albumName: input.albumName,
-        albumType: input.albumType,
-        releaseDate: input.releaseDate,
-        coverUrl: input.coverUrl,
-        spotifyUrl: input.spotifyUrl,
-        totalTracks: input.totalTracks ?? null,
-        syncedAt: now,
-      },
-    });
+  updateArtistAlbumIdentities(id: string, identities: AlbumIdentityInput): Promise<void> {
+    return this.artistAlbumCacheRepository.updateArtistAlbumIdentities(id, identities);
   }
-
-  async updateArtistReleaseSpotifyUrl(
+  upsertArtistAlbumSpotifyUrl(input: ArtistAlbumSpotifyUrlInput): Promise<void> {
+    return this.artistAlbumCacheRepository.upsertArtistAlbumSpotifyUrl(input);
+  }
+  updateArtistReleaseSpotifyUrl(
     artistId: string,
     albumId: string,
     spotifyUrl: string,
   ): Promise<void> {
-    await this.prisma.artistReleaseCache.updateMany({
-      where: { id: `${artistId}:${albumId}` },
-      data: { spotifyUrl, syncedAt: new Date() },
-    });
-  }
-
-  async updateArtistAlbumIdentities(
-    id: string,
-    identities: {
-      deezerAlbumId?: string | null;
-      mbAlbumId?: string | null;
-    },
-  ): Promise<void> {
-    await this.prisma.artistAlbumCache.update({
-      where: { id },
-      data: {
-        ...(identities.deezerAlbumId !== undefined
-          ? { deezerAlbumId: identities.deezerAlbumId }
-          : {}),
-        ...(identities.mbAlbumId !== undefined ? { mbAlbumId: identities.mbAlbumId } : {}),
-      },
-    });
-  }
-
-  async getArtistAlbumCount(spotifyArtistId: string): Promise<number> {
-    return this.prisma.artistAlbumCache.count({
-      where: { spotifyArtistId },
-    });
-  }
-
-  /**
-   * Returns the most recent `syncedAt` for an artist's albums, or null
-   * if the artist has no cached albums.
-   */
-  async getArtistAlbumsFreshness(spotifyArtistId: string): Promise<Date | null> {
-    const row = await this.prisma.artistAlbumCache.findFirst({
-      where: { spotifyArtistId },
-      orderBy: { syncedAt: "desc" },
-      select: { syncedAt: true },
-    });
-    return row?.syncedAt ?? null;
-  }
-
-  /**
-   * Returns artistIds that have NO albums at all in the cache.
-   * These are prioritized in the sync — a user visiting them will always
-   * see "rate limited" until they are populated.
-   */
-  async getArtistIdsWithNoAlbums(): Promise<Set<string>> {
-    const allArtists = await this.prisma.followedArtistCache.findMany({
-      select: { spotifyId: true },
-    });
-    const artistsWithAlbums = await this.prisma.artistAlbumCache.findMany({
-      select: { spotifyArtistId: true },
-      distinct: ["spotifyArtistId"],
-    });
-    const withAlbumsSet = new Set(artistsWithAlbums.map((r) => r.spotifyArtistId));
-    return new Set(allArtists.map((r) => r.spotifyId).filter((id) => !withAlbumsSet.has(id)));
-  }
-
-  /**
-   * Returns the set of artistIds that already have fresh album data in the cache.
-   * "Fresh" means at least one album with syncedAt newer than cutoffDate.
-   * Used by the sync to skip artists that don't need a Spotify call.
-   */
-  async getArtistIdsWithFreshAlbums(cutoffDate: Date): Promise<Set<string>> {
-    const rows = await this.prisma.artistAlbumCache.findMany({
-      where: { syncedAt: { gte: cutoffDate } },
-      select: { spotifyArtistId: true },
-      distinct: ["spotifyArtistId"],
-    });
-    return new Set(rows.map((r) => r.spotifyArtistId));
-  }
-
-  /**
-   * Returns the set of artistIds that already have fresh release data in the cache.
-   * "Fresh" means at least one release with syncedAt newer than cutoffDate.
-   * Used by the sync to skip artists that don't need a Spotify call.
-   */
-  async getArtistIdsWithFreshReleases(cutoffDate: Date): Promise<Set<string>> {
-    const rows = await this.prisma.artistReleaseCache.findMany({
-      where: { syncedAt: { gte: cutoffDate } },
-      select: { artistId: true },
-      distinct: ["artistId"],
-    });
-    return new Set(rows.map((r) => r.artistId));
-  }
-
-  async getArtistAlbums(
-    spotifyArtistId: string,
-    limit: number,
-    offset: number = 0,
-  ): Promise<ArtistRelease[]> {
-    const rows = await this.prisma.artistAlbumCache.findMany({
-      where: { spotifyArtistId },
-      orderBy: [{ releaseDate: "desc" }, { albumId: "asc" }],
-      skip: offset,
-      take: limit,
-    });
-
-    const artistRow = await this.prisma.followedArtistCache.findUnique({
-      where: { spotifyId: spotifyArtistId },
-    });
-
-    const artistMeta = artistRow
-      ? { name: artistRow.name, imageUrl: artistRow.imageUrl }
-      : undefined;
-
-    return rows.map((row) => this.mapArtistAlbumRowToRelease(row, artistMeta));
-  }
-
-  async upsertArtistAlbums(albums: ArtistRelease[]): Promise<void> {
-    if (albums.length === 0) {
-      return;
-    }
-
-    const now = new Date();
-
-    await this.prisma.$transaction(
-      albums.map((album) => {
-        const id = `${album.artistId}:${album.albumId}`;
-
-        return this.prisma.artistAlbumCache.upsert({
-          where: { id },
-          update: {
-            spotifyArtistId: album.artistId,
-            albumId: album.albumId,
-            albumName: album.albumName,
-            albumType: album.albumType,
-            releaseDate: album.releaseDate,
-            coverUrl: album.coverUrl,
-            spotifyUrl: album.spotifyUrl,
-            totalTracks: album.totalTracks ?? null,
-            syncedAt: now,
-          },
-          create: {
-            id,
-            spotifyArtistId: album.artistId,
-            albumId: album.albumId,
-            albumName: album.albumName,
-            albumType: album.albumType,
-            releaseDate: album.releaseDate,
-            coverUrl: album.coverUrl,
-            spotifyUrl: album.spotifyUrl,
-            totalTracks: album.totalTracks ?? null,
-            syncedAt: now,
-          },
-        });
-      }),
+    return this.artistReleaseCacheRepository.updateArtistReleaseSpotifyUrl(
+      artistId,
+      albumId,
+      spotifyUrl,
     );
   }
-
-  async evictStaleFeedCache(artistIds: string[], cutoffDays = 90): Promise<void> {
-    if (artistIds.length === 0) {
-      await this.prisma.$transaction([
-        this.prisma.followedArtistCache.deleteMany({}),
-        this.prisma.artistAlbumCache.deleteMany({}),
-        this.prisma.artistReleaseCache.deleteMany({}),
-      ]);
-      return;
-    }
-
-    const cutoff = new Date(Date.now() - cutoffDays * 24 * 60 * 60 * 1000);
-    await this.prisma.$transaction([
-      this.prisma.followedArtistCache.deleteMany({
-        where: { spotifyId: { notIn: artistIds } },
-      }),
-      this.prisma.artistAlbumCache.deleteMany({
-        where: {
-          OR: [{ syncedAt: { lt: cutoff } }, { spotifyArtistId: { notIn: artistIds } }],
-        },
-      }),
-      this.prisma.artistReleaseCache.deleteMany({
-        where: {
-          OR: [{ syncedAt: { lt: cutoff } }, { artistId: { notIn: artistIds } }],
-        },
-      }),
-    ]);
+  getArtistAlbumCount(spotifyArtistId: string): Promise<number> {
+    return this.artistAlbumCacheRepository.getArtistAlbumCount(spotifyArtistId);
   }
-
-  async getArtistIdsNeedingCatalogSync(cutoffDate: Date, limit: number): Promise<string[]> {
-    const rows = await this.prisma.followedArtistCache.findMany({
-      where: {
-        OR: [{ lastCatalogSyncAt: null }, { lastCatalogSyncAt: { lt: cutoffDate } }],
-      },
-      orderBy: { lastCatalogSyncAt: { sort: "asc", nulls: "first" } },
-      take: limit,
-      select: { spotifyId: true },
-    });
-    return rows.map((r) => r.spotifyId);
+  getArtistAlbumsFreshness(spotifyArtistId: string): Promise<Date | null> {
+    return this.artistAlbumCacheRepository.getArtistAlbumsFreshness(spotifyArtistId);
   }
-
-  async getActiveArtistIdsForReleasesSync(
+  getArtistIdsWithNoAlbums(): Promise<Set<string>> {
+    return this.followedArtistRepository.getArtistIdsWithNoAlbums();
+  }
+  getArtistIdsWithFreshAlbums(cutoffDate: Date): Promise<Set<string>> {
+    return this.artistAlbumCacheRepository.getArtistIdsWithFreshAlbums(cutoffDate);
+  }
+  getArtistIdsWithFreshReleases(cutoffDate: Date): Promise<Set<string>> {
+    return this.artistReleaseCacheRepository.getArtistIdsWithFreshReleases(cutoffDate);
+  }
+  getArtistAlbums(
+    spotifyArtistId: string,
+    limit: number,
+    offset?: number,
+  ): Promise<ArtistRelease[]> {
+    return this.artistAlbumCacheRepository.getArtistAlbums(spotifyArtistId, limit, offset);
+  }
+  upsertArtistAlbums(albums: ArtistRelease[]): Promise<void> {
+    return this.artistAlbumCacheRepository.upsertArtistAlbums(albums);
+  }
+  evictStaleFeedCache(artistIds: string[], cutoffDays?: number): Promise<void> {
+    return this.feedCacheEvictionService.evictStaleFeedCache(artistIds, cutoffDays);
+  }
+  getArtistIdsNeedingCatalogSync(cutoffDate: Date, limit: number): Promise<string[]> {
+    return this.followedArtistRepository.getArtistIdsNeedingCatalogSync(cutoffDate, limit);
+  }
+  getActiveArtistIdsForReleasesSync(
     releaseCutoff: Date,
     activityWindowDate: Date,
     limit: number,
   ): Promise<string[]> {
-    const activityWindowStr = activityWindowDate.toISOString().slice(0, 10);
-
-    const rows = await this.prisma.followedArtistCache.findMany({
-      where: {
-        OR: [{ lastReleasesSyncAt: null }, { lastReleasesSyncAt: { lt: releaseCutoff } }],
-        AND: [
-          {
-            OR: [
-              { lastCatalogSyncAt: null },
-              {
-                releases: {
-                  some: {
-                    releaseDate: { gte: activityWindowStr },
-                  },
-                },
-              },
-            ],
-          },
-        ],
-      },
-      orderBy: { lastReleasesSyncAt: { sort: "asc", nulls: "first" } },
-      take: limit,
-      select: { spotifyId: true },
-    });
-    return rows.map((r) => r.spotifyId);
-  }
-
-  async updateArtistCatalogSyncedAt(artistIds: string[]): Promise<void> {
-    if (artistIds.length === 0) {
-      return;
-    }
-
-    const now = new Date();
-
-    await this.prisma.$transaction(
-      artistIds.map((id) =>
-        this.prisma.followedArtistCache.update({
-          where: { spotifyId: id },
-          data: { lastCatalogSyncAt: now },
-        }),
-      ),
+    return this.followedArtistRepository.getActiveArtistIdsForReleasesSync(
+      releaseCutoff,
+      activityWindowDate,
+      limit,
     );
   }
-
-  async updateArtistReleasesSyncedAt(artistIds: string[]): Promise<void> {
-    if (artistIds.length === 0) {
-      return;
-    }
-
-    const now = new Date();
-
-    await this.prisma.$transaction(
-      artistIds.map((id) =>
-        this.prisma.followedArtistCache.update({
-          where: { spotifyId: id },
-          data: { lastReleasesSyncAt: now },
-        }),
-      ),
-    );
+  updateArtistCatalogSyncedAt(artistIds: string[]): Promise<void> {
+    return this.followedArtistRepository.updateArtistCatalogSyncedAt(artistIds);
   }
-
-  async getSyncState(): Promise<SyncStateRecord> {
-    return this.prisma.syncState.upsert({
-      where: { id: SyncStateId.Feed },
-      update: {},
-      create: {
-        id: SyncStateId.Feed,
-        status: SYNC_STATUS.Idle,
-      },
-    });
+  updateArtistReleasesSyncedAt(artistIds: string[]): Promise<void> {
+    return this.followedArtistRepository.updateArtistReleasesSyncedAt(artistIds);
   }
-
-  async setSyncState(status: SyncStatus, error?: string): Promise<void> {
-    await this.prisma.syncState.upsert({
-      where: { id: SyncStateId.Feed },
-      update: {
-        status,
-        error: error ?? null,
-        lastSyncAt: status === SYNC_STATUS.Running ? undefined : new Date(),
-      },
-      create: {
-        id: SyncStateId.Feed,
-        status,
-        error: error ?? null,
-        lastSyncAt: status === SYNC_STATUS.Running ? null : new Date(),
-      },
-    });
+  getSyncState(): Promise<SyncStateRecord> {
+    return this.feedSyncStateRepository.getSyncState();
   }
-
-  async getCatalogSyncState(): Promise<SyncStateRecord> {
-    return this.prisma.syncState.upsert({
-      where: { id: SyncStateId.Catalog },
-      update: {},
-      create: {
-        id: SyncStateId.Catalog,
-        status: SYNC_STATUS.Idle,
-      },
-    });
+  setSyncState(status: SyncStatus, error?: string): Promise<void> {
+    return this.feedSyncStateRepository.setSyncState(status, error);
   }
-
-  async setCatalogSyncState(status: SyncStatus, error?: string): Promise<void> {
-    await this.prisma.syncState.upsert({
-      where: { id: SyncStateId.Catalog },
-      update: {
-        status,
-        error: error ?? null,
-        lastSyncAt: status === SYNC_STATUS.Running ? undefined : new Date(),
-      },
-      create: {
-        id: SyncStateId.Catalog,
-        status,
-        error: error ?? null,
-        lastSyncAt: status === SYNC_STATUS.Running ? null : new Date(),
-      },
-    });
+  getCatalogSyncState(): Promise<SyncStateRecord> {
+    return this.feedSyncStateRepository.getCatalogSyncState();
+  }
+  setCatalogSyncState(status: SyncStatus, error?: string): Promise<void> {
+    return this.feedSyncStateRepository.setCatalogSyncState(status, error);
   }
 }

--- a/apps/backend/src/infrastructure/database/followed-artist.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/followed-artist.repository.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { FollowedArtistRepository } from "./followed-artist.repository";
+
+describe("FollowedArtistRepository", () => {
+  it("returns empty identities for empty input", async () => {
+    const prisma = { followedArtistCache: { findMany: vi.fn() } } as any;
+    const repo = new FollowedArtistRepository(prisma);
+    const result = await repo.getArtistCatalogIdentities([]);
+    expect(result).toEqual([]);
+    expect(prisma.followedArtistCache.findMany).not.toHaveBeenCalled();
+  });
+
+  it("updates identities transactionally", async () => {
+    const prisma = {
+      $transaction: vi.fn().mockResolvedValue(undefined),
+      followedArtistCache: { update: vi.fn().mockReturnValue(Promise.resolve()) },
+    } as any;
+    const repo = new FollowedArtistRepository(prisma);
+    await repo.updateArtistCatalogIdentities([{ spotifyId: "a1", deezerId: "d1" }]);
+    expect(prisma.$transaction).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/infrastructure/database/followed-artist.repository.ts
+++ b/apps/backend/src/infrastructure/database/followed-artist.repository.ts
@@ -1,0 +1,157 @@
+import type { PrismaClient } from "@prisma/client";
+import type { FollowedArtist } from "@spotiarr/shared";
+import type {
+  CatalogIdentity,
+  CatalogIdentityInput,
+} from "@/application/ports/feed-repository.port";
+
+export class FollowedArtistRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async getArtistBySpotifyId(spotifyId: string): Promise<FollowedArtist | null> {
+    const row = await this.prisma.followedArtistCache.findUnique({ where: { spotifyId } });
+    if (!row) return null;
+    return {
+      id: row.spotifyId,
+      name: row.name,
+      image: row.imageUrl ?? null,
+      spotifyUrl: row.spotifyUrl ?? null,
+    };
+  }
+
+  async getArtistCatalogIdentities(spotifyIds: string[]): Promise<CatalogIdentity[]> {
+    if (spotifyIds.length === 0) return [];
+    const rows = await this.prisma.followedArtistCache.findMany({
+      where: { spotifyId: { in: spotifyIds } },
+      select: { spotifyId: true, deezerId: true, mbid: true },
+    });
+    const rowMap = new Map(rows.map((r) => [r.spotifyId, r]));
+    return spotifyIds.map((id) => ({
+      spotifyId: id,
+      deezerId: rowMap.get(id)?.deezerId ?? null,
+      mbid: rowMap.get(id)?.mbid ?? null,
+    }));
+  }
+
+  async updateArtistCatalogIdentities(identities: CatalogIdentityInput[]): Promise<void> {
+    if (identities.length === 0) return;
+    await this.prisma.$transaction(
+      identities.map(({ spotifyId, deezerId, mbid }) =>
+        this.prisma.followedArtistCache.update({
+          where: { spotifyId },
+          data: {
+            ...(deezerId !== undefined ? { deezerId } : {}),
+            ...(mbid !== undefined ? { mbid } : {}),
+          },
+        }),
+      ),
+    );
+  }
+
+  async getArtists(): Promise<FollowedArtist[]> {
+    const rows = await this.prisma.followedArtistCache.findMany({ orderBy: { name: "asc" } });
+    return rows.map((row) => ({
+      id: row.spotifyId,
+      name: row.name,
+      image: row.imageUrl ?? null,
+      spotifyUrl: row.spotifyUrl ?? null,
+    }));
+  }
+
+  async upsertArtists(artists: FollowedArtist[]): Promise<void> {
+    const now = new Date();
+    await this.prisma.$transaction(
+      artists.map((artist) =>
+        this.prisma.followedArtistCache.upsert({
+          where: { spotifyId: artist.id },
+          update: {
+            name: artist.name,
+            imageUrl: artist.image,
+            spotifyUrl: artist.spotifyUrl,
+            syncedAt: now,
+          },
+          create: {
+            spotifyId: artist.id,
+            name: artist.name,
+            imageUrl: artist.image,
+            spotifyUrl: artist.spotifyUrl,
+            syncedAt: now,
+          },
+        }),
+      ),
+    );
+  }
+
+  async getArtistIdsWithNoAlbums(): Promise<Set<string>> {
+    const allArtists = await this.prisma.followedArtistCache.findMany({
+      select: { spotifyId: true },
+    });
+    const artistsWithAlbums = await this.prisma.artistAlbumCache.findMany({
+      select: { spotifyArtistId: true },
+      distinct: ["spotifyArtistId"],
+    });
+    const withAlbumsSet = new Set(artistsWithAlbums.map((r) => r.spotifyArtistId));
+    return new Set(allArtists.map((r) => r.spotifyId).filter((id) => !withAlbumsSet.has(id)));
+  }
+
+  async getArtistIdsNeedingCatalogSync(cutoffDate: Date, limit: number): Promise<string[]> {
+    const rows = await this.prisma.followedArtistCache.findMany({
+      where: { OR: [{ lastCatalogSyncAt: null }, { lastCatalogSyncAt: { lt: cutoffDate } }] },
+      orderBy: { lastCatalogSyncAt: { sort: "asc", nulls: "first" } },
+      take: limit,
+      select: { spotifyId: true },
+    });
+    return rows.map((r) => r.spotifyId);
+  }
+
+  async updateArtistCatalogSyncedAt(artistIds: string[]): Promise<void> {
+    if (artistIds.length === 0) return;
+    const now = new Date();
+    await this.prisma.$transaction(
+      artistIds.map((id) =>
+        this.prisma.followedArtistCache.update({
+          where: { spotifyId: id },
+          data: { lastCatalogSyncAt: now },
+        }),
+      ),
+    );
+  }
+
+  async updateArtistReleasesSyncedAt(artistIds: string[]): Promise<void> {
+    if (artistIds.length === 0) return;
+    const now = new Date();
+    await this.prisma.$transaction(
+      artistIds.map((id) =>
+        this.prisma.followedArtistCache.update({
+          where: { spotifyId: id },
+          data: { lastReleasesSyncAt: now },
+        }),
+      ),
+    );
+  }
+
+  async getActiveArtistIdsForReleasesSync(
+    releaseCutoff: Date,
+    activityWindowDate: Date,
+    limit: number,
+  ): Promise<string[]> {
+    const activityWindowStr = activityWindowDate.toISOString().slice(0, 10);
+    const rows = await this.prisma.followedArtistCache.findMany({
+      where: {
+        OR: [{ lastReleasesSyncAt: null }, { lastReleasesSyncAt: { lt: releaseCutoff } }],
+        AND: [
+          {
+            OR: [
+              { lastCatalogSyncAt: null },
+              { releases: { some: { releaseDate: { gte: activityWindowStr } } } },
+            ],
+          },
+        ],
+      },
+      orderBy: { lastReleasesSyncAt: { sort: "asc", nulls: "first" } },
+      take: limit,
+      select: { spotifyId: true },
+    });
+    return rows.map((r) => r.spotifyId);
+  }
+}

--- a/apps/backend/src/infrastructure/external/release-feed.service.test.ts
+++ b/apps/backend/src/infrastructure/external/release-feed.service.test.ts
@@ -1,6 +1,6 @@
 import type { ArtistRelease } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { FeedRepository } from "@/infrastructure/database/feed.repository";
+import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { DeezerClient } from "./providers/deezer/deezer.client";
 import type { MusicBrainzClient } from "./providers/musicbrainz/musicbrainz.client";
 import { ReleaseFeedService, type CatalogArtist } from "./release-feed.service";
@@ -28,11 +28,11 @@ function makeArtist(overrides: Partial<CatalogArtist> = {}): CatalogArtist {
   };
 }
 
-function mockRepo(): FeedRepository {
+function mockRepo(): FeedRepositoryPort {
   return {
     getArtistCatalogIdentities: vi.fn().mockResolvedValue([]),
     updateArtistCatalogIdentities: vi.fn().mockResolvedValue(undefined),
-  } as unknown as FeedRepository;
+  } as unknown as FeedRepositoryPort;
 }
 
 function mockDeezer(): DeezerClient {
@@ -51,7 +51,7 @@ function mockMusicBrainz(): MusicBrainzClient {
 
 describe("ReleaseFeedService", () => {
   let service: ReleaseFeedService;
-  let repo: FeedRepository;
+  let repo: FeedRepositoryPort;
   let deezer: DeezerClient;
   let musicBrainz: MusicBrainzClient;
 

--- a/apps/backend/src/infrastructure/external/release-feed.service.ts
+++ b/apps/backend/src/infrastructure/external/release-feed.service.ts
@@ -1,5 +1,5 @@
 import type { ArtistRelease } from "@spotiarr/shared";
-import type { CatalogIdentity, FeedRepository } from "@/infrastructure/database/feed.repository";
+import type { CatalogIdentity, FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { DeezerClient } from "./providers/deezer/deezer.client";
 import type { MusicBrainzClient } from "./providers/musicbrainz/musicbrainz.client";
 
@@ -33,7 +33,7 @@ export interface ArtistDiscographyResult {
  */
 export class ReleaseFeedService {
   constructor(
-    private readonly feedRepository: FeedRepository,
+    private readonly feedRepository: FeedRepositoryPort,
     private readonly deezerClient: DeezerClient,
     private readonly musicBrainzClient: MusicBrainzClient,
   ) {}

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
@@ -1,8 +1,8 @@
 import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { SettingsService } from "@/application/services/settings.service";
 import { SYNC_STATUS } from "../database/feed.repository";
-import type { FeedRepository } from "../database/feed.repository";
 import type { ReleaseFeedService } from "../external/release-feed.service";
 import type { SpotifyUserLibraryService } from "../external/spotify-user-library.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
@@ -57,7 +57,7 @@ function makeMockDeps(): FeedSyncJobDependencies {
       upsertReleases: vi.fn().mockResolvedValue(undefined),
       updateArtistReleasesSyncedAt: vi.fn().mockResolvedValue(undefined),
       evictStaleFeedCache: vi.fn().mockResolvedValue(undefined),
-    } as unknown as FeedRepository,
+    } as unknown as FeedRepositoryPort,
     eventBus: {
       emit: vi.fn(),
     } as unknown as AppEventBus,

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -1,7 +1,8 @@
 import { Worker } from "bullmq";
+import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { SettingsService } from "@/application/services/settings.service";
 import { container } from "@/container";
-import { SYNC_STATUS, type FeedRepository } from "../database/feed.repository";
+import { SYNC_STATUS } from "../database/feed.repository";
 import type { ReleaseFeedService } from "../external/release-feed.service";
 import type { SpotifyUserLibraryService } from "../external/spotify-user-library.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
@@ -23,7 +24,7 @@ const MAX_RELEASES_ARTISTS_PER_CYCLE = 15;
 export interface FeedSyncJobDependencies {
   spotifyUserLibrarySyncService: SpotifyUserLibraryService;
   releaseFeedService: ReleaseFeedService;
-  feedRepository: FeedRepository;
+  feedRepository: FeedRepositoryPort;
   eventBus: AppEventBus;
   settingsService: SettingsService;
 }


### PR DESCRIPTION
## Why

`apps/backend/src/infrastructure/database/feed.repository.ts` had grown to 659 LOC mixing followed-artist CRUD, album cache, release cache, sync-state and cross-table cache eviction in one class. This blocks safe iteration on feed/sync flows.

This PR is enabled by the ports landed in PR #32 (backend layer boundary cleanup) and splits that god-file into bucketed persistence units with a strangler facade so consumers can migrate gradually.

## What changed (PR 1/3)

- **Expanded** `FeedRepositoryPort` to its full public surface (~28 methods) so all consumers can depend on the port instead of the concrete class.
- **Extracted** shared row mappers to `feed-row-mappers.ts` (cover URL upgrade + `ArtistRelease` mapping previously duplicated across buckets).
- **Created** 4 specialised repositories under `infrastructure/database/`:
  - `FollowedArtistRepository`
  - `ArtistAlbumCacheRepository`
  - `ArtistReleaseCacheRepository`
  - `FeedSyncStateRepository` (also owns the cross-bucket selection queries)
- **Created** `FeedCacheEvictionService` (application coordinator) backed by `PrismaFeedCacheEvictionTransaction` (infra adapter). Keeps Prisma out of `application/` while preserving the single `$transaction` covering all 3 cache tables.
- **Converted** `FeedRepository` into a **strangler facade** that delegates to the new repos + eviction coordinator. Same public API → mocks and existing tests keep targeting it.
- **Migrated** consumers off the concrete class:
  - `infrastructure/workers/feed-sync.worker.ts`
  - `infrastructure/external/release-feed.service.ts`
- **Wired** the new graph in `apps/backend/src/container.ts`.

## What did NOT change

- 0 API/route changes.
- 0 DB schema / Prisma migration changes.
- 0 public DTO or shared package changes.
- 0 controller changes.

## Chain context (feature-branch-chain)

This is **PR 1 of 3** of SDD `feed-sync-refactor`. Target branch is the tracker `refactor/feed-sync-refactor`, not `main`.

| PR | Scope | Target |
|----|-------|--------|
| 1/3 (this) | Split `feed.repository.ts` + strangler facade | `refactor/feed-sync-refactor` |
| 2/3 | Split `spotify-user-library.service.ts` into 3 services + facade | builds on PR 1 |
| 3/3 | Cutover — remove both facades, callers consume splits directly | builds on PR 2 |

Only the tracker `refactor/feed-sync-refactor` merges to `main`, after all three slices verify.

## Tests

- Strict TDD: tests written/extended ahead of implementation (see Engram apply-progress for TDD cycle evidence).
- New unit specs added for every new repo, the mappers, and the eviction coordinator.
- Existing 8 backend test files unchanged in assertions — they keep targeting `FeedRepository` because the facade preserves the public surface.
- `__tests__/architecture.test.ts` still enforces R1–R4 invariants from PR #32.

## Quality gates

- `pnpm --filter backend run lint` ✅ — 0 errors (only the `no-explicit-any` warnings on test mocks)
- `pnpm --filter backend run test:run` ✅ — 31 files / 189 tests
- `pnpm --filter backend run build` ✅

## Verify warnings (non-blocking, documented)

1. A few files still import `SYNC_STATUS` via the `feed.repository` re-export — resolved in PR 3/3 cutover.
2. Facade delegation tests cover a subset of methods; full surface coverage lives in the per-repo specs.
3. Some `any`-typed mocks in new specs (lint warnings only).

## SDD artifacts (Engram)

- `sdd/feed-sync-refactor/explore` (#2760)
- `sdd/feed-sync-refactor/proposal` (#2761)
- `sdd/feed-sync-refactor/spec` (#2762)
- `sdd/feed-sync-refactor/design` (#2763)
- `sdd/feed-sync-refactor/tasks` (#2765)
- `sdd/feed-sync-refactor/apply-progress` (#2766)
- `sdd/feed-sync-refactor/verify-report` (#2767)

## Rollback

Revert merge. `feed.repository.ts` is preserved as a facade in this PR — production behaviour stays on the original API surface until PR 3/3.
