### PR TITLE
refactor(frontend): extract AlbumPageLayout (library-views-revamp 1/3)

### DIFF
--- a/apps/frontend/src/components/molecules/AlbumPageLayout.test.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.test.tsx
@@ -1,0 +1,57 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AlbumPageLayout } from "./AlbumPageLayout";
+
+vi.mock("./PlaylistHeader", () => ({
+  PlaylistHeader: ({ title }: { title: string }) => <div>{title}</div>,
+}));
+
+vi.mock("../organisms/PlaylistTracksList", () => ({
+  PlaylistTracksList: ({ tracks }: { tracks: Array<{ id: string }> }) => (
+    <div data-testid="tracks-list">{tracks.map((track) => track.id).join(",")}</div>
+  ),
+}));
+
+describe("AlbumPageLayout", () => {
+  it("renders empty state when tracks are missing", () => {
+    render(
+      <AlbumPageLayout
+        title="Test Album"
+        type={PlaylistTypeEnum.Album}
+        totalCount={0}
+        tracks={[]}
+        emptyTitle="playlist.emptyTracksTitle"
+        emptyDescription="playlist.emptyTracksDescription"
+      />,
+    );
+
+    expect(screen.getByText("Test Album")).toBeDefined();
+    expect(screen.getByText("playlist.emptyTracksTitle")).toBeDefined();
+    expect(screen.getByText("playlist.emptyTracksDescription")).toBeDefined();
+  });
+
+  it("renders actions and tracks when tracks exist", () => {
+    render(
+      <AlbumPageLayout
+        title="Test Album"
+        type={PlaylistTypeEnum.Album}
+        totalCount={1}
+        tracks={[
+          {
+            id: "track-1",
+            name: "Track 1",
+            artist: "Artist 1",
+            status: TrackStatusEnum.New,
+          },
+        ]}
+        actions={<button type="button">action</button>}
+        emptyTitle="playlist.emptyTracksTitle"
+        emptyDescription="playlist.emptyTracksDescription"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "action" })).toBeDefined();
+    expect(screen.getByTestId("tracks-list").textContent).toContain("track-1");
+  });
+});

--- a/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
@@ -1,0 +1,78 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { PlaylistTypeEnum } from "@spotiarr/shared";
+import { FC, ReactNode } from "react";
+import { Track } from "@/types";
+import { PlaylistTracksList } from "../organisms/PlaylistTracksList";
+import { EmptyState } from "./EmptyState";
+import { PlaylistHeader } from "./PlaylistHeader";
+
+export interface AlbumPageLayoutProps {
+  title: string;
+  type: PlaylistTypeEnum;
+  coverUrl?: string | null;
+  description?: ReactNode;
+  metadata?: ReactNode;
+  totalCount: number;
+  tracks: Track[];
+  actions?: ReactNode;
+  emptyTitle: string;
+  emptyDescription: string;
+  onRetryTrack?: (trackId: string) => void;
+  onDownloadTrack?: (track: Track) => void;
+  hasMoreTracks?: boolean;
+  isLoadingMoreTracks?: boolean;
+  onLoadMoreTracks?: () => void;
+}
+
+export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
+  title,
+  type,
+  coverUrl,
+  description,
+  metadata,
+  totalCount,
+  tracks,
+  actions,
+  emptyTitle,
+  emptyDescription,
+  onRetryTrack,
+  onDownloadTrack,
+  hasMoreTracks = false,
+  isLoadingMoreTracks = false,
+  onLoadMoreTracks,
+}) => {
+  return (
+    <div className="bg-background text-text-primary flex-1">
+      <PlaylistHeader
+        title={title}
+        type={type || PlaylistTypeEnum.Playlist}
+        coverUrl={coverUrl || null}
+        description={description}
+        metadata={metadata}
+        totalCount={totalCount}
+      />
+
+      {actions}
+
+      <div className="px-6 pb-8 md:px-8">
+        {tracks.length === 0 ? (
+          <EmptyState
+            icon={faMusic}
+            title={emptyTitle}
+            description={emptyDescription}
+            className="py-12"
+          />
+        ) : (
+          <PlaylistTracksList
+            tracks={tracks}
+            onRetryTrack={onRetryTrack}
+            onDownloadTrack={onDownloadTrack}
+            onLoadMoreTracks={onLoadMoreTracks}
+            hasMoreTracks={hasMoreTracks}
+            isLoadingMoreTracks={isLoadingMoreTracks}
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/organisms/Playlist.test.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.test.tsx
@@ -1,0 +1,163 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AlbumPageLayoutProps } from "../molecules/AlbumPageLayout";
+import { Playlist } from "./Playlist";
+
+const albumPageLayoutSpy = vi.fn<(props: AlbumPageLayoutProps) => void>();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: { name?: string }) => {
+      if (key === "playlist.deleteModal.title") {
+        return `Delete ${params?.name}`;
+      }
+
+      return key;
+    },
+  }),
+}));
+
+vi.mock("../molecules/AlbumPageLayout", () => ({
+  AlbumPageLayout: (props: AlbumPageLayoutProps) => {
+    albumPageLayoutSpy(props);
+
+    return (
+      <div>
+        <button type="button" onClick={() => props.onDownloadTrack?.(props.tracks[0])}>
+          trigger-track-download
+        </button>
+        <button type="button" onClick={() => props.onRetryTrack?.(props.tracks[0]?.id ?? "")}>
+          trigger-track-retry
+        </button>
+        <div data-testid="layout-tracks-count">{props.tracks.length}</div>
+        {props.actions}
+      </div>
+    );
+  },
+}));
+
+vi.mock("../molecules/PlaylistActions", () => ({
+  PlaylistActions: ({
+    onDownload,
+    onDelete,
+    onRetryFailed,
+    onToggleSubscription,
+  }: {
+    onDownload: () => void;
+    onDelete: () => void;
+    onRetryFailed?: () => void;
+    onToggleSubscription?: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onDownload}>
+        action-download-or-retry
+      </button>
+      <button type="button" onClick={onDelete}>
+        action-delete
+      </button>
+      <button type="button" onClick={onRetryFailed}>
+        action-retry-failed
+      </button>
+      <button type="button" onClick={onToggleSubscription}>
+        action-toggle-subscription
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("../organisms/ConfirmModal", () => ({
+  ConfirmModal: ({ isOpen, onConfirm }: { isOpen: boolean; onConfirm: () => void }) =>
+    isOpen ? (
+      <div role="dialog" aria-label="confirm-delete">
+        <button type="button" onClick={onConfirm}>
+          confirm-delete
+        </button>
+      </div>
+    ) : null,
+}));
+
+describe("Playlist", () => {
+  it("wires catalog actions, delete flow, and track callbacks through AlbumPageLayout", () => {
+    const onDownloadOrRetry = vi.fn();
+    const onDownloadTrack = vi.fn();
+    const onRetryTrack = vi.fn();
+    const onConfirmDelete = vi.fn();
+    const onRetryFailed = vi.fn();
+    const onToggleSubscription = vi.fn();
+
+    const tracks = [
+      {
+        id: "track-1",
+        name: "Track 1",
+        artist: "Artist 1",
+        status: TrackStatusEnum.New,
+      },
+    ];
+
+    render(
+      <Playlist
+        playlist={{
+          id: "playlist-1",
+          name: "Playlist 1",
+          type: PlaylistTypeEnum.Album,
+          owner: "Owner",
+          stats: {
+            completedCount: 0,
+            downloadingCount: 0,
+            searchingCount: 0,
+            queuedCount: 0,
+            activeCount: 0,
+            errorCount: 0,
+            totalCount: 1,
+            progress: 0,
+            isDownloading: false,
+            hasErrors: false,
+            isCompleted: false,
+          },
+        }}
+        tracks={tracks}
+        hasFailed={true}
+        isRetrying={false}
+        isDownloading={false}
+        isDownloaded={false}
+        isSaved={true}
+        displayTitle="Playlist Title"
+        completedCount={0}
+        onDownloadOrRetry={onDownloadOrRetry}
+        onDownloadTrack={onDownloadTrack}
+        onRetryTrack={onRetryTrack}
+        onConfirmDelete={onConfirmDelete}
+        onRetryFailed={onRetryFailed}
+        onToggleSubscription={onToggleSubscription}
+      />,
+    );
+
+    expect(screen.getByTestId("layout-tracks-count").textContent).toBe("1");
+
+    fireEvent.click(screen.getByRole("button", { name: "action-download-or-retry" }));
+    expect(onDownloadOrRetry).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "action-retry-failed" }));
+    expect(onRetryFailed).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "action-toggle-subscription" }));
+    expect(onToggleSubscription).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "trigger-track-download" }));
+    expect(onDownloadTrack).toHaveBeenCalledWith(tracks[0]);
+
+    fireEvent.click(screen.getByRole("button", { name: "trigger-track-retry" }));
+    expect(onRetryTrack).toHaveBeenCalledWith("track-1");
+
+    expect(screen.queryByRole("dialog", { name: "confirm-delete" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "action-delete" }));
+    expect(screen.getByRole("dialog", { name: "confirm-delete" })).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "confirm-delete" }));
+    expect(onConfirmDelete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog", { name: "confirm-delete" })).toBeNull();
+
+    expect(albumPageLayoutSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -1,16 +1,13 @@
-import { faMusic } from "@fortawesome/free-solid-svg-icons";
 import { PlaylistTypeEnum } from "@spotiarr/shared";
 import { FC, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PlaylistWithStats } from "@/types";
 import { Track } from "@/types";
-import { EmptyState } from "../molecules/EmptyState";
+import { AlbumPageLayout } from "../molecules/AlbumPageLayout";
 import { PlaylistActions } from "../molecules/PlaylistActions";
 import { PlaylistDescription } from "../molecules/PlaylistDescription";
-import { PlaylistHeader } from "../molecules/PlaylistHeader";
 import { PlaylistMetadata } from "../molecules/PlaylistMetadata";
 import { ConfirmModal } from "../organisms/ConfirmModal";
-import { PlaylistTracksList } from "../organisms/PlaylistTracksList";
 
 interface PlaylistProps {
   playlist: PlaylistWithStats;
@@ -73,72 +70,57 @@ export const Playlist: FC<PlaylistProps> = ({
 
   return (
     <>
-      <div className="bg-background text-text-primary flex-1">
-        <PlaylistHeader
-          title={displayTitle}
-          type={playlist.type || PlaylistTypeEnum.Playlist}
-          coverUrl={playlist.coverUrl || null}
-          description={
-            <PlaylistDescription
-              description={playlist.description}
-              completedCount={completedCount}
-              totalCount={totalCount}
-              isDownloading={isDownloading}
-            />
-          }
-          metadata={
-            <PlaylistMetadata
-              type={playlist.type || PlaylistTypeEnum.Playlist}
-              tracks={tracks}
-              owner={playlist.owner}
-              ownerUrl={playlist.ownerUrl}
-            />
-          }
-          totalCount={totalCount}
-        />
-
-        {/* Action Bar */}
-        <div className="to-background bg-gradient-to-b from-black/20 px-6 py-6 md:px-8">
-          <PlaylistActions
-            isSubscribed={!!playlist?.subscribed}
-            hasFailed={hasFailed}
-            isRetrying={isRetrying}
+      <AlbumPageLayout
+        title={displayTitle}
+        type={playlist.type || PlaylistTypeEnum.Playlist}
+        coverUrl={playlist.coverUrl || null}
+        description={
+          <PlaylistDescription
+            description={playlist.description}
+            completedCount={completedCount}
+            totalCount={totalCount}
             isDownloading={isDownloading}
-            isDownloaded={isDownloaded ?? false}
-            isSaved={isSaved}
-            onToggleSubscription={onToggleSubscription}
-            onRetryFailed={onRetryFailed}
-            onDelete={handleDelete}
-            onDownload={onDownloadOrRetry}
-            spotifyUrl={
-              playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")
-                ? playlist.spotifyUrl
-                : undefined
-            }
           />
-        </div>
-
-        {/* Content */}
-        <div className="px-6 pb-8 md:px-8">
-          {tracks.length === 0 ? (
-            <EmptyState
-              icon={faMusic}
-              title={t("playlist.emptyTracksTitle")}
-              description={t("playlist.emptyTracksDescription")}
-              className="py-12"
+        }
+        metadata={
+          <PlaylistMetadata
+            type={playlist.type || PlaylistTypeEnum.Playlist}
+            tracks={tracks}
+            owner={playlist.owner}
+            ownerUrl={playlist.ownerUrl}
+          />
+        }
+        totalCount={totalCount}
+        tracks={tracks}
+        actions={
+          <div className="to-background bg-gradient-to-b from-black/20 px-6 py-6 md:px-8">
+            <PlaylistActions
+              isSubscribed={!!playlist?.subscribed}
+              hasFailed={hasFailed}
+              isRetrying={isRetrying}
+              isDownloading={isDownloading}
+              isDownloaded={isDownloaded ?? false}
+              isSaved={isSaved}
+              onToggleSubscription={onToggleSubscription}
+              onRetryFailed={onRetryFailed}
+              onDelete={handleDelete}
+              onDownload={onDownloadOrRetry}
+              spotifyUrl={
+                playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")
+                  ? playlist.spotifyUrl
+                  : undefined
+              }
             />
-          ) : (
-            <PlaylistTracksList
-              tracks={tracks}
-              onRetryTrack={onRetryTrack}
-              onDownloadTrack={onDownloadTrack}
-              onLoadMoreTracks={onLoadMoreTracks}
-              hasMoreTracks={hasMoreTracks}
-              isLoadingMoreTracks={isLoadingMoreTracks}
-            />
-          )}
-        </div>
-      </div>
+          </div>
+        }
+        emptyTitle={t("playlist.emptyTracksTitle")}
+        emptyDescription={t("playlist.emptyTracksDescription")}
+        onRetryTrack={onRetryTrack}
+        onDownloadTrack={onDownloadTrack}
+        onLoadMoreTracks={onLoadMoreTracks}
+        hasMoreTracks={hasMoreTracks}
+        isLoadingMoreTracks={isLoadingMoreTracks}
+      />
 
       <ConfirmModal
         isOpen={isDeleteModalOpen}


### PR DESCRIPTION
## Why

First slice of `library-views-revamp` (SDD). Foundation step that extracts a shared `AlbumPageLayout` molecule from the catalog `Playlist` organism so the upcoming library album detail view can reuse the same visual structure without dragging catalog-only actions (download, retry, subscribe, delete).

## What

- New `AlbumPageLayout` molecule with exported `AlbumPageLayoutProps` type.
- `Playlist` organism refactored to consume the shared layout — catalog behavior preserved.
- Regression tests on `Playlist` covering action wiring (download/retry/subscribe/delete) and delete confirmation.
- Component tests on `AlbumPageLayout`.

## Out of scope (next PRs)

- 2/3 — Card redesign (`LibraryArtistCard` + new `LibraryAlbumGridCard`).
- 3/3 — New `/library/artist/:name/album/:albumName` route + `LibraryAlbumDetail` view + i18n.

## Validation

- `pnpm --filter frontend run lint` ✅
- `pnpm --filter frontend run test:run` ✅ (9 files / 55 tests)
- `pnpm --filter frontend run build` ✅

## Stack

Chained PR strategy: `stacked-to-main`. This is PR 1 of 3, each targeting `main`.