### PR TITLE
refactor(frontend): extract local playback hook

### DIFF
--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -1,15 +1,15 @@
 import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
-import { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { generatePath, useParams } from "react-router-dom";
 import { Path } from "@/routes/routes";
 import { Track } from "@/types";
 import { useLibraryArtistQuery } from "../queries/useLibraryArtistQuery";
+import {
+  LocalTrackPlaybackErrorKey,
+  useLocalTrackPlaybackController,
+} from "./useLocalTrackPlaybackController";
 
-export type LibraryPlaybackErrorKey =
-  | "library.album.playbackBlocked"
-  | "library.album.playbackFailed"
-  | "library.album.playbackUnavailable"
-  | "library.album.playbackUnsupported";
+export type LibraryPlaybackErrorKey = LocalTrackPlaybackErrorKey<"library.album">;
 
 const safeDecodeURIComponent = (value: string | undefined): string => {
   if (!value) {
@@ -52,145 +52,23 @@ export const useLibraryAlbumDetailController = () => {
     }));
   }, [album, artistName]);
 
-  const tracksRef = useRef<Track[]>(tracks);
-  tracksRef.current = tracks;
-
-  const [audioElement, setAudioElementState] = useState<HTMLAudioElement | null>(null);
-  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [playbackError, setPlaybackError] = useState<LibraryPlaybackErrorKey | null>(null);
-  const loadedSrcRef = useRef<string | null>(null);
-  const playAttemptRef = useRef(0);
-  const playbackScopeKeyRef = useRef(`${artistName}::${selectedAlbumName}`);
-
-  const currentTrack = useMemo(
-    () => tracks.find((track) => track.id === currentTrackId) ?? null,
-    [tracks, currentTrackId],
-  );
-
-  const audioSrc = currentTrack?.trackUrl ?? null;
-
-  const setAudioElement = useCallback((element: HTMLAudioElement | null) => {
-    loadedSrcRef.current = element ? loadedSrcRef.current : null;
-    setAudioElementState(element);
-  }, []);
-
-  const playOnElement = useCallback(
-    async (element: HTMLAudioElement | null, src: string | null, attemptId: number) => {
-      if (!element || !src) {
-        return;
-      }
-
-      if (loadedSrcRef.current !== src) {
-        element.src = src;
-        loadedSrcRef.current = src;
-      }
-
-      try {
-        const result = element.play();
-
-        if (result && typeof (result as Promise<void>).then === "function") {
-          await result;
-        }
-      } catch (error) {
-        if (playAttemptRef.current !== attemptId || loadedSrcRef.current !== src) {
-          return;
-        }
-
-        if (error instanceof DOMException) {
-          if (error.name === "AbortError") {
-            return;
-          }
-
-          if (error.name === "NotAllowedError") {
-            setIsPlaying(false);
-            setPlaybackError("library.album.playbackBlocked");
-            return;
-          }
-
-          if (error.name === "NotSupportedError") {
-            setIsPlaying(false);
-            setPlaybackError("library.album.playbackUnsupported");
-            return;
-          }
-        }
-
-        setIsPlaying(false);
-        setPlaybackError("library.album.playbackFailed");
-      }
-    },
-    [],
-  );
-
-  const onPlayTrack = useCallback(
-    (trackId: string) => {
-      const targetTrack = tracksRef.current.find((track) => track.id === trackId);
-      const targetSrc = targetTrack?.trackUrl ?? null;
-      const attemptId = playAttemptRef.current + 1;
-
-      playAttemptRef.current = attemptId;
-
-      setPlaybackError(null);
-      setCurrentTrackId(trackId);
-
-      if (audioElement) {
-        void playOnElement(audioElement, targetSrc, attemptId);
-      }
-    },
-    [audioElement, playOnElement],
-  );
-
-  const onPauseTrack = useCallback(() => {
-    audioElement?.pause();
-    setIsPlaying(false);
-  }, [audioElement]);
-
-  const onAudioPlay = useCallback(() => {
-    setIsPlaying(true);
-  }, []);
-
-  const onAudioPause = useCallback(() => {
-    setIsPlaying(false);
-  }, []);
-
-  const onAudioError = useCallback((event?: SyntheticEvent<HTMLAudioElement>) => {
-    const mediaErrorCode = event?.currentTarget.error?.code;
-
-    setIsPlaying(false);
-
-    if (mediaErrorCode === 4) {
-      setPlaybackError("library.album.playbackUnavailable");
-      return;
-    }
-
-    setPlaybackError("library.album.playbackFailed");
-  }, []);
-
-  useEffect(() => {
-    if (!audioElement) {
-      return;
-    }
-
-    return () => {
-      audioElement.pause();
-    };
-  }, [audioElement]);
-
-  useEffect(() => {
-    const nextScopeKey = `${artistName}::${selectedAlbumName}`;
-
-    if (playbackScopeKeyRef.current === nextScopeKey) {
-      return;
-    }
-
-    playbackScopeKeyRef.current = nextScopeKey;
-    playAttemptRef.current += 1;
-    loadedSrcRef.current = null;
-    audioElement?.pause();
-    setCurrentTrackId(null);
-    setIsPlaying(false);
-    setPlaybackError(null);
-  }, [artistName, selectedAlbumName, audioElement]);
+  const {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  } = useLocalTrackPlaybackController({
+    tracks,
+    scopeKey: `${artistName}::${selectedAlbumName}`,
+    errorKeyPrefix: "library.album",
+    getAudioUrl: (track) => track.trackUrl,
+  });
 
   const coverUrl = album?.image
     ? `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/image?path=${encodeURIComponent(album.image)}`
@@ -214,7 +92,7 @@ export const useLibraryAlbumDetailController = () => {
     audioSrc,
     currentTrackId,
     isPlaying,
-    playbackError,
+    playbackError: playbackError as LibraryPlaybackErrorKey | null,
     setAudioElement,
     onPlayTrack,
     onPauseTrack,

--- a/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.test.tsx
@@ -1,0 +1,318 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Track } from "@/types";
+import { useLocalTrackPlaybackController } from "./useLocalTrackPlaybackController";
+
+const tracks: Track[] = [
+  {
+    id: "track-1",
+    name: "Track 1",
+    artist: "Artist 1",
+    album: "Album 1",
+    durationMs: 180000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/1",
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
+  },
+  {
+    id: "track-2",
+    name: "Track 2",
+    artist: "Artist 2",
+    album: "Album 2",
+    durationMs: 200000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/2",
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F02.mp3",
+  },
+  {
+    id: "track-3",
+    name: "Track 3",
+    artist: "Artist 3",
+    album: "Album 3",
+    durationMs: 210000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/3",
+  },
+];
+
+const instrumentAudioElement = (audio: HTMLAudioElement) => {
+  let srcValue = "";
+  let currentTimeValue = 0;
+  let mediaError: MediaError | null = null;
+
+  Object.defineProperty(audio, "src", {
+    configurable: true,
+    get: () => srcValue,
+    set: (value: string) => {
+      srcValue = value;
+      currentTimeValue = 0;
+    },
+  });
+
+  Object.defineProperty(audio, "currentTime", {
+    configurable: true,
+    get: () => currentTimeValue,
+    set: (value: number) => {
+      currentTimeValue = value;
+    },
+  });
+
+  Object.defineProperty(audio, "error", {
+    configurable: true,
+    get: () => mediaError,
+    set: (value: MediaError | null) => {
+      mediaError = value;
+    },
+  });
+};
+
+describe("useLocalTrackPlaybackController", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("plays, pauses, and resumes the same track without resetting progress", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    expect(result.current.currentTrackId).toBe("track-1");
+    expect(result.current.audioSrc).toBe(tracks[0]?.audioUrl);
+
+    act(() => {
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      audioElement.currentTime = 42;
+      result.current.onPauseTrack();
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.isPlaying).toBe(false);
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+    expect(audioElement.currentTime).toBe(42);
+  });
+
+  it("switches tracks, ignores stale AbortError rejections, and resets when the scope changes", async () => {
+    const firstPlayController: { reject: null | ((reason?: unknown) => void) } = { reject: null };
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            firstPlayController.reject = reject;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result, rerender, unmount } = renderHook(
+      ({ scopeKey }) =>
+        useLocalTrackPlaybackController({
+          tracks,
+          scopeKey,
+          errorKeyPrefix: "library.album",
+          getAudioUrl: (track) => track.audioUrl,
+        }),
+      {
+        initialProps: { scopeKey: "album-1" },
+      },
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onPlayTrack("track-2");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      firstPlayController.reject?.(new DOMException("Interrupted", "AbortError"));
+    });
+
+    await waitFor(() => expect(audioElement.src).toContain("%2Ftmp%2F02.mp3"));
+    expect(result.current.playbackError).toBeNull();
+
+    rerender({ scopeKey: "album-2" });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+
+    unmount();
+
+    expect(pauseMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps unavailable and blocked playback failures to scoped error keys", async () => {
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockRejectedValueOnce(new DOMException("Playback blocked", "NotAllowedError"))
+      .mockResolvedValue(undefined);
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.playbackError).toBe("library.album.playbackBlocked"));
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.audioSrc).toBeNull();
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+  });
+
+  it("stops and clears active playback when selecting a track without audio", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.currentTrackId).toBe("track-1");
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.audioSrc).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+  });
+
+  it("keeps unavailable error when a stale pending playback later rejects", async () => {
+    const firstPlayController: { reject: null | ((reason?: unknown) => void) } = { reject: null };
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementationOnce(
+      () =>
+        new Promise<void>((_, reject) => {
+          firstPlayController.reject = reject;
+        }),
+    );
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+
+    await act(async () => {
+      firstPlayController.reject?.(new DOMException("Playback blocked", "NotAllowedError"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.ts
+++ b/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.ts
@@ -1,0 +1,214 @@
+import { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const PLAYBACK_ERROR_SUFFIX = {
+  BLOCKED: "playbackBlocked",
+  FAILED: "playbackFailed",
+  UNAVAILABLE: "playbackUnavailable",
+  UNSUPPORTED: "playbackUnsupported",
+} as const;
+
+type PlaybackErrorSuffix = (typeof PLAYBACK_ERROR_SUFFIX)[keyof typeof PLAYBACK_ERROR_SUFFIX];
+
+export type LocalTrackPlaybackErrorKey<TPrefix extends string> =
+  `${TPrefix}.${PlaybackErrorSuffix}`;
+
+interface LocalTrackPlaybackTrack {
+  id: string;
+}
+
+interface UseLocalTrackPlaybackControllerParams<
+  TTrack extends LocalTrackPlaybackTrack,
+  TPrefix extends string,
+> {
+  tracks: TTrack[];
+  scopeKey: string;
+  errorKeyPrefix: TPrefix;
+  getAudioUrl: (track: TTrack) => string | null | undefined;
+}
+
+const createPlaybackErrorKey = <TPrefix extends string>(
+  prefix: TPrefix,
+  suffix: PlaybackErrorSuffix,
+): LocalTrackPlaybackErrorKey<TPrefix> =>
+  `${prefix}.${suffix}` as LocalTrackPlaybackErrorKey<TPrefix>;
+
+export const useLocalTrackPlaybackController = <
+  TTrack extends LocalTrackPlaybackTrack,
+  TPrefix extends string,
+>({
+  tracks,
+  scopeKey,
+  errorKeyPrefix,
+  getAudioUrl,
+}: UseLocalTrackPlaybackControllerParams<TTrack, TPrefix>) => {
+  const tracksRef = useRef<TTrack[]>(tracks);
+  tracksRef.current = tracks;
+
+  const getAudioUrlRef = useRef(getAudioUrl);
+  getAudioUrlRef.current = getAudioUrl;
+
+  const [audioElement, setAudioElementState] = useState<HTMLAudioElement | null>(null);
+  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackError, setPlaybackError] = useState<LocalTrackPlaybackErrorKey<TPrefix> | null>(
+    null,
+  );
+  const loadedSrcRef = useRef<string | null>(null);
+  const playAttemptRef = useRef(0);
+  const playbackScopeKeyRef = useRef(scopeKey);
+
+  const currentTrack = useMemo(
+    () => tracks.find((track) => track.id === currentTrackId) ?? null,
+    [tracks, currentTrackId],
+  );
+
+  const audioSrc = currentTrack ? (getAudioUrl(currentTrack) ?? null) : null;
+
+  const stopAndClearPlayback = useCallback((element: HTMLAudioElement | null) => {
+    loadedSrcRef.current = null;
+    element?.pause();
+    setCurrentTrackId(null);
+    setIsPlaying(false);
+  }, []);
+
+  const setAudioElement = useCallback((element: HTMLAudioElement | null) => {
+    loadedSrcRef.current = element ? loadedSrcRef.current : null;
+    setAudioElementState(element);
+  }, []);
+
+  const playOnElement = useCallback(
+    async (element: HTMLAudioElement | null, src: string | null, attemptId: number) => {
+      if (!element || !src) {
+        return;
+      }
+
+      if (loadedSrcRef.current !== src) {
+        element.src = src;
+        loadedSrcRef.current = src;
+      }
+
+      try {
+        const result = element.play();
+
+        if (result && typeof (result as Promise<void>).then === "function") {
+          await result;
+        }
+      } catch (error) {
+        if (playAttemptRef.current !== attemptId || loadedSrcRef.current !== src) {
+          return;
+        }
+
+        if (error instanceof DOMException) {
+          if (error.name === "AbortError") {
+            return;
+          }
+
+          if (error.name === "NotAllowedError") {
+            setIsPlaying(false);
+            setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.BLOCKED));
+            return;
+          }
+
+          if (error.name === "NotSupportedError") {
+            setIsPlaying(false);
+            setPlaybackError(
+              createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNSUPPORTED),
+            );
+            return;
+          }
+        }
+
+        setIsPlaying(false);
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.FAILED));
+      }
+    },
+    [errorKeyPrefix],
+  );
+
+  const onPlayTrack = useCallback(
+    (trackId: string) => {
+      const targetTrack = tracksRef.current.find((track) => track.id === trackId);
+      const targetSrc = targetTrack ? (getAudioUrlRef.current(targetTrack) ?? null) : null;
+      const attemptId = playAttemptRef.current + 1;
+
+      playAttemptRef.current = attemptId;
+
+      if (!targetSrc) {
+        stopAndClearPlayback(audioElement);
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNAVAILABLE));
+        return;
+      }
+
+      setPlaybackError(null);
+      setCurrentTrackId(trackId);
+
+      if (audioElement) {
+        void playOnElement(audioElement, targetSrc, attemptId);
+      }
+    },
+    [audioElement, errorKeyPrefix, playOnElement, stopAndClearPlayback],
+  );
+
+  const onPauseTrack = useCallback(() => {
+    audioElement?.pause();
+    setIsPlaying(false);
+  }, [audioElement]);
+
+  const onAudioPlay = useCallback(() => {
+    setIsPlaying(true);
+  }, []);
+
+  const onAudioPause = useCallback(() => {
+    setIsPlaying(false);
+  }, []);
+
+  const onAudioError = useCallback(
+    (event?: SyntheticEvent<HTMLAudioElement>) => {
+      const mediaErrorCode = event?.currentTarget.error?.code;
+
+      setIsPlaying(false);
+
+      if (mediaErrorCode === 4) {
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNAVAILABLE));
+        return;
+      }
+
+      setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.FAILED));
+    },
+    [errorKeyPrefix],
+  );
+
+  useEffect(() => {
+    if (!audioElement) {
+      return;
+    }
+
+    return () => {
+      audioElement.pause();
+    };
+  }, [audioElement]);
+
+  useEffect(() => {
+    if (playbackScopeKeyRef.current === scopeKey) {
+      return;
+    }
+
+    playbackScopeKeyRef.current = scopeKey;
+    playAttemptRef.current += 1;
+    stopAndClearPlayback(audioElement);
+    setPlaybackError(null);
+  }, [audioElement, scopeKey, stopAndClearPlayback]);
+
+  return {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  };
+};


### PR DESCRIPTION
Closes #61

## What
Extract PR2 reusable playback foundation for the `library-playlist-playback` chain. This creates a shared local playback controller hook, moves album-detail playback logic onto it, and adds regression coverage for active, pending, and unavailable track behavior.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Docs / chore

## Scope
- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Checklist
- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change

## Changes
- Add `useLocalTrackPlaybackController` reusable hook
- Add focused hook tests for play/pause, stale promise handling, and unavailable tracks
- Refactor `useLibraryAlbumDetailController` to consume the shared hook
- Keep playlist-detail wiring out of scope for this PR

## Verification
- `pnpm --filter frontend exec vitest run src/hooks/controllers/useLocalTrackPlaybackController.test.tsx`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test:run`
- `pnpm --filter frontend run build`