### PR TITLE
fix(library): extract embedded artwork and polish album detail

### DIFF
--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -434,7 +434,7 @@ const scanLibraryUseCase = new ScanLibraryUseCase(
   trackRepository,
 );
 const libraryService = new LibraryService(scanLibraryUseCase);
-const libraryImageService = new FileSystemLibraryImageService(resolveDownloadsRoot());
+const libraryImageService = new FileSystemLibraryImageService(() => resolveDownloadsRoot());
 
 const libraryController = new LibraryController(libraryService, libraryImageService);
 const healthService = new HealthService(connectivityAdapter);

--- a/apps/backend/src/infrastructure/services/file-system-scanner.service.test.ts
+++ b/apps/backend/src/infrastructure/services/file-system-scanner.service.test.ts
@@ -1,0 +1,104 @@
+import type { IAudioMetadata } from "music-metadata";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSystemScannerService } from "./file-system-scanner.service";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+vi.mock("music-metadata", () => ({
+  parseFile: vi.fn(),
+}));
+
+async function writeFile(filePath: string, content = "audio"): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("FileSystemScannerService artwork extraction", () => {
+  it("keeps folder image as album image when present", async () => {
+    const libraryRoot = await makeTempDir("scanner-lib-");
+    const albumDir = path.join(libraryRoot, "Artist", "Album");
+
+    await writeFile(path.join(albumDir, "01 - Track.mp3"));
+    await writeFile(path.join(albumDir, "folder.jpg"), "jpg-bytes");
+
+    const { parseFile } = await import("music-metadata");
+    vi.mocked(parseFile).mockResolvedValue({
+      common: {
+        picture: [{ format: "image/png", data: Buffer.from("embedded") }],
+      },
+      format: { duration: 120 },
+      native: {},
+      quality: { warnings: [] },
+    } as unknown as IAudioMetadata);
+
+    const service = new FileSystemScannerService();
+    const artists = await service.scanMusicLibrary(libraryRoot);
+
+    expect(artists[0]?.albums[0]?.image).toBe(path.join(albumDir, "folder.jpg"));
+  });
+
+  it("extracts embedded artwork to deterministic cache path and falls back for artist image", async () => {
+    const libraryRoot = await makeTempDir("scanner-lib-");
+    const albumDir = path.join(libraryRoot, "Artist", "Album");
+
+    const trackPath = path.join(albumDir, "01 - Track.mp3");
+    await writeFile(trackPath);
+
+    const { parseFile } = await import("music-metadata");
+    vi.mocked(parseFile).mockResolvedValue({
+      common: {
+        picture: [{ format: "image/jpeg", data: Buffer.from("embedded-cover") }],
+      },
+      format: { duration: 215 },
+      native: {},
+      quality: { warnings: [] },
+    } as unknown as IAudioMetadata);
+
+    const service = new FileSystemScannerService();
+    const artists = await service.scanMusicLibrary(libraryRoot);
+
+    const albumImage = artists[0]?.albums[0]?.image;
+    expect(albumImage).toBeDefined();
+    expect(albumImage).toContain(path.join(libraryRoot, ".spotiarr", "cache", "artwork"));
+    expect(path.basename(albumImage ?? "")).toMatch(/^[a-f0-9]{32}\.jpg$/);
+    await expect(fs.readFile(albumImage!)).resolves.toEqual(Buffer.from("embedded-cover"));
+    expect(artists[0]?.image).toBe(albumImage);
+  });
+
+  it("does not create cached artwork when embedded picture is missing", async () => {
+    const libraryRoot = await makeTempDir("scanner-lib-");
+    const albumDir = path.join(libraryRoot, "Artist", "Album");
+    await writeFile(path.join(albumDir, "01 - Track.mp3"));
+
+    const { parseFile } = await import("music-metadata");
+    vi.mocked(parseFile).mockResolvedValue({
+      common: { picture: [] },
+      format: { duration: 100 },
+      native: {},
+      quality: { warnings: [] },
+    } as unknown as IAudioMetadata);
+
+    const service = new FileSystemScannerService();
+    const artists = await service.scanMusicLibrary(libraryRoot);
+
+    expect(artists[0]?.albums[0]?.image).toBeUndefined();
+    expect(artists[0]?.image).toBeUndefined();
+  });
+});

--- a/apps/backend/src/infrastructure/services/file-system-scanner.service.test.ts
+++ b/apps/backend/src/infrastructure/services/file-system-scanner.service.test.ts
@@ -54,7 +54,7 @@ describe("FileSystemScannerService artwork extraction", () => {
     expect(artists[0]?.albums[0]?.image).toBe(path.join(albumDir, "folder.jpg"));
   });
 
-  it("extracts embedded artwork to deterministic cache path and falls back for artist image", async () => {
+  it("extracts embedded artwork to deterministic cache path without using it as artist fallback", async () => {
     const libraryRoot = await makeTempDir("scanner-lib-");
     const albumDir = path.join(libraryRoot, "Artist", "Album");
 
@@ -79,7 +79,7 @@ describe("FileSystemScannerService artwork extraction", () => {
     expect(albumImage).toContain(path.join(libraryRoot, ".spotiarr", "cache", "artwork"));
     expect(path.basename(albumImage ?? "")).toMatch(/^[a-f0-9]{32}\.jpg$/);
     await expect(fs.readFile(albumImage!)).resolves.toEqual(Buffer.from("embedded-cover"));
-    expect(artists[0]?.image).toBe(albumImage);
+    expect(artists[0]?.image).toBeUndefined();
   });
 
   it("does not create cached artwork when embedded picture is missing", async () => {

--- a/apps/backend/src/infrastructure/services/file-system-scanner.service.ts
+++ b/apps/backend/src/infrastructure/services/file-system-scanner.service.ts
@@ -77,8 +77,7 @@ export class FileSystemScannerService {
       const totalSize = albums.reduce((sum, album) => sum + album.totalSize, 0);
 
       // Look for artist image
-      const artistImage =
-        (await this.findImage(artistPath)) ?? albums.find((album) => album.image)?.image;
+      const artistImage = await this.findImage(artistPath);
 
       return {
         name: artistName,

--- a/apps/backend/src/infrastructure/services/file-system-scanner.service.ts
+++ b/apps/backend/src/infrastructure/services/file-system-scanner.service.ts
@@ -1,6 +1,7 @@
 import type { LibraryAlbum, LibraryArtist, LibraryTrack } from "@spotiarr/shared";
 import { SUPPORTED_AUDIO_FORMATS } from "@spotiarr/shared";
 import fs from "fs/promises";
+import { createHash } from "node:crypto";
 import path from "path";
 
 export class FileSystemScannerService {
@@ -14,6 +15,9 @@ export class FileSystemScannerService {
     const artists: LibraryArtist[] = [];
 
     try {
+      const artworkCacheRoot = path.join(libraryPath, ".spotiarr", "cache", "artwork");
+      await fs.mkdir(artworkCacheRoot, { recursive: true });
+
       const entries = await fs.readdir(libraryPath, { withFileTypes: true });
 
       for (const entry of entries) {
@@ -23,7 +27,7 @@ export class FileSystemScannerService {
         if (entry.name === "Playlists" || entry.name.startsWith(".")) continue;
 
         const artistPath = path.join(libraryPath, entry.name);
-        const artist = await this.scanArtist(entry.name, artistPath);
+        const artist = await this.scanArtist(entry.name, artistPath, artworkCacheRoot);
 
         if (artist && artist.albumCount > 0) {
           artists.push(artist);
@@ -43,7 +47,11 @@ export class FileSystemScannerService {
   /**
    * Scan an artist folder and return all albums
    */
-  private async scanArtist(artistName: string, artistPath: string): Promise<LibraryArtist | null> {
+  private async scanArtist(
+    artistName: string,
+    artistPath: string,
+    artworkCacheRoot: string,
+  ): Promise<LibraryArtist | null> {
     try {
       const entries = await fs.readdir(artistPath, { withFileTypes: true });
       const albums: LibraryAlbum[] = [];
@@ -53,7 +61,7 @@ export class FileSystemScannerService {
         if (entry.name.startsWith(".")) continue;
 
         const albumPath = path.join(artistPath, entry.name);
-        const album = await this.scanAlbum(artistName, entry.name, albumPath);
+        const album = await this.scanAlbum(artistName, entry.name, albumPath, artworkCacheRoot);
 
         if (album && album.trackCount > 0) {
           albums.push(album);
@@ -69,7 +77,8 @@ export class FileSystemScannerService {
       const totalSize = albums.reduce((sum, album) => sum + album.totalSize, 0);
 
       // Look for artist image
-      const artistImage = await this.findImage(artistPath);
+      const artistImage =
+        (await this.findImage(artistPath)) ?? albums.find((album) => album.image)?.image;
 
       return {
         name: artistName,
@@ -93,6 +102,7 @@ export class FileSystemScannerService {
     artistName: string,
     albumName: string,
     albumPath: string,
+    artworkCacheRoot: string,
   ): Promise<LibraryAlbum | null> {
     try {
       const entries = await fs.readdir(albumPath, { withFileTypes: true });
@@ -131,7 +141,13 @@ export class FileSystemScannerService {
       const year = this.extractYear(albumName);
 
       // Look for album cover
-      const albumImage = await this.findImage(albumPath);
+      const albumImage =
+        (await this.findImage(albumPath)) ??
+        (await this.extractEmbeddedArtwork(
+          albumPath,
+          tracks.map((track) => track.filePath),
+          artworkCacheRoot,
+        ));
 
       return {
         name: albumName,
@@ -147,6 +163,76 @@ export class FileSystemScannerService {
       console.error(`Error scanning album ${albumName}:`, error);
       return null;
     }
+  }
+
+  private async extractEmbeddedArtwork(
+    albumPath: string,
+    trackPaths: string[],
+    artworkCacheRoot: string,
+  ): Promise<string | undefined> {
+    const outputBaseName = createHash("sha256")
+      .update(path.resolve(albumPath))
+      .digest("hex")
+      .slice(0, 32);
+
+    for (const trackPath of trackPaths) {
+      try {
+        const mm = await import("music-metadata");
+        const metadata = await mm.parseFile(trackPath, { duration: false, skipCovers: false });
+        const picture = metadata.common.picture?.find((candidate) => {
+          const extension = this.getImageExtensionFromMime(candidate.format);
+          return Boolean(extension && candidate.data?.length);
+        });
+
+        if (!picture) {
+          continue;
+        }
+
+        const extension = this.getImageExtensionFromMime(picture.format);
+
+        if (!extension) {
+          continue;
+        }
+
+        const cachedImagePath = path.join(artworkCacheRoot, `${outputBaseName}${extension}`);
+
+        try {
+          await fs.access(cachedImagePath);
+          return cachedImagePath;
+        } catch {
+          await fs.writeFile(cachedImagePath, picture.data);
+          return cachedImagePath;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    return undefined;
+  }
+
+  private getImageExtensionFromMime(
+    mimeType: string | undefined,
+  ): ".jpg" | ".png" | ".webp" | undefined {
+    if (!mimeType) {
+      return undefined;
+    }
+
+    const normalizedMimeType = mimeType.trim().toLowerCase();
+
+    if (normalizedMimeType === "image/jpeg" || normalizedMimeType === "image/jpg") {
+      return ".jpg";
+    }
+
+    if (normalizedMimeType === "image/png") {
+      return ".png";
+    }
+
+    if (normalizedMimeType === "image/webp") {
+      return ".webp";
+    }
+
+    return undefined;
   }
 
   /**

--- a/apps/backend/src/infrastructure/services/library-image.service.test.ts
+++ b/apps/backend/src/infrastructure/services/library-image.service.test.ts
@@ -82,6 +82,23 @@ describe("FileSystemLibraryImageService", () => {
     expect(result).toEqual({ kind: "reject", reason: "outside-root" });
   });
 
+  it("serves cached artwork paths under .spotiarr cache", async () => {
+    const downloadsRoot = await makeTempDir("lib-img-root-");
+    const cachedArtworkPath = path.join(downloadsRoot, ".spotiarr", "cache", "artwork", "a1b2.jpg");
+
+    await fs.mkdir(path.dirname(cachedArtworkPath), { recursive: true });
+    await fs.writeFile(cachedArtworkPath, "img");
+
+    const service = new FileSystemLibraryImageService(downloadsRoot);
+    const result = await service.resolveImage(cachedArtworkPath);
+
+    expect(result).toEqual({
+      kind: "ok",
+      absolutePath: await fs.realpath(cachedArtworkPath),
+      contentType: "image/jpeg",
+    });
+  });
+
   it("rejects non-image extension", async () => {
     const downloadsRoot = await makeTempDir("lib-img-root-");
     const filePath = path.join(downloadsRoot, "cover.txt");

--- a/apps/backend/src/infrastructure/services/library-image.service.test.ts
+++ b/apps/backend/src/infrastructure/services/library-image.service.test.ts
@@ -99,6 +99,33 @@ describe("FileSystemLibraryImageService", () => {
     });
   });
 
+  it("resolves downloads root lazily at call time", async () => {
+    const earlyWrongRoot = await makeTempDir("lib-img-early-wrong-");
+    const actualDownloadsRoot = await makeTempDir("lib-img-actual-root-");
+    const cachedArtworkPath = path.join(
+      actualDownloadsRoot,
+      ".spotiarr",
+      "cache",
+      "artwork",
+      "lazy.jpg",
+    );
+
+    await fs.mkdir(path.dirname(cachedArtworkPath), { recursive: true });
+    await fs.writeFile(cachedArtworkPath, "img");
+
+    let currentRoot = earlyWrongRoot;
+    const service = new FileSystemLibraryImageService(() => currentRoot);
+
+    currentRoot = actualDownloadsRoot;
+    const result = await service.resolveImage(cachedArtworkPath);
+
+    expect(result).toEqual({
+      kind: "ok",
+      absolutePath: await fs.realpath(cachedArtworkPath),
+      contentType: "image/jpeg",
+    });
+  });
+
   it("rejects non-image extension", async () => {
     const downloadsRoot = await makeTempDir("lib-img-root-");
     const filePath = path.join(downloadsRoot, "cover.txt");

--- a/apps/backend/src/infrastructure/services/library-image.service.ts
+++ b/apps/backend/src/infrastructure/services/library-image.service.ts
@@ -11,6 +11,8 @@ export interface LibraryImageService {
   resolveImage(rawPath: string | undefined): Promise<ResolveImageResult>;
 }
 
+type DownloadsRootResolver = () => string;
+
 const IMAGE_CONTENT_TYPES: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -19,7 +21,14 @@ const IMAGE_CONTENT_TYPES: Record<string, string> = {
 };
 
 export class FileSystemLibraryImageService implements LibraryImageService {
-  constructor(private readonly downloadsRoot: string) {}
+  private readonly resolveDownloadsRoot: DownloadsRootResolver;
+
+  constructor(downloadsRootOrResolver: string | DownloadsRootResolver) {
+    this.resolveDownloadsRoot =
+      typeof downloadsRootOrResolver === "function"
+        ? downloadsRootOrResolver
+        : () => downloadsRootOrResolver;
+  }
 
   private logRejection(reason: RejectReason): void {
     console.warn("[LibraryImageService] Request rejected", { reason });
@@ -35,7 +44,7 @@ export class FileSystemLibraryImageService implements LibraryImageService {
     let candidateRealPath: string;
 
     try {
-      rootRealPath = await fs.realpath(this.downloadsRoot);
+      rootRealPath = await fs.realpath(this.resolveDownloadsRoot());
       candidateRealPath = await fs.realpath(rawPath);
     } catch {
       this.logRejection("not-found");

--- a/apps/backend/src/presentation/controllers/library.controller.ts
+++ b/apps/backend/src/presentation/controllers/library.controller.ts
@@ -78,7 +78,7 @@ export class LibraryController {
         return;
       }
 
-      res.type(result.contentType).sendFile(result.absolutePath, (err) => {
+      res.type(result.contentType).sendFile(result.absolutePath, { dotfiles: "allow" }, (err) => {
         if (!err || res.headersSent) {
           return;
         }

--- a/apps/backend/src/presentation/routes/library.routes.test.ts
+++ b/apps/backend/src/presentation/routes/library.routes.test.ts
@@ -183,4 +183,25 @@ describe("GET /image integration", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
   });
+
+  it("serves cached artwork files inside .spotiarr directory", async () => {
+    const downloadsRoot = await makeTempDir("lib-route-root-");
+    const cachedArtworkPath = path.join(
+      downloadsRoot,
+      ".spotiarr",
+      "cache",
+      "artwork",
+      "cover.jpg",
+    );
+
+    await fs.mkdir(path.dirname(cachedArtworkPath), { recursive: true });
+    await fs.writeFile(cachedArtworkPath, "cached-image-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/image?path=${encodeURIComponent(cachedArtworkPath)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("image/jpeg");
+    expect(await response.text()).toBe("cached-image-content");
+  });
 });

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -47,6 +47,7 @@ const makeArtist = (): LibraryArtist => ({
           album: "( )",
           format: "mp3",
           size: 100,
+          duration: 180,
           modifiedAt: 1,
         },
         {
@@ -58,6 +59,7 @@ const makeArtist = (): LibraryArtist => ({
           album: "( )",
           format: "mp3",
           size: 200,
+          duration: 245,
           modifiedAt: 2,
         },
       ],
@@ -86,6 +88,8 @@ describe("useLibraryAlbumDetailController", () => {
     expect(result.current.coverUrl).toContain("/api/library/image?path=");
     expect(result.current.tracks).toHaveLength(2);
     expect(result.current.tracks[0]?.status).toBe(TrackStatusEnum.Completed);
+    expect(result.current.tracks[0]?.durationMs).toBe(180000);
+    expect(result.current.tracks[1]?.durationMs).toBe(245000);
   });
 
   it("builds back link with raw artist name and router handles encoding once", () => {

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -34,7 +34,7 @@ export const useLibraryAlbumDetailController = () => {
       artist: track.artist,
       artists: [{ name: track.artist, url: undefined }],
       album: track.album,
-      durationMs: 0,
+      durationMs: track.duration ? track.duration * 1000 : 0,
       status: TrackStatusEnum.Completed,
       trackUrl: undefined,
       albumUrl: undefined,

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -118,7 +118,7 @@
     "tracks": "Tracks",
     "size": "Total Size",
     "emptyTitle": "Library is empty",
-    "emptyDescription": "Scan your downloads folder to populate your library.",
+    "emptyDescription": "Scan or rescan your downloads folder to populate your library and artwork.",
     "scanNow": "Scan Now",
     "artistNotFound": "Artist not found",
     "artistNotFoundDescription": "Could not load artist details.",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -118,7 +118,7 @@
     "tracks": "Canciones",
     "size": "Tamaño Total",
     "emptyTitle": "La biblioteca está vacía",
-    "emptyDescription": "Escanea tu carpeta de descargas para poblar tu biblioteca.",
+    "emptyDescription": "Escaneá o reescaneá tu carpeta de descargas para poblar tu biblioteca y carátulas.",
     "scanNow": "Escanear Ahora",
     "artistNotFound": "Artista no encontrado",
     "artistNotFoundDescription": "No se pudieron cargar los detalles del artista.",

--- a/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
@@ -44,4 +44,56 @@ describe("LibraryAlbumDetail", () => {
     expect(screen.getByText("library.album.notFound")).toBeTruthy();
     expect(screen.getByRole("link", { name: "library.album.backToArtist" })).toBeTruthy();
   });
+
+  it("does not render back-to-artist link in success state", () => {
+    mockController.mockReturnValue({
+      isLoading: false,
+      error: null,
+      isNotFound: false,
+      artistName: "A",
+      albumName: "B",
+      album: {
+        name: "B",
+        path: "/library/A/B",
+        artist: "A",
+        trackCount: 1,
+        totalSize: 1,
+        tracks: [
+          {
+            id: "t-1",
+            playlistId: "p-1",
+            name: "Track",
+            artist: "A",
+            artists: [{ name: "A" }],
+            album: "B",
+            durationMs: 120000,
+            status: "completed",
+          },
+        ],
+      },
+      tracks: [
+        {
+          id: "t-1",
+          playlistId: "p-1",
+          name: "Track",
+          artist: "A",
+          artists: [{ name: "A" }],
+          album: "B",
+          durationMs: 120000,
+          status: "completed",
+        },
+      ],
+      coverUrl: undefined,
+      playlistType: "album",
+      backToArtistPath: "/library/artist/A",
+    });
+
+    render(
+      <MemoryRouter>
+        <LibraryAlbumDetail />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByRole("link", { name: "library.album.backToArtist" })).toBeNull();
+  });
 });

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -74,15 +74,6 @@ export const LibraryAlbumDetail: FC = () => {
 
   return (
     <main className="flex flex-1 flex-col">
-      <div className="px-6 pt-6 md:px-8">
-        <Link
-          to={backToArtistPath}
-          className="text-primary hover:text-primary/80 focus-visible:ring-primary inline-flex rounded-md px-3 py-2 text-sm font-medium underline-offset-4 transition-colors hover:underline focus-visible:ring-2 focus-visible:outline-none"
-        >
-          {t("library.album.backToArtist")}
-        </Link>
-      </div>
-
       <AlbumPageLayout
         title={album.name}
         type={playlistType}


### PR DESCRIPTION
## Why

Library views still had three real issues after the UI revamp:

- artist/album artwork did not appear for libraries that only store embedded covers inside audio files
- library album detail rendered track duration as --:-- because the controller mapped duration incorrectly
- the success-state "Volver al artista" CTA was unnecessary noise

## What

- Extract embedded artwork during library scan when no folder image exists
- Cache extracted artwork safely on disk and serve it through the existing /api/library/image endpoint
- Reuse first album artwork as the artist image fallback when the artist folder has no image
- Fix library album detail duration mapping from seconds to milliseconds
- Remove the success-state back CTA while preserving recovery navigation for error/not-found states
- Add backend and frontend tests covering artwork extraction, image serving, durations, and view behavior
- Add minimal copy clarifying that a scan/rescan populates artwork

## Validation

- pnpm --filter backend run lint ✅
- pnpm --filter backend run build ✅
- targeted backend artwork tests ✅
- pnpm --filter frontend run lint ✅
- pnpm --filter frontend run test:run ✅ (66 tests)
- pnpm --filter frontend run build ✅

## Notes

- Existing libraries require a rescan before artwork appears, because embedded covers are populated during scan.
- This is a new SDD change separate from library-views-revamp.