### PR TITLE
feat(backend): add playlist playback audio urls

### DIFF
--- a/apps/backend/src/application/ports/file-system.port.ts
+++ b/apps/backend/src/application/ports/file-system.port.ts
@@ -14,6 +14,7 @@ export interface TrackTags {
 
 export interface FileSystemTrackPathPort {
   getMusicLibraryPath(): string;
+  getTrackFileName(track: ITrack, playlistName?: string): Promise<string>;
   getFolderName(track: ITrack, playlistName?: string): Promise<string>;
   getPlaylistFolderPath(name: string): string;
   getArtistFolderPath(artist: string): string;

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
@@ -1,0 +1,117 @@
+import { ApiRoutes, TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import { Track } from "@/domain/entities/track.entity";
+import { GetTracksUseCase } from "./get-tracks.use-case";
+
+function makeTrack(input: Partial<ITrack> = {}): Track {
+  return new Track({
+    id: "track-1",
+    name: "Track 01",
+    artist: "Artist",
+    trackUrl: "https://open.spotify.com/track/1",
+    status: TrackStatusEnum.Completed,
+    playlistId: "playlist-1",
+    playlistIndex: 1,
+    ...input,
+  });
+}
+
+describe("GetTracksUseCase", () => {
+  const trackRepository = {
+    findAll: vi.fn(),
+    findAllByPlaylist: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteAll: vi.fn(),
+    findStuckTracks: vi.fn(),
+    findAllByStatuses: vi.fn(),
+  };
+
+  const playlistRepository = {
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const trackPathService = {
+    getMusicLibraryPath: vi.fn(),
+    getTrackFileName: vi.fn(),
+    getFolderName: vi.fn(),
+    getPlaylistFolderPath: vi.fn(),
+    getArtistFolderPath: vi.fn(),
+    getAlbumFolderPath: vi.fn(),
+    ensureParentDirectory: vi.fn(),
+  };
+
+  let useCase: GetTracksUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetTracksUseCase(
+      trackRepository as never,
+      playlistRepository as never,
+      trackPathService as never,
+    );
+  });
+
+  it("adds audioUrl for completed playlist tracks and preserves trackUrl", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([makeTrack()]);
+    playlistRepository.findOne.mockResolvedValue(
+      new Playlist({ id: "playlist-1", name: "Road Trip" }),
+    );
+    trackPathService.getTrackFileName.mockResolvedValue(
+      "/tmp/Playlists/Road Trip/01 - Artist - Track 01.mp3",
+    );
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("playlist-1");
+    expect(trackPathService.getTrackFileName).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "track-1", playlistId: "playlist-1" }),
+      "Road Trip",
+    );
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "track-1",
+        trackUrl: "https://open.spotify.com/track/1",
+        audioUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(
+          "/tmp/Playlists/Road Trip/01 - Artist - Track 01.mp3",
+        )}`,
+      }),
+    ]);
+  });
+
+  it("does not add audioUrl for tracks that are not completed", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Downloading }),
+    ]);
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).not.toHaveBeenCalled();
+    expect(trackPathService.getTrackFileName).not.toHaveBeenCalled();
+    expect(result[0]).toMatchObject({
+      id: "track-2",
+      trackUrl: "https://open.spotify.com/track/1",
+    });
+    expect(result[0]).not.toHaveProperty("audioUrl");
+  });
+
+  it("does not add audioUrl when the playlist cannot be resolved", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([makeTrack()]);
+    playlistRepository.findOne.mockResolvedValue(null);
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("playlist-1");
+    expect(trackPathService.getTrackFileName).not.toHaveBeenCalled();
+    expect(result[0]).toMatchObject({ id: "track-1" });
+    expect(result[0]).not.toHaveProperty("audioUrl");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
@@ -1,8 +1,14 @@
-import type { ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import { ApiRoutes, type ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
 
 export class GetTracksUseCase {
-  constructor(private readonly trackRepository: TrackRepository) {}
+  constructor(
+    private readonly trackRepository: TrackRepository,
+    private readonly playlistRepository: PlaylistRepository,
+    private readonly trackPathService: FileSystemTrackPathPort,
+  ) {}
 
   async getAll(where?: Partial<ITrack>): Promise<ITrack[]> {
     const tracks = await this.trackRepository.findAll(where);
@@ -11,7 +17,34 @@ export class GetTracksUseCase {
 
   async getAllByPlaylist(id: string): Promise<ITrack[]> {
     const tracks = await this.trackRepository.findAllByPlaylist(id);
-    return tracks.map((t) => t.toPrimitive());
+    const items = tracks.map((track) => track.toPrimitive());
+    const hasPlayableTrack = items.some((track) => track.status === TrackStatusEnum.Completed);
+
+    if (!hasPlayableTrack) {
+      return items;
+    }
+
+    const playlist = await this.playlistRepository.findOne(id);
+    const playlistName = playlist?.name;
+
+    if (!playlistName) {
+      return items;
+    }
+
+    return Promise.all(
+      items.map(async (track) => {
+        if (track.status !== TrackStatusEnum.Completed) {
+          return track;
+        }
+
+        const filePath = await this.trackPathService.getTrackFileName(track, playlistName);
+
+        return {
+          ...track,
+          audioUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(filePath)}`,
+        };
+      }),
+    );
   }
 
   async get(id: string): Promise<ITrack | null> {

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -380,7 +380,7 @@ const trackPostProcessingService = new TrackPostProcessingService(
 // Use Cases - Tracks
 const createTrackUseCase = new CreateTrackUseCase(trackRepository, queueService);
 const deleteTrackUseCase = new DeleteTrackUseCase(trackRepository);
-const getTracksUseCase = new GetTracksUseCase(trackRepository);
+const getTracksUseCase = new GetTracksUseCase(trackRepository, playlistRepository, trackFileHelper);
 const updateTrackUseCase = new UpdateTrackUseCase(trackRepository);
 const searchTrackOnYoutubeUseCase = new SearchTrackOnYoutubeUseCase(
   trackRepository,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -82,6 +82,7 @@ export interface ITrack {
   totalTracks?: number;
   spotifyUrl?: string;
   trackUrl?: string;
+  audioUrl?: string;
   albumUrl?: string;
   durationMs?: number;
   artists?: TrackArtist[];


### PR DESCRIPTION
Closes #58

## What
Add PR1 backend/shared foundation for chained `library-playlist-playback` delivery. This introduces optional local `audioUrl` support on shared tracks and enriches saved playlist track responses with playable stream URLs when a completed local file can be resolved.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / chore

## Scope
- [ ] Frontend only (`apps/frontend`)
- [x] Backend only (`apps/backend`)
- [x] Shared (`packages/shared`)
- [ ] Cross-workspace

## Checklist
- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change

## Changes
- Extend `ITrack` with optional `audioUrl`
- Resolve saved playlist track `audioUrl` values for completed local tracks only
- Add backend tests for resolved, unresolved, and non-completed track cases

## Verification
- `pnpm --filter @spotiarr/shared run lint`
- `pnpm --filter @spotiarr/shared run build`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test:run`
- `pnpm --filter backend run build`
- `pnpm test`
- `pnpm build`