### PR TITLE
feat(frontend): add library album detail route + page (library-views-revamp 3/3)

### DIFF
--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -1,0 +1,136 @@
+import { LibraryArtist, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { renderHook } from "@testing-library/react";
+import { generatePath } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+import { useLibraryAlbumDetailController } from "./useLibraryAlbumDetailController";
+
+const mockUseParams = vi.fn();
+const mockUseLibraryArtistQuery = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("@/hooks/queries/useLibraryArtistQuery", () => ({
+  useLibraryArtistQuery: (name: string) => mockUseLibraryArtistQuery(name),
+}));
+
+const makeArtist = (): LibraryArtist => ({
+  name: "Sigur Rós",
+  path: "/library/sigur-ros",
+  image: "covers/sigur.jpg",
+  albumCount: 1,
+  trackCount: 2,
+  totalSize: 300,
+  albums: [
+    {
+      name: "( )",
+      path: "/library/sigur-ros/()",
+      artist: "Sigur Rós",
+      trackCount: 2,
+      totalSize: 300,
+      year: 2002,
+      image: "covers/album.jpg",
+      tracks: [
+        {
+          fileName: "01.mp3",
+          filePath: "/tmp/01.mp3",
+          trackNumber: 1,
+          name: "Vaka",
+          artist: "Sigur Rós",
+          album: "( )",
+          format: "mp3",
+          size: 100,
+          modifiedAt: 1,
+        },
+        {
+          fileName: "02.mp3",
+          filePath: "/tmp/02.mp3",
+          trackNumber: 2,
+          name: "Fyrsta",
+          artist: "Sigur Rós",
+          album: "( )",
+          format: "mp3",
+          size: 200,
+          modifiedAt: 2,
+        },
+      ],
+    },
+  ],
+});
+
+describe("useLibraryAlbumDetailController", () => {
+  it("decodes params, resolves album and maps tracks to AlbumPageLayout shape", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(mockUseLibraryArtistQuery).toHaveBeenCalledWith("Sigur Rós");
+    expect(result.current.album?.name).toBe("( )");
+    expect(result.current.playlistType).toBe(PlaylistTypeEnum.Album);
+    expect(result.current.coverUrl).toContain("/api/library/image?path=");
+    expect(result.current.tracks).toHaveLength(2);
+    expect(result.current.tracks[0]?.status).toBe(TrackStatusEnum.Completed);
+  });
+
+  it("builds back link with raw artist name and router handles encoding once", () => {
+    const artistName = "Café del Mar / 100% Hits";
+
+    mockUseParams.mockReturnValue({
+      name: artistName,
+      albumName: "Best Of",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: {
+        ...makeArtist(),
+        name: artistName,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.backToArtistPath).toBe(
+      generatePath(Path.LIBRARY_ARTIST, {
+        name: artistName,
+      }),
+    );
+    expect(result.current.backToArtistPath).toContain(
+      "Caf%C3%A9%20del%20Mar%20%2F%20100%25%20Hits",
+    );
+    expect(result.current.backToArtistPath).not.toContain("%2525");
+  });
+
+  it("returns not-found state when album does not exist", () => {
+    mockUseParams.mockReturnValue({ name: "Sigur%20R%C3%B3s", albumName: "missing" });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.album).toBeUndefined();
+    expect(result.current.isNotFound).toBe(true);
+    expect(result.current.tracks).toEqual([]);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -1,0 +1,63 @@
+import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { generatePath, useParams } from "react-router-dom";
+import { Path } from "@/routes/routes";
+import { Track } from "@/types";
+import { useLibraryArtistQuery } from "../queries/useLibraryArtistQuery";
+
+const safeDecodeURIComponent = (value: string | undefined): string => {
+  if (!value) {
+    return "";
+  }
+
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const useLibraryAlbumDetailController = () => {
+  const { name, albumName } = useParams<{ name: string; albumName: string }>();
+
+  const artistName = safeDecodeURIComponent(name);
+  const selectedAlbumName = safeDecodeURIComponent(albumName);
+
+  const { data: artist, isLoading, error } = useLibraryArtistQuery(artistName);
+
+  const album = artist?.albums.find((candidate) => candidate.name === selectedAlbumName);
+
+  const tracks: Track[] =
+    album?.tracks.map((track, index) => ({
+      id: `${artistName}-${album.name}-${index}`,
+      playlistId: album.path,
+      name: track.name,
+      artist: track.artist,
+      artists: [{ name: track.artist, url: undefined }],
+      album: track.album,
+      durationMs: 0,
+      status: TrackStatusEnum.Completed,
+      trackUrl: undefined,
+      albumUrl: undefined,
+    })) ?? [];
+
+  const coverUrl = album?.image
+    ? `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/image?path=${encodeURIComponent(album.image)}`
+    : undefined;
+
+  const backToArtistPath = generatePath(Path.LIBRARY_ARTIST, {
+    name: artistName,
+  });
+
+  return {
+    artistName,
+    albumName: selectedAlbumName,
+    album,
+    tracks,
+    coverUrl,
+    isLoading,
+    error,
+    isNotFound: !isLoading && !error && (!artist || !album),
+    playlistType: PlaylistTypeEnum.Album,
+    backToArtistPath,
+  };
+};

--- a/apps/frontend/src/hooks/controllers/useLibraryArtistController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryArtistController.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook } from "@testing-library/react";
+import { generatePath } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+import { useLibraryArtistController } from "./useLibraryArtistController";
+
+const mockUseParams = vi.fn();
+const mockUseNavigate = vi.fn();
+const mockUseLibraryArtistQuery = vi.fn();
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+    useNavigate: () => mockUseNavigate,
+  };
+});
+
+vi.mock("@/hooks/queries/useLibraryArtistQuery", () => ({
+  useLibraryArtistQuery: (name: string) => mockUseLibraryArtistQuery(name),
+}));
+
+describe("useLibraryArtistController", () => {
+  it("builds album detail link with raw params and router encodes once", () => {
+    const artistName = "Café del Mar / 100% Hits";
+    const albumName = "Niñez / Éxitos 100%";
+
+    mockUseParams.mockReturnValue({ name: artistName });
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: {
+        name: artistName,
+        albums: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryArtistController());
+
+    result.current.handleAlbumClick(albumName);
+
+    expect(mockUseNavigate).toHaveBeenCalledWith(
+      generatePath(Path.LIBRARY_ALBUM, {
+        name: artistName,
+        albumName,
+      }),
+    );
+
+    const calledPath = mockUseNavigate.mock.calls[0]?.[0] as string;
+    expect(calledPath).toContain("Caf%C3%A9%20del%20Mar%20%2F%20100%25%20Hits");
+    expect(calledPath).toContain("Ni%C3%B1ez%20%2F%20%C3%89xitos%20100%25");
+    expect(calledPath).not.toContain("%2525");
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useLibraryArtistController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryArtistController.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate, useParams } from "react-router-dom";
+import { generatePath, useNavigate, useParams } from "react-router-dom";
 import { useLibraryArtistQuery } from "@/hooks/queries/useLibraryArtistQuery";
+import { Path } from "@/routes/routes";
 
 export const useLibraryArtistController = () => {
   const { name } = useParams<{ name: string }>();
@@ -30,7 +31,12 @@ export const useLibraryArtistController = () => {
         return;
       }
 
-      navigate(`/library/artist/${name}/album/${encodeURIComponent(albumName)}`);
+      navigate(
+        generatePath(Path.LIBRARY_ALBUM, {
+          name,
+          albumName,
+        }),
+      );
     },
     [name, navigate],
   );

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -123,7 +123,16 @@
     "artistNotFound": "Artist not found",
     "artistNotFoundDescription": "Could not load artist details.",
     "artistCardAriaLabel": "Artist {{name}}, {{albums}} albums, {{tracks}} tracks",
-    "albumCardAriaLabel": "Album {{name}} by {{artist}}, {{year}}, {{tracks}} tracks"
+    "albumCardAriaLabel": "Album {{name}} by {{artist}}, {{year}}, {{tracks}} tracks",
+    "album": {
+      "notFound": "Album not found",
+      "notFoundDescription": "Could not find this album in your library.",
+      "backToArtist": "Back to artist",
+      "tracks": "tracks",
+      "loading": "Loading album details...",
+      "error": "Could not load album details.",
+      "emptyTracks": "No tracks found for this album."
+    }
   },
   "history": {
     "title": "Download History",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -123,7 +123,16 @@
     "artistNotFound": "Artista no encontrado",
     "artistNotFoundDescription": "No se pudieron cargar los detalles del artista.",
     "artistCardAriaLabel": "Artista {{name}}, {{albums}} álbumes, {{tracks}} canciones",
-    "albumCardAriaLabel": "Álbum {{name}} de {{artist}}, {{year}}, {{tracks}} canciones"
+    "albumCardAriaLabel": "Álbum {{name}} de {{artist}}, {{year}}, {{tracks}} canciones",
+    "album": {
+      "notFound": "Álbum no encontrado",
+      "notFoundDescription": "No se pudo encontrar este álbum en tu biblioteca.",
+      "backToArtist": "Volver al artista",
+      "tracks": "canciones",
+      "loading": "Cargando detalles del álbum...",
+      "error": "No se pudieron cargar los detalles del álbum.",
+      "emptyTracks": "No se encontraron canciones para este álbum."
+    }
   },
   "history": {
     "title": "Historial de Descargas",

--- a/apps/frontend/src/routes/Routing.tsx
+++ b/apps/frontend/src/routes/Routing.tsx
@@ -30,6 +30,9 @@ const ArtistDetail = lazy(() =>
 const LibraryArtist = lazy(() =>
   import("../views/LibraryArtist").then((module) => ({ default: module.LibraryArtist })),
 );
+const LibraryAlbumDetail = lazy(() =>
+  import("../views/LibraryAlbumDetail").then((module) => ({ default: module.LibraryAlbumDetail })),
+);
 const MyPlaylists = lazy(() =>
   import("../views/MyPlaylists").then((module) => ({ default: module.MyPlaylists })),
 );
@@ -70,6 +73,7 @@ export const Routing: FC<RoutingProps> = ({ pathname, version }) => (
         <Route path={Path.ARTISTS} element={<Artists />} />
         <Route path={Path.ARTIST_DETAIL} element={<ArtistDetail />} />
         <Route path={Path.LIBRARY_ARTIST} element={<LibraryArtist />} />
+        <Route path={Path.LIBRARY_ALBUM} element={<LibraryAlbumDetail />} />
         <Route path={Path.MY_PLAYLISTS} element={<MyPlaylists />} />
         <Route path={Path.SETTINGS} element={<Settings />} />
         <Route path={Path.SEARCH} element={<Search />} />

--- a/apps/frontend/src/routes/routes.ts
+++ b/apps/frontend/src/routes/routes.ts
@@ -9,6 +9,7 @@ export enum Path {
   ARTISTS = "/artists",
   ARTIST_DETAIL = "/artist/:id",
   LIBRARY_ARTIST = "/library/artist/:name",
+  LIBRARY_ALBUM = "/library/artist/:name/album/:albumName",
   MY_PLAYLISTS = "/my-playlists",
   SEARCH = "/search",
   ALBUM_DETAIL = "/album/:artistId/:albumId",

--- a/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { LibraryAlbumDetail } from "./LibraryAlbumDetail";
+
+const mockController = vi.fn();
+
+vi.mock("@/hooks/controllers/useLibraryAlbumDetailController", () => ({
+  useLibraryAlbumDetailController: () => mockController(),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+describe("LibraryAlbumDetail", () => {
+  it("renders not-found UX when album is missing", () => {
+    mockController.mockReturnValue({
+      isLoading: false,
+      error: null,
+      isNotFound: true,
+      artistName: "A",
+      albumName: "B",
+      album: undefined,
+      tracks: [],
+      coverUrl: undefined,
+      playlistType: "album",
+      backToArtistPath: "/library/artist/A",
+    });
+
+    render(
+      <MemoryRouter>
+        <LibraryAlbumDetail />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("library.album.notFound")).toBeTruthy();
+    expect(screen.getByRole("link", { name: "library.album.backToArtist" })).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -1,0 +1,103 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router-dom";
+import { Loading } from "@/components/atoms/Loading";
+import { AlbumPageLayout } from "@/components/molecules/AlbumPageLayout";
+import { EmptyState } from "@/components/molecules/EmptyState";
+import { useLibraryAlbumDetailController } from "@/hooks/controllers/useLibraryAlbumDetailController";
+
+export const LibraryAlbumDetail: FC = () => {
+  const { t } = useTranslation();
+  const {
+    artistName,
+    album,
+    tracks,
+    coverUrl,
+    isLoading,
+    error,
+    isNotFound,
+    playlistType,
+    backToArtistPath,
+  } = useLibraryAlbumDetailController();
+
+  if (isLoading) {
+    return (
+      <main className="bg-background flex flex-1 items-center justify-center p-6">
+        <div className="space-y-3 text-center">
+          <Loading />
+          <p className="text-text-secondary">{t("library.album.loading")}</p>
+        </div>
+      </main>
+    );
+  }
+
+  if (error) {
+    return (
+      <main className="bg-background flex flex-1 items-center justify-center p-6 text-white">
+        <div className="space-y-4">
+          <EmptyState icon={faMusic} title={t("library.album.error")} description={String(error)} />
+          <div className="text-center">
+            <Link
+              to={backToArtistPath}
+              className="text-primary hover:text-primary/80 focus-visible:ring-primary inline-flex rounded-md px-3 py-2 font-medium underline-offset-4 transition-colors hover:underline focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {t("library.album.backToArtist")}
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  if (isNotFound || !album) {
+    return (
+      <main className="bg-background flex flex-1 items-center justify-center p-6 text-white">
+        <div className="space-y-4">
+          <EmptyState
+            icon={faMusic}
+            title={t("library.album.notFound")}
+            description={t("library.album.notFoundDescription")}
+          />
+          <div className="text-center">
+            <Link
+              to={backToArtistPath}
+              className="text-primary hover:text-primary/80 focus-visible:ring-primary inline-flex rounded-md px-3 py-2 font-medium underline-offset-4 transition-colors hover:underline focus-visible:ring-2 focus-visible:outline-none"
+            >
+              {t("library.album.backToArtist")}
+            </Link>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex flex-1 flex-col">
+      <div className="px-6 pt-6 md:px-8">
+        <Link
+          to={backToArtistPath}
+          className="text-primary hover:text-primary/80 focus-visible:ring-primary inline-flex rounded-md px-3 py-2 text-sm font-medium underline-offset-4 transition-colors hover:underline focus-visible:ring-2 focus-visible:outline-none"
+        >
+          {t("library.album.backToArtist")}
+        </Link>
+      </div>
+
+      <AlbumPageLayout
+        title={album.name}
+        type={playlistType}
+        coverUrl={coverUrl}
+        description={artistName}
+        metadata={
+          <span>
+            {tracks.length} {t("library.album.tracks")}
+          </span>
+        }
+        totalCount={tracks.length}
+        tracks={tracks}
+        emptyTitle={t("library.album.emptyTracks")}
+        emptyDescription={t("library.album.emptyTracks")}
+      />
+    </main>
+  );
+};


### PR DESCRIPTION
## Why

Final slice of library-views-revamp (SDD). This completes the library navigation flow introduced in slices 1 and 2 by making album clicks resolve to a real page instead of a dead deep link.

## What

- Add /library/artist/:name/album/:albumName route.
- Add LibraryAlbumDetail view and useLibraryAlbumDetailController.
- Reuse the shared AlbumPageLayout introduced in slice 1.
- Reuse existing library artist data (useLibraryArtistQuery) to derive the selected album instead of introducing a new query hook.
- Add library.album.* i18n keys in both en.json and es.json.
- Add tests for the new controller and view.
- Fix route generation to pass raw params into generatePath (avoids double-encoding for spaces, accents, %, and /).

## Validation

- pnpm --filter frontend run lint ✅
- pnpm --filter frontend run test:run ✅ (15 files / 65 tests)
- pnpm --filter frontend run build ✅

## Notes

- This PR completes the deep link wired in slice 2.
- size:exception approved by maintainer for this final slice (~440 LOC staged diff) to avoid an artificial extra split at the end of the chain.

## Chain

- 1/3 — #37 merged
- 2/3 — #38 merged
- 3/3 — this PR