### PR TITLE
refactor(backend): route catalog sync through Deezer/MusicBrainz cascade

### DIFF
--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
@@ -1,0 +1,240 @@
+import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
+import type { SettingsService } from "@/application/services/settings.service";
+import type { AppEventBus } from "../messaging/app-event-bus";
+import { runCatalogSyncJob, type CatalogSyncJobDependencies } from "./catalog-sync.worker";
+
+function makeFollowedArtist(overrides: Partial<FollowedArtist> = {}): FollowedArtist {
+  return {
+    id: "artist-1",
+    name: "Test Artist",
+    image: "https://image.test/1.jpg",
+    spotifyUrl: "https://spotify.test/artist/1",
+    ...overrides,
+  };
+}
+
+function makeArtistRelease(overrides: Partial<ArtistRelease> = {}): ArtistRelease {
+  return {
+    artistId: "artist-1",
+    artistName: "Test Artist",
+    artistImageUrl: "https://image.test/1.jpg",
+    albumId: "album-1",
+    albumName: "Test Album",
+    albumType: "album",
+    releaseDate: new Date().toISOString().slice(0, 10),
+    coverUrl: null,
+    ...overrides,
+  };
+}
+
+function makeMockDeps(): CatalogSyncJobDependencies {
+  return {
+    feedRepository: {
+      getArtists: vi.fn().mockResolvedValue([makeFollowedArtist()]),
+      getArtistIdsNeedingCatalogSync: vi.fn().mockResolvedValue(["artist-1"]),
+      upsertArtistAlbums: vi.fn().mockResolvedValue(undefined),
+      updateArtistCatalogSyncedAt: vi.fn().mockResolvedValue(undefined),
+      setCatalogSyncState: vi.fn().mockResolvedValue(undefined),
+    } as unknown as FeedRepositoryPort,
+    releaseFeedService: {
+      getArtistDiscography: vi.fn().mockResolvedValue({
+        albums: [makeArtistRelease()],
+      }),
+    } as unknown as ReleaseFeedPort,
+    eventBus: {
+      emit: vi.fn(),
+    } as unknown as AppEventBus,
+    settingsService: {
+      getNumber: vi.fn().mockResolvedValue(5),
+    } as unknown as SettingsService,
+  };
+}
+
+describe("CatalogSyncWorker — runCatalogSyncJob", () => {
+  let deps: CatalogSyncJobDependencies;
+
+  beforeEach(() => {
+    deps = makeMockDeps();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  describe("REQ-1: Artist list sourced from DB cache", () => {
+    it("SHALL call feedRepository.getArtists() to build the artist list and make no Spotify calls", async () => {
+      await runCatalogSyncJob(deps);
+
+      expect(deps.feedRepository.getArtists).toHaveBeenCalledTimes(1);
+      // Verify no Spotify service method is on the deps object
+      expect(
+        (deps as unknown as Record<string, unknown>).spotifyUserLibrarySyncService,
+      ).toBeUndefined();
+    });
+
+    it("SHALL exit immediately with catalog-updated(0,0) when getArtists() returns empty array", async () => {
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue([]);
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.releaseFeedService.getArtistDiscography).not.toHaveBeenCalled();
+      expect(deps.feedRepository.setCatalogSyncState).toHaveBeenLastCalledWith(SYNC_STATUS.Idle);
+      expect(deps.eventBus.emit).toHaveBeenCalledWith("catalog-updated", {
+        artists: 0,
+        albums: 0,
+      });
+    });
+
+    it("SHALL cap processed artists at MAX_CATALOG_ARTISTS_PER_CYCLE", async () => {
+      const maxPerCycle = 2;
+      vi.mocked(deps.settingsService.getNumber).mockResolvedValue(maxPerCycle);
+
+      const artists = [
+        makeFollowedArtist({ id: "a1" }),
+        makeFollowedArtist({ id: "a2" }),
+        makeFollowedArtist({ id: "a3" }),
+      ];
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue(artists);
+      // IDs needing sync — only maxPerCycle returned by repo
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue(["a1", "a2"]);
+
+      await runCatalogSyncJob(deps);
+
+      // Only 2 artists processed
+      expect(deps.releaseFeedService.getArtistDiscography).toHaveBeenCalledTimes(2);
+    });
+
+    it("SHALL map FollowedArtist.image to imageUrl when calling getArtistDiscography", async () => {
+      const artist = makeFollowedArtist({ id: "a1", name: "Artist One", image: "img-url" });
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue([artist]);
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue(["a1"]);
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.releaseFeedService.getArtistDiscography).toHaveBeenCalledWith({
+        id: "a1",
+        name: "Artist One",
+        imageUrl: "img-url",
+      });
+    });
+
+    it("SHALL never call isAppTokenCircuitOpen — no circuit breaker at worker entry", async () => {
+      // The deps object must not have any isAppTokenCircuitOpen-like method
+      // The worker must not import or call it — verified by the lack of the property
+      const depKeys = Object.keys(deps);
+      expect(depKeys).not.toContain("isAppTokenCircuitOpen");
+      await expect(runCatalogSyncJob(deps)).resolves.not.toThrow();
+    });
+  });
+
+  describe("REQ-3 & REQ-4: Per-artist failure tolerance and catalog-updated event", () => {
+    it("SHALL continue cycle when one of three artists throws and emit correct counts", async () => {
+      const artists = [
+        makeFollowedArtist({ id: "a1" }),
+        makeFollowedArtist({ id: "a2" }),
+        makeFollowedArtist({ id: "a3" }),
+      ];
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue(artists);
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue([
+        "a1",
+        "a2",
+        "a3",
+      ]);
+
+      const releases = [makeArtistRelease({ albumId: "alb-1" })];
+      vi.mocked(deps.releaseFeedService.getArtistDiscography)
+        .mockResolvedValueOnce({ albums: releases })
+        .mockRejectedValueOnce(new Error("fetch failed"))
+        .mockResolvedValueOnce({ albums: releases });
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.eventBus.emit).toHaveBeenCalledWith("catalog-updated", {
+        artists: 2,
+        albums: 2,
+      });
+      expect(deps.feedRepository.setCatalogSyncState).toHaveBeenLastCalledWith(SYNC_STATUS.Idle);
+    });
+
+    it("SHALL transition to Error state and throw when all artists fail", async () => {
+      const artists = [makeFollowedArtist({ id: "a1" }), makeFollowedArtist({ id: "a2" })];
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue(artists);
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue(["a1", "a2"]);
+      vi.mocked(deps.releaseFeedService.getArtistDiscography).mockRejectedValue(
+        new Error("all fail"),
+      );
+
+      await expect(runCatalogSyncJob(deps)).rejects.toThrow();
+
+      expect(deps.feedRepository.setCatalogSyncState).toHaveBeenCalledWith(
+        SYNC_STATUS.Error,
+        expect.any(String),
+      );
+      expect(deps.eventBus.emit).not.toHaveBeenCalled();
+    });
+
+    it("SHALL emit catalog-updated with correct counts when all artists succeed", async () => {
+      const artists = [makeFollowedArtist({ id: "a1" }), makeFollowedArtist({ id: "a2" })];
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue(artists);
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue(["a1", "a2"]);
+
+      const alb1 = makeArtistRelease({ albumId: "alb-1" });
+      const alb2 = makeArtistRelease({ albumId: "alb-2" });
+      vi.mocked(deps.releaseFeedService.getArtistDiscography)
+        .mockResolvedValueOnce({ albums: [alb1] })
+        .mockResolvedValueOnce({ albums: [alb2] });
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.eventBus.emit).toHaveBeenCalledTimes(1);
+      expect(deps.eventBus.emit).toHaveBeenCalledWith("catalog-updated", {
+        artists: 2,
+        albums: 2,
+      });
+    });
+
+    it("SHALL emit catalog-updated with zero counts when artist list is empty (S4-C spec wins)", async () => {
+      vi.mocked(deps.feedRepository.getArtists).mockResolvedValue([]);
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.eventBus.emit).toHaveBeenCalledWith("catalog-updated", {
+        artists: 0,
+        albums: 0,
+      });
+    });
+  });
+
+  describe("REQ-5: Sync state lifecycle", () => {
+    it("SHALL transition Running → Idle during a normal successful cycle", async () => {
+      await runCatalogSyncJob(deps);
+
+      const calls = vi.mocked(deps.feedRepository.setCatalogSyncState).mock.calls;
+      expect(calls[0][0]).toBe(SYNC_STATUS.Running);
+      expect(calls[calls.length - 1][0]).toBe(SYNC_STATUS.Idle);
+    });
+
+    it("SHALL transition to Error state and rethrow when getArtists() throws", async () => {
+      vi.mocked(deps.feedRepository.getArtists).mockRejectedValue(new Error("db failure"));
+
+      await expect(runCatalogSyncJob(deps)).rejects.toThrow("db failure");
+
+      expect(deps.feedRepository.setCatalogSyncState).toHaveBeenCalledWith(
+        SYNC_STATUS.Error,
+        "db failure",
+      );
+      expect(deps.eventBus.emit).not.toHaveBeenCalled();
+    });
+
+    it("SHALL transition Running → Idle when no artist IDs need catalog sync", async () => {
+      vi.mocked(deps.feedRepository.getArtistIdsNeedingCatalogSync).mockResolvedValue([]);
+
+      await runCatalogSyncJob(deps);
+
+      expect(deps.releaseFeedService.getArtistDiscography).not.toHaveBeenCalled();
+      expect(deps.feedRepository.setCatalogSyncState).toHaveBeenLastCalledWith(SYNC_STATUS.Idle);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
@@ -1,15 +1,109 @@
 import { Worker } from "bullmq";
-import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
+import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
+import type { SettingsService } from "@/application/services/settings.service";
 import { container } from "@/container";
-import { isAppTokenCircuitOpen } from "@/infrastructure/external/spotify-http.client";
+import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { CATALOG_SYNC_QUEUE } from "../setup/queues";
 
-const { spotifyUserLibrarySyncService, feedRepository, eventBus, settingsService } = container;
+export interface CatalogSyncJobDependencies {
+  feedRepository: FeedRepositoryPort;
+  releaseFeedService: ReleaseFeedPort;
+  eventBus: AppEventBus;
+  settingsService: SettingsService;
+}
 
 const CATALOG_SYNC_TTL_DAYS = 7;
 
+export async function runCatalogSyncJob(deps: CatalogSyncJobDependencies): Promise<void> {
+  const { feedRepository, settingsService, releaseFeedService, eventBus } = deps;
+
+  await feedRepository.setCatalogSyncState(SYNC_STATUS.Running);
+
+  try {
+    const artists = await feedRepository.getArtists();
+
+    if (artists.length === 0) {
+      console.log("[CatalogSyncWorker] No artists in DB cache — skipping catalog cycle");
+      await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
+      eventBus.emit("catalog-updated", { artists: 0, albums: 0 });
+      return;
+    }
+
+    const cutoffDate = new Date(Date.now() - CATALOG_SYNC_TTL_DAYS * 24 * 60 * 60 * 1000);
+    const maxArtistsPerCycle = await settingsService.getNumber("MAX_CATALOG_ARTISTS_PER_CYCLE", 5);
+
+    const artistIds = await feedRepository.getArtistIdsNeedingCatalogSync(
+      cutoffDate,
+      maxArtistsPerCycle,
+    );
+
+    if (artistIds.length === 0) {
+      console.log("[CatalogSyncWorker] No artists need catalog sync");
+      await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
+      return;
+    }
+
+    console.log(`[CatalogSyncWorker] Processing catalog for ${artistIds.length} artists`);
+
+    const artistMap = new Map(artists.map((a) => [a.id, a]));
+    const artistsToSync = artistIds
+      .map((id) => artistMap.get(id))
+      .filter((a): a is NonNullable<typeof a> => a !== undefined);
+
+    const allAlbums: import("@spotiarr/shared").ArtistRelease[] = [];
+    let successCount = 0;
+    const failedArtistIds: string[] = [];
+
+    for (const artist of artistsToSync) {
+      try {
+        const result = await releaseFeedService.getArtistDiscography({
+          id: artist.id,
+          name: artist.name,
+          imageUrl: artist.image,
+        });
+
+        const albums = result.albums;
+        await feedRepository.upsertArtistAlbums(albums);
+        await feedRepository.updateArtistCatalogSyncedAt([artist.id]);
+        allAlbums.push(...albums);
+        successCount++;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`[CatalogSyncWorker] Failed to sync artist ${artist.id}:`, message);
+        failedArtistIds.push(artist.id);
+      }
+    }
+
+    console.log(
+      `[CatalogSyncWorker] Synced ${successCount}/${artistsToSync.length} artists (${failedArtistIds.length} failed)`,
+    );
+
+    if (successCount === 0) {
+      const errorMessage =
+        failedArtistIds.length > 0
+          ? `All artists failed to sync. First failures: ${failedArtistIds.slice(0, 3).join(", ")}`
+          : "No artists were synced";
+      await feedRepository.setCatalogSyncState(SYNC_STATUS.Error, errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
+    eventBus.emit("catalog-updated", {
+      artists: successCount,
+      albums: allAlbums.length,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await feedRepository.setCatalogSyncState(SYNC_STATUS.Error, message);
+    throw error;
+  }
+}
+
 export function createCatalogSyncWorker(): Worker {
+  const { feedRepository, releaseFeedService, eventBus, settingsService } = container;
+
   // If the process crashed mid-sync, the state is stuck in "running".
   // Reset it on startup so the cron can enqueue a new job.
   feedRepository
@@ -28,116 +122,8 @@ export function createCatalogSyncWorker(): Worker {
 
   const worker = new Worker(
     CATALOG_SYNC_QUEUE,
-    async () => {
-      if (isAppTokenCircuitOpen()) {
-        console.warn(
-          "[CatalogSyncWorker] Skipping run — Spotify circuit breaker is open. Will retry on next scheduled tick.",
-        );
-        await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
-        return;
-      }
-
-      await feedRepository.setCatalogSyncState(SYNC_STATUS.Running);
-
-      try {
-        const artists = await spotifyUserLibrarySyncService.getFollowedArtists();
-        await feedRepository.upsertArtists(artists);
-
-        const cutoffDate = new Date(Date.now() - CATALOG_SYNC_TTL_DAYS * 24 * 60 * 60 * 1000);
-
-        const maxArtistsPerCycle = await settingsService.getNumber(
-          "MAX_CATALOG_ARTISTS_PER_CYCLE",
-          5,
-        );
-
-        const artistIds = await feedRepository.getArtistIdsNeedingCatalogSync(
-          cutoffDate,
-          maxArtistsPerCycle,
-        );
-
-        if (artistIds.length === 0) {
-          console.log("[CatalogSyncWorker] No artists need catalog sync");
-          await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
-          return;
-        }
-
-        console.log(`[CatalogSyncWorker] Processing catalog for ${artistIds.length} artists`);
-
-        const artistMap = new Map(artists.map((a) => [a.id, a]));
-        const artistsToSync = artistIds
-          .map((id) => artistMap.get(id))
-          .filter((a): a is NonNullable<typeof a> => a !== undefined);
-
-        const lookbackDays = await container.settingsService.getNumber(
-          "CATALOG_LOOKBACK_DAYS",
-          365,
-        );
-        const safeLookbackDays = lookbackDays > 0 ? lookbackDays : 365;
-        const earlyStopBeforeDate = new Date(Date.now() - safeLookbackDays * 24 * 60 * 60 * 1000);
-
-        const allAlbums: import("@spotiarr/shared").ArtistRelease[] = [];
-        let successCount = 0;
-        const failedArtistIds: string[] = [];
-
-        for (const artist of artistsToSync) {
-          try {
-            const albums = await spotifyUserLibrarySyncService.getArtistCatalogData(
-              [
-                {
-                  id: artist.id,
-                  name: artist.name,
-                  imageUrl: artist.image,
-                },
-              ],
-              earlyStopBeforeDate,
-            );
-
-            await feedRepository.upsertArtistAlbums(albums);
-            await feedRepository.updateArtistCatalogSyncedAt([artist.id]);
-            allAlbums.push(...albums);
-            successCount++;
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            // Circuit breaker open — abort cycle gracefully, don't hammer Spotify
-            if (
-              error instanceof Error &&
-              "errorCode" in error &&
-              (error as { errorCode: string }).errorCode === "circuit_open"
-            ) {
-              console.warn(
-                `[CatalogSyncWorker] Circuit breaker open — aborting cycle after ${successCount} artists`,
-              );
-              break;
-            }
-            console.warn(`[CatalogSyncWorker] Failed to sync artist ${artist.id}:`, message);
-            failedArtistIds.push(artist.id);
-          }
-        }
-
-        console.log(
-          `[CatalogSyncWorker] Synced ${successCount}/${artistsToSync.length} artists (${failedArtistIds.length} failed)`,
-        );
-
-        if (successCount === 0) {
-          const errorMessage =
-            failedArtistIds.length > 0
-              ? `All artists failed to sync. First failures: ${failedArtistIds.slice(0, 3).join(", ")}`
-              : "No artists were synced";
-          await feedRepository.setCatalogSyncState(SYNC_STATUS.Error, errorMessage);
-          throw new Error(errorMessage);
-        }
-
-        await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
-        eventBus.emit("catalog-updated", {
-          artists: successCount,
-          albums: allAlbums.length,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        await feedRepository.setCatalogSyncState(SYNC_STATUS.Error, message);
-        throw error;
-      }
-    },
+    async () =>
+      runCatalogSyncJob({ feedRepository, releaseFeedService, eventBus, settingsService }),
     {
       connection: {
         host: getEnv().REDIS_HOST,


### PR DESCRIPTION
## Summary

Phase 2 of the Spotify catalog migration. `CatalogSyncWorker` no longer
calls Spotify directly — it now reuses the `ReleaseFeedService` cascade
introduced in Phase 1 (Deezer → MusicBrainz → Spotify last-resort) and
sources the artist list from the local `FollowedArtistCache` via
`FeedRepository`. The vestigial app-token circuit-breaker guard,
`upsertArtists` refresh, `earlyStopBeforeDate` cutoff, and `circuit_open`
error branch were removed because they're no longer reachable.

The worker job body is now an exported pure function
`runCatalogSyncJob(deps)`, with `createCatalogSyncWorker()` reduced to a
thin BullMQ factory that delegates to it. Tests cover artist-source
correctness, partial-failure tolerance, sync-state lifecycle, and
`catalog-updated` event emission.

### Why

- Eliminate the per-artist Spotify catalog requests that were opening
  the rate-limit circuit breaker (`retryAfterMs: 14399999` observed in
  prod logs).
- Close out the second phase of `spotify-catalog-migration`; Phase 1
  already migrated `FeedSyncWorker` the same way.
- Improve catalog completeness: Deezer returns full discography in one
  pass (the previous 365-day Spotify lookback is no longer needed).

### Notable behavior changes

- All-fail path keeps the prior semantics: throw an error and set sync
  state to Error (no `catalog-updated` event emitted). This is an
  accepted divergence from the spec scenario REQ-4 S4-C.
- `CATALOG_LOOKBACK_DAYS` setting is no longer read for catalog cycles.
- `MAX_CATALOG_ARTISTS_PER_CYCLE` and `CATALOG_SYNC_TTL_DAYS` unchanged.

## Test plan

- [x] `pnpm --filter @spotiarr/backend test` — 287/287 passing
- [x] `pnpm --filter @spotiarr/backend lint` — clean
- [x] `pnpm --filter @spotiarr/backend build` — clean
- [ ] Manual smoke: run dev backend, trigger catalog sync, confirm
      zero Spotify catalog calls in logs for artists with cached
      `deezerId`/`mbid`