### PR TITLE
ci: build arm64 on native runner and merge multi-arch manifest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,29 +5,76 @@ on:
     tags:
       - "v*.*.*" # Trigger on version tags like v0.1.0, v1.2.3, etc.
 
+env:
+  IMAGE: mralexandersaavedra/spotiarr
+
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  build:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.20.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
-          node-version: "24"
-          cache: "pnpm"
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -42,21 +89,19 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: mralexandersaavedra/spotiarr
+          images: ${{ env.IMAGE }}
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Summary

- Split the Docker image build into a matrix per platform.
- `linux/amd64` runs on `ubuntu-latest`, `linux/arm64` runs on the free `ubuntu-24.04-arm` runner.
- Each platform pushes by digest, then a merge job combines the per-arch digests into the multi-arch manifest under the same semver tags.

## Why

The `v1.7.1` tag build hung for over an hour in QEMU-emulated arm64. Two consecutive runs both ended in `cancelled` without producing an image, leaving the new release un-deployable through `docker compose pull`.

QEMU emulation is the documented bottleneck (and a known source of intermittent hangs) when arm64 is built from an amd64 runner. GitHub now offers native arm64 runners for free on public repos, so we can build each arch natively and stitch the manifest at the end.

Multi-arch support stays exactly the same — amd64, arm64 (Raspberry Pi, Apple Silicon, ARM servers) all still receive their own image under the published tags.

## Test plan

- [ ] After merge, retag (or re-run) the `v1.7.1` build and confirm:
  - Two parallel `Build (linux/amd64)` and `Build (linux/arm64)` jobs succeed.
  - The `Merge manifests` job pushes the multi-arch tag.
  - `docker buildx imagetools inspect mralexandersaavedra/spotiarr:1.7.1` shows both `linux/amd64` and `linux/arm64` entries.