### PR TITLE
refactor(backend): centralize artwork persistence for jellyfin assets

### DIFF
--- a/apps/backend/src/application/ports/artwork-assets.port.ts
+++ b/apps/backend/src/application/ports/artwork-assets.port.ts
@@ -1,0 +1,4 @@
+export interface ArtworkAssetsPort {
+  downloadImage(url: string): Promise<Buffer | null>;
+  writeFileIfMissing(filePath: string, content: Buffer): Promise<void>;
+}

--- a/apps/backend/src/application/ports/file-system.port.ts
+++ b/apps/backend/src/application/ports/file-system.port.ts
@@ -9,7 +9,7 @@ export interface TrackTags {
   trackNumber?: number;
   discNumber?: number;
   totalTracks?: number;
-  coverUrl?: string;
+  coverBuffer?: Buffer;
 }
 
 export interface FileSystemTrackPathPort {
@@ -26,7 +26,6 @@ export interface FileSystemScannerPort {
 
 export interface MetadataPort {
   writeTags(filePath: string, tags: TrackTags): Promise<void>;
-  saveCoverArt(directory: string, url: string, fileName?: string): Promise<void>;
 }
 
 export interface M3uPort {

--- a/apps/backend/src/application/services/artwork.service.test.ts
+++ b/apps/backend/src/application/services/artwork.service.test.ts
@@ -1,0 +1,134 @@
+import { PlaylistTypeEnum, type ITrack } from "@spotiarr/shared";
+import * as path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import { ArtworkService } from "./artwork.service";
+
+describe("ArtworkService", () => {
+  const playlistRepository = { findOne: vi.fn() };
+  const spotifyService = { getCoverImage: vi.fn() };
+  const pathService = { getArtistFolderPath: vi.fn() };
+  const artworkAssets = {
+    downloadImage: vi.fn(),
+    writeFileIfMissing: vi.fn(),
+    clearCache: vi.fn(),
+  };
+
+  const track: ITrack = {
+    name: "Track",
+    artist: "Track Artist",
+    albumArtist: "Album Artist",
+    album: "Album",
+    playlistId: "playlist-1",
+    spotifyUrl: "https://open.spotify.com/track/123",
+  };
+
+  const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff]);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pathService.getArtistFolderPath.mockReturnValue(path.join("/music", "Album Artist"));
+    spotifyService.getCoverImage.mockResolvedValue("https://image.test/track.jpg");
+    playlistRepository.findOne.mockResolvedValue(
+      new Playlist({
+        id: "playlist-1",
+        type: PlaylistTypeEnum.Album,
+        coverUrl: "https://image.test/playlist.jpg",
+        artistImageUrl: "https://image.test/artist.jpg",
+      }),
+    );
+    artworkAssets.downloadImage.mockResolvedValue(jpegBuffer);
+    artworkAssets.writeFileIfMissing.mockResolvedValue(undefined);
+  });
+
+  it("downloads playlist, track, and artist artwork through the assets port", async () => {
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+
+    const artwork = await service.resolveTrackArtwork(track);
+
+    expect(artwork).toEqual({
+      tagCoverBuffer: jpegBuffer,
+      folderCoverBuffer: jpegBuffer,
+      artistImageBuffer: jpegBuffer,
+    });
+    expect(artworkAssets.downloadImage).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to playlist cover for non-playlist folder cover when track cover is unavailable", async () => {
+    spotifyService.getCoverImage.mockResolvedValue("");
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+
+    const artwork = await service.resolveTrackArtwork(track);
+
+    expect(artwork.tagCoverBuffer).toEqual(jpegBuffer);
+    expect(artwork.folderCoverBuffer).toEqual(jpegBuffer);
+  });
+
+  it("never uses album/playlist cover as artist image fallback", async () => {
+    playlistRepository.findOne.mockResolvedValue(
+      new Playlist({
+        id: "playlist-1",
+        type: PlaylistTypeEnum.Album,
+        coverUrl: "https://image.test/playlist.jpg",
+      }),
+    );
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+
+    const artwork = await service.resolveTrackArtwork(track);
+
+    expect(artwork.artistImageBuffer).toBeNull();
+  });
+
+  it("persists album cover.jpg and artist folder.jpg through the assets port", async () => {
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+    const artwork = await service.resolveTrackArtwork(track);
+
+    const albumDir = path.join("/music", "Album Artist", "Album");
+    await service.saveAlbumCover(albumDir, artwork);
+    await service.saveArtistImageIfNeeded(track, artwork);
+
+    expect(artworkAssets.writeFileIfMissing).toHaveBeenNthCalledWith(
+      1,
+      path.join(albumDir, "cover.jpg"),
+      jpegBuffer,
+    );
+    expect(artworkAssets.writeFileIfMissing).toHaveBeenNthCalledWith(
+      2,
+      path.join("/music", "Album Artist", "folder.jpg"),
+      jpegBuffer,
+    );
+  });
+
+  it("clears the underlying assets cache when available", () => {
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+
+    service.clearCache();
+
+    expect(artworkAssets.clearCache).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/application/services/artwork.service.ts
+++ b/apps/backend/src/application/services/artwork.service.ts
@@ -1,0 +1,103 @@
+import type { ITrack } from "@spotiarr/shared";
+import * as path from "path";
+import type { ArtworkAssetsPort } from "@/application/ports/artwork-assets.port";
+import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
+import type { SpotifyService } from "@/application/services/spotify.service";
+import { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export interface ResolvedArtwork {
+  tagCoverBuffer: Buffer | null;
+  folderCoverBuffer: Buffer | null;
+  artistImageBuffer: Buffer | null;
+}
+
+export class ArtworkService {
+  constructor(
+    private readonly playlistRepository: PlaylistRepository,
+    private readonly spotifyService: SpotifyService,
+    private readonly pathService: FileSystemTrackPathPort,
+    private readonly artworkAssets: ArtworkAssetsPort,
+  ) {}
+
+  async resolveTrackArtwork(track: ITrack): Promise<ResolvedArtwork> {
+    let playlistCoverBuffer: Buffer | null = null;
+    let trackCoverBuffer: Buffer | null = null;
+    let artistImageBuffer: Buffer | null = null;
+    let isPlaylistType = false;
+
+    const playlist = track.playlistId
+      ? await this.playlistRepository.findOne(track.playlistId)
+      : null;
+    isPlaylistType = playlist?.type === "playlist";
+
+    if (playlist?.coverUrl) {
+      playlistCoverBuffer = await this.artworkAssets.downloadImage(playlist.coverUrl);
+    }
+
+    const urlToResolve = track.spotifyUrl || track.trackUrl;
+    if (urlToResolve) {
+      try {
+        const resolvedTrackCoverUrl = await this.spotifyService.getCoverImage(urlToResolve);
+        if (resolvedTrackCoverUrl) {
+          trackCoverBuffer = await this.artworkAssets.downloadImage(resolvedTrackCoverUrl);
+        }
+      } catch (error) {
+        console.warn(`Failed to resolve track cover for ${track.name}: ${toErrorMessage(error)}`);
+      }
+    }
+
+    if (playlist && playlist.type !== "playlist" && playlist.artistImageUrl) {
+      artistImageBuffer = await this.artworkAssets.downloadImage(playlist.artistImageUrl);
+    }
+
+    const tagCoverBuffer = trackCoverBuffer || playlistCoverBuffer;
+    const folderCoverBuffer = isPlaylistType
+      ? playlistCoverBuffer || trackCoverBuffer
+      : trackCoverBuffer || playlistCoverBuffer;
+
+    return {
+      tagCoverBuffer,
+      folderCoverBuffer,
+      artistImageBuffer,
+    };
+  }
+
+  async saveAlbumCover(directory: string, artwork: ResolvedArtwork): Promise<void> {
+    if (!artwork.folderCoverBuffer) {
+      return;
+    }
+
+    await this.artworkAssets.writeFileIfMissing(
+      path.join(directory, "cover.jpg"),
+      artwork.folderCoverBuffer,
+    );
+  }
+
+  async saveArtistImageIfNeeded(track: ITrack, artwork: ResolvedArtwork): Promise<void> {
+    if (!track.playlistId || !artwork.artistImageBuffer) {
+      return;
+    }
+
+    try {
+      const artistFolderPath = this.pathService.getArtistFolderPath(
+        track.albumArtist || track.artist,
+      );
+      await this.artworkAssets.writeFileIfMissing(
+        path.join(artistFolderPath, "folder.jpg"),
+        artwork.artistImageBuffer,
+      );
+    } catch (error) {
+      console.warn(`Failed to save artist image for ${track.name}: ${toErrorMessage(error)}`);
+    }
+  }
+
+  clearCache(): void {
+    if ("clearCache" in this.artworkAssets && typeof this.artworkAssets.clearCache === "function") {
+      this.artworkAssets.clearCache();
+    }
+  }
+}

--- a/apps/backend/src/application/services/spotify.service.test.ts
+++ b/apps/backend/src/application/services/spotify.service.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { SpotifyService } from "./spotify.service";
+
+describe("SpotifyService", () => {
+  it("enriches track downloads with the primary artist image", async () => {
+    const artistClient = {
+      getArtistDetails: vi.fn().mockResolvedValue({
+        name: "Artist",
+        image: "https://image.test/artist.jpg",
+        spotifyUrl: "https://open.spotify.com/artist/abc123",
+        followers: null,
+        genres: [],
+      }),
+    };
+
+    const service = new SpotifyService({
+      artistClient,
+      trackClient: {
+        getTrackDetails: vi.fn().mockResolvedValue({
+          name: "Track",
+          artist: "Artist",
+          primaryArtist: "Artist",
+          primaryArtistImage: null,
+          album: "Album",
+          albumCoverUrl: "https://image.test/album.jpg",
+          artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+        }),
+      },
+      albumClient: {
+        getAlbumTracks: vi.fn(),
+        getAlbumDetails: vi.fn(),
+      },
+      playlistClient: {
+        getPlaylistMetadata: vi.fn(),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      },
+      searchClient: {
+        searchCatalog: vi.fn(),
+      },
+      userLibraryService: {
+        getMyPlaylists: vi.fn(),
+      },
+    });
+
+    const result = await service.getPlaylistDetail("https://open.spotify.com/track/track123");
+
+    expect(artistClient.getArtistDetails).toHaveBeenCalledWith("abc123");
+    expect(result.tracks[0]?.primaryArtistImage).toBe("https://image.test/artist.jpg");
+    expect(result.tracks[0]?.albumCoverUrl).toBe("https://image.test/album.jpg");
+  });
+
+  it("enriches album downloads with the primary artist image without using album cover fallback", async () => {
+    const artistClient = {
+      getArtistDetails: vi.fn().mockResolvedValue({
+        name: "Artist",
+        image: "https://image.test/artist.jpg",
+        spotifyUrl: "https://open.spotify.com/artist/abc123",
+        followers: null,
+        genres: [],
+      }),
+    };
+
+    const service = new SpotifyService({
+      artistClient,
+      trackClient: {
+        getTrackDetails: vi.fn(),
+      },
+      albumClient: {
+        getAlbumTracks: vi.fn().mockResolvedValue([
+          {
+            name: "Track 1",
+            artist: "Artist",
+            primaryArtist: "Artist",
+            primaryArtistImage: null,
+            album: "Album",
+            albumCoverUrl: "https://image.test/album.jpg",
+            artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+          },
+          {
+            name: "Track 2",
+            artist: "Artist",
+            primaryArtist: "Artist",
+            primaryArtistImage: null,
+            album: "Album",
+            albumCoverUrl: "https://image.test/album.jpg",
+            artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+          },
+        ]),
+        getAlbumDetails: vi.fn(),
+      },
+      playlistClient: {
+        getPlaylistMetadata: vi.fn(),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      },
+      searchClient: {
+        searchCatalog: vi.fn(),
+      },
+      userLibraryService: {
+        getMyPlaylists: vi.fn(),
+      },
+    });
+
+    const result = await service.getPlaylistDetail("https://open.spotify.com/album/album123");
+
+    expect(artistClient.getArtistDetails).toHaveBeenCalledTimes(1);
+    expect(result.tracks[0]?.primaryArtistImage).toBe("https://image.test/artist.jpg");
+    expect(result.tracks[0]?.primaryArtistImage).not.toBe(result.tracks[0]?.albumCoverUrl);
+    expect(result.tracks[1]?.primaryArtistImage).toBe("https://image.test/artist.jpg");
+  });
+});

--- a/apps/backend/src/application/services/spotify.service.ts
+++ b/apps/backend/src/application/services/spotify.service.ts
@@ -2,7 +2,15 @@ import { NormalizedTrack, SpotifyPlaylist, SpotifySearchResults } from "@spotiar
 import { AppError } from "@/domain/errors/app-error";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 
-type SpotifyArtistClientLike = { getArtistDetails(id: string): Promise<unknown> };
+type SpotifyArtistClientLike = {
+  getArtistDetails(id: string): Promise<{
+    name: string;
+    image: string | null;
+    spotifyUrl: string | null;
+    followers: number | null;
+    genres: string[];
+  }>;
+};
 type SpotifyTrackClientLike = { getTrackDetails(id: string): Promise<NormalizedTrack> };
 type SpotifyAlbumClientLike = {
   getAlbumTracks(id: string): Promise<NormalizedTrack[]>;
@@ -74,12 +82,20 @@ export class SpotifyService {
       if (urlType === SpotifyUrlType.Track) {
         const trackId = SpotifyUrlHelper.extractId(spotifyUrl);
         const track = await this.deps.trackClient.getTrackDetails(trackId);
-        return { name: track.name, tracks: [track], image: track.albumCoverUrl ?? "", type };
+        const [enrichedTrack] = await this.populatePrimaryArtistImages([track]);
+        return {
+          name: enrichedTrack.name,
+          tracks: [enrichedTrack],
+          image: enrichedTrack.albumCoverUrl ?? "",
+          type,
+        };
       }
 
       if (urlType === SpotifyUrlType.Album) {
         const albumId = SpotifyUrlHelper.extractId(spotifyUrl);
-        const tracks = await this.deps.albumClient.getAlbumTracks(albumId);
+        const tracks = await this.populatePrimaryArtistImages(
+          await this.deps.albumClient.getAlbumTracks(albumId),
+        );
         return {
           name: tracks[0]?.album || "Unknown Album",
           tracks: tracks || [],
@@ -114,6 +130,42 @@ export class SpotifyService {
       console.error(`Error getting playlist details: ${toErrorMessage(error)}`);
       throw error;
     }
+  }
+
+  private async populatePrimaryArtistImages(tracks: PlaylistTrack[]): Promise<PlaylistTrack[]> {
+    const artistImageCache = new Map<string, Promise<string | null>>();
+
+    return Promise.all(
+      tracks.map(async (track) => {
+        if (track.primaryArtistImage) {
+          return track;
+        }
+
+        const primaryArtistUrl = track.artists[0]?.url;
+        if (!primaryArtistUrl) {
+          return track;
+        }
+
+        try {
+          const artistId = SpotifyUrlHelper.extractId(primaryArtistUrl);
+
+          if (!artistImageCache.has(artistId)) {
+            artistImageCache.set(
+              artistId,
+              this.deps.artistClient
+                .getArtistDetails(artistId)
+                .then((artist) => artist.image ?? null)
+                .catch(() => null),
+            );
+          }
+
+          const artistImage = await artistImageCache.get(artistId);
+          return artistImage ? { ...track, primaryArtistImage: artistImage } : track;
+        } catch {
+          return track;
+        }
+      }),
+    );
   }
 
   async getCoverImage(spotifyUrl: string): Promise<string> {

--- a/apps/backend/src/application/services/track-post-processing.service.test.ts
+++ b/apps/backend/src/application/services/track-post-processing.service.test.ts
@@ -1,0 +1,96 @@
+import type { ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedArtwork } from "@/application/services/artwork.service";
+import { TrackPostProcessingService } from "./track-post-processing.service";
+
+describe("TrackPostProcessingService", () => {
+  const artworkService = {
+    resolveTrackArtwork: vi.fn(),
+    saveAlbumCover: vi.fn(),
+    saveArtistImageIfNeeded: vi.fn(),
+  };
+
+  const metadataService = {
+    writeTags: vi.fn(),
+  };
+
+  const playlistRepository = {
+    findOne: vi.fn(),
+  };
+
+  const trackRepository = {
+    findAllByPlaylist: vi.fn(),
+  };
+
+  const trackPathService = {
+    getPlaylistFolderPath: vi.fn(),
+  };
+
+  const m3uService = {
+    generateM3uFile: vi.fn(),
+    getCompletedTracksCount: vi.fn(),
+  };
+
+  const track: ITrack = {
+    name: "Track",
+    artist: "Track Artist",
+    albumArtist: "Album Artist",
+    album: "Album",
+    playlistId: "playlist-1",
+  };
+
+  let resolvedArtwork: ResolvedArtwork;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    metadataService.writeTags.mockResolvedValue(undefined);
+    resolvedArtwork = {
+      tagCoverBuffer: Buffer.from("tag-cover"),
+      folderCoverBuffer: Buffer.from("folder-cover"),
+      artistImageBuffer: Buffer.from("artist-image"),
+    };
+    artworkService.resolveTrackArtwork.mockResolvedValue(resolvedArtwork);
+    artworkService.saveAlbumCover.mockResolvedValue(undefined);
+    artworkService.saveArtistImageIfNeeded.mockResolvedValue(undefined);
+  });
+
+  it("delegates album and artist artwork persistence to ArtworkService", async () => {
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await service.process(track, "/library/Album Artist/Album/01 - Track.mp3");
+
+    expect(artworkService.resolveTrackArtwork).toHaveBeenCalledWith(track);
+    expect(artworkService.saveAlbumCover).toHaveBeenCalledWith(
+      "/library/Album Artist/Album",
+      resolvedArtwork,
+    );
+    expect(artworkService.saveArtistImageIfNeeded).toHaveBeenCalledWith(track, resolvedArtwork);
+  });
+
+  it("passes resolved coverBuffer to metadata writer", async () => {
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await service.process(track, "/library/Album Artist/Album/01 - Track.mp3");
+
+    expect(metadataService.writeTags).toHaveBeenCalledWith(
+      "/library/Album Artist/Album/01 - Track.mp3",
+      expect.objectContaining({
+        coverBuffer: resolvedArtwork.tagCoverBuffer,
+      }),
+    );
+  });
+});

--- a/apps/backend/src/application/services/track-post-processing.service.ts
+++ b/apps/backend/src/application/services/track-post-processing.service.ts
@@ -1,12 +1,11 @@
-import { PlaylistTypeEnum, type ITrack } from "@spotiarr/shared";
-import * as fs from "fs";
+import type { ITrack } from "@spotiarr/shared";
 import * as path from "path";
 import type {
   FileSystemTrackPathPort,
   M3uPort,
   MetadataPort,
 } from "@/application/ports/file-system.port";
-import type { SpotifyService } from "@/application/services/spotify.service";
+import { ArtworkService } from "@/application/services/artwork.service";
 import { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackRepository } from "@/domain/repositories/track.repository";
 
@@ -16,7 +15,7 @@ function toErrorMessage(error: unknown): string {
 
 export class TrackPostProcessingService {
   constructor(
-    private readonly spotifyService: SpotifyService,
+    private readonly artworkService: ArtworkService,
     private readonly metadataService: MetadataPort,
     private readonly playlistRepository: PlaylistRepository,
     private readonly trackRepository: TrackRepository,
@@ -30,9 +29,9 @@ export class TrackPostProcessingService {
    */
   async process(track: ITrack, trackFilePath: string): Promise<void> {
     try {
-      const { trackCoverUrl, playlistCoverUrl, isPlaylistType } = await this.getCoverUrls(track);
+      const artwork = await this.artworkService.resolveTrackArtwork(track);
 
-      // 1. Embed ID3 Tags (prefer specific track cover)
+      // 1. Embed ID3 Tags (prefer specific track cover via artwork service)
       await this.metadataService.writeTags(trackFilePath, {
         title: track.name,
         artist: track.artist,
@@ -42,19 +41,15 @@ export class TrackPostProcessingService {
         trackNumber: track.trackNumber,
         discNumber: track.discNumber,
         totalTracks: track.totalTracks,
-        coverUrl: trackCoverUrl || playlistCoverUrl || "",
+        coverBuffer: artwork.tagCoverBuffer || undefined,
       });
 
       // 2. Save folder cover.jpg
       const trackDirectory = path.dirname(trackFilePath);
-      const folderCoverUrl = isPlaylistType ? playlistCoverUrl : trackCoverUrl;
-
-      if (folderCoverUrl) {
-        await this.metadataService.saveCoverArt(trackDirectory, folderCoverUrl);
-      }
+      await this.artworkService.saveAlbumCover(trackDirectory, artwork);
 
       // 3. Save Artist Image (if applicable)
-      await this.saveArtistImageIfNeeded(track);
+      await this.artworkService.saveArtistImageIfNeeded(track, artwork);
     } catch (error) {
       console.error(
         `Error during post-processing for track ${track.name}: ${toErrorMessage(error)}`,
@@ -87,64 +82,6 @@ export class TrackPostProcessingService {
       }
     } catch (err) {
       console.error(`Failed to generate M3U file: ${toErrorMessage(err)}`);
-    }
-  }
-
-  private async getCoverUrls(track: ITrack): Promise<{
-    trackCoverUrl: string;
-    playlistCoverUrl?: string;
-    isPlaylistType: boolean;
-  }> {
-    let playlistCoverUrl: string | undefined;
-    let isPlaylistType = false;
-
-    // Get Playlist Info
-    if (track.playlistId) {
-      const playlist = await this.playlistRepository.findOne(track.playlistId);
-      isPlaylistType = playlist?.type === "playlist";
-      if (playlist) {
-        playlistCoverUrl = playlist.coverUrl;
-      }
-    }
-
-    // Get Specific Track Cover from Spotify — uses minimum API calls (no track fetching)
-    let trackCoverUrl = "";
-    const urlToUse = track.spotifyUrl || track.trackUrl;
-
-    if (urlToUse) {
-      try {
-        trackCoverUrl = await this.spotifyService.getCoverImage(urlToUse);
-      } catch (e) {
-        console.warn(`Failed to fetch cover for track ${track.name}: ${toErrorMessage(e)}`);
-      }
-    }
-
-    return { trackCoverUrl, playlistCoverUrl, isPlaylistType };
-  }
-
-  private async saveArtistImageIfNeeded(track: ITrack): Promise<void> {
-    if (!track.playlistId) return;
-
-    try {
-      const playlist = await this.playlistRepository.findOne(track.playlistId);
-
-      // Only save artist image if it's NOT a generic playlist and we have an image
-      if (playlist && playlist.type !== PlaylistTypeEnum.Playlist && playlist.artistImageUrl) {
-        const artistFolderPath = this.trackPathService.getArtistFolderPath(track.artist);
-
-        if (!fs.existsSync(artistFolderPath)) {
-          fs.mkdirSync(artistFolderPath, { recursive: true });
-        }
-
-        // Save as folder.jpg (standard)
-        await this.metadataService.saveCoverArt(
-          artistFolderPath,
-          playlist.artistImageUrl,
-          "folder.jpg",
-        );
-      }
-    } catch (error) {
-      console.warn(`Failed to save artist image: ${toErrorMessage(error)}`);
     }
   }
 }

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -56,6 +56,7 @@ function makeStubs() {
       {
         name: "Track 1",
         artist: "Artist",
+        primaryArtistImage: "http://track-artist.jpg",
         artists: [{ name: "Artist", url: undefined }],
         album: "Album",
         trackNumber: 1,
@@ -65,6 +66,12 @@ function makeStubs() {
   };
 
   const feedRepository = {
+    getArtistBySpotifyId: vi.fn().mockResolvedValue({
+      id: "artist-1",
+      name: "Artist",
+      image: "http://artist.jpg",
+      spotifyUrl: "https://open.spotify.com/artist/artist1",
+    }),
     getArtistAlbumWithArtist: vi.fn().mockResolvedValue({
       albumName: "Album",
       artistName: "Artist",
@@ -110,6 +117,7 @@ describe("CreatePlaylistUseCase — albumTrack branch", () => {
       {
         name: "Track 1",
         artist: "Artist",
+        primaryArtistImage: "http://track-artist.jpg",
         artists: [{ name: "Artist", url: undefined }],
         album: "Album",
         trackNumber: 1,
@@ -118,6 +126,7 @@ describe("CreatePlaylistUseCase — albumTrack branch", () => {
       {
         name: "Track 2",
         artist: "Artist",
+        primaryArtistImage: "http://track-artist.jpg",
         artists: [{ name: "Artist", url: undefined }],
         album: "Album",
         trackNumber: 2,
@@ -168,8 +177,31 @@ describe("CreatePlaylistUseCase — albumTrack branch", () => {
     expect(savedPlaylist.toPrimitive()).toMatchObject({
       name: "Release Artist - Track 2",
       coverUrl: "http://release-cover.jpg",
+      artistImageUrl: "http://artist.jpg",
       owner: "Release Artist",
     });
+  });
+
+  it("falls back to track artist image when cached artist image is unavailable", async () => {
+    stubs.feedRepository.getArtistBySpotifyId.mockResolvedValue({
+      id: "artist-1",
+      name: "Artist",
+      image: null,
+      spotifyUrl: "https://open.spotify.com/artist/artist1",
+    });
+
+    const useCase = makeUseCase(stubs);
+
+    await useCase.execute({
+      kind: "albumTrack",
+      artistId: "artist-1",
+      albumId: "album-1",
+      trackIndex: 1,
+    });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+
+    expect(savedPlaylist.toPrimitive().artistImageUrl).toBe("http://track-artist.jpg");
   });
 
   it("throws 404 when trackIndex is out of range", async () => {
@@ -263,6 +295,7 @@ describe("CreatePlaylistUseCase — album branch", () => {
     expect(savedPlaylist.toPrimitive()).toMatchObject({
       name: "Release Artist - Release Album",
       coverUrl: "http://release-cover.jpg",
+      artistImageUrl: "http://artist.jpg",
       owner: "Release Artist",
     });
   });

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -28,6 +28,7 @@ interface AlbumMetadata {
   albumName: string;
   artistName: string;
   coverUrl?: string;
+  artistImageUrl?: string;
 }
 
 export class CreatePlaylistUseCase {
@@ -154,6 +155,8 @@ export class CreatePlaylistUseCase {
     const albumName = albumMetadata.albumName;
     const artistName = albumMetadata.artistName;
     const coverUrl = albumMetadata.coverUrl;
+    const artistImageUrl =
+      albumMetadata.artistImageUrl ?? tracks[0]?.primaryArtistImage ?? undefined;
 
     const playlist = new Playlist({
       id: crypto.randomUUID(),
@@ -164,7 +167,7 @@ export class CreatePlaylistUseCase {
       `${artistName} - ${albumName}`,
       PlaylistTypeEnum.Album,
       coverUrl,
-      undefined,
+      artistImageUrl,
       artistName,
       undefined,
     );
@@ -216,6 +219,8 @@ export class CreatePlaylistUseCase {
     const albumMetadata = await this.resolveAlbumMetadata(artistId, albumId);
     const artistName = albumMetadata.artistName;
     const coverUrl = albumMetadata.coverUrl;
+    const artistImageUrl =
+      albumMetadata.artistImageUrl ?? pickedTrack.primaryArtistImage ?? undefined;
 
     const trackName = pickedTrack.name ?? "Unknown Track";
 
@@ -228,7 +233,7 @@ export class CreatePlaylistUseCase {
       `${artistName} - ${trackName}`,
       PlaylistTypeEnum.Track,
       coverUrl,
-      undefined,
+      artistImageUrl,
       artistName,
       undefined,
     );
@@ -246,12 +251,16 @@ export class CreatePlaylistUseCase {
   }
 
   private async resolveAlbumMetadata(artistId: string, albumId: string): Promise<AlbumMetadata> {
+    const artist = await this.feedRepository?.getArtistBySpotifyId(artistId);
+    const artistImageUrl = artist?.image ?? undefined;
+
     const albumCache = await this.feedRepository?.getArtistAlbumWithArtist(artistId, albumId);
     if (albumCache) {
       return {
         albumName: albumCache.albumName,
         artistName: albumCache.artistName,
         coverUrl: albumCache.coverUrl ?? undefined,
+        artistImageUrl,
       };
     }
 
@@ -261,12 +270,14 @@ export class CreatePlaylistUseCase {
         albumName: releaseCache.albumName,
         artistName: releaseCache.artistName,
         coverUrl: releaseCache.coverUrl ?? undefined,
+        artistImageUrl,
       };
     }
 
     return {
       albumName: "Unknown Album",
       artistName: "Unknown Artist",
+      artistImageUrl,
     };
   }
 

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -1,5 +1,6 @@
 import type { FeedRepositoryPort } from "./application/ports/feed-repository.port";
 import type { SpotifyUserLibraryPort } from "./application/ports/spotify-user-library.port";
+import { ArtworkService } from "./application/services/artwork.service";
 import { FeedCacheEvictionService } from "./application/services/feed-cache-eviction.service";
 import { HealthService } from "./application/services/health.service";
 import { LibraryService } from "./application/services/library.service";
@@ -62,6 +63,7 @@ import { YoutubeDownloadService } from "./infrastructure/external/youtube-downlo
 import { YoutubeSearchService } from "./infrastructure/external/youtube-search.service";
 import { AppEventBus } from "./infrastructure/messaging/app-event-bus";
 import { BullMqTrackQueueService } from "./infrastructure/messaging/bullmq-track-queue.service";
+import { ArtworkAssetsService } from "./infrastructure/services/artwork-assets.service";
 import { FileSystemM3uService } from "./infrastructure/services/file-system-m3u.service";
 import { FileSystemScannerService } from "./infrastructure/services/file-system-scanner.service";
 import { FileSystemTrackPathService } from "./infrastructure/services/file-system-track-path.service";
@@ -197,6 +199,7 @@ const m3uService = new FileSystemM3uService(settingsService, trackFileHelper);
 const youtubeSearchService = new YoutubeSearchService(settingsService);
 const youtubeDownloadService = new YoutubeDownloadService(settingsService, youtubeSearchService);
 const metadataService = new MetadataService();
+const artworkAssetsService = new ArtworkAssetsService();
 
 const queueService = new BullMqTrackQueueService();
 const eventBus = new AppEventBus();
@@ -343,8 +346,14 @@ const spotifyServiceSync = new SpotifyService({
 });
 
 // Services (Post-Processing) — uses sync service to avoid starving interactive requests
-const trackPostProcessingService = new TrackPostProcessingService(
+const artworkService = new ArtworkService(
+  playlistRepository,
   spotifyServiceSync,
+  trackFileHelper,
+  artworkAssetsService,
+);
+const trackPostProcessingService = new TrackPostProcessingService(
+  artworkService,
   metadataService,
   playlistRepository,
   trackRepository,

--- a/apps/backend/src/infrastructure/services/artwork-assets.service.test.ts
+++ b/apps/backend/src/infrastructure/services/artwork-assets.service.test.ts
@@ -1,0 +1,60 @@
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ArtworkAssetsService } from "./artwork-assets.service";
+
+describe("ArtworkAssetsService", () => {
+  const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff]);
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "artwork-assets-"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        arrayBuffer: async () => jpegBuffer,
+      }),
+    );
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("deduplicates repeated image downloads by URL", async () => {
+    const service = new ArtworkAssetsService();
+
+    await service.downloadImage("https://image.test/cover.jpg");
+    await service.downloadImage("https://image.test/cover.jpg");
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("evicts the oldest cached download when the cache is full", async () => {
+    const service = new ArtworkAssetsService();
+
+    for (let index = 0; index < 51; index += 1) {
+      await service.downloadImage(`https://image.test/${index}.jpg`);
+    }
+
+    await service.downloadImage("https://image.test/0.jpg");
+
+    expect(fetch).toHaveBeenCalledTimes(52);
+  });
+
+  it("writes files once and keeps existing content", async () => {
+    const service = new ArtworkAssetsService();
+    const filePath = path.join(tmpDir, "Artist", "cover.jpg");
+    const originalBuffer = Buffer.from("first");
+    const ignoredBuffer = Buffer.from("second");
+
+    await service.writeFileIfMissing(filePath, originalBuffer);
+    await service.writeFileIfMissing(filePath, ignoredBuffer);
+
+    await expect(access(filePath)).resolves.toBeUndefined();
+    await expect(readFile(filePath)).resolves.toEqual(originalBuffer);
+  });
+});

--- a/apps/backend/src/infrastructure/services/artwork-assets.service.ts
+++ b/apps/backend/src/infrastructure/services/artwork-assets.service.ts
@@ -1,0 +1,73 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ArtworkAssetsPort } from "@/application/ports/artwork-assets.port";
+
+const MAX_IMAGE_CACHE_ENTRIES = 50;
+
+export class ArtworkAssetsService implements ArtworkAssetsPort {
+  private readonly imageCache = new Map<string, Promise<Buffer | null>>();
+
+  async downloadImage(url: string): Promise<Buffer | null> {
+    if (!url) {
+      return null;
+    }
+
+    const cached = this.imageCache.get(url);
+    if (cached) {
+      this.imageCache.delete(url);
+      this.imageCache.set(url, cached);
+      return cached;
+    }
+
+    const downloadPromise = (async () => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          return null;
+        }
+
+        return Buffer.from(await response.arrayBuffer());
+      } catch {
+        return null;
+      }
+    })();
+
+    this.imageCache.set(url, downloadPromise);
+    this.evictIfNeeded();
+    return downloadPromise;
+  }
+
+  async writeFileIfMissing(filePath: string, content: Buffer): Promise<void> {
+    await mkdir(dirname(filePath), { recursive: true });
+
+    try {
+      await writeFile(filePath, content, { flag: "wx" });
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "EEXIST"
+      ) {
+        return;
+      }
+
+      throw error;
+    }
+  }
+
+  clearCache(): void {
+    this.imageCache.clear();
+  }
+
+  private evictIfNeeded(): void {
+    while (this.imageCache.size > MAX_IMAGE_CACHE_ENTRIES) {
+      const oldestKey = this.imageCache.keys().next().value;
+      if (!oldestKey) {
+        return;
+      }
+
+      this.imageCache.delete(oldestKey);
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/services/metadata.service.test.ts
+++ b/apps/backend/src/infrastructure/services/metadata.service.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MetadataService } from "./metadata.service";
+
+const { writeMock } = vi.hoisted(() => ({
+  writeMock: vi.fn(),
+}));
+
+vi.mock("node-id3", () => ({
+  default: {
+    write: writeMock,
+  },
+  write: writeMock,
+}));
+
+describe("MetadataService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeMock.mockReturnValue(true);
+  });
+
+  it("embeds artwork image using provided coverBuffer", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const service = new MetadataService();
+    const coverBuffer = Buffer.from([0xff, 0xd8, 0xff]);
+
+    await service.writeTags("/library/song.mp3", {
+      title: "Track",
+      artist: "Artist",
+      coverBuffer,
+    });
+
+    expect(writeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: expect.objectContaining({
+          imageBuffer: coverBuffer,
+        }),
+      }),
+      "/library/song.mp3",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not fetch artwork when no coverBuffer is provided", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const service = new MetadataService();
+
+    await service.writeTags("/library/song.mp3", {
+      title: "Track",
+      artist: "Artist",
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not expose a URL-based saveCoverArt API", () => {
+    const service = new MetadataService() as MetadataService & {
+      saveCoverArt?: unknown;
+    };
+
+    expect(service.saveCoverArt).toBeUndefined();
+  });
+});

--- a/apps/backend/src/infrastructure/services/metadata.service.ts
+++ b/apps/backend/src/infrastructure/services/metadata.service.ts
@@ -1,8 +1,4 @@
-import * as fs from "fs";
 import * as NodeID3 from "node-id3";
-import { join } from "path";
-import { AppError } from "@/domain/errors/app-error";
-import { getErrorMessage } from "../utils/error.utils";
 
 export class MetadataService {
   async writeTags(
@@ -16,7 +12,7 @@ export class MetadataService {
       trackNumber?: number;
       discNumber?: number;
       totalTracks?: number;
-      coverUrl?: string; // Optional: download and embed if present
+      coverBuffer?: Buffer;
     },
   ): Promise<void> {
     const {
@@ -28,7 +24,7 @@ export class MetadataService {
       trackNumber,
       discNumber,
       totalTracks,
-      coverUrl,
+      coverBuffer,
     } = fileTags;
 
     const tags: NodeID3.Tags = {
@@ -53,72 +49,18 @@ export class MetadataService {
       tags.partOfSet = discNumber.toString();
     }
 
-    if (coverUrl) {
-      try {
-        const res = await fetch(coverUrl);
-        const arrayBuf = await res.arrayBuffer();
-        const imageBuffer = Buffer.from(arrayBuf);
-
-        tags.image = {
-          mime: "image/jpeg",
-          type: { id: 3, name: "front cover" }, // Cover (front)
-          description: "cover",
-          imageBuffer,
-        };
-      } catch (error) {
-        console.warn(`Failed to download cover for embedding: ${getErrorMessage(error)}`);
-      }
+    if (coverBuffer) {
+      tags.image = {
+        mime: "image/jpeg",
+        type: { id: 3, name: "front cover" },
+        description: "cover",
+        imageBuffer: coverBuffer,
+      };
     }
 
     const success = NodeID3.write(tags, folderName);
     if (!success) {
       console.warn(`NodeID3.write returned false for ${folderName}`);
-    }
-  }
-
-  /**
-   * Saves cover art in the specified directory for Jellyfin detection
-   * Jellyfin looks for: cover.jpg
-   * Downloads the image only if it doesn't exist yet
-   */
-  async saveCoverArt(
-    directory: string,
-    coverUrl: string,
-    fileName: string = "cover.jpg",
-  ): Promise<void> {
-    if (!coverUrl) {
-      return;
-    }
-
-    try {
-      const coverFile = join(directory, fileName);
-
-      // Only download if the file doesn't exist
-      if (fs.existsSync(coverFile)) {
-        console.debug(`Cover art already exists in ${directory}`);
-        return;
-      }
-
-      // Download the image
-      console.debug(`Downloading cover art to ${directory}`);
-      const response = await fetch(coverUrl);
-
-      if (!response.ok) {
-        throw new AppError(
-          500,
-          "internal_server_error",
-          `Failed to download cover: ${response.statusText}`,
-        );
-      }
-
-      const imageBuffer = Buffer.from(await response.arrayBuffer());
-
-      // Save file
-      fs.writeFileSync(coverFile, imageBuffer);
-
-      console.debug(`✓ Cover art saved: ${coverFile}`);
-    } catch (error) {
-      console.warn(`Failed to save cover art in ${directory}: ${getErrorMessage(error)}`);
     }
   }
 }


### PR DESCRIPTION
Closes #41

## Type
- [x] Code refactoring

## Summary
- Centralize artwork resolution, download and filesystem persistence behind an application-layer `ArtworkService` and an infrastructure `ArtworkAssetsService` exposed via `ArtworkAssetsPort`.
- Preserve jellyfin-compatible filesystem outputs: `cover.jpg` for albums and `folder.jpg` for artists.
- Closes two real artwork regressions surfaced while auditing the previous flow (artist `folder.jpg` written to the wrong folder; album `cover.jpg` not persisted in Deezer-backed synthetic album flows).

## Changes
| File | Change |
|------|--------|
| `apps/backend/src/application/ports/artwork-assets.port.ts` | New port for image download + filesystem persistence. |
| `apps/backend/src/infrastructure/services/artwork-assets.service.ts` | Concrete adapter with bounded image dedup cache. |
| `apps/backend/src/application/services/artwork.service.ts` | Application-layer orchestrator for resolution and delegation. |
| `apps/backend/src/application/services/track-post-processing.service.ts` | Delegates artwork ownership to `ArtworkService`, fixes artist folder target and album cover fallback. |
| `apps/backend/src/application/services/spotify.service.ts` | Enriches `primaryArtistImage` for track/album URL flows with per-artist cache. |
| `apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts` | Synthetic `album`/`albumTrack` flows now persist real `artistImageUrl` via feed metadata, no album-cover fallback. |
| `apps/backend/src/infrastructure/services/metadata.service.ts` | Reduced to pure ID3 embedding via cover buffers; no longer fetches remote artwork. |
| `apps/backend/src/application/ports/file-system.port.ts` | Removed metadata-owned `saveCoverArt`. |
| `apps/backend/src/container.ts` | DI wiring for new port/services. |
| `apps/backend/src/**/*.test.ts` | New and updated coverage for artwork orchestration, fallbacks and persistence. |

## Test Plan
- [x] `pnpm --filter backend run test:run` → **222 passed**
- [x] `pnpm --filter backend run build` → ok
- [x] `pnpm --filter backend run lint` → ok (pre-existing `no-explicit-any` warnings in unrelated repo tests)
- [x] Manual end-to-end: `downloads/<artist>/folder.jpg` and `downloads/<artist>/<album>/cover.jpg` now persist consistently across spotify + synthetic + Deezer-backed flows.

## Notes
- `size:exception` requested: forecast was 600-750 changed lines under a `single-pr` strategy and a 800-line review budget agreed in this SDD pass. Final diff: 768 insertions / 150 deletions.
- Architectural intent: keep application-layer orchestration free of raw `fetch`/`fs`; all I/O lives behind `ArtworkAssetsPort` in infrastructure.

## Contributor Checklist
- [x] Linked an approved issue (#41)
- [x] Added exactly one `type:*` label (`type:refactor`)
- [x] Backend tests, build and lint pass
- [x] Skills used for context and review
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers