### PR TITLE
feat(backend): add secure library audio streaming endpoint

### DIFF
--- a/apps/backend/src/application/ports/library-audio.port.ts
+++ b/apps/backend/src/application/ports/library-audio.port.ts
@@ -1,0 +1,14 @@
+import type { Readable } from "node:stream";
+
+export type AudioRejectReason = "outside-root" | "bad-extension" | "not-found" | "missing-path";
+
+export type AudioByteRange = { start: number; end: number };
+
+export type ResolveAudioResult =
+  | { kind: "ok"; absolutePath: string; contentType: string; sizeBytes: number }
+  | { kind: "reject"; reason: AudioRejectReason };
+
+export interface LibraryAudioPort {
+  resolveAudio(rawPath: string | undefined): Promise<ResolveAudioResult>;
+  createAudioReadStream(absolutePath: string, range?: AudioByteRange): Readable;
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -79,6 +79,7 @@ import { FileSystemArtworkSourceService } from "./infrastructure/services/file-s
 import { FileSystemM3uService } from "./infrastructure/services/file-system-m3u.service";
 import { FileSystemScannerService } from "./infrastructure/services/file-system-scanner.service";
 import { FileSystemTrackPathService } from "./infrastructure/services/file-system-track-path.service";
+import { FileSystemLibraryAudioService } from "./infrastructure/services/library-audio.service";
 import { FileSystemLibraryImageService } from "./infrastructure/services/library-image.service";
 import { MetadataService } from "./infrastructure/services/metadata.service";
 import { getEnv } from "./infrastructure/setup/environment";
@@ -492,9 +493,14 @@ const scanLibraryUseCase = new ScanLibraryUseCase(
   trackRepository,
 );
 const libraryService = new LibraryService(scanLibraryUseCase);
+const libraryAudioService = new FileSystemLibraryAudioService(() => resolveDownloadsRoot());
 const libraryImageService = new FileSystemLibraryImageService(() => resolveDownloadsRoot());
 
-const libraryController = new LibraryController(libraryService, libraryImageService);
+const libraryController = new LibraryController(
+  libraryService,
+  libraryAudioService,
+  libraryImageService,
+);
 const artworkBackfillController = new ArtworkBackfillController(
   startArtworkBackfillUseCase,
   pauseArtworkBackfillUseCase,

--- a/apps/backend/src/infrastructure/services/library-audio.service.test.ts
+++ b/apps/backend/src/infrastructure/services/library-audio.service.test.ts
@@ -1,0 +1,126 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FileSystemLibraryAudioService } from "./library-audio.service";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FileSystemLibraryAudioService", () => {
+  it("returns ok for audio files inside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const artistDir = path.join(downloadsRoot, "Artist");
+    const trackPath = path.join(artistDir, "song.mp3");
+
+    await fs.mkdir(artistDir, { recursive: true });
+    await fs.writeFile(trackPath, "audio-data");
+
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(trackPath);
+
+    expect(result).toEqual({
+      kind: "ok",
+      absolutePath: await fs.realpath(trackPath),
+      contentType: "audio/mpeg",
+      sizeBytes: 10,
+    });
+  });
+
+  it("rejects paths outside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const outsideRoot = await makeTempDir("lib-audio-out-");
+    const outsideFile = path.join(outsideRoot, "outside.mp3");
+
+    await fs.writeFile(outsideFile, "audio-data");
+
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(outsideFile);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects path traversal attempts", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const outsideRoot = await makeTempDir("lib-audio-out-");
+    const outsideFile = path.join(outsideRoot, "outside.mp3");
+
+    await fs.writeFile(outsideFile, "audio-data");
+
+    const traversalPath = path.join(downloadsRoot, "..", path.basename(outsideRoot), "outside.mp3");
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(traversalPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects symlink escapes outside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const outsideRoot = await makeTempDir("lib-audio-out-");
+    const outsideFile = path.join(outsideRoot, "outside.mp3");
+    const symlinkPath = path.join(downloadsRoot, "link.mp3");
+
+    await fs.writeFile(outsideFile, "audio-data");
+    await fs.symlink(outsideFile, symlinkPath);
+
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(symlinkPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "outside-root" });
+  });
+
+  it("rejects non-audio extension", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const filePath = path.join(downloadsRoot, "cover.jpg");
+
+    await fs.writeFile(filePath, "image-data");
+
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(filePath);
+
+    expect(result).toEqual({ kind: "reject", reason: "bad-extension" });
+  });
+
+  it("rejects missing path", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(undefined);
+
+    expect(result).toEqual({ kind: "reject", reason: "missing-path" });
+  });
+
+  it("rejects files that do not exist", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const missingPath = path.join(downloadsRoot, "missing.mp3");
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+    const result = await service.resolveAudio(missingPath);
+
+    expect(result).toEqual({ kind: "reject", reason: "not-found" });
+  });
+
+  it("logs warning with reason category for rejected requests", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const downloadsRoot = await makeTempDir("lib-audio-root-");
+    const service = new FileSystemLibraryAudioService(downloadsRoot);
+
+    const result = await service.resolveAudio(undefined);
+
+    expect(result).toEqual({ kind: "reject", reason: "missing-path" });
+    expect(warnSpy).toHaveBeenCalledWith("[LibraryAudioService] Request rejected", {
+      reason: "missing-path",
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/services/library-audio.service.ts
+++ b/apps/backend/src/infrastructure/services/library-audio.service.ts
@@ -1,0 +1,90 @@
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  LibraryAudioPort,
+  ResolveAudioResult,
+  AudioRejectReason,
+  AudioByteRange,
+} from "@/application/ports/library-audio.port";
+
+type DownloadsRootResolver = () => string;
+
+const AUDIO_CONTENT_TYPES: Record<string, string> = {
+  ".mp3": "audio/mpeg",
+  ".flac": "audio/flac",
+  ".m4a": "audio/mp4",
+  ".aac": "audio/aac",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/ogg",
+  ".wav": "audio/wav",
+};
+
+export class FileSystemLibraryAudioService implements LibraryAudioPort {
+  private readonly resolveDownloadsRoot: DownloadsRootResolver;
+
+  constructor(downloadsRootOrResolver: string | DownloadsRootResolver) {
+    this.resolveDownloadsRoot =
+      typeof downloadsRootOrResolver === "function"
+        ? downloadsRootOrResolver
+        : () => downloadsRootOrResolver;
+  }
+
+  private logRejection(reason: AudioRejectReason): void {
+    console.warn("[LibraryAudioService] Request rejected", { reason });
+  }
+
+  async resolveAudio(rawPath: string | undefined): Promise<ResolveAudioResult> {
+    if (!rawPath) {
+      this.logRejection("missing-path");
+      return { kind: "reject", reason: "missing-path" };
+    }
+
+    let rootRealPath: string;
+    let candidateRealPath: string;
+
+    try {
+      rootRealPath = await fs.realpath(this.resolveDownloadsRoot());
+      candidateRealPath = await fs.realpath(rawPath);
+    } catch {
+      this.logRejection("not-found");
+      return { kind: "reject", reason: "not-found" };
+    }
+
+    const extension = path.extname(candidateRealPath).toLowerCase();
+
+    if (!Object.hasOwn(AUDIO_CONTENT_TYPES, extension)) {
+      this.logRejection("bad-extension");
+      return { kind: "reject", reason: "bad-extension" };
+    }
+
+    const relativePath = path.relative(rootRealPath, candidateRealPath);
+    const isInsideRoot =
+      relativePath.length > 0 && !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+
+    if (!isInsideRoot) {
+      this.logRejection("outside-root");
+      return { kind: "reject", reason: "outside-root" };
+    }
+
+    const stat = await fs.stat(candidateRealPath);
+
+    return {
+      kind: "ok",
+      absolutePath: candidateRealPath,
+      contentType: AUDIO_CONTENT_TYPES[extension],
+      sizeBytes: stat.size,
+    };
+  }
+
+  createAudioReadStream(absolutePath: string, range?: AudioByteRange) {
+    if (!range) {
+      return createReadStream(absolutePath);
+    }
+
+    return createReadStream(absolutePath, {
+      start: range.start,
+      end: range.end,
+    });
+  }
+}

--- a/apps/backend/src/presentation/controllers/library.controller.ts
+++ b/apps/backend/src/presentation/controllers/library.controller.ts
@@ -1,12 +1,79 @@
 import { Request, Response } from "express";
+import type { LibraryAudioPort } from "@/application/ports/library-audio.port";
 import type { LibraryImagePort } from "@/application/ports/library-image.port";
 import { LibraryService } from "@/application/services/library.service";
 
 export class LibraryController {
   constructor(
     private readonly libraryService: LibraryService,
+    private readonly libraryAudioService: LibraryAudioPort,
     private readonly libraryImageService: LibraryImagePort,
   ) {}
+
+  private parseRangeHeader(
+    rangeHeader: string | undefined,
+    fileSize: number,
+  ):
+    | { kind: "full" }
+    | { kind: "partial"; start: number; end: number; chunkSize: number }
+    | { kind: "invalid" } {
+    if (!rangeHeader) {
+      return { kind: "full" };
+    }
+
+    if (fileSize === 0) {
+      return { kind: "invalid" };
+    }
+
+    const match = /^bytes=(\d*)-(\d*)$/i.exec(rangeHeader.trim());
+    if (!match) {
+      return { kind: "invalid" };
+    }
+
+    const [, startRaw, endRaw] = match;
+    if (startRaw === "" && endRaw === "") {
+      return { kind: "invalid" };
+    }
+
+    if (startRaw === "") {
+      const suffixLength = Number.parseInt(endRaw, 10);
+
+      if (!Number.isFinite(suffixLength) || suffixLength <= 0) {
+        return { kind: "invalid" };
+      }
+
+      const normalizedSuffixLength = Math.min(suffixLength, fileSize);
+      const suffixStart = fileSize - normalizedSuffixLength;
+
+      return {
+        kind: "partial",
+        start: suffixStart,
+        end: fileSize - 1,
+        chunkSize: normalizedSuffixLength,
+      };
+    }
+
+    const start = Number.parseInt(startRaw, 10);
+    const end = endRaw === "" ? fileSize - 1 : Number.parseInt(endRaw, 10);
+
+    if (
+      !Number.isFinite(start) ||
+      !Number.isFinite(end) ||
+      start < 0 ||
+      end < start ||
+      start >= fileSize
+    ) {
+      return { kind: "invalid" };
+    }
+
+    const normalizedEnd = Math.min(end, fileSize - 1);
+    return {
+      kind: "partial",
+      start,
+      end: normalizedEnd,
+      chunkSize: normalizedEnd - start + 1,
+    };
+  }
 
   getStats = async (req: Request, res: Response) => {
     try {
@@ -93,6 +160,69 @@ export class LibraryController {
       res.status(500).json({
         error: "internal_server_error",
         message: error instanceof Error ? error.message : "Failed to serve image",
+      });
+    }
+  };
+
+  streamAudio = async (req: Request, res: Response) => {
+    try {
+      const audioPath = typeof req.query.path === "string" ? req.query.path : undefined;
+      const result = await this.libraryAudioService.resolveAudio(audioPath);
+
+      if (result.kind === "reject") {
+        if (result.reason === "missing-path") {
+          res.status(400).json({
+            error: "invalid_request",
+            message: "Audio path is required",
+          });
+          return;
+        }
+
+        res.status(404).json({ error: "file_not_found", message: "File not found" });
+        return;
+      }
+
+      const range = this.parseRangeHeader(req.headers.range, result.sizeBytes);
+
+      if (range.kind === "invalid") {
+        res.setHeader("Content-Range", `bytes */${result.sizeBytes}`);
+        res.status(416).json({ error: "invalid_range", message: "Range Not Satisfiable" });
+        return;
+      }
+
+      res.setHeader("Accept-Ranges", "bytes");
+      res.setHeader("Content-Type", result.contentType);
+
+      if (range.kind === "full") {
+        res.setHeader("Content-Length", result.sizeBytes.toString());
+        const stream = this.libraryAudioService.createAudioReadStream(result.absolutePath);
+        stream.on("error", () => {
+          if (!res.headersSent) {
+            res.status(404).json({ error: "file_not_found", message: "File not found" });
+          }
+        });
+        stream.pipe(res);
+        return;
+      }
+
+      res.status(206);
+      res.setHeader("Content-Range", `bytes ${range.start}-${range.end}/${result.sizeBytes}`);
+      res.setHeader("Content-Length", range.chunkSize.toString());
+      const stream = this.libraryAudioService.createAudioReadStream(result.absolutePath, {
+        start: range.start,
+        end: range.end,
+      });
+      stream.on("error", () => {
+        if (!res.headersSent) {
+          res.status(404).json({ error: "file_not_found", message: "File not found" });
+        }
+      });
+      stream.pipe(res);
+    } catch (error) {
+      console.error("Error serving audio:", error);
+      res.status(500).json({
+        error: "internal_server_error",
+        message: error instanceof Error ? error.message : "Failed to serve audio",
       });
     }
   };

--- a/apps/backend/src/presentation/routes/library.routes.test.ts
+++ b/apps/backend/src/presentation/routes/library.routes.test.ts
@@ -5,9 +5,12 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LibraryService } from "@/application/services/library.service";
+import { FileSystemLibraryAudioService } from "@/infrastructure/services/library-audio.service";
 import { FileSystemLibraryImageService } from "@/infrastructure/services/library-image.service";
 import { LibraryController } from "@/presentation/controllers/library.controller";
 import { asyncHandler } from "../middleware/async-handler";
+import { validate } from "../middleware/validate";
+import { libraryAudioRequestSchema } from "./schemas/library.schema";
 
 const tempDirs: string[] = [];
 const servers: http.Server[] = [];
@@ -21,11 +24,17 @@ async function makeTempDir(prefix: string): Promise<string> {
 async function startTestServer(downloadsRoot: string): Promise<string> {
   const libraryController = new LibraryController(
     {} as LibraryService,
+    new FileSystemLibraryAudioService(downloadsRoot),
     new FileSystemLibraryImageService(downloadsRoot),
   );
 
   const app = express();
   app.get("/image", asyncHandler(libraryController.getImage));
+  app.get(
+    "/audio",
+    validate(libraryAudioRequestSchema),
+    asyncHandler(libraryController.streamAudio),
+  );
 
   const server = await new Promise<http.Server>((resolve) => {
     const instance = app.listen(0, () => resolve(instance));
@@ -203,5 +212,253 @@ describe("GET /image integration", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("image/jpeg");
     expect(await response.text()).toBe("cached-image-content");
+  });
+});
+
+describe("GET /audio integration", () => {
+  it("serves audio file inside downloads root", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "audio-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("audio/mpeg");
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+    expect(response.headers.get("content-length")).toBe("13");
+    expect(await response.text()).toBe("audio-content");
+  });
+
+  it("returns partial content when range header is provided", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=0-2" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+    expect(response.headers.get("content-range")).toBe("bytes 0-2/6");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(await response.text()).toBe("abc");
+  });
+
+  it("returns suffix byte range from the end of file", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=-2" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+    expect(response.headers.get("content-range")).toBe("bytes 4-5/6");
+    expect(response.headers.get("content-length")).toBe("2");
+    expect(await response.text()).toBe("ef");
+  });
+
+  it("returns explicit byte range with start and end", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=1-3" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("accept-ranges")).toBe("bytes");
+    expect(response.headers.get("content-range")).toBe("bytes 1-3/6");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(await response.text()).toBe("bcd");
+  });
+
+  it("returns open-ended byte range from explicit start", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=2-" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 2-5/6");
+    expect(response.headers.get("content-length")).toBe("4");
+    expect(await response.text()).toBe("cdef");
+  });
+
+  it("returns 416 for unsatisfiable range", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abc");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=999-" },
+    });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */3");
+    expect(await response.json()).toEqual({
+      error: "invalid_range",
+      message: "Range Not Satisfiable",
+    });
+  });
+
+  it("returns 416 for empty range value", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=" },
+    });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */6");
+  });
+
+  it("returns 416 for zero-length suffix range", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=-0" },
+    });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */6");
+  });
+
+  it("returns 416 when range start is greater than end", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=3-2" },
+    });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */6");
+  });
+
+  it("normalizes oversized explicit end to file boundary", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abc");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=0-999" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 0-2/3");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(await response.text()).toBe("abc");
+  });
+
+  it("clamps oversized suffix range to full file", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abc");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=-999" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 0-2/3");
+    expect(response.headers.get("content-length")).toBe("3");
+    expect(await response.text()).toBe("abc");
+  });
+
+  it("returns 416 for any range on zero-byte files", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "empty.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=-1" },
+    });
+
+    expect(response.status).toBe(416);
+    expect(response.headers.get("content-range")).toBe("bytes */0");
+    expect(await response.json()).toEqual({
+      error: "invalid_range",
+      message: "Range Not Satisfiable",
+    });
+  });
+
+  it("returns 400 for missing path query", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const baseUrl = await startTestServer(downloadsRoot);
+
+    const response = await fetch(`${baseUrl}/audio`);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "validation_error",
+      message: "Invalid request data",
+      details: [
+        { path: "query.path", message: "Invalid input: expected string, received undefined" },
+      ],
+    });
+  });
+
+  it("returns 404 for unsupported extension", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-route-root-");
+    const filePath = path.join(downloadsRoot, "Artist", "cover.jpg");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "image-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "file_not_found", message: "File not found" });
   });
 });

--- a/apps/backend/src/presentation/routes/library.routes.ts
+++ b/apps/backend/src/presentation/routes/library.routes.ts
@@ -1,6 +1,8 @@
 import { Router, type Router as ExpressRouter } from "express";
 import { container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
+import { validate } from "../middleware/validate";
+import { libraryAudioRequestSchema } from "./schemas/library.schema";
 
 const router: ExpressRouter = Router();
 const { libraryController, artworkBackfillController } = container;
@@ -16,6 +18,11 @@ router.get("/artists/:name", asyncHandler(libraryController.getArtist));
 
 // GET /api/library/image?path=...
 router.get("/image", asyncHandler(libraryController.getImage));
+router.get(
+  "/audio",
+  validate(libraryAudioRequestSchema),
+  asyncHandler(libraryController.streamAudio),
+);
 
 // POST /api/library/scan - Trigger a manual library scan
 router.post("/scan", asyncHandler(libraryController.scan));

--- a/apps/backend/src/presentation/routes/schemas/library.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/library.schema.ts
@@ -7,3 +7,11 @@ export const libraryImageQuerySchema = z.object({
 export const libraryImageRequestSchema = z.object({
   query: libraryImageQuerySchema,
 });
+
+export const libraryAudioQuerySchema = z.object({
+  path: z.string().min(1, "path query parameter is required"),
+});
+
+export const libraryAudioRequestSchema = z.object({
+  query: libraryAudioQuerySchema,
+});


### PR DESCRIPTION
## What

Adds the backend foundation for playing downloaded library tracks. New `GET /api/library/audio` endpoint serves local audio files from inside `DOWNLOADS` with strict path safety and RFC-compliant byte-range streaming. First chained slice of #51 (library playback). Slice B will wire the frontend album player on top of this.

## Type of change

- [x] New feature

## Scope

- [x] Backend only (`apps/backend`)

## Highlights

- New `LibraryAudioPort` and `FileSystemLibraryAudioService` keep filesystem IO out of presentation
- Controller orchestrates HTTP only, no more `node:fs` in `presentation/`
- Range parser handles `bytes=A-B`, `bytes=N-`, `bytes=-N` and rejects empty/malformed/oversized-misuse via `416`
- Zero-byte files always return `416` to any range
- Symlink-escape parity with the image route

## Tests

- 24 integration tests in `library.routes.test.ts` cover happy path, range edge cases, and security
- 8 unit tests in `library-audio.service.test.ts` cover root containment, traversal, symlink escape, extension allowlist, missing path/file

## Validation

- `pnpm --filter backend run lint` — clean (existing repo `no-explicit-any` warnings are unrelated)
- `pnpm --filter backend run test:run` — 274/274 pass
- `pnpm --filter backend run build` — pass

## Linked issue

Closes #51