### PR TITLE
feat(frontend): add playback support to library album detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.8.0](https://github.com/mralexsaavedra/spotiarr/compare/v1.7.2...v1.8.0) (2026-06-02)
+
+### Features
+
+- **Library Playback**: Added a native audio player to the library album detail view, supporting seamless playback of downloaded tracks with assertive browser-restriction handling and error recovery.
+- **Secure Streaming**: Implemented a secure backend endpoint for streaming library audio files with proper range support and authentication.
+
 ## [1.7.2](https://github.com/mralexsaavedra/spotiarr/compare/v1.7.1...v1.7.2) (2026-06-01)
 
 ### Bug Fixes

--- a/apps/frontend/src/components/molecules/AlbumPageLayout.test.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.test.tsx
@@ -7,10 +7,13 @@ vi.mock("./PlaylistHeader", () => ({
   PlaylistHeader: ({ title }: { title: string }) => <div>{title}</div>,
 }));
 
+const mockPlaylistTracksList = vi.fn(({ tracks }: { tracks: Array<{ id: string }> }) => (
+  <div data-testid="tracks-list">{tracks.map((track) => track.id).join(",")}</div>
+));
+
 vi.mock("../organisms/PlaylistTracksList", () => ({
-  PlaylistTracksList: ({ tracks }: { tracks: Array<{ id: string }> }) => (
-    <div data-testid="tracks-list">{tracks.map((track) => track.id).join(",")}</div>
-  ),
+  PlaylistTracksList: (props: unknown) =>
+    mockPlaylistTracksList(props as { tracks: Array<{ id: string }> }),
 }));
 
 describe("AlbumPageLayout", () => {
@@ -53,5 +56,41 @@ describe("AlbumPageLayout", () => {
 
     expect(screen.getByRole("button", { name: "action" })).toBeDefined();
     expect(screen.getByTestId("tracks-list").textContent).toContain("track-1");
+  });
+
+  it("passes playback props to PlaylistTracksList", () => {
+    const onPlayTrack = vi.fn();
+    const onPauseTrack = vi.fn();
+
+    render(
+      <AlbumPageLayout
+        title="Playback Album"
+        type={PlaylistTypeEnum.Album}
+        totalCount={1}
+        tracks={[
+          {
+            id: "track-1",
+            name: "Track 1",
+            artist: "Artist 1",
+            status: TrackStatusEnum.Completed,
+          },
+        ]}
+        emptyTitle="playlist.emptyTracksTitle"
+        emptyDescription="playlist.emptyTracksDescription"
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        currentTrackId="track-1"
+        isPlaying={true}
+      />,
+    );
+
+    expect(mockPlaylistTracksList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onPlayTrack,
+        onPauseTrack,
+        currentTrackId: "track-1",
+        isPlaying: true,
+      }),
+    );
   });
 });

--- a/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
@@ -22,6 +22,10 @@ export interface AlbumPageLayoutProps {
   hasMoreTracks?: boolean;
   isLoadingMoreTracks?: boolean;
   onLoadMoreTracks?: () => void;
+  onPlayTrack?: (trackId: string) => void;
+  onPauseTrack?: () => void;
+  currentTrackId?: string | null;
+  isPlaying?: boolean;
 }
 
 export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
@@ -40,6 +44,10 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
   hasMoreTracks = false,
   isLoadingMoreTracks = false,
   onLoadMoreTracks,
+  onPlayTrack,
+  onPauseTrack,
+  currentTrackId,
+  isPlaying = false,
 }) => {
   return (
     <div className="bg-background text-text-primary flex-1">
@@ -70,6 +78,10 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
             onLoadMoreTracks={onLoadMoreTracks}
             hasMoreTracks={hasMoreTracks}
             isLoadingMoreTracks={isLoadingMoreTracks}
+            onPlayTrack={onPlayTrack}
+            onPauseTrack={onPauseTrack}
+            currentTrackId={currentTrackId}
+            isPlaying={isPlaying}
           />
         )}
       </div>

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
@@ -1,0 +1,80 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Track } from "@/types";
+import { PlaylistTracksList } from "./PlaylistTracksList";
+
+vi.mock("@/contexts/DownloadStatusContext", () => ({
+  useBulkTrackStatus: () => new Map<string, TrackStatusEnum>(),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("../molecules/VirtualList", () => ({
+  VirtualList: ({
+    items,
+    renderItem,
+  }: {
+    items: Track[];
+    renderItem: (track: Track, index: number) => React.ReactNode;
+  }) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={item.id}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const tracks: Track[] = [
+  {
+    id: "track-1",
+    name: "Track 1",
+    artist: "Artist 1",
+    album: "Album 1",
+    durationMs: 120000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
+  },
+];
+
+describe("PlaylistTracksList playback", () => {
+  it("renders a pause button for currently playing track", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId="track-1"
+        isPlaying={true}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "library.album.pauseTrack" })).toBeTruthy();
+  });
+
+  it("calls onPlayTrack when play is pressed", () => {
+    const onPlayTrack = vi.fn();
+
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={onPlayTrack}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
+    expect(onPlayTrack).toHaveBeenCalledWith("track-1");
+  });
+});

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
@@ -20,10 +20,24 @@ interface PlaylistTrackItemProps {
   status?: TrackStatusEnum;
   onRetryTrack?: (trackId: string) => void;
   onDownloadTrack?: (track: Track) => void;
+  onPlayTrack?: (trackId: string) => void;
+  onPauseTrack?: () => void;
+  currentTrackId?: string | null;
+  isPlaying?: boolean;
 }
 
 const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
-  ({ track, index, status, onRetryTrack, onDownloadTrack }) => {
+  ({
+    track,
+    index,
+    status,
+    onRetryTrack,
+    onDownloadTrack,
+    onPlayTrack,
+    onPauseTrack,
+    currentTrackId,
+    isPlaying,
+  }) => {
     const { t } = useTranslation();
     const artists = track.artists || [{ name: track.artist }];
 
@@ -50,6 +64,26 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
     const stopPropagation = useCallback((e: MouseEvent) => {
       e.stopPropagation();
     }, []);
+
+    const isCurrent = currentTrackId === track.id;
+
+    const handleTogglePlayback = useCallback(
+      (e: MouseEvent) => {
+        e.stopPropagation();
+
+        if (!onPlayTrack) {
+          return;
+        }
+
+        if (isCurrent && isPlaying && onPauseTrack) {
+          onPauseTrack();
+          return;
+        }
+
+        onPlayTrack(track.id);
+      },
+      [isCurrent, isPlaying, onPauseTrack, onPlayTrack, track.id],
+    );
 
     return (
       <div className="group grid grid-cols-[auto_1fr_auto] items-center gap-4 rounded-md px-4 py-2 transition-colors hover:bg-white/10 md:grid-cols-[16px_1fr_1fr_180px]">
@@ -104,6 +138,20 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
         {/* Duration & Actions */}
         <div className="flex items-center justify-end gap-4">
           <div className="text-text-secondary flex min-w-[40px] items-center justify-end gap-2 text-right text-sm tabular-nums">
+            {onPlayTrack ? (
+              <button
+                type="button"
+                onClick={handleTogglePlayback}
+                className="text-primary hover:text-primary/80 focus-visible:ring-primary rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                aria-label={
+                  isCurrent && isPlaying
+                    ? t("library.album.pauseTrack")
+                    : t("library.album.playTrack")
+                }
+              >
+                {isCurrent && isPlaying ? t("library.album.pause") : t("library.album.play")}
+              </button>
+            ) : null}
             {(status ?? track.status) === "completed" && (
               <FontAwesomeIcon
                 icon={faCircleCheck}
@@ -126,6 +174,10 @@ interface PlaylistTracksListProps {
   onLoadMoreTracks?: () => void;
   hasMoreTracks?: boolean;
   isLoadingMoreTracks?: boolean;
+  onPlayTrack?: (trackId: string) => void;
+  onPauseTrack?: () => void;
+  currentTrackId?: string | null;
+  isPlaying?: boolean;
 }
 
 export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
@@ -135,6 +187,10 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
   onLoadMoreTracks,
   hasMoreTracks = false,
   isLoadingMoreTracks = false,
+  onPlayTrack,
+  onPauseTrack,
+  currentTrackId,
+  isPlaying = false,
 }) => {
   const { t } = useTranslation();
 
@@ -155,10 +211,22 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
           status={status}
           onRetryTrack={onRetryTrack}
           onDownloadTrack={onDownloadTrack}
+          onPlayTrack={onPlayTrack}
+          onPauseTrack={onPauseTrack}
+          currentTrackId={currentTrackId}
+          isPlaying={isPlaying}
         />
       );
     },
-    [onRetryTrack, onDownloadTrack, trackStatusesMap],
+    [
+      onRetryTrack,
+      onDownloadTrack,
+      onPlayTrack,
+      onPauseTrack,
+      currentTrackId,
+      isPlaying,
+      trackStatusesMap,
+    ],
   );
 
   return (

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -1,5 +1,5 @@
 import { LibraryArtist, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { generatePath } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { Path } from "@/routes/routes";
@@ -90,6 +90,7 @@ describe("useLibraryAlbumDetailController", () => {
     expect(result.current.tracks[0]?.status).toBe(TrackStatusEnum.Completed);
     expect(result.current.tracks[0]?.durationMs).toBe(180000);
     expect(result.current.tracks[1]?.durationMs).toBe(245000);
+    expect(result.current.tracks[0]?.trackUrl).toBe("/api/library/audio?path=%2Ftmp%2F01.mp3");
   });
 
   it("builds back link with raw artist name and router handles encoding once", () => {
@@ -136,5 +137,69 @@ describe("useLibraryAlbumDetailController", () => {
     expect(result.current.album).toBeUndefined();
     expect(result.current.isNotFound).toBe(true);
     expect(result.current.tracks).toEqual([]);
+  });
+
+  it("pauses and resets playback when route params change without unmount", () => {
+    const pause = vi.fn();
+    const audioElement = { pause } as unknown as HTMLAudioElement;
+
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result, rerender } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+      result.current.onPlayTrack(result.current.tracks[0]!.id);
+      result.current.onAudioPlay();
+      result.current.onAudioError();
+    });
+
+    expect(result.current.currentTrackId).toBe(result.current.tracks[0]!.id);
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.playbackError).toBe("library.album.playbackFailed");
+
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "Different%20Album",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: {
+        ...makeArtist(),
+        albums: [
+          {
+            ...makeArtist().albums[0]!,
+            name: "Different Album",
+            path: "/library/sigur-ros/different-album",
+            tracks: [
+              {
+                ...makeArtist().albums[0]!.tracks[0]!,
+                filePath: "/tmp/different.mp3",
+                name: "Different Track",
+                album: "Different Album",
+              },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    rerender();
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.playbackError).toBeNull();
   });
 });

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -1,8 +1,15 @@
 import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { generatePath, useParams } from "react-router-dom";
 import { Path } from "@/routes/routes";
 import { Track } from "@/types";
 import { useLibraryArtistQuery } from "../queries/useLibraryArtistQuery";
+
+export type LibraryPlaybackErrorKey =
+  | "library.album.playbackBlocked"
+  | "library.album.playbackFailed"
+  | "library.album.playbackUnavailable"
+  | "library.album.playbackUnsupported";
 
 const safeDecodeURIComponent = (value: string | undefined): string => {
   if (!value) {
@@ -26,8 +33,12 @@ export const useLibraryAlbumDetailController = () => {
 
   const album = artist?.albums.find((candidate) => candidate.name === selectedAlbumName);
 
-  const tracks: Track[] =
-    album?.tracks.map((track, index) => ({
+  const tracks: Track[] = useMemo(() => {
+    if (!album) {
+      return [];
+    }
+
+    return album.tracks.map((track, index) => ({
       id: `${artistName}-${album.name}-${index}`,
       playlistId: album.path,
       name: track.name,
@@ -36,9 +47,150 @@ export const useLibraryAlbumDetailController = () => {
       album: track.album,
       durationMs: track.duration ? track.duration * 1000 : 0,
       status: TrackStatusEnum.Completed,
-      trackUrl: undefined,
+      trackUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(track.filePath)}`,
       albumUrl: undefined,
-    })) ?? [];
+    }));
+  }, [album, artistName]);
+
+  const tracksRef = useRef<Track[]>(tracks);
+  tracksRef.current = tracks;
+
+  const [audioElement, setAudioElementState] = useState<HTMLAudioElement | null>(null);
+  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackError, setPlaybackError] = useState<LibraryPlaybackErrorKey | null>(null);
+  const loadedSrcRef = useRef<string | null>(null);
+  const playAttemptRef = useRef(0);
+  const playbackScopeKeyRef = useRef(`${artistName}::${selectedAlbumName}`);
+
+  const currentTrack = useMemo(
+    () => tracks.find((track) => track.id === currentTrackId) ?? null,
+    [tracks, currentTrackId],
+  );
+
+  const audioSrc = currentTrack?.trackUrl ?? null;
+
+  const setAudioElement = useCallback((element: HTMLAudioElement | null) => {
+    loadedSrcRef.current = element ? loadedSrcRef.current : null;
+    setAudioElementState(element);
+  }, []);
+
+  const playOnElement = useCallback(
+    async (element: HTMLAudioElement | null, src: string | null, attemptId: number) => {
+      if (!element || !src) {
+        return;
+      }
+
+      if (loadedSrcRef.current !== src) {
+        element.src = src;
+        loadedSrcRef.current = src;
+      }
+
+      try {
+        const result = element.play();
+
+        if (result && typeof (result as Promise<void>).then === "function") {
+          await result;
+        }
+      } catch (error) {
+        if (playAttemptRef.current !== attemptId || loadedSrcRef.current !== src) {
+          return;
+        }
+
+        if (error instanceof DOMException) {
+          if (error.name === "AbortError") {
+            return;
+          }
+
+          if (error.name === "NotAllowedError") {
+            setIsPlaying(false);
+            setPlaybackError("library.album.playbackBlocked");
+            return;
+          }
+
+          if (error.name === "NotSupportedError") {
+            setIsPlaying(false);
+            setPlaybackError("library.album.playbackUnsupported");
+            return;
+          }
+        }
+
+        setIsPlaying(false);
+        setPlaybackError("library.album.playbackFailed");
+      }
+    },
+    [],
+  );
+
+  const onPlayTrack = useCallback(
+    (trackId: string) => {
+      const targetTrack = tracksRef.current.find((track) => track.id === trackId);
+      const targetSrc = targetTrack?.trackUrl ?? null;
+      const attemptId = playAttemptRef.current + 1;
+
+      playAttemptRef.current = attemptId;
+
+      setPlaybackError(null);
+      setCurrentTrackId(trackId);
+
+      if (audioElement) {
+        void playOnElement(audioElement, targetSrc, attemptId);
+      }
+    },
+    [audioElement, playOnElement],
+  );
+
+  const onPauseTrack = useCallback(() => {
+    audioElement?.pause();
+    setIsPlaying(false);
+  }, [audioElement]);
+
+  const onAudioPlay = useCallback(() => {
+    setIsPlaying(true);
+  }, []);
+
+  const onAudioPause = useCallback(() => {
+    setIsPlaying(false);
+  }, []);
+
+  const onAudioError = useCallback((event?: SyntheticEvent<HTMLAudioElement>) => {
+    const mediaErrorCode = event?.currentTarget.error?.code;
+
+    setIsPlaying(false);
+
+    if (mediaErrorCode === 4) {
+      setPlaybackError("library.album.playbackUnavailable");
+      return;
+    }
+
+    setPlaybackError("library.album.playbackFailed");
+  }, []);
+
+  useEffect(() => {
+    if (!audioElement) {
+      return;
+    }
+
+    return () => {
+      audioElement.pause();
+    };
+  }, [audioElement]);
+
+  useEffect(() => {
+    const nextScopeKey = `${artistName}::${selectedAlbumName}`;
+
+    if (playbackScopeKeyRef.current === nextScopeKey) {
+      return;
+    }
+
+    playbackScopeKeyRef.current = nextScopeKey;
+    playAttemptRef.current += 1;
+    loadedSrcRef.current = null;
+    audioElement?.pause();
+    setCurrentTrackId(null);
+    setIsPlaying(false);
+    setPlaybackError(null);
+  }, [artistName, selectedAlbumName, audioElement]);
 
   const coverUrl = album?.image
     ? `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/image?path=${encodeURIComponent(album.image)}`
@@ -59,5 +211,15 @@ export const useLibraryAlbumDetailController = () => {
     isNotFound: !isLoading && !error && (!artist || !album),
     playlistType: PlaylistTypeEnum.Album,
     backToArtistPath,
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
   };
 };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -131,7 +131,15 @@
       "tracks": "tracks",
       "loading": "Loading album details...",
       "error": "Could not load album details.",
-      "emptyTracks": "No tracks found for this album."
+      "emptyTracks": "No tracks found for this album.",
+      "play": "Play",
+      "pause": "Pause",
+      "playTrack": "Play track",
+      "pauseTrack": "Pause track",
+      "playbackBlocked": "Your browser blocked playback. Try pressing play again or checking autoplay permissions.",
+      "playbackFailed": "Playback failed for this track. Try again.",
+      "playbackUnavailable": "This track could not be loaded for playback. The source may be unavailable or unsupported.",
+      "playbackUnsupported": "Playback is not supported for this track format in your browser."
     },
     "scanModal": {
       "title": "Scan library",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -131,7 +131,15 @@
       "tracks": "canciones",
       "loading": "Cargando detalles del álbum...",
       "error": "No se pudieron cargar los detalles del álbum.",
-      "emptyTracks": "No se encontraron canciones para este álbum."
+      "emptyTracks": "No se encontraron canciones para este álbum.",
+      "play": "Reproducir",
+      "pause": "Pausar",
+      "playTrack": "Reproducir canción",
+      "pauseTrack": "Pausar canción",
+      "playbackBlocked": "Tu navegador bloqueó la reproducción. Probá reproducir de nuevo o revisá los permisos de autoplay.",
+      "playbackFailed": "La reproducción falló para esta canción. Probá de nuevo.",
+      "playbackUnavailable": "No se pudo cargar esta canción para reproducirla. La fuente puede no estar disponible o no ser compatible.",
+      "playbackUnsupported": "Este formato de audio no es compatible con tu navegador."
     },
     "scanModal": {
       "title": "Escanear biblioteca",

--- a/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
@@ -1,12 +1,14 @@
-import { render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { LibraryArtist } from "@spotiarr/shared";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { LibraryAlbumDetail } from "./LibraryAlbumDetail";
 
-const mockController = vi.fn();
+const mockUseLibraryArtistQuery = vi.fn();
 
-vi.mock("@/hooks/controllers/useLibraryAlbumDetailController", () => ({
-  useLibraryAlbumDetailController: () => mockController(),
+vi.mock("@/hooks/queries/useLibraryArtistQuery", () => ({
+  useLibraryArtistQuery: (name: string) => mockUseLibraryArtistQuery(name),
 }));
 
 vi.mock("react-i18next", async (importOriginal) => {
@@ -20,80 +22,305 @@ vi.mock("react-i18next", async (importOriginal) => {
   };
 });
 
+vi.mock("@/components/molecules/VirtualList", () => ({
+  VirtualList: ({
+    items,
+    renderItem,
+  }: {
+    items: Array<{ id: string }>;
+    renderItem: (item: { id: string }, index: number) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={item.id}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makeArtist = (): LibraryArtist => ({
+  name: "Sigur Rós",
+  path: "/library/sigur-ros",
+  image: "covers/sigur.jpg",
+  albumCount: 1,
+  trackCount: 2,
+  totalSize: 300,
+  albums: [
+    {
+      name: "( )",
+      path: "/library/sigur-ros/()",
+      artist: "Sigur Rós",
+      trackCount: 2,
+      totalSize: 300,
+      year: 2002,
+      image: "covers/album.jpg",
+      tracks: [
+        {
+          fileName: "01.mp3",
+          filePath: "/tmp/01.mp3",
+          trackNumber: 1,
+          name: "Vaka",
+          artist: "Sigur Rós",
+          album: "( )",
+          format: "mp3",
+          size: 100,
+          duration: 180,
+          modifiedAt: 1,
+        },
+        {
+          fileName: "02.mp3",
+          filePath: "/tmp/02.mp3",
+          trackNumber: 2,
+          name: "Fyrsta",
+          artist: "Sigur Rós",
+          album: "( )",
+          format: "mp3",
+          size: 200,
+          duration: 245,
+          modifiedAt: 2,
+        },
+      ],
+    },
+  ],
+});
+
+const renderLibraryAlbumDetail = () =>
+  render(
+    <MemoryRouter initialEntries={["/library/artist/Sigur%20R%C3%B3s/album/%28%20%29"]}>
+      <Routes>
+        <Route path="/library/artist/:name/album/:albumName" element={<LibraryAlbumDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+const instrumentAudioElement = (audio: HTMLAudioElement) => {
+  let srcValue = "";
+  let currentTimeValue = 0;
+  let mediaError: MediaError | null = null;
+
+  Object.defineProperty(audio, "src", {
+    configurable: true,
+    get: () => srcValue,
+    set: (value: string) => {
+      srcValue = value;
+      currentTimeValue = 0;
+    },
+  });
+
+  Object.defineProperty(audio, "currentTime", {
+    configurable: true,
+    get: () => currentTimeValue,
+    set: (value: number) => {
+      currentTimeValue = value;
+    },
+  });
+
+  Object.defineProperty(audio, "error", {
+    configurable: true,
+    get: () => mediaError,
+    set: (value: MediaError | null) => {
+      mediaError = value;
+    },
+  });
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  mockUseLibraryArtistQuery.mockReset();
+});
+
 describe("LibraryAlbumDetail", () => {
   it("renders not-found UX when album is missing", () => {
-    mockController.mockReturnValue({
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: null,
       isLoading: false,
       error: null,
-      isNotFound: true,
-      artistName: "A",
-      albumName: "B",
-      album: undefined,
-      tracks: [],
-      coverUrl: undefined,
-      playlistType: "album",
-      backToArtistPath: "/library/artist/A",
     });
 
-    render(
-      <MemoryRouter>
-        <LibraryAlbumDetail />
-      </MemoryRouter>,
-    );
+    renderLibraryAlbumDetail();
 
     expect(screen.getByText("library.album.notFound")).toBeTruthy();
     expect(screen.getByRole("link", { name: "library.album.backToArtist" })).toBeTruthy();
   });
 
-  it("does not render back-to-artist link in success state", () => {
-    mockController.mockReturnValue({
+  it("starts playback and resumes same track after pause", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
       isLoading: false,
       error: null,
-      isNotFound: false,
-      artistName: "A",
-      albumName: "B",
-      album: {
-        name: "B",
-        path: "/library/A/B",
-        artist: "A",
-        trackCount: 1,
-        totalSize: 1,
-        tracks: [
-          {
-            id: "t-1",
-            playlistId: "p-1",
-            name: "Track",
-            artist: "A",
-            artists: [{ name: "A" }],
-            album: "B",
-            durationMs: 120000,
-            status: "completed",
-          },
-        ],
-      },
-      tracks: [
-        {
-          id: "t-1",
-          playlistId: "p-1",
-          name: "Track",
-          artist: "A",
-          artists: [{ name: "A" }],
-          album: "B",
-          durationMs: 120000,
-          status: "completed",
-        },
-      ],
-      coverUrl: undefined,
-      playlistType: "album",
-      backToArtistPath: "/library/artist/A",
     });
 
-    render(
-      <MemoryRouter>
-        <LibraryAlbumDetail />
-      </MemoryRouter>,
+    const { container } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    expect(audio?.src ?? "").toContain("/api/library/audio?path=");
+
+    fireEvent.play(audio!);
+    audio!.currentTime = 73;
+    fireEvent.click(screen.getByRole("button", { name: "library.album.pauseTrack" }));
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+    expect(audio?.currentTime).toBe(73);
+  });
+
+  it("switches tracks and pauses active audio on unmount", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container, unmount } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    fireEvent.play(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+    expect(audio?.src ?? "").toContain("%2Ftmp%2F02.mp3");
+
+    unmount();
+
+    expect(pauseMock).toHaveBeenCalled();
+  });
+
+  it("shows truthful assertive playback feedback for blocked play and generic media errors", async () => {
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockRejectedValueOnce(new DOMException("Playback blocked", "NotAllowedError"))
+      .mockResolvedValue(undefined);
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+
+    const rejectionAlert = await screen.findByRole("alert");
+    expect(rejectionAlert.textContent).toBe("library.album.playbackBlocked");
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+
+    Object.defineProperty(audio, "error", {
+      configurable: true,
+      value: { code: 2 } as MediaError,
+    });
+    fireEvent.error(audio!);
+
+    const mediaErrorAlert = await screen.findByRole("alert");
+    expect(mediaErrorAlert.textContent).toBe("library.album.playbackFailed");
+  });
+
+  it("shows unsupported playback feedback for NotSupportedError rejections", async () => {
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockRejectedValueOnce(
+      new DOMException("Unsupported", "NotSupportedError"),
     );
 
-    expect(screen.queryByRole("link", { name: "library.album.backToArtist" })).toBeNull();
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+
+    const unsupportedAlert = await screen.findByRole("alert");
+    expect(unsupportedAlert.textContent).toBe("library.album.playbackUnsupported");
+  });
+
+  it("treats media element source support errors as unavailable playback sources", async () => {
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+    Object.defineProperty(audio, "error", {
+      configurable: true,
+      value: { code: 4 } as MediaError,
+    });
+    fireEvent.error(audio!);
+
+    const failureAlert = await screen.findByRole("alert");
+    expect(failureAlert.textContent).toBe("library.album.playbackUnavailable");
+  });
+
+  it("ignores stale AbortError rejections from an interrupted prior track", async () => {
+    const firstPlayController: { reject: null | ((reason?: unknown) => void) } = { reject: null };
+
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            firstPlayController.reject = reject;
+          }),
+      )
+      .mockResolvedValue(undefined);
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { container } = renderLibraryAlbumDetail();
+    const audio = container.querySelector("audio");
+
+    instrumentAudioElement(audio!);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[0]!);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "library.album.playTrack" })[1]!);
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+
+    if (firstPlayController.reject) {
+      firstPlayController.reject(new DOMException("Interrupted", "AbortError"));
+    }
+    await waitFor(() => expect(audio?.src ?? "").toContain("%2Ftmp%2F02.mp3"));
+
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 });

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -19,6 +19,15 @@ export const LibraryAlbumDetail: FC = () => {
     isNotFound,
     playlistType,
     backToArtistPath,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioError,
+    onAudioPlay,
+    onAudioPause,
   } = useLibraryAlbumDetailController();
 
   if (isLoading) {
@@ -86,9 +95,25 @@ export const LibraryAlbumDetail: FC = () => {
         }
         totalCount={tracks.length}
         tracks={tracks}
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        currentTrackId={currentTrackId}
+        isPlaying={isPlaying}
         emptyTitle={t("library.album.emptyTracks")}
         emptyDescription={t("library.album.emptyTracks")}
       />
+      <audio
+        ref={setAudioElement}
+        className="sr-only"
+        onError={onAudioError}
+        onPlay={onAudioPlay}
+        onPause={onAudioPause}
+      />
+      {playbackError ? (
+        <p className="text-text-secondary px-6 py-3 text-sm" role="alert" aria-live="assertive">
+          {t(playbackError)}
+        </p>
+      ) : null}
     </main>
   );
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spotiarr",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Self-hosted Spotify downloader with Jellyfin/Plex integration. Lidarr-inspired music automation.",
   "keywords": [
     "spotify",


### PR DESCRIPTION
## What

This PR adds native audio playback support to the library album detail view. Users can now play and pause tracks directly from the library.

- Implements a dedicated audio element manager in the controller with support for browser autoplay restrictions (`NotAllowedError`) and media error recovery.
- Adds Play/Pause controls to track lists and album layouts.
- Integrates with the new secure library audio streaming endpoint.
- Includes comprehensive unit and integration tests for the playback flow.
- Bumps version to `v1.8.0`.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs / chore

## Scope

- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Checklist

- [x] Lint + build pass for affected scope (`pnpm --filter frontend run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [x] `CHANGELOG.md` updated if this is a user-facing change