### PR TITLE
fix: harden Spotify rate-limit handling and unify album navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.7.1](https://github.com/mralexsaavedra/spotiarr/compare/v1.7.0...v1.7.1) (2026-06-01)
+
+### Bug Fixes
+
+- **album navigation**: Always resolve album detail through the Deezer-first cascade route (`/album/:artistId/:albumId`) instead of falling back to the Spotify-only `/preview` route when an album has a cached `spotifyUrl`. Spotify rate-limit storms no longer block browsing cached albums.
+- **playlist sync**: Skip the entire run when the Spotify app-token circuit breaker is open, and abort the loop on transient rate-limit errors instead of writing per-playlist error rows on every cycle.
+- **playlist sync**: Permanently unsubscribe playlists that return `playlist_not_accessible` or `playlist_not_found` (third-party playlists unreachable since the Spotify API February 2026 update), so they stop being retried every cycle.
+- **catalog sync**: Skip catalog sync runs when the Spotify circuit breaker is open instead of issuing the first request and tripping the breaker again.
+
 ## [1.7.0](https://github.com/mralexsaavedra/spotiarr/compare/v1.6.0...v1.7.0) (2026-06-01)
 
 ### Features

--- a/apps/backend/src/application/ports/spotify-circuit-breaker.port.ts
+++ b/apps/backend/src/application/ports/spotify-circuit-breaker.port.ts
@@ -1,0 +1,3 @@
+export interface SpotifyCircuitBreakerPort {
+  isOpen(): boolean;
+}

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -1,7 +1,12 @@
 import { PlaylistTypeEnum, type ITrack } from "@spotiarr/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Playlist } from "@/domain/entities/playlist.entity";
+import { AppError } from "@/domain/errors/app-error";
 import { SyncSubscribedPlaylistsUseCase } from "./sync-subscribed-playlists.use-case";
+
+const spotifyCircuitBreaker = {
+  isOpen: vi.fn(() => false),
+};
 
 describe("SyncSubscribedPlaylistsUseCase", () => {
   const playlist = new Playlist({
@@ -33,6 +38,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    spotifyCircuitBreaker.isOpen.mockReturnValue(false);
     playlistRepository.findAll.mockResolvedValue([playlist]);
     playlistRepository.save.mockResolvedValue(undefined);
     playlistRepository.update.mockResolvedValue(undefined);
@@ -71,10 +77,83 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       spotifyService as never,
       trackService as never,
       eventBus as never,
+      spotifyCircuitBreaker as never,
     );
 
     await useCase.execute();
 
     expect(trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("skips the run entirely when the Spotify circuit breaker is open", async () => {
+    spotifyCircuitBreaker.isOpen.mockReturnValue(true);
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+    );
+
+    await useCase.execute();
+
+    expect(playlistRepository.findAll).not.toHaveBeenCalled();
+    expect(spotifyService.getPlaylistDetail).not.toHaveBeenCalled();
+  });
+
+  it("unsubscribes 3rd-party playlists permanently on playlist_not_accessible", async () => {
+    const thirdParty = new Playlist({
+      id: "other-user-playlist",
+      spotifyUrl: "https://open.spotify.com/playlist/other-user-playlist",
+      subscribed: true,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Foreign",
+    });
+    playlistRepository.findAll.mockResolvedValue([thirdParty]);
+    spotifyService.getPlaylistDetail.mockRejectedValue(
+      new AppError(403, "playlist_not_accessible", "belongs to another user"),
+    );
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+    );
+
+    await useCase.execute();
+
+    expect(thirdParty.subscribed).toBe(false);
+    expect(thirdParty.error).toBe("belongs to another user");
+    expect(playlistRepository.update).toHaveBeenCalledWith(thirdParty.id, thirdParty);
+  });
+
+  it("aborts the loop on circuit_open instead of marking every playlist as errored", async () => {
+    const second = new Playlist({
+      id: "playlist-2",
+      spotifyUrl: "https://open.spotify.com/playlist/playlist-2",
+      subscribed: true,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Second",
+    });
+    playlistRepository.findAll.mockResolvedValue([playlist, second]);
+    spotifyService.getPlaylistDetail.mockRejectedValue(
+      new AppError(503, "circuit_open", "Spotify rate limit circuit breaker is open"),
+    );
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+    );
+
+    await useCase.execute();
+
+    expect(spotifyService.getPlaylistDetail).toHaveBeenCalledTimes(1);
+    expect(playlistRepository.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -1,9 +1,16 @@
 import { PlaylistTypeEnum } from "@spotiarr/shared";
+import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
 import { SpotifyService, type PlaylistTrack } from "@/application/services/spotify.service";
+import { AppError } from "@/domain/errors/app-error";
 import { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackService } from "../../services/track.service";
+
+const PERMANENTLY_UNAVAILABLE_ERROR_CODES = new Set([
+  "playlist_not_accessible",
+  "playlist_not_found",
+]);
 
 function getTrackIdentityUrl(track: { trackUrl?: string; spotifyUrl?: string }): string {
   return track.trackUrl ?? track.spotifyUrl ?? "undefined";
@@ -15,9 +22,17 @@ export class SyncSubscribedPlaylistsUseCase {
     private readonly spotifyService: SpotifyService,
     private readonly trackService: TrackService,
     private readonly eventBus: EventBus,
+    private readonly spotifyCircuitBreaker: SpotifyCircuitBreakerPort,
   ) {}
 
   async execute(): Promise<void> {
+    if (this.spotifyCircuitBreaker.isOpen()) {
+      console.warn(
+        "[SyncSubscribedPlaylists] Skipping run — Spotify circuit breaker is open. Will retry on next scheduled tick.",
+      );
+      return;
+    }
+
     const subscribedPlaylists = await this.playlistRepository.findAll(false, { subscribed: true });
 
     for (const playlist of subscribedPlaylists) {
@@ -42,7 +57,31 @@ export class SyncSubscribedPlaylistsUseCase {
         );
         await this.playlistRepository.save(playlist);
       } catch (error) {
-        playlist.markAsError(error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        const errorCode = error instanceof AppError ? error.errorCode : undefined;
+
+        if (errorCode && PERMANENTLY_UNAVAILABLE_ERROR_CODES.has(errorCode)) {
+          // Permanent: 3rd-party playlists are unreachable since Spotify API
+          // Feb 2026 update. Unsubscribe so we stop retrying every cycle.
+          playlist.markAsUnsubscribed();
+          playlist.markAsError(message);
+          await this.playlistRepository.update(playlist.id, playlist);
+          console.warn(
+            `[SyncSubscribedPlaylists] Unsubscribed permanently-unavailable playlist ${playlist.id}: ${errorCode}`,
+          );
+          continue;
+        }
+
+        if (errorCode === "circuit_open" || errorCode === "spotify_rate_limited") {
+          // Transient: stop the loop entirely — every other playlist will fail
+          // for the same reason and we'll just spam writes.
+          console.warn(
+            "[SyncSubscribedPlaylists] Aborting run — Spotify rate limited. Will retry on next scheduled tick.",
+          );
+          return;
+        }
+
+        playlist.markAsError(message);
         await this.playlistRepository.update(playlist.id, playlist);
         continue;
       }

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -61,6 +61,7 @@ import { SpotifyArtistCatalogService } from "./infrastructure/external/spotify-a
 import { SpotifyArtistClient } from "./infrastructure/external/spotify-artist.client";
 import { SpotifyArtworkSourceService } from "./infrastructure/external/spotify-artwork-source.service";
 import { SpotifyAuthService } from "./infrastructure/external/spotify-auth.service";
+import { SpotifyCircuitBreakerAdapter } from "./infrastructure/external/spotify-circuit-breaker.adapter";
 import { SpotifyFollowedArtistsService } from "./infrastructure/external/spotify-followed-artists.service";
 import { SpotifyPlaylistLibraryService } from "./infrastructure/external/spotify-playlist-library.service";
 import { SpotifyPlaylistClient } from "./infrastructure/external/spotify-playlist.client";
@@ -435,11 +436,14 @@ const getPlaylistsUseCase = new GetPlaylistsUseCase(playlistRepository);
 const deletePlaylistUseCase = new DeletePlaylistUseCase(playlistRepository, eventBus);
 const updatePlaylistUseCase = new UpdatePlaylistUseCase(playlistRepository, eventBus);
 
+const spotifyCircuitBreakerAdapter = new SpotifyCircuitBreakerAdapter();
+
 const syncSubscribedPlaylistsUseCase = new SyncSubscribedPlaylistsUseCase(
   playlistRepository,
   spotifyServiceSync,
   trackService,
   eventBus,
+  spotifyCircuitBreakerAdapter,
 );
 
 const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(

--- a/apps/backend/src/infrastructure/external/circuit-breaker.ts
+++ b/apps/backend/src/infrastructure/external/circuit-breaker.ts
@@ -59,6 +59,15 @@ export class CircuitBreaker {
     this.onOpenCallback = fn;
   }
 
+  isOpen(): boolean {
+    if (this.state !== CIRCUIT_BREAKER_STATE.OPEN) return false;
+    return Date.now() < this.openUntil;
+  }
+
+  getOpenUntil(): number {
+    return this.openUntil;
+  }
+
   /**
    * Restore persisted open-until timestamp after construction.
    * Safe to call even if the window has already passed — no-op in that case.

--- a/apps/backend/src/infrastructure/external/spotify-circuit-breaker.adapter.ts
+++ b/apps/backend/src/infrastructure/external/spotify-circuit-breaker.adapter.ts
@@ -1,0 +1,8 @@
+import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
+import { isAppTokenCircuitOpen } from "./spotify-http.client";
+
+export class SpotifyCircuitBreakerAdapter implements SpotifyCircuitBreakerPort {
+  isOpen(): boolean {
+    return isAppTokenCircuitOpen();
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-http.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-http.client.ts
@@ -108,6 +108,14 @@ const appTokenCircuitBreaker = new CircuitBreaker();
  * @param initialOpenUntilMs - timestamp (ms) read from persistent storage
  * @param onOpen             - called whenever the circuit opens; persist this value
  */
+export function isAppTokenCircuitOpen(): boolean {
+  return appTokenCircuitBreaker.isOpen();
+}
+
+export function getAppTokenCircuitOpenUntil(): number {
+  return appTokenCircuitBreaker.getOpenUntil();
+}
+
 export function configureAppTokenCircuitBreaker(
   initialOpenUntilMs: number,
   onOpen: (openUntilMs: number) => void,

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
@@ -1,6 +1,7 @@
 import { Worker } from "bullmq";
 import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
 import { container } from "@/container";
+import { isAppTokenCircuitOpen } from "@/infrastructure/external/spotify-http.client";
 import { getEnv } from "../setup/environment";
 import { CATALOG_SYNC_QUEUE } from "../setup/queues";
 
@@ -28,6 +29,14 @@ export function createCatalogSyncWorker(): Worker {
   const worker = new Worker(
     CATALOG_SYNC_QUEUE,
     async () => {
+      if (isAppTokenCircuitOpen()) {
+        console.warn(
+          "[CatalogSyncWorker] Skipping run — Spotify circuit breaker is open. Will retry on next scheduled tick.",
+        );
+        await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
+        return;
+      }
+
       await feedRepository.setCatalogSyncState(SYNC_STATUS.Running);
 
       try {

--- a/apps/frontend/src/hooks/useAlbumPreviewNavigation.ts
+++ b/apps/frontend/src/hooks/useAlbumPreviewNavigation.ts
@@ -7,24 +7,18 @@ export const useAlbumPreviewNavigation = () => {
   const navigate = useNavigate();
   const { data: playlists = [] } = usePlaylistsQuery();
 
-  const navigateToSpotifyUrl = (spotifyUrl: string) => {
-    const existingPlaylist = playlists.find((playlist) => playlist.spotifyUrl === spotifyUrl);
-
-    if (existingPlaylist) {
-      navigate(Path.PLAYLIST_DETAIL.replace(":id", existingPlaylist.id));
-      return;
-    }
-
-    navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(spotifyUrl)}`);
-  };
-
   const navigateToAlbumPreview = (album: ArtistRelease) => {
+    // If the album is already a downloaded playlist, jump to its detail view.
     if (album.spotifyUrl) {
-      navigateToSpotifyUrl(album.spotifyUrl);
-      return;
+      const existingPlaylist = playlists.find((p) => p.spotifyUrl === album.spotifyUrl);
+      if (existingPlaylist) {
+        navigate(Path.PLAYLIST_DETAIL.replace(":id", existingPlaylist.id));
+        return;
+      }
     }
 
-    // No spotifyUrl (Deezer-sourced album): navigate directly to the AlbumDetail view.
+    // Always resolve through AlbumDetail (Deezer-first cascade) so Spotify
+    // rate-limit storms don't block album browsing.
     navigate(
       Path.ALBUM_DETAIL.replace(":artistId", album.artistId).replace(":albumId", album.albumId),
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotiarr",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Self-hosted Spotify downloader with Jellyfin/Plex integration. Lidarr-inspired music automation.",
   "keywords": [
     "spotify",


### PR DESCRIPTION
## Summary

- Always resolve album navigation through the Deezer-first cascade route (`/album/:artistId/:albumId`) instead of falling back to the Spotify-only `/preview` route when an album has a cached `spotifyUrl`. Spotify rate-limit storms no longer block browsing cached albums.
- Skip subscribed-playlist sync and catalog sync runs entirely when the Spotify app-token circuit breaker is open; abort the playlist sync loop on transient rate-limit errors so we stop writing per-playlist error rows on every scheduled cycle.
- Permanently unsubscribe playlists that return `playlist_not_accessible` or `playlist_not_found` (third-party playlists unreachable since the Spotify API February 2026 update) so they stop being retried every cycle.
- Bump to `v1.7.1`.

## Why

Server was repeatedly tripping a 4-hour Spotify circuit-breaker window because:

1. Catalog sync and the scheduled playlist check kept firing while the breaker was already open, generating spam logs and DB writes.
2. Third-party subscribed playlists (unreachable post Feb-2026 Spotify API change) were retried every cycle, each retry writing an error row.
3. Even with the breaker open, opening a cached album from an artist navigated to `/preview` (Spotify-only resolution) and returned 503, even though the same album was reachable through the Deezer-first cascade route.

## Implementation notes

- Added `SpotifyCircuitBreakerPort` (application layer) + `SpotifyCircuitBreakerAdapter` (infrastructure) so the use case can short-circuit without an application→infrastructure import (passes the existing architecture boundary test).
- Exposed `isOpen()` / `getOpenUntil()` on the circuit breaker.
- Used inside `SyncSubscribedPlaylistsUseCase` and `CatalogSyncWorker` to skip runs cleanly.

## Test plan

- [x] `pnpm --filter backend test` — 253/253 passing, including 3 new tests for the sync use case (circuit-open skip, third-party unsubscribe, transient-error abort).
- [x] `pnpm --filter frontend test` — 82/82 passing.
- [x] `pnpm --filter backend lint` / `pnpm --filter frontend lint` — no new warnings.
- [x] `pnpm --filter backend build` — passes (tsc + tsc-alias).
- [x] Manual: opened a cached Aitana album (`/album/7eLcDZDYHXZCebtQmVFL25/1lKquzZlhL5AWMHTeGej4M`) with `spotifyUrl` set and `deezerAlbumId` null — tracks load through Deezer cascade, no `/preview` redirect.