### PR TITLE
feat(frontend): add playlist detail playback

### DIFF
--- a/apps/frontend/src/components/atoms/Button.tsx
+++ b/apps/frontend/src/components/atoms/Button.tsx
@@ -18,6 +18,7 @@ export interface ButtonProps {
   className?: string;
   type?: "button" | "submit" | "reset";
   title?: string;
+  ariaLabel?: string;
 }
 
 const VARIANT_STYLES: Record<ButtonVariant, string> = {
@@ -46,6 +47,7 @@ export const Button: FC<ButtonProps> = ({
   className = "",
   type = "button",
   title,
+  ariaLabel,
 }) => {
   const isDisabled = disabled || loading;
 
@@ -64,6 +66,7 @@ export const Button: FC<ButtonProps> = ({
       type={type}
       onClick={onClick}
       disabled={isDisabled}
+      aria-label={ariaLabel}
       className={cn(
         BASE_STYLES,
         VARIANT_STYLES[variant],

--- a/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
@@ -24,6 +24,7 @@ export interface AlbumPageLayoutProps {
   onLoadMoreTracks?: () => void;
   onPlayTrack?: (trackId: string) => void;
   onPauseTrack?: () => void;
+  canPlayTrack?: (track: Track) => boolean;
   currentTrackId?: string | null;
   isPlaying?: boolean;
 }
@@ -46,6 +47,7 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
   onLoadMoreTracks,
   onPlayTrack,
   onPauseTrack,
+  canPlayTrack,
   currentTrackId,
   isPlaying = false,
 }) => {
@@ -80,6 +82,7 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
             isLoadingMoreTracks={isLoadingMoreTracks}
             onPlayTrack={onPlayTrack}
             onPauseTrack={onPauseTrack}
+            canPlayTrack={canPlayTrack}
             currentTrackId={currentTrackId}
             isPlaying={isPlaying}
           />

--- a/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistActions } from "./PlaylistActions";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("PlaylistActions playback", () => {
+  it("renders a primary play control for saved playlists with playable tracks", () => {
+    const onPlayPlaylist = vi.fn();
+
+    render(
+      <PlaylistActions
+        isSubscribed={true}
+        hasFailed={false}
+        isRetrying={false}
+        isDownloading={false}
+        isDownloaded={true}
+        isSaved={true}
+        hasPlayableTracks={true}
+        isPlaying={false}
+        onPlayPlaylist={onPlayPlaylist}
+        onPausePlaylist={vi.fn()}
+        onToggleSubscription={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onDelete={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
+    expect(onPlayPlaylist).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches the primary control to pause while playback is active", () => {
+    const onPausePlaylist = vi.fn();
+
+    render(
+      <PlaylistActions
+        isSubscribed={true}
+        hasFailed={false}
+        isRetrying={false}
+        isDownloading={false}
+        isDownloaded={true}
+        isSaved={true}
+        hasPlayableTracks={true}
+        isPlaying={true}
+        onPlayPlaylist={vi.fn()}
+        onPausePlaylist={onPausePlaylist}
+        onToggleSubscription={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onDelete={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "library.album.pauseTrack" }));
+    expect(onPausePlaylist).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -1,5 +1,13 @@
 import { faBell as faBellRegular } from "@fortawesome/free-regular-svg-icons";
-import { faBell, faCheck, faDownload, faRepeat, faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faBell,
+  faCheck,
+  faDownload,
+  faPause,
+  faPlay,
+  faRepeat,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,6 +23,10 @@ interface PlaylistActionsProps {
   isDownloading: boolean;
   isDownloaded: boolean;
   isSaved: boolean;
+  hasPlayableTracks?: boolean;
+  isPlaying?: boolean;
+  onPlayPlaylist?: () => void;
+  onPausePlaylist?: () => void;
   onToggleSubscription: () => void;
   onRetryFailed: () => void;
   onDelete: () => void;
@@ -28,6 +40,10 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   isDownloading,
   isDownloaded,
   isSaved,
+  hasPlayableTracks = false,
+  isPlaying = false,
+  onPlayPlaylist,
+  onPausePlaylist,
   onToggleSubscription,
   onRetryFailed,
   onDelete,
@@ -38,6 +54,22 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
 
   return (
     <div className="flex items-center gap-3 md:gap-4">
+      {hasPlayableTracks ? (
+        <Button
+          variant="primary"
+          size="lg"
+          className="!h-12 !w-12 justify-center !rounded-full !p-0 shadow-lg transition-transform hover:scale-105 md:!h-14 md:!w-14"
+          onClick={isPlaying ? onPausePlaylist : onPlayPlaylist}
+          title={isPlaying ? t("library.album.pauseTrack") : t("library.album.playTrack")}
+          ariaLabel={isPlaying ? t("library.album.pauseTrack") : t("library.album.playTrack")}
+          icon={isPlaying ? faPause : faPlay}
+        >
+          <span className="sr-only">
+            {isPlaying ? t("library.album.pause") : t("library.album.play")}
+          </span>
+        </Button>
+      ) : null}
+
       <Button
         variant="primary"
         size="lg"

--- a/apps/frontend/src/components/organisms/Playlist.test.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.test.tsx
@@ -127,6 +127,13 @@ describe("Playlist", () => {
         onDownloadOrRetry={onDownloadOrRetry}
         onDownloadTrack={onDownloadTrack}
         onRetryTrack={onRetryTrack}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+        onPlayPlaylist={vi.fn()}
+        onPausePlaylist={vi.fn()}
+        currentTrackId="track-1"
+        isPlaying={true}
+        hasPlayableTracks={true}
         onConfirmDelete={onConfirmDelete}
         onRetryFailed={onRetryFailed}
         onToggleSubscription={onToggleSubscription}
@@ -159,5 +166,13 @@ describe("Playlist", () => {
     expect(screen.queryByRole("dialog", { name: "confirm-delete" })).toBeNull();
 
     expect(albumPageLayoutSpy).toHaveBeenCalled();
+    expect(albumPageLayoutSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onPlayTrack: expect.any(Function),
+        onPauseTrack: expect.any(Function),
+        currentTrackId: "track-1",
+        isPlaying: true,
+      }),
+    );
   });
 });

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -24,6 +24,13 @@ interface PlaylistProps {
   onRetryTrack?: (trackId: string) => void;
   onDownloadTrack?: (track: Track) => void;
   onLoadMoreTracks?: () => void;
+  onPlayTrack?: (trackId: string) => void;
+  onPauseTrack?: () => void;
+  onPlayPlaylist?: () => void;
+  onPausePlaylist?: () => void;
+  currentTrackId?: string | null;
+  isPlaying?: boolean;
+  hasPlayableTracks?: boolean;
   onConfirmDelete: (() => void) | undefined;
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
@@ -45,6 +52,13 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryTrack,
   onDownloadTrack,
   onLoadMoreTracks,
+  onPlayTrack,
+  onPauseTrack,
+  onPlayPlaylist,
+  onPausePlaylist,
+  currentTrackId = null,
+  isPlaying = false,
+  hasPlayableTracks = false,
   onConfirmDelete,
   onRetryFailed,
   onToggleSubscription,
@@ -101,6 +115,10 @@ export const Playlist: FC<PlaylistProps> = ({
               isDownloading={isDownloading}
               isDownloaded={isDownloaded ?? false}
               isSaved={isSaved}
+              hasPlayableTracks={hasPlayableTracks}
+              isPlaying={isPlaying}
+              onPlayPlaylist={onPlayPlaylist}
+              onPausePlaylist={onPausePlaylist}
               onToggleSubscription={onToggleSubscription}
               onRetryFailed={onRetryFailed}
               onDelete={handleDelete}
@@ -120,6 +138,11 @@ export const Playlist: FC<PlaylistProps> = ({
         onLoadMoreTracks={onLoadMoreTracks}
         hasMoreTracks={hasMoreTracks}
         isLoadingMoreTracks={isLoadingMoreTracks}
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+        currentTrackId={currentTrackId}
+        isPlaying={isPlaying}
       />
 
       <ConfirmModal

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
@@ -43,6 +43,7 @@ const tracks: Track[] = [
     album: "Album 1",
     durationMs: 120000,
     status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
     trackUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
   },
 ];
@@ -56,6 +57,7 @@ describe("PlaylistTracksList playback", () => {
         isPlaying={true}
         onPlayTrack={vi.fn()}
         onPauseTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
       />,
     );
 
@@ -71,10 +73,31 @@ describe("PlaylistTracksList playback", () => {
         currentTrackId={null}
         isPlaying={false}
         onPlayTrack={onPlayTrack}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
     expect(onPlayTrack).toHaveBeenCalledWith("track-1");
+  });
+
+  it("hides playback controls for tracks without a playable audioUrl", () => {
+    render(
+      <PlaylistTracksList
+        tracks={[
+          {
+            ...tracks[0],
+            id: "track-2",
+            audioUrl: undefined,
+          },
+        ]}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "library.album.playTrack" })).toBeNull();
   });
 });

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
@@ -18,6 +18,7 @@ interface PlaylistTrackItemProps {
   track: Track;
   index: number;
   status?: TrackStatusEnum;
+  isPlayable: boolean;
   onRetryTrack?: (trackId: string) => void;
   onDownloadTrack?: (track: Track) => void;
   onPlayTrack?: (trackId: string) => void;
@@ -31,6 +32,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
     track,
     index,
     status,
+    isPlayable,
     onRetryTrack,
     onDownloadTrack,
     onPlayTrack,
@@ -66,12 +68,13 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
     }, []);
 
     const isCurrent = currentTrackId === track.id;
+    const canPlayTrack = isPlayable && Boolean(onPlayTrack);
 
     const handleTogglePlayback = useCallback(
       (e: MouseEvent) => {
         e.stopPropagation();
 
-        if (!onPlayTrack) {
+        if (!canPlayTrack || !onPlayTrack) {
           return;
         }
 
@@ -82,7 +85,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
 
         onPlayTrack(track.id);
       },
-      [isCurrent, isPlaying, onPauseTrack, onPlayTrack, track.id],
+      [canPlayTrack, isCurrent, isPlaying, onPauseTrack, onPlayTrack, track.id],
     );
 
     return (
@@ -138,7 +141,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
         {/* Duration & Actions */}
         <div className="flex items-center justify-end gap-4">
           <div className="text-text-secondary flex min-w-[40px] items-center justify-end gap-2 text-right text-sm tabular-nums">
-            {onPlayTrack ? (
+            {canPlayTrack ? (
               <button
                 type="button"
                 onClick={handleTogglePlayback}
@@ -176,6 +179,7 @@ interface PlaylistTracksListProps {
   isLoadingMoreTracks?: boolean;
   onPlayTrack?: (trackId: string) => void;
   onPauseTrack?: () => void;
+  canPlayTrack?: (track: Track) => boolean;
   currentTrackId?: string | null;
   isPlaying?: boolean;
 }
@@ -189,6 +193,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
   isLoadingMoreTracks = false,
   onPlayTrack,
   onPauseTrack,
+  canPlayTrack,
   currentTrackId,
   isPlaying = false,
 }) => {
@@ -209,6 +214,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
           track={track}
           index={index + 1}
           status={status}
+          isPlayable={canPlayTrack ? canPlayTrack(track) : Boolean(track.trackUrl)}
           onRetryTrack={onRetryTrack}
           onDownloadTrack={onDownloadTrack}
           onPlayTrack={onPlayTrack}
@@ -223,6 +229,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
       onDownloadTrack,
       onPlayTrack,
       onPauseTrack,
+      canPlayTrack,
       currentTrackId,
       isPlaying,
       trackStatusesMap,

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -1,0 +1,162 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePlaylistDetailController } from "./usePlaylistDetailController";
+
+const mockUseParams = vi.fn();
+const mockUsePlaylistsQuery = vi.fn();
+const mockUseTracksQuery = vi.fn();
+const mockUseNavigationHelpers = vi.fn();
+const mockUsePlaylistController = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("../queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: () => mockUsePlaylistsQuery(),
+}));
+
+vi.mock("../queries/useTracksQuery", () => ({
+  useTracksQuery: (playlistId: string | undefined) => mockUseTracksQuery(playlistId),
+}));
+
+vi.mock("../useNavigationHelpers", () => ({
+  useNavigationHelpers: () => mockUseNavigationHelpers(),
+}));
+
+vi.mock("./usePlaylistController", () => ({
+  usePlaylistController: (params: unknown) => mockUsePlaylistController(params),
+}));
+
+const playlist = {
+  id: "playlist-1",
+  name: "Road Trip",
+  type: PlaylistTypeEnum.Playlist,
+  spotifyUrl: "https://open.spotify.com/playlist/playlist-1",
+  subscribed: true,
+  stats: {
+    completedCount: 2,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 0,
+    activeCount: 0,
+    errorCount: 0,
+    totalCount: 3,
+    progress: 100,
+    isDownloading: false,
+    hasErrors: false,
+    isCompleted: true,
+  },
+};
+
+const tracks = [
+  {
+    id: "track-1",
+    name: "Intro",
+    artist: "Artist 1",
+    status: TrackStatusEnum.Completed,
+    audioUrl: undefined,
+    trackUrl: "https://open.spotify.com/track/1",
+  },
+  {
+    id: "track-2",
+    name: "Main Theme",
+    artist: "Artist 2",
+    status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Fmusic%2Fmain-theme.mp3",
+    trackUrl: "https://open.spotify.com/track/2",
+  },
+  {
+    id: "track-3",
+    name: "Finale",
+    artist: "Artist 3",
+    status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Fmusic%2Ffinale.mp3",
+    trackUrl: "https://open.spotify.com/track/3",
+  },
+];
+
+describe("usePlaylistDetailController", () => {
+  it("starts playlist playback from the first playable track and exposes local playback state", () => {
+    mockUseParams.mockReturnValue({ id: "playlist-1" });
+    mockUseNavigationHelpers.mockReturnValue({ handleGoHome: vi.fn() });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
+    mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
+    mockUsePlaylistController.mockReturnValue({
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 2,
+      displayTitle: "Road Trip",
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      mutations: { retryFailedTracks: { isPending: false } },
+    });
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(result.current.hasPlayableTracks).toBe(true);
+    expect(result.current.currentTrackId).toBe("track-2");
+    expect(result.current.audioSrc).toBe(tracks[1]?.audioUrl);
+    expect(typeof result.current.onPlayTrack).toBe("function");
+    expect(typeof result.current.onPauseTrack).toBe("function");
+  });
+
+  it("resets scoped playback when the playlist route changes", () => {
+    mockUseNavigationHelpers.mockReturnValue({ handleGoHome: vi.fn() });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
+    mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
+    mockUsePlaylistController.mockReturnValue({
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 2,
+      displayTitle: "Road Trip",
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      mutations: { retryFailedTracks: { isPending: false } },
+    });
+
+    const pause = vi.fn();
+    const audioElement = { pause } as unknown as HTMLAudioElement;
+
+    mockUseParams.mockReturnValue({ id: "playlist-1" });
+    const { result, rerender } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+      result.current.onPlayTrack("track-2");
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.currentTrackId).toBe("track-2");
+    expect(result.current.isPlaying).toBe(true);
+
+    mockUseParams.mockReturnValue({ id: "playlist-2" });
+    mockUsePlaylistsQuery.mockReturnValue({
+      data: [{ ...playlist, id: "playlist-2", name: "Night Drive" }],
+      isLoading: false,
+    });
+    mockUseTracksQuery.mockReturnValue({ data: tracks.slice(1), isLoading: false });
+
+    rerender();
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -1,9 +1,15 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useTracksQuery } from "../queries/useTracksQuery";
 import { useNavigationHelpers } from "../useNavigationHelpers";
+import {
+  LocalTrackPlaybackErrorKey,
+  useLocalTrackPlaybackController,
+} from "./useLocalTrackPlaybackController";
 import { usePlaylistController } from "./usePlaylistController";
+
+export type PlaylistPlaybackErrorKey = LocalTrackPlaybackErrorKey<"library.album">;
 
 export const usePlaylistDetailController = () => {
   const { handleGoHome } = useNavigationHelpers();
@@ -13,6 +19,41 @@ export const usePlaylistDetailController = () => {
   const { data: tracks = [], isLoading: isTracksLoading } = useTracksQuery(id);
 
   const playlist = useMemo(() => playlists.find((p) => p.id === id), [playlists, id]);
+
+  const {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  } = useLocalTrackPlaybackController({
+    tracks,
+    scopeKey: id ?? "playlist-detail",
+    errorKeyPrefix: "library.album",
+    getAudioUrl: (track) => track.audioUrl,
+  });
+
+  const firstPlayableTrackId = useMemo(
+    () => tracks.find((track) => track.audioUrl)?.id ?? null,
+    [tracks],
+  );
+
+  const hasPlayableTracks = firstPlayableTrackId !== null;
+
+  const onPlayPlaylist = useCallback(() => {
+    const targetTrackId = currentTrackId ?? firstPlayableTrackId;
+
+    if (!targetTrackId) {
+      return;
+    }
+
+    onPlayTrack(targetTrackId);
+  }, [currentTrackId, firstPlayableTrackId, onPlayTrack]);
 
   const {
     isDownloading,
@@ -48,5 +89,18 @@ export const usePlaylistDetailController = () => {
     handleRetryFailed,
     handleRetryTrack,
     handleGoHome,
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError: playbackError as PlaylistPlaybackErrorKey | null,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onPlayPlaylist,
+    onPausePlaylist: onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+    hasPlayableTracks,
   };
 };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -199,6 +199,7 @@
     },
     "emptyTracksTitle": "No tracks in this playlist yet",
     "emptyTracksDescription": "Tracks you download or sync will appear here.",
+    "noPlayableTracks": "Download tracks in this playlist to start local playback.",
     "deleteModal": {
       "title": "Delete {{name}}?",
       "description": "This will remove the playlist from your library. Downloaded files will NOT be deleted."

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -199,6 +199,7 @@
     },
     "emptyTracksTitle": "Lista vacía",
     "emptyTracksDescription": "Las canciones que descargues o sincronices aparecerán aquí.",
+    "noPlayableTracks": "Descarga canciones de esta lista para iniciar la reproducción local.",
     "deleteModal": {
       "title": "¿Eliminar {{name}}?",
       "description": "Esto eliminará la lista de tu biblioteca. Los archivos descargados NO se borrarán."

--- a/apps/frontend/src/views/PlaylistDetail.test.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistDetail } from "./PlaylistDetail";
+
+const mockUsePlaylistDetailController = vi.fn();
+
+vi.mock("@/hooks/controllers/usePlaylistDetailController", () => ({
+  usePlaylistDetailController: () => mockUsePlaylistDetailController(),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("@/components/organisms/Playlist", () => ({
+  Playlist: () => <div data-testid="playlist-view" />,
+}));
+
+describe("PlaylistDetail", () => {
+  it("renders local playback audio element and assertive playback errors for saved playlists", () => {
+    mockUsePlaylistDetailController.mockReturnValue({
+      playlist: { id: "playlist-1", name: "Road Trip" },
+      tracks: [],
+      isPlaylistsLoading: false,
+      isTracksLoading: false,
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 0,
+      displayTitle: "Road Trip",
+      retryFailedTracks: { isPending: false },
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      handleGoHome: vi.fn(),
+      audioSrc: "/api/library/audio?path=%2Fmusic%2Ftrack.mp3",
+      playbackError: "library.album.playbackUnavailable",
+      setAudioElement: vi.fn(),
+      onPlayTrack: vi.fn(),
+      onPauseTrack: vi.fn(),
+      onPlayPlaylist: vi.fn(),
+      onPausePlaylist: vi.fn(),
+      onAudioError: vi.fn(),
+      onAudioPlay: vi.fn(),
+      onAudioPause: vi.fn(),
+      currentTrackId: "track-1",
+      isPlaying: true,
+      hasPlayableTracks: true,
+    });
+
+    const { container } = render(<PlaylistDetail />);
+
+    expect(screen.getByTestId("playlist-view")).toBeTruthy();
+    expect(container.querySelector("audio")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("library.album.playbackUnavailable");
+  });
+
+  it("renders a passive no-playable-tracks message when tracks exist but none are playable yet", () => {
+    mockUsePlaylistDetailController.mockReturnValue({
+      playlist: { id: "playlist-1", name: "Road Trip" },
+      tracks: [{ id: "track-1", title: "First Track" }],
+      isPlaylistsLoading: false,
+      isTracksLoading: false,
+      isDownloading: false,
+      isDownloaded: false,
+      hasFailed: false,
+      completedCount: 0,
+      displayTitle: "Road Trip",
+      retryFailedTracks: { isPending: false },
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      handleGoHome: vi.fn(),
+      playbackError: null,
+      setAudioElement: vi.fn(),
+      onPlayTrack: vi.fn(),
+      onPauseTrack: vi.fn(),
+      onPlayPlaylist: vi.fn(),
+      onPausePlaylist: vi.fn(),
+      onAudioError: vi.fn(),
+      onAudioPlay: vi.fn(),
+      onAudioPause: vi.fn(),
+      currentTrackId: null,
+      isPlaying: false,
+      hasPlayableTracks: false,
+    });
+
+    render(<PlaylistDetail />);
+
+    expect(screen.getByRole("status").textContent).toBe("playlist.noPlayableTracks");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -1,10 +1,12 @@
 import { FC } from "react";
+import { useTranslation } from "react-i18next";
 import { PlaylistNotFound } from "@/components/molecules/PlaylistNotFound";
 import { Playlist } from "@/components/organisms/Playlist";
 import { PlaylistSkeleton } from "@/components/skeletons/PlaylistSkeleton";
 import { usePlaylistDetailController } from "@/hooks/controllers/usePlaylistDetailController";
 
 export const PlaylistDetail: FC = () => {
+  const { t } = useTranslation();
   const {
     playlist,
     tracks,
@@ -21,6 +23,18 @@ export const PlaylistDetail: FC = () => {
     handleRetryFailed,
     handleRetryTrack,
     handleGoHome,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onPlayPlaylist,
+    onPausePlaylist,
+    onAudioError,
+    onAudioPlay,
+    onAudioPause,
+    currentTrackId,
+    isPlaying,
+    hasPlayableTracks,
   } = usePlaylistDetailController();
 
   if (isPlaylistsLoading || isTracksLoading) {
@@ -32,24 +46,50 @@ export const PlaylistDetail: FC = () => {
   }
 
   return (
-    <Playlist
-      playlist={playlist}
-      tracks={tracks}
-      isDownloading={isDownloading}
-      isDownloaded={isDownloaded}
-      displayTitle={displayTitle}
-      completedCount={completedCount}
-      onRetryTrack={(trackId) => {
-        const track = tracks.find((t) => t.id === trackId);
-        if (track) handleRetryTrack(track);
-      }}
-      onConfirmDelete={handleDelete}
-      onRetryFailed={handleRetryFailed}
-      hasFailed={hasFailed}
-      isRetrying={retryFailedTracks.isPending}
-      onToggleSubscription={handleToggleSubscription}
-      onDownloadTrack={(track) => handleRetryTrack(track)}
-      onDownloadOrRetry={handleRetryFailed}
-    />
+    <main className="flex flex-1 flex-col">
+      <Playlist
+        playlist={playlist}
+        tracks={tracks}
+        isDownloading={isDownloading}
+        isDownloaded={isDownloaded}
+        displayTitle={displayTitle}
+        completedCount={completedCount}
+        onRetryTrack={(trackId) => {
+          const track = tracks.find((t) => t.id === trackId);
+          if (track) handleRetryTrack(track);
+        }}
+        onConfirmDelete={handleDelete}
+        onRetryFailed={handleRetryFailed}
+        hasFailed={hasFailed}
+        isRetrying={retryFailedTracks.isPending}
+        onToggleSubscription={handleToggleSubscription}
+        onDownloadTrack={(track) => handleRetryTrack(track)}
+        onDownloadOrRetry={handleRetryFailed}
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        onPlayPlaylist={onPlayPlaylist}
+        onPausePlaylist={onPausePlaylist}
+        currentTrackId={currentTrackId}
+        isPlaying={isPlaying}
+        hasPlayableTracks={hasPlayableTracks}
+      />
+      <audio
+        ref={setAudioElement}
+        className="sr-only"
+        onError={onAudioError}
+        onPlay={onAudioPlay}
+        onPause={onAudioPause}
+      />
+      {playbackError ? (
+        <p className="text-text-secondary px-6 py-3 text-sm" role="alert" aria-live="assertive">
+          {t(playbackError)}
+        </p>
+      ) : null}
+      {!hasPlayableTracks && tracks.length > 0 ? (
+        <p className="text-text-secondary px-6 py-3 text-sm" role="status" aria-live="polite">
+          {t("playlist.noPlayableTracks")}
+        </p>
+      ) : null}
+    </main>
   );
 };


### PR DESCRIPTION
Closes #63

## What
Complete PR3 of the `library-playlist-playback` chain by wiring saved playlist detail playback on top of the reusable local playback hook and backend `audioUrl` foundation. This adds page-local playback controls and feedback for saved playlists without expanding scope to a global player.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / chore

## Scope
- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Checklist
- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change

## Changes
- Compose `usePlaylistDetailController` with the reusable local playback hook
- Render playlist detail audio element, playback error feedback, and passive no-playable-tracks state
- Add playlist-level and row-level saved playlist playback controls gated by `audioUrl`
- Preserve existing album playback behavior through shared playability handling

## Verification
- `pnpm --filter frontend exec vitest run src/hooks/controllers/usePlaylistDetailController.test.ts src/views/PlaylistDetail.test.tsx src/components/molecules/PlaylistActions.test.tsx src/components/organisms/Playlist.test.tsx src/components/organisms/PlaylistTracksList.test.tsx`
- `pnpm --filter frontend run test:run`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run build`