### PR TITLE
feat(backend): migrate catalog search to Deezer with provider flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,8 @@ DOWNLOADS_DIR=/path/to/your/downloads/folder
 # Advanced Redis (Optional)
 # REDIS_HOST=redis
 # REDIS_PORT=6379
+# Search provider (Optional)
+# Controls which provider is used for catalog search (artist + album).
+# "spotify" (default): uses Spotify search API (legacy)
+# "deezer": uses Deezer search API (Deezer-first, no Spotify search calls)
+# SEARCH_PROVIDER=spotify

--- a/apps/backend/src/application/ports/catalog-search.port.ts
+++ b/apps/backend/src/application/ports/catalog-search.port.ts
@@ -1,0 +1,15 @@
+import type { ArtistRelease, FollowedArtist, NormalizedTrack } from "@spotiarr/shared";
+
+export interface CatalogSearchResult {
+  tracks: NormalizedTrack[];
+  albums: ArtistRelease[];
+  artists: FollowedArtist[];
+}
+
+export interface CatalogSearchPort {
+  searchCatalog(
+    query: string,
+    types: string[],
+    limits: { track?: number; album?: number; artist?: number },
+  ): Promise<CatalogSearchResult>;
+}

--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
@@ -1,4 +1,5 @@
 import type { ArtistDetail, ArtistRelease } from "@spotiarr/shared";
+import { isDeezerArtistId } from "@spotiarr/shared";
 import type { SpotifyArtistLookupPort } from "@/application/ports/artist-lookup.port";
 import type { DeezerArtistLookupPort } from "@/application/ports/deezer-artist-lookup.port";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
@@ -9,9 +10,6 @@ import {
   isArtistCacheFresh,
   withTimeout,
 } from "./artist-catalog.constants";
-
-// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
-const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
 
 export class GetArtistDetailUseCase {
   constructor(
@@ -39,7 +37,7 @@ export class GetArtistDetailUseCase {
       details = {
         name: cachedArtist.name,
         image: cachedArtist.image,
-        spotifyUrl: cachedArtist.spotifyUrl,
+        spotifyUrl: cachedArtist.spotifyUrl ?? null,
         followers: null,
         genres: [],
       };

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -54,8 +54,10 @@ import { PrismaSettingsRepository } from "./infrastructure/database/prisma-setti
 import { PrismaTrackRepository } from "./infrastructure/database/prisma-track.repository";
 import { PromiseCache } from "./infrastructure/external/promise-cache";
 import { DeezerArtistLookupAdapter } from "./infrastructure/external/providers/deezer/deezer-artist-lookup.adapter";
+import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/deezer/deezer-catalog-search.adapter";
 import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.client";
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
+import { SpotifyCatalogSearchAdapter } from "./infrastructure/external/providers/spotify/spotify-catalog-search.adapter";
 import { ReleaseFeedService } from "./infrastructure/external/release-feed.service";
 import { SpotifyAlbumClient } from "./infrastructure/external/spotify-album.client";
 import { SpotifyArtistCatalogService } from "./infrastructure/external/spotify-artist-catalog.service";
@@ -340,6 +342,21 @@ spotifyUserLibrarySyncService = {
 // External catalog providers (Deezer primary, MusicBrainz fallback; Spotify URLs materialize on demand)
 const deezerClient = new DeezerClient();
 const deezerArtistLookupAdapter = new DeezerArtistLookupAdapter(deezerClient);
+
+// Catalog search provider — controlled by SEARCH_PROVIDER env var.
+// "deezer": Deezer-first search (no Spotify search API calls). Default target.
+// "spotify" (default): legacy Spotify search path kept until PR-3.4 cleanup.
+function resolveSearchProvider(): "spotify" | "deezer" {
+  try {
+    return getEnv().SEARCH_PROVIDER;
+  } catch {
+    return "spotify";
+  }
+}
+const catalogSearchPort =
+  resolveSearchProvider() === "deezer"
+    ? new DeezerCatalogSearchAdapter(deezerClient, feedRepository)
+    : new SpotifyCatalogSearchAdapter(spotifySearchClient);
 const musicBrainzClient = new MusicBrainzClient();
 const releaseFeedService = new ReleaseFeedService(feedRepository, deezerClient, musicBrainzClient);
 
@@ -568,7 +585,7 @@ const artistController = new ArtistController(
   getArtistAlbumsUseCase,
   getAlbumTracksUseCase,
 );
-const searchController = new SearchController(spotifyService);
+const searchController = new SearchController(catalogSearchPort);
 
 const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 

--- a/apps/backend/src/infrastructure/database/followed-artist.repository.ts
+++ b/apps/backend/src/infrastructure/database/followed-artist.repository.ts
@@ -1,13 +1,10 @@
 import type { PrismaClient } from "@prisma/client";
 import type { FollowedArtist } from "@spotiarr/shared";
+import { isDeezerArtistId, isSpotifyArtistId } from "@spotiarr/shared";
 import type {
   CatalogIdentity,
   CatalogIdentityInput,
 } from "@/application/ports/feed-repository.port";
-
-// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
-const isSpotifyArtistId = (id: string): boolean => /^[0-9A-Za-z]{22}$/.test(id);
-const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
 
 export class FollowedArtistRepository {
   constructor(private readonly prisma: PrismaClient) {}

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import { DeezerCatalogSearchAdapter } from "./deezer-catalog-search.adapter";
+import type { DeezerClient } from "./deezer.client";
+
+function makeMockDeezerClient(): DeezerClient {
+  return {
+    searchArtistList: vi.fn().mockResolvedValue([]),
+    searchAlbumList: vi.fn().mockResolvedValue([]),
+    searchArtist: vi.fn().mockResolvedValue(null),
+    searchAlbum: vi.fn().mockResolvedValue(null),
+    getArtistById: vi.fn().mockResolvedValue(null),
+    getArtistAlbums: vi.fn().mockResolvedValue([]),
+    getAlbumTracks: vi.fn().mockResolvedValue([]),
+  } as unknown as DeezerClient;
+}
+
+function makeMockFeedRepo(): FeedRepositoryPort {
+  return {
+    getArtistByAnyId: vi.fn().mockResolvedValue(null),
+    getArtistBySpotifyId: vi.fn().mockResolvedValue(null),
+    getArtistCatalogIdentities: vi.fn().mockResolvedValue([]),
+    updateArtistCatalogIdentities: vi.fn().mockResolvedValue(undefined),
+    getReleases: vi.fn().mockResolvedValue([]),
+    getArtists: vi.fn().mockResolvedValue([]),
+    upsertArtists: vi.fn().mockResolvedValue(undefined),
+    upsertReleases: vi.fn().mockResolvedValue(undefined),
+    getArtistAlbumWithArtist: vi.fn().mockResolvedValue(null),
+    getArtistReleaseWithArtist: vi.fn().mockResolvedValue(null),
+    updateArtistAlbumIdentities: vi.fn().mockResolvedValue(undefined),
+    upsertArtistAlbumSpotifyUrl: vi.fn().mockResolvedValue(undefined),
+    updateArtistReleaseSpotifyUrl: vi.fn().mockResolvedValue(undefined),
+    getArtistAlbumCount: vi.fn().mockResolvedValue(0),
+    getArtistAlbumsFreshness: vi.fn().mockResolvedValue(null),
+    getArtistIdsWithNoAlbums: vi.fn().mockResolvedValue(new Set()),
+    getArtistIdsWithFreshAlbums: vi.fn().mockResolvedValue(new Set()),
+    getArtistIdsWithFreshReleases: vi.fn().mockResolvedValue(new Set()),
+    getArtistAlbums: vi.fn().mockResolvedValue([]),
+    upsertArtistAlbums: vi.fn().mockResolvedValue(undefined),
+    evictStaleFeedCache: vi.fn().mockResolvedValue(undefined),
+    getArtistIdsNeedingCatalogSync: vi.fn().mockResolvedValue([]),
+    getActiveArtistIdsForReleasesSync: vi.fn().mockResolvedValue([]),
+    updateArtistCatalogSyncedAt: vi.fn().mockResolvedValue(undefined),
+    updateArtistReleasesSyncedAt: vi.fn().mockResolvedValue(undefined),
+    getSyncState: vi
+      .fn()
+      .mockResolvedValue({ id: 1, lastSyncAt: null, status: "idle", error: null }),
+    setSyncState: vi.fn().mockResolvedValue(undefined),
+    getCatalogSyncState: vi
+      .fn()
+      .mockResolvedValue({ id: 1, lastSyncAt: null, status: "idle", error: null }),
+    setCatalogSyncState: vi.fn().mockResolvedValue(undefined),
+  } as unknown as FeedRepositoryPort;
+}
+
+describe("DeezerCatalogSearchAdapter", () => {
+  let deezerClient: ReturnType<typeof makeMockDeezerClient>;
+  let feedRepo: ReturnType<typeof makeMockFeedRepo>;
+  let adapter: DeezerCatalogSearchAdapter;
+
+  beforeEach(() => {
+    deezerClient = makeMockDeezerClient();
+    feedRepo = makeMockFeedRepo();
+    adapter = new DeezerCatalogSearchAdapter(deezerClient, feedRepo);
+  });
+
+  describe("searchCatalog — artist type", () => {
+    it("returns empty artists array when Deezer returns no results", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([]);
+
+      const result = await adapter.searchCatalog("unknown query", ["artist"], { artist: 5 });
+
+      expect(result.artists).toEqual([]);
+      expect(result.albums).toEqual([]);
+      expect(result.tracks).toEqual([]);
+    });
+
+    it("surfaces Deezer ID when artist not found in FollowedArtistCache", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 12345, name: "Test Artist" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 5 });
+
+      expect(result.artists).toHaveLength(1);
+      expect(result.artists[0].id).toBe("12345");
+      expect(result.artists[0].name).toBe("Test Artist");
+      expect(result.artists[0].spotifyUrl).toBeNull();
+    });
+
+    it("resolves Spotify ID when artist has deezerId in FollowedArtistCache", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 12345, name: "Followed Artist" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue({
+        id: "spotifyId22chars0000000",
+        name: "Followed Artist",
+        image: "http://img.jpg",
+        spotifyUrl: "https://open.spotify.com/artist/spotifyId22chars0000000",
+      });
+
+      const result = await adapter.searchCatalog("Followed Artist", ["artist"], { artist: 5 });
+
+      expect(result.artists).toHaveLength(1);
+      expect(result.artists[0].id).toBe("spotifyId22chars0000000");
+      expect(result.artists[0].spotifyUrl).toBe(
+        "https://open.spotify.com/artist/spotifyId22chars0000000",
+      );
+    });
+
+    it("does not emit Spotify search calls for artist queries", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 99, name: "Deezer Artist" },
+      ]);
+
+      await adapter.searchCatalog("Deezer Artist", ["artist"], { artist: 5 });
+
+      // feedRepo.getArtistByAnyId may be called for ID resolution, but no Spotify HTTP call
+      // The adapter only calls deezerClient methods, never Spotify
+      expect(deezerClient.searchArtistList).toHaveBeenCalledWith("Deezer Artist", 5);
+    });
+  });
+
+  describe("searchCatalog — album type", () => {
+    it("returns albums with kind, artistId, and albumId fields", async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 777,
+          title: "Test Album",
+          cover_medium: "http://cover.jpg",
+          release_date: "2024-01-01",
+          artist: { id: 99, name: "Test Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("Test Album", ["album"], { album: 5 });
+
+      expect(result.albums).toHaveLength(1);
+      expect(result.albums[0].albumId).toBe("777");
+      expect(result.albums[0].artistId).toBe("99");
+      expect(result.albums[0].albumName).toBe("Test Album");
+    });
+
+    it("returns empty albums array when Deezer returns no results", async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([]);
+
+      const result = await adapter.searchCatalog("nonexistent", ["album"], { album: 5 });
+
+      expect(result.albums).toEqual([]);
+    });
+
+    it("does not emit Spotify search calls for album queries", async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([]);
+
+      await adapter.searchCatalog("some album", ["album"], { album: 5 });
+
+      expect(deezerClient.searchAlbumList).toHaveBeenCalledWith("some album", 5);
+    });
+  });
+
+  describe("searchCatalog — Deezer error / 429 graceful degradation", () => {
+    it("returns empty results when DeezerClient throws on artist search", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockRejectedValue(
+        new Error("429 Too Many Requests"),
+      );
+
+      const result = await adapter.searchCatalog("artist", ["artist"], { artist: 5 });
+
+      expect(result.artists).toEqual([]);
+    });
+
+    it("returns empty results when DeezerClient throws on album search", async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockRejectedValue(new Error("network error"));
+
+      const result = await adapter.searchCatalog("album", ["album"], { album: 5 });
+
+      expect(result.albums).toEqual([]);
+    });
+  });
+
+  describe("searchCatalog — track type (deferred to PR-3.1b)", () => {
+    it("returns empty tracks array when track type requested (not yet implemented)", async () => {
+      const result = await adapter.searchCatalog("query", ["track"], { track: 5 });
+
+      expect(result.tracks).toEqual([]);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -1,0 +1,93 @@
+import type { ArtistRelease, FollowedArtist, NormalizedTrack } from "@spotiarr/shared";
+import type {
+  CatalogSearchPort,
+  CatalogSearchResult,
+} from "@/application/ports/catalog-search.port";
+import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { DeezerClient } from "./deezer.client";
+
+/**
+ * Implements CatalogSearchPort using Deezer as the primary search provider.
+ *
+ * Artist ID resolution (Design D1):
+ * - For each Deezer artist result, look up FollowedArtistCache by the Deezer numeric ID.
+ * - If a cache hit exists, surface the Spotify ID (the stable internal PK).
+ * - If no cache entry, surface the Deezer ID so the frontend can still navigate.
+ *
+ * Track search is deferred to PR-3.1b. This adapter always returns an empty tracks array.
+ */
+export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
+  constructor(
+    private readonly deezerClient: DeezerClient,
+    private readonly feedRepository: FeedRepositoryPort,
+  ) {}
+
+  async searchCatalog(
+    query: string,
+    types: string[],
+    limits: { track?: number; album?: number; artist?: number },
+  ): Promise<CatalogSearchResult> {
+    const [artists, albums] = await Promise.all([
+      types.includes("artist")
+        ? this.searchArtists(query, limits.artist ?? 5)
+        : Promise.resolve<FollowedArtist[]>([]),
+      types.includes("album")
+        ? this.searchAlbums(query, limits.album ?? 10)
+        : Promise.resolve<ArtistRelease[]>([]),
+    ]);
+
+    // Track search deferred to PR-3.1b
+    const tracks: NormalizedTrack[] = [];
+
+    return { tracks, albums, artists };
+  }
+
+  private async searchArtists(query: string, limit: number): Promise<FollowedArtist[]> {
+    try {
+      const deezerArtists = await this.deezerClient.searchArtistList(query, limit);
+
+      const resolved = await Promise.all(
+        deezerArtists.map(async (deezerArtist): Promise<FollowedArtist> => {
+          // Look up the cache by Deezer ID to resolve to the Spotify ID
+          const cached = await this.feedRepository.getArtistByAnyId(String(deezerArtist.id));
+          if (cached) {
+            return cached;
+          }
+          // Artist not in cache — surface the Deezer ID as the identifier
+          return {
+            id: String(deezerArtist.id),
+            name: deezerArtist.name,
+            image: deezerArtist.picture ?? null,
+            spotifyUrl: null,
+          };
+        }),
+      );
+
+      return resolved;
+    } catch {
+      return [];
+    }
+  }
+
+  private async searchAlbums(query: string, limit: number): Promise<ArtistRelease[]> {
+    try {
+      const deezerAlbums = await this.deezerClient.searchAlbumList(query, limit);
+
+      return deezerAlbums.map(
+        (album): ArtistRelease => ({
+          artistId: album.artist ? String(album.artist.id) : "unknown",
+          artistName: album.artist?.name ?? "Unknown Artist",
+          artistImageUrl: null,
+          albumId: String(album.id),
+          albumName: album.title,
+          albumType: undefined,
+          releaseDate: album.release_date,
+          coverUrl: album.cover_medium ?? album.cover ?? null,
+          spotifyUrl: undefined,
+        }),
+      );
+    } catch {
+      return [];
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
@@ -103,6 +103,33 @@ export class DeezerClient {
   }
 
   /**
+   * Search for artists by name and return multiple matches up to limit.
+   * Unlike searchArtist, this does not filter to an exact name match —
+   * it returns all results up to `limit` so the caller can apply its own ranking.
+   */
+  async searchArtistList(name: string, limit: number): Promise<DeezerArtist[]> {
+    const encoded = encodeURIComponent(name);
+    const result = await this.fetchJson<{ data: DeezerArtist[] }>(
+      `${DEEZER_API_BASE}/search/artist?q=${encoded}&limit=${limit}`,
+    );
+    return result?.data?.slice(0, limit) ?? [];
+  }
+
+  /**
+   * Search for albums by query and return multiple matches up to limit.
+   */
+  async searchAlbumList(
+    query: string,
+    limit: number,
+  ): Promise<(DeezerAlbum & { artist?: { id: number; name: string } })[]> {
+    const encoded = encodeURIComponent(query);
+    const result = await this.fetchJson<{
+      data: (DeezerAlbum & { artist?: { id: number; name: string } })[];
+    }>(`${DEEZER_API_BASE}/search/album?q=${encoded}&limit=${limit}`);
+    return result?.data?.slice(0, limit) ?? [];
+  }
+
+  /**
    * Fetch albums for a given Deezer artist ID.
    * Deezer returns albums, singles, and compilations under the same endpoint.
    * We map album + single types to ArtistRelease.

--- a/apps/backend/src/infrastructure/external/providers/spotify/spotify-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/spotify/spotify-catalog-search.adapter.ts
@@ -1,0 +1,23 @@
+import type {
+  CatalogSearchPort,
+  CatalogSearchResult,
+} from "@/application/ports/catalog-search.port";
+import type { SpotifySearchClient } from "../../spotify-search.client";
+
+/**
+ * Thin wrapper around SpotifySearchClient that implements CatalogSearchPort.
+ *
+ * This adapter exists only for the SEARCH_PROVIDER=spotify rollout period.
+ * It will be deleted in PR-3.4 once Deezer-first is the permanent default.
+ */
+export class SpotifyCatalogSearchAdapter implements CatalogSearchPort {
+  constructor(private readonly spotifySearchClient: SpotifySearchClient) {}
+
+  async searchCatalog(
+    query: string,
+    types: string[],
+    limits: { track?: number; album?: number; artist?: number },
+  ): Promise<CatalogSearchResult> {
+    return this.spotifySearchClient.searchCatalog(query, types, limits);
+  }
+}

--- a/apps/backend/src/infrastructure/setup/environment.ts
+++ b/apps/backend/src/infrastructure/setup/environment.ts
@@ -128,6 +128,9 @@ const envSchema = z
     DOWNLOADS: z.string().optional(),
     DATABASE_URL: z.string().optional(),
 
+    // Feature flags
+    SEARCH_PROVIDER: z.enum(["spotify", "deezer"]).optional().default("spotify"),
+
     // System
     NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
   })

--- a/apps/backend/src/presentation/controllers/search.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/search.controller.test.ts
@@ -1,0 +1,113 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CatalogSearchPort } from "@/application/ports/catalog-search.port";
+import { SearchController } from "./search.controller";
+
+function mockRes(): Response {
+  const jsonFn = vi.fn().mockReturnThis();
+  const statusFn = vi.fn().mockReturnThis();
+  return { json: jsonFn, status: statusFn } as unknown as Response;
+}
+
+function makeMockCatalogSearch(overrides: Partial<CatalogSearchPort> = {}): CatalogSearchPort {
+  return {
+    searchCatalog: vi.fn().mockResolvedValue({ tracks: [], albums: [], artists: [] }),
+    ...overrides,
+  };
+}
+
+describe("SearchController", () => {
+  let catalogSearch: CatalogSearchPort;
+  let controller: SearchController;
+
+  beforeEach(() => {
+    catalogSearch = makeMockCatalogSearch();
+    controller = new SearchController(catalogSearch);
+  });
+
+  describe("searchCatalog", () => {
+    it("returns empty results when query is missing", async () => {
+      const req = { query: {} } as unknown as Request;
+      const res = mockRes();
+
+      await controller.searchCatalog(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: { tracks: [], albums: [], artists: [] } });
+      expect(catalogSearch.searchCatalog).not.toHaveBeenCalled();
+    });
+
+    it("delegates to CatalogSearchPort with parsed params", async () => {
+      const fakeResult = {
+        tracks: [],
+        albums: [
+          {
+            albumId: "1",
+            albumName: "Test",
+            artistId: "a",
+            artistName: "A",
+            artistImageUrl: null,
+            coverUrl: null,
+          },
+        ],
+        artists: [{ id: "a", name: "Test Artist", image: null, spotifyUrl: null }],
+      };
+      vi.mocked(catalogSearch.searchCatalog).mockResolvedValue(fakeResult);
+
+      const req = {
+        query: { q: "test", types: "artist,album", limit: "5" },
+      } as unknown as Request;
+      const res = mockRes();
+
+      await controller.searchCatalog(req, res);
+
+      expect(catalogSearch.searchCatalog).toHaveBeenCalledWith("test", ["artist", "album"], {
+        track: 5,
+        album: 5,
+        artist: 5,
+      });
+      expect(res.json).toHaveBeenCalledWith({ data: fakeResult });
+    });
+
+    it("defaults to all types when types param is absent", async () => {
+      const req = { query: { q: "anything" } } as unknown as Request;
+      const res = mockRes();
+
+      await controller.searchCatalog(req, res);
+
+      expect(catalogSearch.searchCatalog).toHaveBeenCalledWith(
+        "anything",
+        ["track", "album", "artist"],
+        { track: 10, album: 10, artist: 10 },
+      );
+    });
+
+    it("clamps limit between 1 and 10", async () => {
+      const req = { query: { q: "x", limit: "999" } } as unknown as Request;
+      const res = mockRes();
+
+      await controller.searchCatalog(req, res);
+
+      expect(catalogSearch.searchCatalog).toHaveBeenCalledWith("x", ["track", "album", "artist"], {
+        track: 10,
+        album: 10,
+        artist: 10,
+      });
+    });
+
+    it("uses DeezerCatalogSearchAdapter results (no Spotify call) — structural contract", async () => {
+      const deezerResult = {
+        tracks: [],
+        albums: [],
+        artists: [{ id: "123456789", name: "Deezer Artist", image: null, spotifyUrl: null }],
+      };
+      vi.mocked(catalogSearch.searchCatalog).mockResolvedValue(deezerResult);
+
+      const req = { query: { q: "deezer artist", types: "artist" } } as unknown as Request;
+      const res = mockRes();
+
+      await controller.searchCatalog(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: deezerResult });
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/search.controller.ts
+++ b/apps/backend/src/presentation/controllers/search.controller.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from "express";
-import { SpotifyService } from "@/application/services/spotify.service";
+import type { CatalogSearchPort } from "@/application/ports/catalog-search.port";
 
 export class SearchController {
-  constructor(private readonly spotifyService: SpotifyService) {}
+  constructor(private readonly catalogSearchPort: CatalogSearchPort) {}
 
   searchCatalog = async (req: Request, res: Response) => {
     const query = req.query.q as string;
@@ -18,16 +18,13 @@ export class SearchController {
     const safeLimit = Number.isNaN(requestedLimit) ? 10 : requestedLimit;
     const limit = Math.max(1, Math.min(safeLimit, 10));
 
-    const limits =
-      types.length === 1
-        ? { track: limit, album: limit, artist: limit }
-        : {
-            track: limit,
-            album: limit,
-            artist: limit,
-          };
+    const limits = {
+      track: limit,
+      album: limit,
+      artist: limit,
+    };
 
-    const results = await this.spotifyService.searchCatalog(query, types, limits);
+    const results = await this.catalogSearchPort.searchCatalog(query, types, limits);
     res.json({ data: results });
   };
 }

--- a/apps/frontend/src/components/organisms/ArtistList.tsx
+++ b/apps/frontend/src/components/organisms/ArtistList.tsx
@@ -14,7 +14,7 @@ const ArtistListItem: FC<ArtistListItemProps> = memo(({ artist, onClick }) => {
       id={artist.id}
       name={artist.name}
       image={artist.image}
-      spotifyUrl={artist.spotifyUrl}
+      spotifyUrl={artist.spotifyUrl ?? null}
       onClick={onClick}
     />
   );

--- a/apps/frontend/src/views/Search.tsx
+++ b/apps/frontend/src/views/Search.tsx
@@ -112,7 +112,7 @@ export const Search: FC = () => {
                     id={artist.id}
                     name={artist.name}
                     image={artist.image}
-                    spotifyUrl={artist.spotifyUrl}
+                    spotifyUrl={artist.spotifyUrl ?? null}
                     onClick={handleArtistClick}
                   />
                 ))}

--- a/packages/shared/src/identity.ts
+++ b/packages/shared/src/identity.ts
@@ -1,0 +1,19 @@
+/**
+ * Identity helpers for distinguishing Spotify IDs from Deezer IDs.
+ *
+ * Spotify IDs are base62-encoded strings of exactly 22 characters.
+ * Deezer IDs are numeric strings (integer values).
+ *
+ * These are the canonical detection functions for the dual-ID strategy (Design D1).
+ * All code that needs to dispatch between Spotify and Deezer identifiers MUST
+ * import from this module rather than defining local regex constants.
+ */
+
+/** Returns true when id matches the Spotify artist/album/track ID format (base62, 22 chars). */
+export const isSpotifyArtistId = (id: string): boolean => /^[0-9A-Za-z]{22}$/.test(id);
+
+/** Returns true when id matches the Deezer entity ID format (numeric string). */
+export const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
+
+/** Alias for isSpotifyArtistId — albums share the same base62-22 format. */
+export const isSpotifyAlbumId = (id: string): boolean => /^[0-9A-Za-z]{22}$/.test(id);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./routes.js";
+export * from "./identity.js";
 export const SUPPORTED_AUDIO_FORMATS = [
   "aac",
   "flac",
@@ -251,10 +252,21 @@ export interface DownloadStatusResponse {
 }
 
 export interface FollowedArtist {
+  /**
+   * Stable internal identifier.
+   * Equals the Spotify ID when the artist was synced from a Spotify follow.
+   * Equals the Deezer ID transiently for Deezer-only search results that have
+   * not yet been persisted to FollowedArtistCache.
+   */
   id: string;
   name: string;
   image: string | null;
-  spotifyUrl: string | null;
+  /**
+   * Spotify profile URL.
+   * null when the artist was resolved exclusively via Deezer (unfollowed artist).
+   * undefined when the value has not been fetched yet (lazy resolution pending).
+   */
+  spotifyUrl: string | null | undefined;
 }
 
 export type NormalizedTrack = ITrack & {


### PR DESCRIPTION
## Summary

Implements **REQ CSA-1** — Deezer-first artist and album search behind a feature flag.

- Introduces `CatalogSearchPort` — provider-agnostic application boundary for catalog search (artist + album; track deferred to PR-3.1b)
- Adds `DeezerCatalogSearchAdapter` implementing the port: artist ID resolves to Spotify ID via `FollowedArtistCache.deezerId` lookup when available; falls back to Deezer ID for unfollowed artists
- Adds `SpotifyCatalogSearchAdapter` — thin wrapper around `SpotifySearchClient` kept for `SEARCH_PROVIDER=spotify` rollout period (deleted in PR-3.4)
- Migrates `SearchController` to depend on `CatalogSearchPort` only (no provider knowledge)
- Adds `isSpotifyArtistId` / `isDeezerArtistId` / `isSpotifyAlbumId` to `packages/shared/src/identity.ts` (Design D1)
- Wires `SEARCH_PROVIDER` env var in `environment.ts` + `container.ts` (Zod-validated, architecture rule R4 compliant)

## Feature flag

```
SEARCH_PROVIDER=spotify   # default — legacy Spotify search (no change in behavior)
SEARCH_PROVIDER=deezer    # Deezer-first search (no Spotify search API calls for artist/album)
```

Default is `spotify` — zero behavior change on deploy. Flip to `deezer` in staging to canary.

## Chain context (stacked-to-main)

```
main
  └─ feature/phase3-album-tracks-fallback-removal   (PR #56 — merged)
       └─ feature/phase3-artist-detail-deezer-miss  (PR #57 — stacked on above)
            └─ feature/phase3-search-deezer-first   (📍 this PR)
                 └─ feature/phase3-track-search-lazy-url  (next: PR-3.1b)
                      └─ feature/phase3-cleanup-dead-clients  (PR-3.4)
```

Stacked on PR #57. Next PR-3.1b adds track search to `CatalogSearchPort` + lazy Spotify URL resolver.

## What is NOT in this PR

- Track search (deferred to PR-3.1b)
- Lazy Spotify URL resolver / `ExternalUrlCache` (PR-3.1b)
- Frontend download flow changes (PR-3.1b)
- `SpotifySearchClient` deletion (PR-3.4)

## Test plan

- [x] 307/307 backend tests pass (`pnpm --filter backend test --run`)
- [x] Build clean — zero TypeScript errors (`pnpm --filter backend build`)
- [x] Architecture rule R4 satisfied — `process.env` reads routed through `getEnv()`
- [x] Architecture rules R1–R5 all pass
- [x] `DeezerCatalogSearchAdapter` tested: artist hit/miss, Spotify ID resolution, album mapping, 429 graceful degradation
- [x] `SearchController` tested: empty query, param parsing, limit clamping, port delegation
- [x] Rollback: set `SEARCH_PROVIDER=spotify` in env — no code change needed