### PR TITLE
refactor(backend): split spotify-user-library into specialised services (PR 2/3)

### DIFF
--- a/apps/backend/src/application/ports/settings.port.ts
+++ b/apps/backend/src/application/ports/settings.port.ts
@@ -1,5 +1,4 @@
 export interface SettingsPort {
   getString(key: string, fallback?: string): Promise<string>;
   getNumber(key: string, fallback?: number): Promise<number>;
-  getBoolean(key: string, fallback?: boolean): Promise<boolean>;
 }

--- a/apps/backend/src/application/ports/settings.port.ts
+++ b/apps/backend/src/application/ports/settings.port.ts
@@ -1,0 +1,5 @@
+export interface SettingsPort {
+  getString(key: string, fallback?: string): Promise<string>;
+  getNumber(key: string, fallback?: number): Promise<number>;
+  getBoolean(key: string, fallback?: boolean): Promise<boolean>;
+}

--- a/apps/backend/src/application/services/settings.service.ts
+++ b/apps/backend/src/application/services/settings.service.ts
@@ -1,3 +1,4 @@
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { SETTINGS_METADATA } from "@/constants/settings-metadata";
 import { AppError } from "@/domain/errors/app-error";
 import type { SettingsRepository } from "@/domain/repositories/settings.repository";
@@ -22,7 +23,7 @@ const INTERNALIZED_NUMERIC_SETTINGS = {
 type InternalizedNumericSettingKey =
   (typeof INTERNALIZED_NUMERIC_SETTINGS)[keyof typeof INTERNALIZED_NUMERIC_SETTINGS];
 
-export class SettingsService {
+export class SettingsService implements SettingsPort {
   constructor(
     private readonly repo: SettingsRepository,
     private readonly getInternalizedNumericValue: (key: string) => number | undefined,

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -49,8 +49,11 @@ import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
 import { ReleaseFeedService } from "./infrastructure/external/release-feed.service";
 import { SpotifyAlbumClient } from "./infrastructure/external/spotify-album.client";
+import { SpotifyArtistCatalogService } from "./infrastructure/external/spotify-artist-catalog.service";
 import { SpotifyArtistClient } from "./infrastructure/external/spotify-artist.client";
 import { SpotifyAuthService } from "./infrastructure/external/spotify-auth.service";
+import { SpotifyFollowedArtistsService } from "./infrastructure/external/spotify-followed-artists.service";
+import { SpotifyPlaylistLibraryService } from "./infrastructure/external/spotify-playlist-library.service";
 import { SpotifyPlaylistClient } from "./infrastructure/external/spotify-playlist.client";
 import { SpotifySearchClient } from "./infrastructure/external/spotify-search.client";
 import { SpotifyTrackClient } from "./infrastructure/external/spotify-track.client";
@@ -198,11 +201,46 @@ const spotifySearchClient = new SpotifySearchClient(
 const spotifyUserLibraryService = SpotifyUserLibraryService.getInstance(
   settingsService,
   spotifyAuthService,
+  "user",
+  {
+    spotifyFollowedArtistsService: new SpotifyFollowedArtistsService(
+      settingsService,
+      spotifyAuthService,
+      "user",
+    ),
+    spotifyPlaylistLibraryService: new SpotifyPlaylistLibraryService(
+      settingsService,
+      spotifyAuthService,
+      "user",
+    ),
+    spotifyArtistCatalogService: new SpotifyArtistCatalogService(
+      settingsService,
+      spotifyAuthService,
+      "user",
+    ),
+  },
 );
 const spotifyUserLibrarySyncService = SpotifyUserLibraryService.getInstance(
   settingsService,
   spotifyAuthService,
   "sync",
+  {
+    spotifyFollowedArtistsService: new SpotifyFollowedArtistsService(
+      settingsService,
+      spotifyAuthService,
+      "sync",
+    ),
+    spotifyPlaylistLibraryService: new SpotifyPlaylistLibraryService(
+      settingsService,
+      spotifyAuthService,
+      "sync",
+    ),
+    spotifyArtistCatalogService: new SpotifyArtistCatalogService(
+      settingsService,
+      spotifyAuthService,
+      "sync",
+    ),
+  },
 );
 
 // External catalog providers (Deezer primary, MusicBrainz fallback; Spotify URLs materialize on demand)

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -272,7 +272,7 @@ const spotifyServiceSync = new SpotifyService({
   albumClient: spotifyAlbumClient,
   playlistClient: spotifyPlaylistClientSync,
   searchClient: spotifySearchClient,
-  userLibraryService: spotifyUserLibraryService,
+  userLibraryService: spotifyUserLibrarySyncService,
 });
 
 // Services (Post-Processing) — uses sync service to avoid starving interactive requests

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -151,8 +151,14 @@ const metadataService = new MetadataService();
 const queueService = new BullMqTrackQueueService();
 const eventBus = new AppEventBus();
 
+let spotifyUserLibraryService: SpotifyUserLibraryService | null = null;
+let spotifyUserLibrarySyncService: SpotifyUserLibraryService | null = null;
+
 // Spotify
-const spotifyAuthService = SpotifyAuthService.getInstance(settingsService);
+const spotifyAuthService = SpotifyAuthService.getInstance(settingsService, () => {
+  spotifyUserLibraryService?.clearCache();
+  spotifyUserLibrarySyncService?.clearCache();
+});
 const spotifyRequestCache = new PromiseCache({ ttlMs: 30_000 });
 const spotifyArtistClient = new SpotifyArtistClient(
   spotifyAuthService,
@@ -198,7 +204,7 @@ const spotifySearchClient = new SpotifySearchClient(
   "interactive",
 );
 
-const spotifyUserLibraryService = SpotifyUserLibraryService.getInstance(
+spotifyUserLibraryService = SpotifyUserLibraryService.getInstance(
   settingsService,
   spotifyAuthService,
   "user",
@@ -220,7 +226,7 @@ const spotifyUserLibraryService = SpotifyUserLibraryService.getInstance(
     ),
   },
 );
-const spotifyUserLibrarySyncService = SpotifyUserLibraryService.getInstance(
+spotifyUserLibrarySyncService = SpotifyUserLibraryService.getInstance(
   settingsService,
   spotifyAuthService,
   "sync",

--- a/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { SpotifyArtistCatalogService } from "./spotify-artist-catalog.service";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+const buildService = (market = "ES") =>
+  new SpotifyArtistCatalogService(
+    {
+      getNumber: vi.fn().mockResolvedValue(30),
+      getString: vi.fn().mockResolvedValue(market),
+    } as unknown as SettingsService,
+    {
+      getAppToken: vi.fn().mockResolvedValue("app-token"),
+      getUserToken: vi.fn().mockResolvedValue("user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService,
+  );
+
+beforeEach(() => {
+  buildService().clearCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SpotifyArtistCatalogService", () => {
+  it("maps artist album catalog data", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = input.toString();
+      if (!url.includes("https://api.spotify.com/v1/artists/artist-1/albums")) {
+        throw new Error(`Unexpected Spotify URL: ${url}`);
+      }
+
+      return jsonResponse({
+        items: [
+          {
+            id: "album-1",
+            name: "Album 1",
+            album_type: "album",
+            release_date: "2026-01-01",
+            images: [{ url: "https://img/album-1" }],
+            external_urls: { spotify: "https://open.spotify.com/album/album-1" },
+            total_tracks: 9,
+          },
+        ],
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const releases = await buildService().getArtistCatalogData([
+      { id: "artist-1", name: "Artist 1", imageUrl: "https://img/artist-1" },
+    ]);
+
+    expect(releases).toHaveLength(1);
+    expect(releases[0]?.artistId).toBe("artist-1");
+    expect(releases[0]?.albumId).toBe("album-1");
+  });
+
+  it("uses cache for repeated inputs", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ items: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = buildService();
+    const artists = [{ id: "artist-1", name: "Artist 1", imageUrl: null }];
+    await service.getArtistCatalogData(artists);
+    await service.getArtistCatalogData(artists);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.ts
@@ -1,5 +1,5 @@
 import type { AlbumType, ArtistRelease } from "@spotiarr/shared";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import type { CacheEntry } from "./cache.types";
 import type { SpotifyAuthService } from "./spotify-auth.service";
@@ -13,7 +13,7 @@ export class SpotifyArtistCatalogService extends SpotifyHttpClient {
   private readonly cache: Map<string, CacheEntry<unknown>> = new Map();
 
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     authService: SpotifyAuthService,
     limiterMode: SpotifyLimiterMode = "user",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.ts
@@ -1,0 +1,140 @@
+import type { AlbumType, ArtistRelease } from "@spotiarr/shared";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AppError } from "@/domain/errors/app-error";
+import type { CacheEntry } from "./cache.types";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import { SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT } from "./spotify-constants";
+import { SpotifyHttpClient, type SpotifyLimiterMode } from "./spotify-http.client";
+import type { SpotifyArtistAlbumsResponse } from "./spotify.types";
+
+type CatalogArtist = { id: string; name: string; imageUrl?: string | null };
+
+export class SpotifyArtistCatalogService extends SpotifyHttpClient {
+  private readonly cache: Map<string, CacheEntry<unknown>> = new Map();
+
+  constructor(
+    private readonly settingsService: SettingsService,
+    authService: SpotifyAuthService,
+    limiterMode: SpotifyLimiterMode = "user",
+  ) {
+    super(authService, limiterMode);
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  private getCacheKey(method: string, ...args: unknown[]): string {
+    return `${method}:${JSON.stringify(args)}`;
+  }
+
+  private async getFromCache<T>(key: string): Promise<T | null> {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+
+    const cacheMinutes = await this.settingsService.getNumber("RELEASES_CACHE_MINUTES");
+    const cacheTTL = cacheMinutes * 60 * 1000;
+    if (Date.now() - entry.createdAt > cacheTTL) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.value as T;
+  }
+
+  private setCache<T>(key: string, data: T): void {
+    this.cache.set(key, { value: data, createdAt: Date.now(), ttlMs: 0 });
+  }
+
+  private async getMarket(): Promise<string> {
+    try {
+      return await this.settingsService.getString("SPOTIFY_MARKET");
+    } catch {
+      return "ES";
+    }
+  }
+
+  async getArtistCatalogData(
+    artists: CatalogArtist[],
+    earlyStopBeforeDate?: Date,
+  ): Promise<ArtistRelease[]> {
+    const cacheKey = this.getCacheKey(
+      "getArtistCatalogData",
+      artists,
+      earlyStopBeforeDate?.toISOString(),
+    );
+    const cached = await this.getFromCache<ArtistRelease[]>(cacheKey);
+    if (cached) return cached;
+
+    const market = await this.getMarket();
+    const albumsPerArtist: ArtistRelease[][] = [];
+
+    for (const artist of artists) {
+      const albums: ArtistRelease[] = [];
+      let offset = 0;
+      let shouldStop = false;
+
+      while (!shouldStop) {
+        const albumsUrl = `https://api.spotify.com/v1/artists/${artist.id}/albums?include_groups=album,single,compilation&limit=${SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT}&offset=${offset}&market=${market}`;
+        const albumsResponse = await this.fetchWithAppToken(albumsUrl);
+
+        if (!albumsResponse.ok) {
+          const errorText = await albumsResponse.text();
+          if (albumsResponse.status === 429) {
+            throw new AppError(
+              429,
+              "spotify_rate_limited",
+              "Rate limited by Spotify API while fetching artist catalog.",
+            );
+          }
+          console.warn(
+            `[SpotifyArtistCatalogService] Failed to fetch catalog for artist ${artist.id}: ${albumsResponse.status} ${errorText}`,
+          );
+          break;
+        }
+
+        const albumsData = (await albumsResponse.json()) as SpotifyArtistAlbumsResponse;
+        const pageAlbums = albumsData.items ?? [];
+        if (pageAlbums.length === 0) break;
+
+        const mapped = pageAlbums.map((album) => ({
+          artistId: artist.id,
+          artistName: artist.name,
+          artistImageUrl: artist.imageUrl ?? null,
+          albumId: album.id as string,
+          albumName: album.name,
+          albumType: album.album_type as AlbumType,
+          releaseDate: album.release_date,
+          coverUrl: album.images?.[0]?.url ?? null,
+          spotifyUrl: album.external_urls?.spotify,
+          totalTracks: album.total_tracks,
+        }));
+
+        albums.push(...mapped);
+
+        if (earlyStopBeforeDate && mapped.length > 0) {
+          const oldestOnPage = mapped[mapped.length - 1];
+          if (oldestOnPage?.releaseDate) {
+            const parts = oldestOnPage.releaseDate.split("-");
+            const year = Number(parts[0]);
+            const month = parts.length >= 2 ? Number(parts[1]) - 1 : 0;
+            const day = parts.length >= 3 ? Number(parts[2]) : 1;
+            if (!Number.isNaN(year) && year > 0) {
+              const oldestDate = new Date(year, month, day);
+              if (oldestDate < earlyStopBeforeDate) shouldStop = true;
+            }
+          }
+        }
+
+        if (pageAlbums.length < SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT) break;
+        offset += pageAlbums.length;
+      }
+
+      albumsPerArtist.push(albums);
+    }
+
+    const flattened = albumsPerArtist.flat();
+    this.setCache(cacheKey, flattened);
+    return flattened;
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-auth.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-auth.service.test.ts
@@ -1,0 +1,112 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AppError } from "@/domain/errors/app-error";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { SpotifyAuthService } from "./spotify-auth.service";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const textResponse = (body: string, status = 500) => new Response(body, { status });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifyAuthService invalidation", () => {
+  const invalidateUserLibraryCache = vi.fn();
+  const settingsService = {
+    getString: vi.fn(),
+    setString: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as SettingsService;
+
+  let service: SpotifyAuthService;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    invalidateUserLibraryCache.mockReset();
+
+    (settingsService.getString as ReturnType<typeof vi.fn>).mockReset();
+    (settingsService.setString as ReturnType<typeof vi.fn>).mockReset();
+    (settingsService.delete as ReturnType<typeof vi.fn>).mockReset();
+
+    service = new SpotifyAuthService(settingsService, invalidateUserLibraryCache);
+  });
+
+  it("calls invalidator after successful token exchange", async () => {
+    (settingsService.setString as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          access_token: "new-access-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      ),
+    );
+
+    await service.exchangeCodeForToken("auth-code");
+
+    expect(settingsService.setString).toHaveBeenCalledWith(
+      "spotify_user_access_token",
+      "new-access-token",
+    );
+    expect(settingsService.setString).toHaveBeenCalledWith(
+      "spotify_user_refresh_token",
+      "new-refresh-token",
+    );
+    expect(invalidateUserLibraryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls invalidator after successful refresh", async () => {
+    (settingsService.getString as ReturnType<typeof vi.fn>).mockResolvedValue("refresh-token");
+    (settingsService.setString as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          access_token: "refreshed-access-token",
+          refresh_token: "refreshed-refresh-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      ),
+    );
+
+    const refreshed = await service.refreshUserToken();
+
+    expect(refreshed).toBe(true);
+    expect(invalidateUserLibraryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls invalidator after successful logout", async () => {
+    (settingsService.delete as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    await service.logout();
+
+    expect(settingsService.delete).toHaveBeenCalledWith("spotify_user_access_token");
+    expect(settingsService.delete).toHaveBeenCalledWith("spotify_user_refresh_token");
+    expect(invalidateUserLibraryCache).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call invalidator when token exchange fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => textResponse("bad request", 400)),
+    );
+
+    await expect(service.exchangeCodeForToken("bad-code")).rejects.toBeInstanceOf(AppError);
+    expect(invalidateUserLibraryCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-auth.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-auth.service.ts
@@ -2,7 +2,6 @@ import { SettingsService } from "@/application/services/settings.service";
 import { AppError } from "@/domain/errors/app-error";
 import { getEnv } from "../setup/environment";
 import { getErrorMessage } from "../utils/error.utils";
-import { SpotifyUserLibraryService } from "./spotify-user-library.service";
 
 interface SpotifyTokenResponse {
   access_token: string;
@@ -15,11 +14,20 @@ export class SpotifyAuthService {
   private tokenExpiry: number = 0;
   private appTokenPromise: Promise<string> | null = null;
 
-  constructor(private readonly settingsService: SettingsService) {}
+  constructor(
+    private readonly settingsService: SettingsService,
+    private readonly invalidateUserLibraryCache: () => void = () => {},
+  ) {}
 
-  static getInstance(settingsService: SettingsService): SpotifyAuthService {
+  static getInstance(
+    settingsService: SettingsService,
+    invalidateUserLibraryCache?: () => void,
+  ): SpotifyAuthService {
     if (!SpotifyAuthService.instance) {
-      SpotifyAuthService.instance = new SpotifyAuthService(settingsService);
+      SpotifyAuthService.instance = new SpotifyAuthService(
+        settingsService,
+        invalidateUserLibraryCache,
+      );
     }
     return SpotifyAuthService.instance;
   }
@@ -176,7 +184,7 @@ export class SpotifyAuthService {
         await this.settingsService.setString(refreshTokenKey, data.refresh_token);
       }
 
-      SpotifyUserLibraryService.clearGlobalCache();
+      this.invalidateUserLibraryCache();
 
       this.log("Successfully refreshed Spotify user access token");
       return true;
@@ -237,7 +245,7 @@ export class SpotifyAuthService {
     try {
       await this.settingsService.delete("spotify_user_access_token");
       await this.settingsService.delete("spotify_user_refresh_token");
-      SpotifyUserLibraryService.clearGlobalCache();
+      this.invalidateUserLibraryCache();
       this.log("Successfully logged out from Spotify");
     } catch (error) {
       this.log(`Failed to logout from Spotify: ${getErrorMessage(error)}`, "error");

--- a/apps/backend/src/infrastructure/external/spotify-auth.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-auth.service.ts
@@ -239,6 +239,8 @@ export class SpotifyAuthService {
     if (data.refresh_token) {
       await this.settingsService.setString("spotify_user_refresh_token", data.refresh_token);
     }
+
+    this.invalidateUserLibraryCache();
   }
 
   async logout(): Promise<void> {

--- a/apps/backend/src/infrastructure/external/spotify-followed-artists.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-followed-artists.service.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyFollowedArtistsService } from "./spotify-followed-artists.service";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+const buildService = () =>
+  new SpotifyFollowedArtistsService(
+    {
+      getNumber: vi
+        .fn()
+        .mockImplementation((key: string) =>
+          Promise.resolve(key === "FOLLOWED_ARTISTS_MAX" ? 10 : 30),
+        ),
+    } as unknown as SettingsService,
+    {
+      getUserToken: vi.fn().mockResolvedValue("user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService,
+  );
+
+beforeEach(() => {
+  buildService().clearCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SpotifyFollowedArtistsService", () => {
+  it("sorts and maps followed artists", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = input.toString();
+      if (!url.includes("https://api.spotify.com/v1/me/following")) {
+        throw new Error(`Unexpected Spotify URL: ${url}`);
+      }
+
+      return jsonResponse({
+        artists: {
+          items: [
+            {
+              id: "2",
+              name: "Zulu",
+              images: [{ url: "https://img/zulu" }],
+              external_urls: { spotify: "https://open.spotify.com/artist/2" },
+            },
+            {
+              id: "1",
+              name: "Alpha",
+              images: [{ url: "https://img/alpha" }],
+              external_urls: { spotify: "https://open.spotify.com/artist/1" },
+            },
+          ],
+          cursors: {},
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const artists = await buildService().getFollowedArtists();
+
+    expect(artists.map((artist) => artist.id)).toEqual(["1", "2"]);
+    expect(artists[0]?.spotifyUrl).toBe("https://open.spotify.com/artist/1");
+  });
+
+  it("uses cache for repeated calls", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        artists: {
+          items: [
+            {
+              id: "1",
+              name: "Alpha",
+              images: [{ url: "https://img/alpha" }],
+              external_urls: { spotify: "https://open.spotify.com/artist/1" },
+            },
+          ],
+          cursors: {},
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = buildService();
+    await service.getFollowedArtists();
+    await service.getFollowedArtists();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-followed-artists.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-followed-artists.service.ts
@@ -1,5 +1,5 @@
 import type { FollowedArtist } from "@spotiarr/shared";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getErrorMessage } from "../utils/error.utils";
 import type { CacheEntry } from "./cache.types";
@@ -16,7 +16,7 @@ export class SpotifyFollowedArtistsService extends SpotifyHttpClient {
   private readonly inFlightPromises = new PromiseCache({ ttlMs: 30_000 });
 
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     authService: SpotifyAuthService,
     limiterMode: SpotifyLimiterMode = "user",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-followed-artists.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-followed-artists.service.ts
@@ -1,0 +1,139 @@
+import type { FollowedArtist } from "@spotiarr/shared";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AppError } from "@/domain/errors/app-error";
+import { getErrorMessage } from "../utils/error.utils";
+import type { CacheEntry } from "./cache.types";
+import { PromiseCache } from "./promise-cache";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyHttpClient, type SpotifyLimiterMode } from "./spotify-http.client";
+import type { SpotifyArtistFull, SpotifyFollowedArtistsResponse } from "./spotify.types";
+
+const FOLLOWED_ARTISTS_CACHE_KEY = "followed-artists:list";
+const FOLLOWED_ARTISTS_IN_FLIGHT_KEY = "followed-artists:in-flight";
+
+export class SpotifyFollowedArtistsService extends SpotifyHttpClient {
+  private readonly cache: Map<string, CacheEntry<unknown>> = new Map();
+  private readonly inFlightPromises = new PromiseCache({ ttlMs: 30_000 });
+
+  constructor(
+    private readonly settingsService: SettingsService,
+    authService: SpotifyAuthService,
+    limiterMode: SpotifyLimiterMode = "user",
+  ) {
+    super(authService, limiterMode);
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+    this.inFlightPromises.clear();
+  }
+
+  private getCacheKey(method: string, ...args: unknown[]): string {
+    return `${method}:${JSON.stringify(args)}`;
+  }
+
+  private async getFromCache<T>(key: string): Promise<T | null> {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+
+    const cacheMinutes = await this.settingsService.getNumber("RELEASES_CACHE_MINUTES");
+    const cacheTTL = cacheMinutes * 60 * 1000;
+    if (Date.now() - entry.createdAt > cacheTTL) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.value as T;
+  }
+
+  private setCache<T>(key: string, data: T): void {
+    this.cache.set(key, { value: data, createdAt: Date.now(), ttlMs: 0 });
+  }
+
+  private async getFollowedArtistsSnapshot(maxArtists: number): Promise<SpotifyArtistFull[]> {
+    const cacheKey = this.getCacheKey(FOLLOWED_ARTISTS_CACHE_KEY, maxArtists);
+    const cached = await this.getFromCache<SpotifyArtistFull[]>(cacheKey);
+    if (cached) return cached;
+
+    return this.inFlightPromises.getOrSet(
+      `${FOLLOWED_ARTISTS_IN_FLIGHT_KEY}:${maxArtists}`,
+      async () => {
+        const warmCache = await this.getFromCache<SpotifyArtistFull[]>(cacheKey);
+        if (warmCache) return warmCache;
+
+        const artists = await this.fetchAllFollowedArtists(maxArtists);
+        const slicedArtists = artists.slice(0, maxArtists);
+        this.setCache(cacheKey, slicedArtists);
+        return slicedArtists;
+      },
+    );
+  }
+
+  async getFollowedArtists(): Promise<FollowedArtist[]> {
+    const cacheKey = this.getCacheKey("getFollowedArtists");
+    const cached = await this.getFromCache<FollowedArtist[]>(cacheKey);
+    if (cached) return cached;
+
+    try {
+      const maxArtists = await this.settingsService.getNumber("FOLLOWED_ARTISTS_MAX");
+      const artists = await this.getFollowedArtistsSnapshot(maxArtists);
+      const sorted = artists.slice(0, maxArtists).sort((a, b) => a.name.localeCompare(b.name));
+      const mapped = sorted.map((artist) => ({
+        id: artist.id,
+        name: artist.name,
+        image: artist.images?.[0]?.url ?? null,
+        spotifyUrl: artist.external_urls?.spotify ?? null,
+      }));
+      this.setCache(cacheKey, mapped);
+      return mapped;
+    } catch (error) {
+      console.error(`[SpotifyFollowedArtistsService] ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+
+  private async fetchAllFollowedArtists(maxArtists: number): Promise<SpotifyArtistFull[]> {
+    const artists: SpotifyArtistFull[] = [];
+    let after: string | undefined;
+    const pageLimit = Math.min(Math.max(maxArtists, 1), 50);
+
+    do {
+      const url = new URL("https://api.spotify.com/v1/me/following");
+      url.searchParams.set("type", "artist");
+      url.searchParams.set("limit", pageLimit.toString());
+      if (after) url.searchParams.set("after", after);
+
+      const response = await this.fetchWithUserToken(url.toString());
+      if (!response.ok) {
+        const errorText = await response.text();
+        if (response.status === 401) {
+          throw new AppError(
+            401,
+            "missing_user_access_token",
+            "Spotify user token expired or invalid",
+          );
+        }
+        if (response.status === 429) {
+          throw new AppError(
+            429,
+            "spotify_rate_limited",
+            `Spotify rate limit exceeded while fetching followed artists: ${errorText}`,
+          );
+        }
+        throw new AppError(
+          response.status,
+          "failed_to_fetch_followed_artists",
+          `Failed to fetch followed artists: ${response.status} ${errorText}`,
+        );
+      }
+
+      const data = (await response.json()) as SpotifyFollowedArtistsResponse;
+      artists.push(...(data.artists?.items ?? []));
+      after = data.artists?.cursors?.after;
+
+      if (artists.length >= maxArtists) break;
+    } while (after);
+
+    return artists;
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-playlist-library.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist-library.service.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import {
+  isOwnedPlaylist,
+  needsPlaylistItemsAccessCheck,
+  SpotifyPlaylistLibraryService,
+  type SpotifyUserPlaylistItem,
+} from "./spotify-playlist-library.service";
+
+const buildPlaylist = (
+  overrides: Partial<SpotifyUserPlaylistItem> = {},
+): SpotifyUserPlaylistItem => ({
+  id: "playlist-id",
+  name: "Playlist",
+  collaborative: false,
+  images: [],
+  owner: {
+    id: "other-user",
+    display_name: "Other User",
+    external_urls: { spotify: "https://open.spotify.com/user/other-user" },
+  },
+  tracks: { total: 10 },
+  external_urls: { spotify: "https://open.spotify.com/playlist/playlist-id" },
+  ...overrides,
+});
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+const buildService = () =>
+  new SpotifyPlaylistLibraryService(
+    {
+      getNumber: vi.fn().mockResolvedValue(30),
+    } as unknown as SettingsService,
+    {
+      getUserToken: vi.fn().mockResolvedValue("user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService,
+  );
+
+beforeEach(() => {
+  buildService().clearCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("isOwnedPlaylist", () => {
+  it("detects playlists owned by the current user", () => {
+    const playlist = buildPlaylist({ owner: { ...buildPlaylist().owner, id: "current-user" } });
+
+    expect(isOwnedPlaylist(playlist, "current-user")).toBe(true);
+  });
+
+  it("does not treat non-owned collaborative playlists as owned", () => {
+    const playlist = buildPlaylist({ collaborative: true });
+
+    expect(isOwnedPlaylist(playlist, "current-user")).toBe(false);
+  });
+});
+
+describe("needsPlaylistItemsAccessCheck", () => {
+  it("skips the access probe for owned playlists", () => {
+    const playlist = buildPlaylist({ owner: { ...buildPlaylist().owner, id: "current-user" } });
+
+    expect(needsPlaylistItemsAccessCheck(playlist, "current-user")).toBe(false);
+  });
+
+  it("probes non-owned playlists instead of trusting the collaborative flag", () => {
+    const playlist = buildPlaylist({ collaborative: true });
+
+    expect(needsPlaylistItemsAccessCheck(playlist, "current-user")).toBe(true);
+  });
+});
+
+describe("SpotifyPlaylistLibraryService.getMyPlaylists", () => {
+  it("keeps owned playlists, probes non-owned playlists, and filters inaccessible ones", async () => {
+    const ownedPlaylist = buildPlaylist({
+      id: "owned",
+      name: "Owned",
+      owner: { ...buildPlaylist().owner, id: "current-user", display_name: "Me" },
+      external_urls: { spotify: "https://open.spotify.com/playlist/owned" },
+    });
+    const accessiblePlaylist = buildPlaylist({
+      id: "accessible",
+      name: "Accessible",
+      external_urls: { spotify: "https://open.spotify.com/playlist/accessible" },
+    });
+    const inaccessiblePlaylist = buildPlaylist({
+      id: "inaccessible",
+      name: "Inaccessible",
+      external_urls: { spotify: "https://open.spotify.com/playlist/inaccessible" },
+    });
+
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = input.toString();
+
+      if (url === "https://api.spotify.com/v1/me") {
+        return jsonResponse({ id: "current-user" });
+      }
+
+      if (url === "https://api.spotify.com/v1/me/playlists?limit=50") {
+        return jsonResponse({
+          items: [ownedPlaylist, accessiblePlaylist, inaccessiblePlaylist],
+          next: null,
+        });
+      }
+
+      if (url.includes("/playlists/accessible/items")) {
+        return jsonResponse({ total: 1 });
+      }
+
+      if (url.includes("/playlists/inaccessible/items")) {
+        return jsonResponse({ error: { status: 403 } }, 403);
+      }
+
+      throw new Error(`Unexpected Spotify URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const playlists = await buildService().getMyPlaylists();
+
+    expect(playlists.map((playlist) => playlist.id)).toEqual(["owned", "accessible"]);
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-playlist-library.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist-library.service.ts
@@ -1,0 +1,277 @@
+import type { SpotifyPlaylist } from "@spotiarr/shared";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AppError } from "@/domain/errors/app-error";
+import { getEnv } from "../setup/environment";
+import { getErrorMessage } from "../utils/error.utils";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyHttpClient, type SpotifyLimiterMode } from "./spotify-http.client";
+
+const PLAYLIST_ACCESS_CACHE_MAX_ENTRIES = 1_000;
+const PLAYLIST_ACCESS_ALLOWED_TTL_MS = 30 * 60 * 1000;
+const PLAYLIST_ACCESS_DENIED_TTL_MS = 5 * 60 * 1000;
+const PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS = 60 * 1000;
+
+type SpotifyCurrentUserResponse = { id: string };
+type PlaylistAccessStatus = "allowed" | "denied" | "rate_limited";
+type PlaylistAccessResult = { status: PlaylistAccessStatus; trackTotal?: number };
+type PlaylistAccessCacheEntry = {
+  status: Exclude<PlaylistAccessStatus, "rate_limited">;
+  trackTotal?: number;
+  expiresAt: number;
+};
+
+export type SpotifyUserPlaylistItem = {
+  id: string;
+  name: string;
+  collaborative?: boolean;
+  images: { url: string }[];
+  owner: { id?: string; display_name: string; external_urls: { spotify: string } };
+  tracks?: { total?: number };
+  external_urls: { spotify: string };
+};
+
+export const isOwnedPlaylist = (item: SpotifyUserPlaylistItem, currentUserId: string) =>
+  item.owner?.id === currentUserId;
+
+export const needsPlaylistItemsAccessCheck = (
+  item: SpotifyUserPlaylistItem,
+  currentUserId: string,
+) => !isOwnedPlaylist(item, currentUserId);
+
+export class SpotifyPlaylistLibraryService extends SpotifyHttpClient {
+  private readonly playlistAccessCache = new Map<string, PlaylistAccessCacheEntry>();
+  private playlistAccessProbeCooldownUntil = 0;
+
+  constructor(
+    private readonly settingsService: SettingsService,
+    authService: SpotifyAuthService,
+    limiterMode: SpotifyLimiterMode = "user",
+  ) {
+    super(authService, limiterMode);
+  }
+
+  clearCache(): void {
+    this.playlistAccessCache.clear();
+    this.playlistAccessProbeCooldownUntil = 0;
+    this.log("Cache cleared");
+  }
+
+  private log(message: string, level: "debug" | "error" | "warn" = "debug") {
+    const prefix = `[SpotifyPlaylistLibraryService]`;
+    if (level === "error") console.error(prefix, message);
+    else if (level === "warn") console.warn(prefix, message);
+    else if (getEnv().NODE_ENV === "development") console.log(prefix, message);
+  }
+
+  private getPlaylistAccessCache(playlistId: string): PlaylistAccessResult | null {
+    const entry = this.playlistAccessCache.get(playlistId);
+    if (!entry) return null;
+    if (Date.now() >= entry.expiresAt) {
+      this.playlistAccessCache.delete(playlistId);
+      return null;
+    }
+    return { status: entry.status, trackTotal: entry.trackTotal };
+  }
+
+  private setPlaylistAccessCache(
+    playlistId: string,
+    status: Exclude<PlaylistAccessStatus, "rate_limited">,
+    trackTotal?: number,
+  ): void {
+    const ttlMs =
+      status === "allowed" ? PLAYLIST_ACCESS_ALLOWED_TTL_MS : PLAYLIST_ACCESS_DENIED_TTL_MS;
+    this.playlistAccessCache.set(playlistId, {
+      status,
+      trackTotal,
+      expiresAt: Date.now() + ttlMs,
+    });
+    this.prunePlaylistAccessCache();
+  }
+
+  private prunePlaylistAccessCache(): void {
+    const now = Date.now();
+    for (const [playlistId, entry] of this.playlistAccessCache) {
+      if (now >= entry.expiresAt) this.playlistAccessCache.delete(playlistId);
+    }
+    while (this.playlistAccessCache.size > PLAYLIST_ACCESS_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.playlistAccessCache.keys().next().value;
+      if (!oldestKey) break;
+      this.playlistAccessCache.delete(oldestKey);
+    }
+  }
+
+  private getRetryAfterMs(response: Response): number {
+    const retryAfter = response.headers.get("Retry-After");
+    if (!retryAfter) return PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS;
+
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000;
+
+    const retryAt = Date.parse(retryAfter);
+    if (Number.isFinite(retryAt)) {
+      return Math.max(retryAt - Date.now(), PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS);
+    }
+
+    return PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS;
+  }
+
+  private isPlaylistAccessProbeCoolingDown(): boolean {
+    return Date.now() < this.playlistAccessProbeCooldownUntil;
+  }
+
+  private async getCurrentUserId(): Promise<string> {
+    const response = await this.fetchWithUserToken("https://api.spotify.com/v1/me");
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new AppError(
+          401,
+          "missing_user_access_token",
+          "Reconnect Spotify to grant the required playlist scopes.",
+        );
+      }
+      if (response.status === 403) {
+        throw new AppError(
+          401,
+          "missing_user_access_token",
+          "Reconnect Spotify to grant the user-read-private scope.",
+        );
+      }
+      const errorText = await response.text();
+      throw new AppError(
+        response.status,
+        "internal_server_error",
+        `Failed to fetch current Spotify user: ${response.status} ${errorText}`,
+      );
+    }
+    const data = (await response.json()) as SpotifyCurrentUserResponse;
+    return data.id;
+  }
+
+  private async canAccessPlaylistItems(playlistId: string): Promise<PlaylistAccessResult> {
+    const cached = this.getPlaylistAccessCache(playlistId);
+    if (cached) return cached;
+    if (this.isPlaylistAccessProbeCoolingDown()) return { status: "rate_limited" };
+
+    const fields = "total";
+    const url = `https://api.spotify.com/v1/playlists/${playlistId}/items?limit=1&fields=${encodeURIComponent(fields)}`;
+    const response = await this.fetchWithUserToken(url);
+
+    if (response.ok) {
+      const data = (await response.json()) as { total?: unknown };
+      const trackTotal =
+        typeof data.total === "number" && Number.isFinite(data.total) ? data.total : undefined;
+      this.setPlaylistAccessCache(playlistId, "allowed", trackTotal);
+      return { status: "allowed", trackTotal };
+    }
+
+    if (response.status === 403 || response.status === 404) {
+      this.setPlaylistAccessCache(playlistId, "denied");
+      return { status: "denied" };
+    }
+
+    if (response.status === 401) {
+      throw new AppError(
+        401,
+        "missing_user_access_token",
+        "Reconnect Spotify to grant the required playlist scopes.",
+      );
+    }
+
+    if (response.status === 429) {
+      const cooldownMs = this.getRetryAfterMs(response);
+      this.playlistAccessProbeCooldownUntil = Date.now() + cooldownMs;
+      this.log(
+        `Spotify rate limited playlist access probes; cooling down for ${cooldownMs}ms`,
+        "warn",
+      );
+      return { status: "rate_limited" };
+    }
+
+    const errorText = await response.text();
+    throw new AppError(
+      response.status >= 500 ? 502 : 500,
+      "internal_server_error",
+      `Failed to check playlist item access: ${response.status} ${errorText}`,
+    );
+  }
+
+  private async getPlaylistVisibility(
+    item: SpotifyUserPlaylistItem,
+    currentUserId: string,
+  ): Promise<PlaylistAccessResult> {
+    if (isOwnedPlaylist(item, currentUserId)) return { status: "allowed" };
+    return this.canAccessPlaylistItems(item.id);
+  }
+
+  async getMyPlaylists(): Promise<SpotifyPlaylist[]> {
+    try {
+      const currentUserId = await this.getCurrentUserId();
+      const allPlaylists: SpotifyPlaylist[] = [];
+      let nextUrl: string | null = "https://api.spotify.com/v1/me/playlists?limit=50";
+
+      while (nextUrl) {
+        const response = await this.fetchWithUserToken(nextUrl);
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new AppError(
+              401,
+              "missing_user_access_token",
+              "Reconnect Spotify to grant the required playlist scopes.",
+            );
+          }
+          if (response.status === 403) {
+            throw new AppError(
+              401,
+              "missing_user_access_token",
+              "Reconnect Spotify to grant the user-read-private and playlist-read-private scopes.",
+            );
+          }
+          const errorText = await response.text();
+          throw new AppError(
+            response.status,
+            "internal_server_error",
+            `Failed to fetch user playlists: ${response.status} ${errorText}`,
+          );
+        }
+
+        const data = (await response.json()) as {
+          items: SpotifyUserPlaylistItem[];
+          next: string | null;
+        };
+
+        const accessibleItems: { item: SpotifyUserPlaylistItem; trackTotal?: number }[] = [];
+        for (const item of data.items) {
+          const visibility = await this.getPlaylistVisibility(item, currentUserId);
+          if (visibility.status === "allowed") {
+            accessibleItems.push({ item, trackTotal: visibility.trackTotal });
+          }
+        }
+
+        const mapped = accessibleItems.map(({ item, trackTotal }) => {
+          const playlistTrackTotal = item.tracks?.total;
+          const tracks =
+            typeof playlistTrackTotal === "number" && Number.isFinite(playlistTrackTotal)
+              ? playlistTrackTotal
+              : (trackTotal ?? 0);
+          return {
+            id: item.id,
+            name: item.name,
+            image: item.images?.[0]?.url ?? null,
+            owner: item.owner?.display_name ?? "Unknown",
+            tracks,
+            spotifyUrl: item.external_urls?.spotify,
+            ownerUrl: item.owner?.external_urls?.spotify,
+          };
+        });
+
+        allPlaylists.push(...mapped);
+        nextUrl = data.next;
+      }
+
+      return allPlaylists;
+    } catch (error) {
+      this.log(`Failed to get user playlists: ${getErrorMessage(error)}`);
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-playlist-library.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist-library.service.ts
@@ -1,5 +1,5 @@
 import type { SpotifyPlaylist } from "@spotiarr/shared";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getEnv } from "../setup/environment";
 import { getErrorMessage } from "../utils/error.utils";
@@ -43,7 +43,7 @@ export class SpotifyPlaylistLibraryService extends SpotifyHttpClient {
   private playlistAccessProbeCooldownUntil = 0;
 
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     authService: SpotifyAuthService,
     limiterMode: SpotifyLimiterMode = "user",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-user-library.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-user-library.service.ts
@@ -1,82 +1,46 @@
-import type { AlbumType, ArtistRelease, FollowedArtist, SpotifyPlaylist } from "@spotiarr/shared";
+import type { ArtistRelease, FollowedArtist, SpotifyPlaylist } from "@spotiarr/shared";
+import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import type { SettingsService } from "@/application/services/settings.service";
 import { AppError } from "@/domain/errors/app-error";
-import { getEnv } from "../setup/environment";
-import { getErrorMessage } from "../utils/error.utils";
-import type { CacheEntry } from "./cache.types";
-import { PromiseCache } from "./promise-cache";
+import { SpotifyArtistCatalogService } from "./spotify-artist-catalog.service";
 import type { SpotifyAuthService } from "./spotify-auth.service";
-import { SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT } from "./spotify-constants";
-import { SpotifyHttpClient } from "./spotify-http.client";
-import type {
-  SpotifyArtistAlbumsResponse,
-  SpotifyArtistFull,
-  SpotifyFollowedArtistsResponse,
-  SpotifyImage,
-} from "./spotify.types";
+import { SpotifyFollowedArtistsService } from "./spotify-followed-artists.service";
+import { type SpotifyLimiterMode } from "./spotify-http.client";
+import {
+  isOwnedPlaylist,
+  needsPlaylistItemsAccessCheck,
+  SpotifyPlaylistLibraryService,
+  type SpotifyUserPlaylistItem,
+} from "./spotify-playlist-library.service";
 
-const FOLLOWED_ARTISTS_CACHE_KEY = "followed-artists:list";
-const FOLLOWED_ARTISTS_IN_FLIGHT_KEY = "followed-artists:in-flight";
-const PLAYLIST_ACCESS_CACHE_MAX_ENTRIES = 1_000;
-const PLAYLIST_ACCESS_ALLOWED_TTL_MS = 30 * 60 * 1000;
-const PLAYLIST_ACCESS_DENIED_TTL_MS = 5 * 60 * 1000;
-const PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS = 60 * 1000;
+export { isOwnedPlaylist, needsPlaylistItemsAccessCheck, type SpotifyUserPlaylistItem };
 
-type SpotifyCurrentUserResponse = {
-  id: string;
+type SpotifyUserLibraryDependencies = {
+  spotifyFollowedArtistsService: SpotifyFollowedArtistsService;
+  spotifyPlaylistLibraryService: SpotifyPlaylistLibraryService;
+  spotifyArtistCatalogService: SpotifyArtistCatalogService;
 };
 
-type PlaylistAccessStatus = "allowed" | "denied" | "rate_limited";
-
-type PlaylistAccessResult = {
-  status: PlaylistAccessStatus;
-  trackTotal?: number;
-};
-
-type PlaylistAccessCacheEntry = {
-  status: Exclude<PlaylistAccessStatus, "rate_limited">;
-  trackTotal?: number;
-  expiresAt: number;
-};
-
-export type SpotifyUserPlaylistItem = {
-  id: string;
-  name: string;
-  collaborative?: boolean;
-  images: SpotifyImage[];
-  owner: { id?: string; display_name: string; external_urls: { spotify: string } };
-  tracks?: { total?: number };
-  external_urls: { spotify: string };
-};
-
-export const isOwnedPlaylist = (item: SpotifyUserPlaylistItem, currentUserId: string) =>
-  item.owner?.id === currentUserId;
-
-export const needsPlaylistItemsAccessCheck = (
-  item: SpotifyUserPlaylistItem,
-  currentUserId: string,
-) => !isOwnedPlaylist(item, currentUserId);
-
-export class SpotifyUserLibraryService extends SpotifyHttpClient {
+export class SpotifyUserLibraryService implements SpotifyUserLibraryPort {
   private static instance: SpotifyUserLibraryService | null = null;
   private static syncInstance: SpotifyUserLibraryService | null = null;
-  private readonly cache: Map<string, CacheEntry<unknown>> = new Map();
-  private readonly playlistAccessCache = new Map<string, PlaylistAccessCacheEntry>();
-  private playlistAccessProbeCooldownUntil = 0;
-  private readonly inFlightPromises = new PromiseCache({ ttlMs: 30_000 });
 
-  private constructor(
-    private readonly settingsService: SettingsService,
-    authService: SpotifyAuthService,
-    limiterMode: "user" | "sync" = "user",
-  ) {
-    super(authService, limiterMode);
+  private constructor(private readonly deps: SpotifyUserLibraryDependencies) {}
+
+  // Compatibility bridge for existing tests during strangler phase.
+  private get playlistAccessCache() {
+    return (
+      this.deps.spotifyPlaylistLibraryService as unknown as {
+        playlistAccessCache: Map<string, { expiresAt: number }>;
+      }
+    ).playlistAccessCache;
   }
 
   static getInstance(
     settingsService?: SettingsService,
     authService?: SpotifyAuthService,
-    limiterMode: "user" | "sync" = "user",
+    limiterMode: SpotifyLimiterMode = "user",
+    deps?: SpotifyUserLibraryDependencies,
   ): SpotifyUserLibraryService {
     const instanceKey = limiterMode === "sync" ? "syncInstance" : "instance";
 
@@ -88,12 +52,28 @@ export class SpotifyUserLibraryService extends SpotifyHttpClient {
           "SettingsService and SpotifyAuthService must be provided when initializing SpotifyUserLibraryService",
         );
       }
+
       SpotifyUserLibraryService[instanceKey] = new SpotifyUserLibraryService(
-        settingsService,
-        authService,
-        limiterMode,
+        deps ?? {
+          spotifyFollowedArtistsService: new SpotifyFollowedArtistsService(
+            settingsService,
+            authService,
+            limiterMode,
+          ),
+          spotifyPlaylistLibraryService: new SpotifyPlaylistLibraryService(
+            settingsService,
+            authService,
+            limiterMode,
+          ),
+          spotifyArtistCatalogService: new SpotifyArtistCatalogService(
+            settingsService,
+            authService,
+            limiterMode,
+          ),
+        },
       );
     }
+
     return SpotifyUserLibraryService[instanceKey] as SpotifyUserLibraryService;
   }
 
@@ -102,487 +82,24 @@ export class SpotifyUserLibraryService extends SpotifyHttpClient {
     SpotifyUserLibraryService.syncInstance?.clearCache();
   }
 
-  private getCacheKey(method: string, ...args: unknown[]): string {
-    return `${method}:${JSON.stringify(args)}`;
-  }
-
-  private async getFromCache<T>(key: string): Promise<T | null> {
-    const entry = this.cache.get(key);
-    if (!entry) return null;
-
-    const cacheMinutes = await this.settingsService.getNumber("RELEASES_CACHE_MINUTES");
-    const cacheTTL = cacheMinutes * 60 * 1000;
-
-    const now = Date.now();
-    if (now - entry.createdAt > cacheTTL) {
-      this.cache.delete(key);
-      return null;
-    }
-
-    return entry.value as T;
-  }
-
-  private setCache<T>(key: string, data: T): void {
-    this.cache.set(key, {
-      value: data,
-      createdAt: Date.now(),
-      ttlMs: 0,
-    });
-  }
-
-  clearCache(): void {
-    this.cache.clear();
-    this.playlistAccessCache.clear();
-    this.playlistAccessProbeCooldownUntil = 0;
-    this.inFlightPromises.clear();
-    this.log("Cache cleared");
-  }
-
-  private getPlaylistAccessCache(playlistId: string): PlaylistAccessResult | null {
-    const entry = this.playlistAccessCache.get(playlistId);
-    if (!entry) return null;
-
-    if (Date.now() >= entry.expiresAt) {
-      this.playlistAccessCache.delete(playlistId);
-      return null;
-    }
-
-    return { status: entry.status, trackTotal: entry.trackTotal };
-  }
-
-  private setPlaylistAccessCache(
-    playlistId: string,
-    status: Exclude<PlaylistAccessStatus, "rate_limited">,
-    trackTotal?: number,
-  ): void {
-    const ttlMs =
-      status === "allowed" ? PLAYLIST_ACCESS_ALLOWED_TTL_MS : PLAYLIST_ACCESS_DENIED_TTL_MS;
-    this.playlistAccessCache.set(playlistId, {
-      status,
-      trackTotal,
-      expiresAt: Date.now() + ttlMs,
-    });
-
-    this.prunePlaylistAccessCache();
-  }
-
-  private prunePlaylistAccessCache(): void {
-    const now = Date.now();
-    for (const [playlistId, entry] of this.playlistAccessCache) {
-      if (now >= entry.expiresAt) {
-        this.playlistAccessCache.delete(playlistId);
-      }
-    }
-
-    while (this.playlistAccessCache.size > PLAYLIST_ACCESS_CACHE_MAX_ENTRIES) {
-      const oldestKey = this.playlistAccessCache.keys().next().value;
-      if (!oldestKey) break;
-      this.playlistAccessCache.delete(oldestKey);
-    }
-  }
-
-  private getRetryAfterMs(response: Response): number {
-    const retryAfter = response.headers.get("Retry-After");
-    if (!retryAfter) return PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS;
-
-    const seconds = Number(retryAfter);
-    if (Number.isFinite(seconds) && seconds > 0) {
-      return seconds * 1000;
-    }
-
-    const retryAt = Date.parse(retryAfter);
-    if (Number.isFinite(retryAt)) {
-      return Math.max(retryAt - Date.now(), PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS);
-    }
-
-    return PLAYLIST_ACCESS_RATE_LIMIT_FALLBACK_COOLDOWN_MS;
-  }
-
-  private isPlaylistAccessProbeCoolingDown(): boolean {
-    return Date.now() < this.playlistAccessProbeCooldownUntil;
-  }
-
-  private async getFollowedArtistsSnapshot(maxArtists: number): Promise<SpotifyArtistFull[]> {
-    const cacheKey = this.getCacheKey(FOLLOWED_ARTISTS_CACHE_KEY, maxArtists);
-    const cached = await this.getFromCache<SpotifyArtistFull[]>(cacheKey);
-
-    if (cached) {
-      return cached;
-    }
-
-    return this.inFlightPromises.getOrSet(
-      `${FOLLOWED_ARTISTS_IN_FLIGHT_KEY}:${maxArtists}`,
-      async () => {
-        const warmCache = await this.getFromCache<SpotifyArtistFull[]>(cacheKey);
-        if (warmCache) {
-          return warmCache;
-        }
-
-        const artists = await this.fetchAllFollowedArtists(maxArtists);
-        const slicedArtists = artists.slice(0, maxArtists);
-        this.setCache(cacheKey, slicedArtists);
-        return slicedArtists;
-      },
-    );
-  }
-
-  private log(message: string, level: "debug" | "error" | "warn" = "debug") {
-    const prefix = `[SpotifyUserLibraryService]`;
-    if (level === "error") console.error(prefix, message);
-    else if (level === "warn") console.warn(prefix, message);
-    else if (getEnv().NODE_ENV === "development") console.log(prefix, message);
-  }
-
-  private async getMarket(): Promise<string> {
-    try {
-      return await this.settingsService.getString("SPOTIFY_MARKET");
-    } catch {
-      return "ES";
-    }
-  }
-
-  private async getCurrentUserId(): Promise<string> {
-    const response = await this.fetchWithUserToken("https://api.spotify.com/v1/me");
-
-    if (!response.ok) {
-      if (response.status === 401) {
-        throw new AppError(
-          401,
-          "missing_user_access_token",
-          "Reconnect Spotify to grant the required playlist scopes.",
-        );
-      }
-
-      if (response.status === 403) {
-        throw new AppError(
-          401,
-          "missing_user_access_token",
-          "Reconnect Spotify to grant the user-read-private scope.",
-        );
-      }
-
-      const errorText = await response.text();
-      throw new AppError(
-        response.status,
-        "internal_server_error",
-        `Failed to fetch current Spotify user: ${response.status} ${errorText}`,
-      );
-    }
-
-    const data = (await response.json()) as SpotifyCurrentUserResponse;
-    return data.id;
-  }
-
-  private async canAccessPlaylistItems(playlistId: string): Promise<PlaylistAccessResult> {
-    const cached = this.getPlaylistAccessCache(playlistId);
-    if (cached) {
-      return cached;
-    }
-
-    if (this.isPlaylistAccessProbeCoolingDown()) {
-      return { status: "rate_limited" };
-    }
-
-    const fields = "total";
-    const url = `https://api.spotify.com/v1/playlists/${playlistId}/items?limit=1&fields=${encodeURIComponent(fields)}`;
-    const response = await this.fetchWithUserToken(url);
-
-    if (response.ok) {
-      const data = (await response.json()) as { total?: unknown };
-      const trackTotal =
-        typeof data.total === "number" && Number.isFinite(data.total) ? data.total : undefined;
-      this.setPlaylistAccessCache(playlistId, "allowed", trackTotal);
-      return { status: "allowed", trackTotal };
-    }
-
-    if (response.status === 403 || response.status === 404) {
-      this.setPlaylistAccessCache(playlistId, "denied");
-      return { status: "denied" };
-    }
-
-    if (response.status === 401) {
-      throw new AppError(
-        401,
-        "missing_user_access_token",
-        "Reconnect Spotify to grant the required playlist scopes.",
-      );
-    }
-
-    if (response.status === 429) {
-      const cooldownMs = this.getRetryAfterMs(response);
-      this.playlistAccessProbeCooldownUntil = Date.now() + cooldownMs;
-      this.log(
-        `Spotify rate limited playlist access probes; cooling down for ${cooldownMs}ms`,
-        "warn",
-      );
-      return { status: "rate_limited" };
-    }
-
-    const errorText = await response.text();
-    throw new AppError(
-      response.status >= 500 ? 502 : 500,
-      "internal_server_error",
-      `Failed to check playlist item access: ${response.status} ${errorText}`,
-    );
-  }
-
-  private async getPlaylistVisibility(
-    item: SpotifyUserPlaylistItem,
-    currentUserId: string,
-  ): Promise<PlaylistAccessResult> {
-    if (isOwnedPlaylist(item, currentUserId)) {
-      return { status: "allowed" };
-    }
-
-    return this.canAccessPlaylistItems(item.id);
+  async getFollowedArtists(): Promise<FollowedArtist[]> {
+    return this.deps.spotifyFollowedArtistsService.getFollowedArtists();
   }
 
   async getMyPlaylists(): Promise<SpotifyPlaylist[]> {
-    try {
-      this.log("Getting user's playlists from Spotify");
-      const currentUserId = await this.getCurrentUserId();
-      const allPlaylists: SpotifyPlaylist[] = [];
-
-      let nextUrl: string | null = "https://api.spotify.com/v1/me/playlists?limit=50";
-
-      while (nextUrl) {
-        const response: Response = await this.fetchWithUserToken(nextUrl);
-
-        if (!response.ok) {
-          if (response.status === 401) {
-            throw new AppError(
-              401,
-              "missing_user_access_token",
-              "Reconnect Spotify to grant the required playlist scopes.",
-            );
-          }
-
-          if (response.status === 403) {
-            throw new AppError(
-              401,
-              "missing_user_access_token",
-              "Reconnect Spotify to grant the user-read-private and playlist-read-private scopes.",
-            );
-          }
-
-          const errorText = await response.text();
-          throw new AppError(
-            response.status,
-            "internal_server_error",
-            `Failed to fetch user playlists: ${response.status} ${errorText}`,
-          );
-        }
-
-        const data = (await response.json()) as {
-          items: SpotifyUserPlaylistItem[];
-          next: string | null;
-        };
-
-        const accessibleItems: { item: SpotifyUserPlaylistItem; trackTotal?: number }[] = [];
-
-        for (const item of data.items) {
-          const visibility = await this.getPlaylistVisibility(item, currentUserId);
-          if (visibility.status === "allowed") {
-            accessibleItems.push({ item, trackTotal: visibility.trackTotal });
-          }
-        }
-
-        const mapped = accessibleItems.map(({ item, trackTotal }) => {
-          const playlistTrackTotal = item.tracks?.total;
-          const tracks =
-            typeof playlistTrackTotal === "number" && Number.isFinite(playlistTrackTotal)
-              ? playlistTrackTotal
-              : (trackTotal ?? 0);
-
-          return {
-            id: item.id,
-            name: item.name,
-            image: item.images?.[0]?.url ?? null,
-            owner: item.owner?.display_name ?? "Unknown",
-            tracks,
-            spotifyUrl: item.external_urls?.spotify,
-            ownerUrl: item.owner?.external_urls?.spotify,
-          };
-        });
-
-        allPlaylists.push(...mapped);
-        nextUrl = data.next;
-      }
-
-      return allPlaylists;
-    } catch (error) {
-      this.log(`Failed to get user playlists: ${getErrorMessage(error)}`);
-      throw error;
-    }
+    return this.deps.spotifyPlaylistLibraryService.getMyPlaylists();
   }
 
   async getArtistCatalogData(
     artists: { id: string; name: string; imageUrl?: string | null }[],
     earlyStopBeforeDate?: Date,
   ): Promise<ArtistRelease[]> {
-    const market = await this.getMarket();
-    const albumsPerArtist: ArtistRelease[][] = [];
-
-    for (const artist of artists) {
-      const albums: ArtistRelease[] = [];
-      let offset = 0;
-      let shouldStop = false;
-
-      while (!shouldStop) {
-        const albumsUrl = `https://api.spotify.com/v1/artists/${artist.id}/albums?include_groups=album,single,compilation&limit=${SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT}&offset=${offset}&market=${market}`;
-        const albumsResponse = await this.fetchWithAppToken(albumsUrl);
-
-        if (!albumsResponse.ok) {
-          const errorText = await albumsResponse.text();
-
-          if (albumsResponse.status === 429) {
-            throw new AppError(
-              429,
-              "spotify_rate_limited",
-              "Rate limited by Spotify API while fetching artist catalog.",
-            );
-          }
-
-          this.log(
-            `Failed to fetch catalog for artist ${artist.id}: ${albumsResponse.status} ${errorText}`,
-            "warn",
-          );
-          break;
-        }
-
-        const albumsData = (await albumsResponse.json()) as SpotifyArtistAlbumsResponse;
-        const pageAlbums = albumsData.items ?? [];
-
-        if (pageAlbums.length === 0) {
-          break;
-        }
-
-        const mapped = pageAlbums.map((album) => ({
-          artistId: artist.id,
-          artistName: artist.name,
-          artistImageUrl: artist.imageUrl ?? null,
-          albumId: album.id as string,
-          albumName: album.name,
-          albumType: album.album_type as AlbumType,
-          releaseDate: album.release_date,
-          coverUrl: album.images?.[0]?.url ?? null,
-          spotifyUrl: album.external_urls?.spotify,
-          totalTracks: album.total_tracks,
-        }));
-
-        albums.push(...mapped);
-
-        if (earlyStopBeforeDate && mapped.length > 0) {
-          const oldestOnPage = mapped[mapped.length - 1];
-          if (oldestOnPage.releaseDate) {
-            const parts = oldestOnPage.releaseDate.split("-");
-            const year = Number(parts[0]);
-            const month = parts.length >= 2 ? Number(parts[1]) - 1 : 0;
-            const day = parts.length >= 3 ? Number(parts[2]) : 1;
-            if (!Number.isNaN(year) && year > 0) {
-              const oldestDate = new Date(year, month, day);
-              if (oldestDate < earlyStopBeforeDate) {
-                shouldStop = true;
-              }
-            }
-          }
-        }
-
-        if (pageAlbums.length < SPOTIFY_ARTIST_ALBUMS_MAX_LIMIT) {
-          break;
-        }
-
-        offset += pageAlbums.length;
-      }
-
-      albumsPerArtist.push(albums);
-    }
-
-    return albumsPerArtist.flat();
+    return this.deps.spotifyArtistCatalogService.getArtistCatalogData(artists, earlyStopBeforeDate);
   }
 
-  async getFollowedArtists(): Promise<FollowedArtist[]> {
-    const cacheKey = this.getCacheKey("getFollowedArtists");
-    const cached = await this.getFromCache<FollowedArtist[]>(cacheKey);
-    if (cached) {
-      this.log("Returning cached followed artists list");
-      return cached;
-    }
-
-    try {
-      const maxArtists = await this.settingsService.getNumber("FOLLOWED_ARTISTS_MAX");
-      const artists = await this.getFollowedArtistsSnapshot(maxArtists);
-
-      const sliced = artists.slice(0, maxArtists);
-
-      const sorted = sliced.sort((a, b) => a.name.localeCompare(b.name));
-
-      const mapped = sorted.map((artist) => ({
-        id: artist.id,
-        name: artist.name,
-        image: artist.images?.[0]?.url ?? null,
-        spotifyUrl: artist.external_urls?.spotify ?? null,
-      }));
-
-      this.setCache(cacheKey, mapped);
-      return mapped;
-    } catch (error) {
-      this.log(`Failed to get followed artists list: ${getErrorMessage(error)}`);
-      throw error;
-    }
-  }
-
-  private async fetchAllFollowedArtists(maxArtists: number): Promise<SpotifyArtistFull[]> {
-    const artists: SpotifyArtistFull[] = [];
-    let after: string | undefined;
-    const pageLimit = Math.min(Math.max(maxArtists, 1), 50);
-
-    do {
-      const url = new URL("https://api.spotify.com/v1/me/following");
-      url.searchParams.set("type", "artist");
-      url.searchParams.set("limit", pageLimit.toString());
-      if (after) {
-        url.searchParams.set("after", after);
-      }
-
-      const response = await this.fetchWithUserToken(url.toString());
-
-      if (!response.ok) {
-        const errorText = await response.text();
-
-        if (response.status === 401) {
-          throw new AppError(
-            401,
-            "missing_user_access_token",
-            "Spotify user token expired or invalid",
-          );
-        }
-
-        if (response.status === 429) {
-          throw new AppError(
-            429,
-            "spotify_rate_limited",
-            `Spotify rate limit exceeded while fetching followed artists: ${errorText}`,
-          );
-        }
-
-        throw new AppError(
-          response.status,
-          "failed_to_fetch_followed_artists",
-          `Failed to fetch followed artists: ${response.status} ${errorText}`,
-        );
-      }
-
-      const data = (await response.json()) as SpotifyFollowedArtistsResponse;
-      const pageArtists = data.artists?.items ?? [];
-      artists.push(...pageArtists);
-      after = data.artists?.cursors?.after;
-
-      if (artists.length >= maxArtists) {
-        break;
-      }
-    } while (after);
-
-    return artists;
+  clearCache(): void {
+    this.deps.spotifyFollowedArtistsService.clearCache();
+    this.deps.spotifyPlaylistLibraryService.clearCache();
+    this.deps.spotifyArtistCatalogService.clearCache();
   }
 }

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -1,10 +1,10 @@
 import { Worker } from "bullmq";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import type { SettingsService } from "@/application/services/settings.service";
 import { container } from "@/container";
 import { SYNC_STATUS } from "../database/feed.repository";
 import type { ReleaseFeedService } from "../external/release-feed.service";
-import type { SpotifyUserLibraryService } from "../external/spotify-user-library.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { FEED_SYNC_QUEUE } from "../setup/queues";
@@ -22,7 +22,7 @@ const RELEASES_ACTIVITY_WINDOW_DAYS = 90;
 const MAX_RELEASES_ARTISTS_PER_CYCLE = 15;
 
 export interface FeedSyncJobDependencies {
-  spotifyUserLibrarySyncService: SpotifyUserLibraryService;
+  spotifyUserLibrarySyncService: SpotifyUserLibraryPort;
   releaseFeedService: ReleaseFeedService;
   feedRepository: FeedRepositoryPort;
   eventBus: AppEventBus;


### PR DESCRIPTION
## Why

`apps/backend/src/infrastructure/external/spotify-user-library.service.ts` had grown to 588 LOC mixing followed-artists fetch, playlist access probing, artist catalog data, and singleton/cache infra in one class. This PR splits it under the strangler pattern, in line with PR 1/3 (`feed.repository` split).

## What changed (PR 2/3)

- **Created 3 specialised services** in `infrastructure/external/`:
  - `SpotifyFollowedArtistsService` — followed-artists fetch + pagination + in-flight dedupe + request cache.
  - `SpotifyPlaylistLibraryService` — current-user lookup, playlist access probing, per-playlist access cache, 429 cooldown, `getMyPlaylists`.
  - `SpotifyArtistCatalogService` — market resolution, artist albums pagination, early-stop, request cache.
- **Converted** `SpotifyUserLibraryService` into a **strangler facade** delegating to the 3 new services. Preserves `getInstance()` singleton (user + sync contexts) and `clearCache` semantics so existing consumers and the 340-LOC service test keep working unchanged.
- **Decoupled consumers from the concrete facade**:
  - `feed-sync.worker.ts` now depends on `SpotifyUserLibraryPort` instead of the concrete class.
  - `spotify-auth.service.ts` no longer imports the concrete facade — it now receives an injected `invalidateUserLibraryCache` callback wired in `container.ts`.
- **Introduced `SettingsPort`** (`apps/backend/src/application/ports/settings.port.ts`) and routed the 3 new split services through it. `SettingsService` declares `implements SettingsPort`. Container wiring unchanged.
- **Bug fixed (caught by re-verify)**: `spotifyServiceSync` was wired with the **user-context** `SpotifyUserLibraryService` at `container.ts:269`. Now correctly wired with `spotifyUserLibrarySyncService`, so sync paths use their own rate limiter / cache.
- **Bug fixed (caught by re-verify)**: `exchangeCodeForToken()` no longer invalidated user-library caches after the original static `clearGlobalCache()` was removed. Login/reconnect could leave stale followed-artists/playlist/catalog entries from the previous token. Now calls the invalidator callback after successful token persistence. Covered by 4 new tests in `spotify-auth.service.test.ts`.

## What did NOT change

- 0 API/route changes.
- 0 DB schema / Prisma migration changes.
- 0 public DTO or shared package changes.
- 0 changes to `SpotifyUserLibraryPort` (still just `getFollowedArtists` + `clearCache`).
- 0 changes to `SpotifyService` public API.
- `spotify-user-library.service.test.ts` (340 LOC) passes unchanged in assertions thanks to the strangler facade.

## Deferred (consciously, out of PR2 scope)

The verifier flagged that preexisting infra files (`spotify-auth.service.ts`, `feed-sync.worker.ts`, the facade itself, plus legacy clients like `spotify-base.client.ts`, `spotify-track.client.ts`, `youtube-search.service.ts`, etc.) still import the concrete `SettingsService`. PR2 introduced `SettingsPort` for the new split services — the seam its scope required. Migrating the rest of the legacy infra requires either extending `SettingsPort` to cover write/delete (auth needs `setString`/`delete`) or introducing a separate auth-settings port. Both deserve their own design discussion and are queued as follow-up for PR 3/3 cutover or a small dedicated SDD.

## Chain context (feature-branch-chain)

This is **PR 2 of 3**. Target branch: tracker `refactor/feed-sync-refactor` (PR 1/3 already merged at commit `71889a2`).

| PR | Scope | Target |
|----|-------|--------|
| 1/3 | Split `feed.repository.ts` + strangler facade | merged into tracker |
| 2/3 (this) | Split `spotify-user-library.service.ts` + decouple consumers + new `SettingsPort` | tracker |
| 3/3 | Cutover — remove both facades, eliminate legacy files, callers consume splits directly | builds on this |

Only the tracker merges to `main`, after all three slices verify.

## Tests

- Strict TDD followed for the `SpotifyAuthService` invalidator bug: RED-first test, then minimal GREEN.
- New unit specs for each of the 3 split services + `SpotifyAuthService`.
- Existing `spotify-user-library.service.test.ts` untouched in assertions — preserved behaviour via facade.
- Total backend tests: **202** (up from 189 at end of PR1).
- TDD Cycle Evidence: see Engram apply-progress `sdd/feed-sync-refactor/apply-progress` (#2766).

## Quality gates

- `pnpm --filter backend run lint` ✅ — 0 errors (14 preexisting `no-explicit-any` warnings in PR1 database test files only)
- `pnpm --filter backend run test:run` ✅ — 34 files / 202 tests
- `pnpm --filter backend run build` ✅
- `__tests__/architecture.test.ts` ✅ — R1–R4 invariants still hold

## Verify journey (3 rounds)

| Round | Verdict | Action |
|-------|---------|--------|
| 1 | BLOCKED — concrete `SpotifyUserLibraryService` leaks + concrete `SettingsService` in 3 new split services | fix-blockers: SettingsPort introduced + worker/auth decoupled + sync-context wiring fixed |
| 2 | BLOCKED — auth `exchangeCodeForToken` regression (missed invalidator) + scope-expanded settings-port audit | fix-blockers: bug fixed with RED-first test + `SettingsPort` trimmed; settings-port broader migration deferred by scope decision |
| 3 | APPROVED ✅ — 0 CRITICAL, 0 WARNING, 1 SUGGESTION, 3 deferred follow-ups | open PR2 |

## SDD artifacts (Engram)

- `sdd/feed-sync-refactor/explore` (#2760)
- `sdd/feed-sync-refactor/proposal` (#2761)
- `sdd/feed-sync-refactor/spec` (#2762)
- `sdd/feed-sync-refactor/design` (#2763)
- `sdd/feed-sync-refactor/tasks` (#2765)
- `sdd/feed-sync-refactor/apply-progress` (#2766) — includes PR1 + PR2 + 2 fix-blocker rounds + deferred-scope decision
- `sdd/feed-sync-refactor/verify-report` (#2767)

## Rollback

Revert merge. `SpotifyUserLibraryService` is preserved as facade in this PR — production behaviour stays on the original API surface until PR 3/3.
