### PR TITLE
refactor(backend): clarify spotifyUrl, previewUrl and trackUrl semantics

### DIFF
--- a/apps/backend/src/application/services/artwork.service.test.ts
+++ b/apps/backend/src/application/services/artwork.service.test.ts
@@ -20,7 +20,8 @@ describe("ArtworkService", () => {
     albumArtist: "Album Artist",
     album: "Album",
     playlistId: "playlist-1",
-    spotifyUrl: "https://open.spotify.com/track/123",
+    spotifyUrl: "https://p.scdn.co/mp3-preview/123",
+    trackUrl: "https://open.spotify.com/track/123",
   };
 
   const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff]);
@@ -57,6 +58,26 @@ describe("ArtworkService", () => {
       artistImageBuffer: jpegBuffer,
     });
     expect(artworkAssets.downloadImage).toHaveBeenCalledTimes(3);
+    expect(spotifyService.getCoverImage).toHaveBeenCalledWith("https://open.spotify.com/track/123");
+  });
+
+  it("falls back to legacy spotifyUrl when trackUrl is missing", async () => {
+    const service = new ArtworkService(
+      playlistRepository as never,
+      spotifyService as never,
+      pathService as never,
+      artworkAssets as never,
+    );
+
+    await service.resolveTrackArtwork({
+      ...track,
+      trackUrl: undefined,
+      spotifyUrl: "https://open.spotify.com/track/legacy-123",
+    });
+
+    expect(spotifyService.getCoverImage).toHaveBeenCalledWith(
+      "https://open.spotify.com/track/legacy-123",
+    );
   });
 
   it("falls back to playlist cover for non-playlist folder cover when track cover is unavailable", async () => {

--- a/apps/backend/src/application/services/artwork.service.ts
+++ b/apps/backend/src/application/services/artwork.service.ts
@@ -38,7 +38,8 @@ export class ArtworkService {
       playlistCoverBuffer = await this.artworkAssets.downloadImage(playlist.coverUrl);
     }
 
-    const urlToResolve = track.spotifyUrl || track.trackUrl;
+    // Prefer the explicit track URL; keep spotifyUrl only as a legacy fallback for older rows.
+    const urlToResolve = track.trackUrl || track.spotifyUrl;
     if (urlToResolve) {
       try {
         const resolvedTrackCoverUrl = await this.spotifyService.getCoverImage(urlToResolve);

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -336,4 +336,41 @@ describe("CreatePlaylistUseCase — album branch", () => {
     );
     expect(stubs.getAlbumTracksUseCase.execute).not.toHaveBeenCalled();
   });
+
+  it("persists trackUrl without overloading spotifyUrl with previewUrl", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Song",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: "https://open.spotify.com/artist/artist-1" }],
+          album: "Album",
+          albumUrl: "https://open.spotify.com/album/album-1",
+          albumYear: 2026,
+          trackUrl: "https://open.spotify.com/track/track-1",
+          previewUrl: "https://p.scdn.co/mp3-preview/track-1",
+          durationMs: 180000,
+        },
+      ],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc123",
+    });
+
+    const createdTrack = stubs.trackService.create.mock.calls[0]?.[0];
+
+    expect(createdTrack).toMatchObject({
+      trackUrl: "https://open.spotify.com/track/track-1",
+      albumUrl: "https://open.spotify.com/album/album-1",
+    });
+    expect(createdTrack).not.toHaveProperty("spotifyUrl");
+  });
 });

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -361,7 +361,6 @@ export class CreatePlaylistUseCase {
         album: track.album ?? (useSinglesFallback ? "Singles" : context.playlistName),
         albumYear: track.albumYear,
         trackNumber: trackNumber,
-        spotifyUrl: track.previewUrl ?? undefined,
         artists: track.artists,
         trackUrl: track.trackUrl,
         albumUrl: track.albumUrl,

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -1,0 +1,80 @@
+import { PlaylistTypeEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import { SyncSubscribedPlaylistsUseCase } from "./sync-subscribed-playlists.use-case";
+
+describe("SyncSubscribedPlaylistsUseCase", () => {
+  const playlist = new Playlist({
+    id: "playlist-1",
+    spotifyUrl: "https://open.spotify.com/playlist/playlist-1",
+    subscribed: true,
+    type: PlaylistTypeEnum.Playlist,
+    name: "Playlist",
+  });
+
+  const playlistRepository = {
+    findAll: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+  };
+
+  const spotifyService = {
+    getPlaylistDetail: vi.fn(),
+  };
+
+  const trackService = {
+    getAllByPlaylist: vi.fn(),
+    create: vi.fn(),
+  };
+
+  const eventBus = {
+    emit: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    playlistRepository.findAll.mockResolvedValue([playlist]);
+    playlistRepository.save.mockResolvedValue(undefined);
+    playlistRepository.update.mockResolvedValue(undefined);
+    spotifyService.getPlaylistDetail.mockResolvedValue({
+      name: "Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+      tracks: [
+        {
+          name: "Song",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: "https://open.spotify.com/artist/artist-1" }],
+          album: "Album",
+          albumYear: 2026,
+          trackUrl: "https://open.spotify.com/track/track-1",
+          previewUrl: "https://p.scdn.co/mp3-preview/track-1",
+          durationMs: 180000,
+        },
+      ],
+    });
+    trackService.create.mockResolvedValue(undefined);
+  });
+
+  it("dedupes using trackUrl instead of legacy spotifyUrl semantics", async () => {
+    const existingTrack: ITrack = {
+      name: "Song",
+      artist: "Artist",
+      trackUrl: "https://open.spotify.com/track/track-1",
+    };
+    trackService.getAllByPlaylist.mockResolvedValue([existingTrack]);
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+    );
+
+    await useCase.execute();
+
+    expect(trackService.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -5,6 +5,10 @@ import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.h
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackService } from "../../services/track.service";
 
+function getTrackIdentityUrl(track: { trackUrl?: string; spotifyUrl?: string }): string {
+  return track.trackUrl ?? track.spotifyUrl ?? "undefined";
+}
+
 export class SyncSubscribedPlaylistsUseCase {
   constructor(
     private readonly playlistRepository: PlaylistRepository,
@@ -49,7 +53,7 @@ export class SyncSubscribedPlaylistsUseCase {
 
       const existingTracks = await this.trackService.getAllByPlaylist(playlist.id);
       const existingTrackKeys = new Set(
-        existingTracks.map((t) => `${t.artist}|${t.name}|${t.spotifyUrl || "undefined"}`),
+        existingTracks.map((t) => `${t.artist}|${t.name}|${getTrackIdentityUrl(t)}`),
       );
 
       const tracksToCreate: { track: PlaylistTrack; index: number }[] = [];
@@ -68,13 +72,12 @@ export class SyncSubscribedPlaylistsUseCase {
           album: track.album ?? (isTrack ? "Singles" : playlist.name),
           albumYear: track.albumYear,
           trackNumber: isAlbum ? (track.trackNumber ?? i + 1) : i + 1,
-          spotifyUrl: track.previewUrl ?? undefined,
           artists: track.artists,
           trackUrl: track.trackUrl,
           durationMs: track.durationMs,
         };
 
-        const key = `${track2Save.artist}|${track2Save.name}|${track2Save.spotifyUrl || "undefined"}`;
+        const key = `${track2Save.artist}|${track2Save.name}|${getTrackIdentityUrl(track2Save)}`;
 
         if (!existingTrackKeys.has(key)) {
           tracksToCreate.push({ track: track, index: i });
@@ -97,7 +100,6 @@ export class SyncSubscribedPlaylistsUseCase {
                 album: track.album ?? (isTrack ? "Singles" : playlist.name),
                 albumYear: track.albumYear,
                 trackNumber: isAlbum ? (track.trackNumber ?? index + 1) : index + 1,
-                spotifyUrl: track.previewUrl ?? undefined,
                 artists: track.artists,
                 trackUrl: track.trackUrl,
                 durationMs: track.durationMs,


### PR DESCRIPTION
Closes #43

## Type
- [x] Code refactoring

## Summary
- Stop new track ingestion from misusing `spotifyUrl` to hold Spotify preview MP3 URLs.
- Keep `trackUrl` as the explicit canonical Spotify track URL for persisted tracks.
- Make sync dedupe key on `trackUrl` first, fall back to legacy `spotifyUrl` only for older persisted rows.
- Make artwork resolution prefer `trackUrl`, removing the previous overloaded fallback that mixed preview audio URLs with resource references.

## Changes
| File | Change |
|------|--------|
| `apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts` | Drop misuse of `spotifyUrl` for preview MP3 URL. |
| `apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts` | Dedupe by `trackUrl` first, `spotifyUrl` only as legacy fallback. |
| `apps/backend/src/application/services/artwork.service.ts` | Artwork lookup now prefers `trackUrl`. |
| `apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts` | New ingestion no longer writes preview into `spotifyUrl`. |
| `apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts` | New sync dedupe behavior. |
| `apps/backend/src/application/services/artwork.service.test.ts` | Artwork preference covered. |

## Test Plan
- [x] `pnpm --filter backend run test:run` → **225 passed**
- [x] `pnpm --filter backend run build` → ok
- [x] `pnpm --filter backend run lint` → ok (pre-existing `no-explicit-any` warnings in unrelated tests)

## Notes
- Existing persisted rows may still contain old `spotifyUrl` values populated by prior behavior; runtime fallback preserves compatibility, no data migration is included or required for this fix.

## Contributor Checklist
- [x] Linked an approved issue (#43)
- [x] Added exactly one `type:*` label (`type:refactor`)
- [x] Backend tests, build and lint pass
- [x] Skills used for context and review
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers