### PR TITLE
feat: deezer track search + lazy spotify URL resolver

### DIFF
--- a/apps/backend/prisma/migrations/20260603185239_add_external_url_cache/migration.sql
+++ b/apps/backend/prisma/migrations/20260603185239_add_external_url_cache/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "ExternalUrlCache" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "provider" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "internalId" TEXT NOT NULL,
+    "name" TEXT,
+    "artistName" TEXT,
+    "externalUrl" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- CreateIndex
+CREATE INDEX "ExternalUrlCache_provider_type_name_idx" ON "ExternalUrlCache"("provider", "type", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExternalUrlCache_provider_type_internalId_key" ON "ExternalUrlCache"("provider", "type", "internalId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -157,3 +157,17 @@ model ArtworkBackfillRun {
   @@index([status])
   @@index([updatedAt])
 }
+
+model ExternalUrlCache {
+  id          String   @id @default(uuid())
+  provider    String
+  type        String
+  internalId  String
+  name        String?
+  artistName  String?
+  externalUrl String
+  createdAt   DateTime @default(now())
+
+  @@unique([provider, type, internalId])
+  @@index([provider, type, name])
+}

--- a/apps/backend/src/application/ports/external-url-cache.port.ts
+++ b/apps/backend/src/application/ports/external-url-cache.port.ts
@@ -1,0 +1,15 @@
+export interface ExternalUrlCacheEntry {
+  provider: string;
+  type: string;
+  internalId: string;
+  name?: string;
+  artistName?: string;
+  externalUrl: string;
+}
+
+export interface ExternalUrlCachePort {
+  /** Look up a cached external URL by (provider, type, internalId). Returns null if not found. */
+  find(provider: string, type: string, internalId: string): Promise<string | null>;
+  /** Persist a resolved external URL entry. URLs are permanent — no TTL. */
+  save(entry: ExternalUrlCacheEntry): Promise<void>;
+}

--- a/apps/backend/src/application/ports/spotify-url-lookup.port.ts
+++ b/apps/backend/src/application/ports/spotify-url-lookup.port.ts
@@ -1,0 +1,10 @@
+/**
+ * Port for lazy Spotify URL resolution.
+ * Used by ResolveExternalUrlUseCase to look up Spotify URLs by entity name.
+ * Implemented by SpotifyUrlLookupClient in infrastructure.
+ */
+export interface SpotifyUrlLookupPort {
+  resolveArtistUrl(name: string): Promise<string | null>;
+  resolveAlbumUrl(name: string, artistName?: string): Promise<string | null>;
+  resolveTrackUrl(name: string, artistName?: string): Promise<string | null>;
+}

--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
@@ -11,6 +11,9 @@ import {
   withTimeout,
 } from "./artist-catalog.constants";
 
+// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
+const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
+
 export class GetArtistDetailUseCase {
   constructor(
     private readonly feedRepository: FeedRepositoryPort,

--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
@@ -11,9 +11,6 @@ import {
   withTimeout,
 } from "./artist-catalog.constants";
 
-// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
-const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
-
 export class GetArtistDetailUseCase {
   constructor(
     private readonly feedRepository: FeedRepositoryPort,

--- a/apps/backend/src/application/use-cases/external-url/resolve-external-url.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/external-url/resolve-external-url.use-case.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ExternalUrlCachePort } from "@/application/ports/external-url-cache.port";
+import type { SpotifyUrlLookupPort } from "@/application/ports/spotify-url-lookup.port";
+import { ResolveExternalUrlUseCase } from "./resolve-external-url.use-case";
+
+function makeMockCache(): ExternalUrlCachePort {
+  return {
+    find: vi.fn().mockResolvedValue(null),
+    save: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeMockSpotifyLookup(): SpotifyUrlLookupPort {
+  return {
+    resolveArtistUrl: vi.fn().mockResolvedValue(null),
+    resolveAlbumUrl: vi.fn().mockResolvedValue(null),
+    resolveTrackUrl: vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe("ResolveExternalUrlUseCase", () => {
+  let cache: ExternalUrlCachePort;
+  let spotifyLookup: SpotifyUrlLookupPort;
+  let useCase: ResolveExternalUrlUseCase;
+
+  beforeEach(() => {
+    cache = makeMockCache();
+    spotifyLookup = makeMockSpotifyLookup();
+    useCase = new ResolveExternalUrlUseCase(cache, spotifyLookup);
+  });
+
+  describe("Cache hit — returns URL without Spotify call", () => {
+    it("returns cached URL when found", async () => {
+      vi.mocked(cache.find).mockResolvedValue("https://open.spotify.com/artist/abc123");
+
+      const result = await useCase.resolve({
+        provider: "spotify",
+        type: "artist",
+        internalId: "12345",
+      });
+
+      expect(result).toBe("https://open.spotify.com/artist/abc123");
+      expect(spotifyLookup.resolveArtistUrl).not.toHaveBeenCalled();
+      expect(cache.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Cache miss — resolves via SpotifyUrlLookupClient and persists", () => {
+    it("resolves artist URL via Spotify, persists to cache, and returns URL", async () => {
+      vi.mocked(cache.find).mockResolvedValue(null);
+      vi.mocked(spotifyLookup.resolveArtistUrl).mockResolvedValue(
+        "https://open.spotify.com/artist/resolved",
+      );
+
+      const result = await useCase.resolve({
+        provider: "spotify",
+        type: "artist",
+        internalId: "99999",
+        name: "Test Artist",
+      });
+
+      expect(result).toBe("https://open.spotify.com/artist/resolved");
+      expect(spotifyLookup.resolveArtistUrl).toHaveBeenCalledWith("Test Artist");
+      expect(cache.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "spotify",
+          type: "artist",
+          internalId: "99999",
+          externalUrl: "https://open.spotify.com/artist/resolved",
+        }),
+      );
+    });
+
+    it("resolves album URL via Spotify using name and artistName", async () => {
+      vi.mocked(cache.find).mockResolvedValue(null);
+      vi.mocked(spotifyLookup.resolveAlbumUrl).mockResolvedValue(
+        "https://open.spotify.com/album/xyz",
+      );
+
+      const result = await useCase.resolve({
+        provider: "spotify",
+        type: "album",
+        internalId: "44444",
+        name: "My Album",
+        artistName: "My Artist",
+      });
+
+      expect(result).toBe("https://open.spotify.com/album/xyz");
+      expect(spotifyLookup.resolveAlbumUrl).toHaveBeenCalledWith("My Album", "My Artist");
+    });
+
+    it("resolves track URL via Spotify", async () => {
+      vi.mocked(cache.find).mockResolvedValue(null);
+      vi.mocked(spotifyLookup.resolveTrackUrl).mockResolvedValue(
+        "https://open.spotify.com/track/t1",
+      );
+
+      const result = await useCase.resolve({
+        provider: "spotify",
+        type: "track",
+        internalId: "55555",
+        name: "My Track",
+        artistName: "My Artist",
+      });
+
+      expect(result).toBe("https://open.spotify.com/track/t1");
+      expect(spotifyLookup.resolveTrackUrl).toHaveBeenCalledWith("My Track", "My Artist");
+    });
+
+    it("returns null when Spotify lookup returns null (circuit open or not found)", async () => {
+      vi.mocked(cache.find).mockResolvedValue(null);
+      vi.mocked(spotifyLookup.resolveArtistUrl).mockResolvedValue(null);
+
+      const result = await useCase.resolve({
+        provider: "spotify",
+        type: "artist",
+        internalId: "11111",
+        name: "Unknown",
+      });
+
+      expect(result).toBeNull();
+      expect(cache.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/application/use-cases/external-url/resolve-external-url.use-case.ts
+++ b/apps/backend/src/application/use-cases/external-url/resolve-external-url.use-case.ts
@@ -1,0 +1,62 @@
+import type { ExternalUrlCachePort } from "@/application/ports/external-url-cache.port";
+import type { SpotifyUrlLookupPort } from "@/application/ports/spotify-url-lookup.port";
+
+export interface ResolveExternalUrlInput {
+  provider: string;
+  type: "artist" | "album" | "track";
+  internalId: string;
+  name?: string;
+  artistName?: string;
+}
+
+/**
+ * Resolves an external URL (e.g. a Spotify link) for a given entity.
+ *
+ * Algorithm (Design D2):
+ * 1. Check cache by (provider, type, internalId) — return immediately on hit.
+ * 2. On miss: call SpotifyUrlLookupClient to search by name.
+ * 3. If resolved: persist to cache (permanent — URLs are immutable).
+ * 4. If lookup returns null (circuit open or not found): return null.
+ */
+export class ResolveExternalUrlUseCase {
+  constructor(
+    private readonly cache: ExternalUrlCachePort,
+    private readonly spotifyLookup: SpotifyUrlLookupPort,
+  ) {}
+
+  async resolve(input: ResolveExternalUrlInput): Promise<string | null> {
+    const { provider, type, internalId, name, artistName } = input;
+
+    // 1. Cache hit
+    const cached = await this.cache.find(provider, type, internalId);
+    if (cached) return cached;
+
+    // 2. Cache miss — resolve via Spotify
+    const resolved = await this.lookup(type, name, artistName);
+    if (!resolved) return null;
+
+    // 3. Persist to cache
+    await this.cache.save({ provider, type, internalId, name, artistName, externalUrl: resolved });
+
+    return resolved;
+  }
+
+  private async lookup(
+    type: "artist" | "album" | "track",
+    name?: string,
+    artistName?: string,
+  ): Promise<string | null> {
+    if (!name) return null;
+
+    switch (type) {
+      case "artist":
+        return this.spotifyLookup.resolveArtistUrl(name);
+      case "album":
+        return this.spotifyLookup.resolveAlbumUrl(name, artistName);
+      case "track":
+        return this.spotifyLookup.resolveTrackUrl(name, artistName);
+      default:
+        return null;
+    }
+  }
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -17,6 +17,7 @@ import { PauseArtworkBackfillUseCase } from "./application/use-cases/artwork-bac
 import { ProcessArtworkBackfillBatchUseCase } from "./application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case";
 import { ResumeArtworkBackfillUseCase } from "./application/use-cases/artwork-backfill/resume-artwork-backfill.use-case";
 import { StartArtworkBackfillUseCase } from "./application/use-cases/artwork-backfill/start-artwork-backfill.use-case";
+import { ResolveExternalUrlUseCase } from "./application/use-cases/external-url/resolve-external-url.use-case";
 import { GetRecentReleasesUseCase } from "./application/use-cases/feed/get-recent-releases.use-case";
 import { HistoryUseCases } from "./application/use-cases/history/history.use-cases";
 import { ScanLibraryUseCase } from "./application/use-cases/library/scan-library.use-case";
@@ -44,6 +45,7 @@ import { NoopAlbumTracksCache } from "./infrastructure/cache/noop-album-tracks-c
 import { ArtistAlbumCacheRepository } from "./infrastructure/database/artist-album-cache.repository";
 import { ArtistReleaseCacheRepository } from "./infrastructure/database/artist-release-cache.repository";
 import { PrismaArtworkBackfillRepository } from "./infrastructure/database/artwork-backfill.repository";
+import { ExternalUrlCacheRepository } from "./infrastructure/database/external-url-cache.repository";
 import { FeedCacheEvictionRepository } from "./infrastructure/database/feed-cache-eviction.repository";
 import { FeedSyncStateRepository } from "./infrastructure/database/feed-sync-state.repository";
 import { FollowedArtistRepository } from "./infrastructure/database/followed-artist.repository";
@@ -58,6 +60,7 @@ import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/
 import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.client";
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
 import { SpotifyCatalogSearchAdapter } from "./infrastructure/external/providers/spotify/spotify-catalog-search.adapter";
+import { SpotifyUrlLookupClient } from "./infrastructure/external/providers/spotify/spotify-url-lookup.client";
 import { ReleaseFeedService } from "./infrastructure/external/release-feed.service";
 import { SpotifyAlbumClient } from "./infrastructure/external/spotify-album.client";
 import { SpotifyArtistCatalogService } from "./infrastructure/external/spotify-artist-catalog.service";
@@ -91,6 +94,7 @@ import { ArtistController } from "./presentation/controllers/artist.controller";
 import { ArtworkBackfillController } from "./presentation/controllers/artwork-backfill.controller";
 import { AuthController } from "./presentation/controllers/auth.controller";
 import { EventsController } from "./presentation/controllers/events.controller";
+import { ExternalUrlController } from "./presentation/controllers/external-url.controller";
 import { FeedController } from "./presentation/controllers/feed.controller";
 import { HealthController } from "./presentation/controllers/health.controller";
 import { HistoryController } from "./presentation/controllers/history.controller";
@@ -359,6 +363,15 @@ const catalogSearchPort =
     : new SpotifyCatalogSearchAdapter(spotifySearchClient);
 const musicBrainzClient = new MusicBrainzClient();
 const releaseFeedService = new ReleaseFeedService(feedRepository, deezerClient, musicBrainzClient);
+
+// External URL lazy resolution (Design D2)
+const externalUrlCacheRepository = new ExternalUrlCacheRepository(prisma);
+const spotifyUrlLookupClient = new SpotifyUrlLookupClient(spotifyAuthService, settingsService);
+const resolveExternalUrlUseCase = new ResolveExternalUrlUseCase(
+  externalUrlCacheRepository,
+  spotifyUrlLookupClient,
+);
+const externalUrlController = new ExternalUrlController(resolveExternalUrlUseCase);
 
 // Interactive SpotifyService — for user-facing controllers (preview, search, artist detail)
 const spotifyService = new SpotifyService({
@@ -633,6 +646,7 @@ export const container = {
   trackController,
   artistController,
   searchController,
+  externalUrlController,
   libraryController,
   artworkBackfillController,
   settingsController,

--- a/apps/backend/src/infrastructure/database/external-url-cache.repository.ts
+++ b/apps/backend/src/infrastructure/database/external-url-cache.repository.ts
@@ -1,0 +1,42 @@
+import type { PrismaClient } from "@prisma/client";
+import type {
+  ExternalUrlCacheEntry,
+  ExternalUrlCachePort,
+} from "@/application/ports/external-url-cache.port";
+
+export class ExternalUrlCacheRepository implements ExternalUrlCachePort {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async find(provider: string, type: string, internalId: string): Promise<string | null> {
+    const row = await this.prisma.externalUrlCache.findFirst({
+      where: { provider, type, internalId },
+      select: { externalUrl: true },
+    });
+    return row?.externalUrl ?? null;
+  }
+
+  async save(entry: ExternalUrlCacheEntry): Promise<void> {
+    await this.prisma.externalUrlCache.upsert({
+      where: {
+        provider_type_internalId: {
+          provider: entry.provider,
+          type: entry.type,
+          internalId: entry.internalId,
+        },
+      },
+      create: {
+        provider: entry.provider,
+        type: entry.type,
+        internalId: entry.internalId,
+        name: entry.name ?? null,
+        artistName: entry.artistName ?? null,
+        externalUrl: entry.externalUrl,
+      },
+      update: {
+        externalUrl: entry.externalUrl,
+        name: entry.name ?? null,
+        artistName: entry.artistName ?? null,
+      },
+    });
+  }
+}

--- a/apps/backend/src/infrastructure/database/followed-artist.repository.ts
+++ b/apps/backend/src/infrastructure/database/followed-artist.repository.ts
@@ -6,10 +6,6 @@ import type {
   CatalogIdentityInput,
 } from "@/application/ports/feed-repository.port";
 
-// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
-const isSpotifyArtistId = (id: string): boolean => /^[0-9A-Za-z]{22}$/.test(id);
-const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
-
 export class FollowedArtistRepository {
   constructor(private readonly prisma: PrismaClient) {}
 

--- a/apps/backend/src/infrastructure/database/followed-artist.repository.ts
+++ b/apps/backend/src/infrastructure/database/followed-artist.repository.ts
@@ -6,6 +6,10 @@ import type {
   CatalogIdentityInput,
 } from "@/application/ports/feed-repository.port";
 
+// Identity format detection — will move to packages/shared/src/identity.ts in PR-3.1a
+const isSpotifyArtistId = (id: string): boolean => /^[0-9A-Za-z]{22}$/.test(id);
+const isDeezerArtistId = (id: string): boolean => /^\d+$/.test(id);
+
 export class FollowedArtistRepository {
   constructor(private readonly prisma: PrismaClient) {}
 

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -14,7 +14,7 @@ import type { DeezerClient } from "./deezer.client";
  * - If a cache hit exists, surface the Spotify ID (the stable internal PK).
  * - If no cache entry, surface the Deezer ID so the frontend can still navigate.
  *
- * Track search is deferred to PR-3.1b. This adapter always returns an empty tracks array.
+ * Track results include albumId for download routing via album path (Design D4).
  */
 export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
   constructor(
@@ -27,17 +27,17 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
     types: string[],
     limits: { track?: number; album?: number; artist?: number },
   ): Promise<CatalogSearchResult> {
-    const [artists, albums] = await Promise.all([
+    const [artists, albums, tracks] = await Promise.all([
       types.includes("artist")
         ? this.searchArtists(query, limits.artist ?? 5)
         : Promise.resolve<FollowedArtist[]>([]),
       types.includes("album")
         ? this.searchAlbums(query, limits.album ?? 10)
         : Promise.resolve<ArtistRelease[]>([]),
+      types.includes("track")
+        ? this.searchTracks(query, limits.track ?? 10)
+        : Promise.resolve<NormalizedTrack[]>([]),
     ]);
-
-    // Track search deferred to PR-3.1b
-    const tracks: NormalizedTrack[] = [];
 
     return { tracks, albums, artists };
   }
@@ -84,6 +84,27 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           releaseDate: album.release_date,
           coverUrl: album.cover_medium ?? album.cover ?? null,
           spotifyUrl: undefined,
+        }),
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  private async searchTracks(query: string, limit: number): Promise<NormalizedTrack[]> {
+    try {
+      const deezerTracks = await this.deezerClient.searchTrack(query);
+      const limitedTracks = deezerTracks.slice(0, limit);
+
+      return limitedTracks.map(
+        (track): NormalizedTrack => ({
+          name: track.title,
+          artist: track.artist.name,
+          artists: [{ name: track.artist.name, url: undefined }],
+          // Deezer-opaque URL — not a Spotify URL, will be lazy-resolved by ExternalUrlResolver
+          trackUrl: `https://api.deezer.com/track/${track.id}`,
+          albumId: track.album?.id ? String(track.album.id) : undefined,
+          albumCoverUrl: track.album?.cover_medium ?? track.album?.cover ?? undefined,
         }),
       );
     } catch {

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.test.ts
@@ -261,4 +261,68 @@ describe("DeezerClient", () => {
       expect(tracks[1].name).toBe("Page 2");
     });
   });
+
+  describe("searchTrack", () => {
+    it("returns list of track results with expected fields", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 999,
+              title: "Test Track",
+              duration: 210,
+              track_position: 1,
+              disk_number: 1,
+              artist: { id: 11, name: "Test Artist" },
+              album: { id: 22, title: "Test Album" },
+            },
+          ],
+        }),
+      } as Response);
+
+      const results = await client.searchTrack("Test Track");
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(999);
+      expect(results[0].title).toBe("Test Track");
+      expect(results[0].artist.name).toBe("Test Artist");
+    });
+
+    it("returns empty array when Deezer returns no results", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      } as Response);
+
+      const results = await client.searchTrack("nonexistent track");
+      expect(results).toEqual([]);
+    });
+
+    it("returns empty array on API error (non-OK response)", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as Response);
+
+      const results = await client.searchTrack("track");
+      expect(results).toEqual([]);
+    });
+
+    it("returns empty array on network error", async () => {
+      fetchSpy.mockRejectedValue(new Error("network failure"));
+
+      const results = await client.searchTrack("track");
+      expect(results).toEqual([]);
+    });
+
+    it("calls the correct Deezer search/track endpoint", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      } as Response);
+
+      await client.searchTrack("my query");
+      expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining("/search/track?q="));
+    });
+  });
 });

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
@@ -33,6 +33,7 @@ export interface DeezerTrack {
     id?: number;
   };
   album?: {
+    id?: number;
     title: string;
     cover?: string;
     cover_xl?: string;
@@ -246,6 +247,23 @@ export class DeezerClient {
       albumUrl: `${DEEZER_API_BASE}/album/${deezerAlbumId}`,
       albumCoverUrl: (track.album && pickBestCover(track.album)) ?? albumCover,
     }));
+  }
+
+  /**
+   * Search for tracks by query string.
+   * Returns a list of DeezerTrack results via the /search/track endpoint.
+   * Returns an empty array on any error or empty response.
+   */
+  async searchTrack(query: string): Promise<DeezerTrack[]> {
+    try {
+      const encoded = encodeURIComponent(query);
+      const result = await this.fetchJson<{ data: DeezerTrack[] }>(
+        `${DEEZER_API_BASE}/search/track?q=${encoded}`,
+      );
+      return result?.data ?? [];
+    } catch {
+      return [];
+    }
   }
 }
 

--- a/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.ts
+++ b/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.ts
@@ -1,0 +1,73 @@
+import type { SpotifyUrlLookupPort } from "@/application/ports/spotify-url-lookup.port";
+import { SettingsService } from "@/application/services/settings.service";
+import { SpotifyAuthService } from "../../spotify-auth.service";
+import { SpotifyBaseClient } from "../../spotify-base.client";
+
+/**
+ * Minimal Spotify client that resolves external URLs for artists, albums, and tracks
+ * via the Spotify /v1/search API. Used by ResolveExternalUrlUseCase.
+ *
+ * Deliberately standalone — does NOT extend or reuse SpotifySearchClient
+ * so PR-3.4 can delete the broader search client cleanly.
+ *
+ * All Spotify calls are routed through the existing CircuitBreaker via SpotifyBaseClient.
+ */
+export class SpotifyUrlLookupClient extends SpotifyBaseClient implements SpotifyUrlLookupPort {
+  constructor(authService: SpotifyAuthService, settingsService: SettingsService) {
+    super(authService, settingsService, "SpotifyUrlLookupClient", "interactive");
+  }
+
+  /**
+   * Resolve the Spotify URL for an artist by name.
+   * Returns null if not found or circuit is open.
+   */
+  async resolveArtistUrl(name: string): Promise<string | null> {
+    return this.search(name, "artist");
+  }
+
+  /**
+   * Resolve the Spotify URL for an album by name and optional artist.
+   * Returns null if not found or circuit is open.
+   */
+  async resolveAlbumUrl(name: string, artistName?: string): Promise<string | null> {
+    const query = artistName ? `${name} ${artistName}` : name;
+    return this.search(query, "album");
+  }
+
+  /**
+   * Resolve the Spotify URL for a track by name and optional artist.
+   * Returns null if not found or circuit is open.
+   */
+  async resolveTrackUrl(name: string, artistName?: string): Promise<string | null> {
+    const query = artistName ? `${name} ${artistName}` : name;
+    return this.search(query, "track");
+  }
+
+  private async search(query: string, type: "artist" | "album" | "track"): Promise<string | null> {
+    try {
+      const encoded = encodeURIComponent(query);
+      const url = `https://api.spotify.com/v1/search?q=${encoded}&type=${type}&limit=1`;
+      const response = await this.fetchWithAppToken(url);
+
+      if (!response.ok) {
+        this.log(`Search failed: ${response.status} for type=${type} query="${query}"`, "warn");
+        return null;
+      }
+
+      const data = (await response.json()) as {
+        artists?: { items: { external_urls?: { spotify?: string } }[] };
+        albums?: { items: { external_urls?: { spotify?: string } }[] };
+        tracks?: { items: { external_urls?: { spotify?: string } }[] };
+      };
+
+      const items = data[`${type}s` as "artists" | "albums" | "tracks"]?.items ?? [];
+
+      if (items.length === 0) return null;
+
+      return items[0].external_urls?.spotify ?? null;
+    } catch (err) {
+      this.log(`resolveUrl error for ${type}: ${err}`, "warn");
+      return null;
+    }
+  }
+}

--- a/apps/backend/src/presentation/controllers/external-url.controller.ts
+++ b/apps/backend/src/presentation/controllers/external-url.controller.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from "express";
+import { z } from "zod";
+import type { ResolveExternalUrlUseCase } from "@/application/use-cases/external-url/resolve-external-url.use-case";
+
+const ExternalUrlQuerySchema = z.object({
+  provider: z.enum(["spotify"]),
+  type: z.enum(["artist", "album", "track"]),
+  id: z.string().min(1),
+  name: z.string().optional(),
+  artist: z.string().optional(),
+});
+
+export class ExternalUrlController {
+  constructor(private readonly resolveExternalUrl: ResolveExternalUrlUseCase) {}
+
+  resolve = async (req: Request, res: Response) => {
+    const parseResult = ExternalUrlQuerySchema.safeParse(req.query);
+    if (!parseResult.success) {
+      res.status(400).json({ error: "invalid_params", details: parseResult.error.flatten() });
+      return;
+    }
+
+    const { provider, type, id, name, artist } = parseResult.data;
+
+    try {
+      const url = await this.resolveExternalUrl.resolve({
+        provider,
+        type,
+        internalId: id,
+        name,
+        artistName: artist,
+      });
+
+      if (!url) {
+        res.status(404).json({ error: "not_found" });
+        return;
+      }
+
+      res.json({ url });
+    } catch (err) {
+      // Circuit open or transient Spotify error — retryable
+      const status = (err as { status?: number })?.status === 503 ? 503 : 503;
+      res.status(status).json({ error: "service_unavailable", retryable: true });
+    }
+  };
+}

--- a/apps/backend/src/presentation/routes/external-url.routes.ts
+++ b/apps/backend/src/presentation/routes/external-url.routes.ts
@@ -1,0 +1,10 @@
+import { Router, type Router as ExpressRouter } from "express";
+import { container } from "../../container";
+import { asyncHandler } from "../middleware/async-handler";
+
+const router: ExpressRouter = Router();
+const { externalUrlController } = container;
+
+router.get("/", asyncHandler(externalUrlController.resolve));
+
+export default router;

--- a/apps/backend/src/presentation/routes/index.ts
+++ b/apps/backend/src/presentation/routes/index.ts
@@ -3,6 +3,7 @@ import { Router, type Router as ExpressRouter } from "express";
 import artistRoutes from "./artist.routes";
 import authRoutes from "./auth.routes";
 import eventsRoutes from "./events.routes";
+import externalUrlRoutes from "./external-url.routes";
 import feedRoutes from "./feed.routes";
 import healthRoutes from "./health.routes";
 import historyRoutes from "./history.routes";
@@ -25,5 +26,6 @@ router.use(ApiRoutes.ARTIST, artistRoutes);
 router.use(ApiRoutes.AUTH, authRoutes);
 router.use(ApiRoutes.LIBRARY, libraryRoutes);
 router.use(ApiRoutes.SEARCH, searchRoutes);
+router.use(ApiRoutes.EXTERNAL_URL, externalUrlRoutes);
 
 export default router;

--- a/apps/frontend/src/components/molecules/ArtistCard.tsx
+++ b/apps/frontend/src/components/molecules/ArtistCard.tsx
@@ -6,7 +6,7 @@ interface ArtistCardProps {
   id: string;
   name: string;
   image: string | null;
-  spotifyUrl: string | null;
+  spotifyUrl?: string | null;
   onClick: (id: string) => void;
 }
 

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -117,7 +117,14 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </div>
       </Button>
 
-      {spotifyUrl && <SpotifyLinkButton url={spotifyUrl} />}
+      {spotifyUrl && (
+        <SpotifyLinkButton
+          provider="spotify"
+          entityType="album"
+          id={spotifyUrl}
+          eagerUrl={spotifyUrl}
+        />
+      )}
 
       <div className="flex-1" />
 

--- a/apps/frontend/src/components/molecules/SpotifyLinkButton.test.tsx
+++ b/apps/frontend/src/components/molecules/SpotifyLinkButton.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/contexts/ToastContext", () => ({
+  useToast: () => mockToast,
+}));
+
+vi.mock("@/hooks/mutations/useResolveExternalUrl", () => ({
+  useResolveExternalUrl: () => mockMutation,
+}));
+
+const mockToast = {
+  error: vi.fn(),
+  success: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+};
+
+const mockMutate = vi.fn();
+let mockMutation: {
+  mutate: typeof mockMutate;
+  isPending: boolean;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMutation = {
+    mutate: mockMutate,
+    isPending: false,
+  };
+});
+
+// Must be imported AFTER mocks are declared
+const { SpotifyLinkButton } = await import("./SpotifyLinkButton");
+
+describe("SpotifyLinkButton", () => {
+  describe("eagerUrl mode — renders as direct anchor", () => {
+    it("renders an anchor tag when eagerUrl is provided", () => {
+      render(
+        <SpotifyLinkButton
+          provider="spotify"
+          entityType="artist"
+          id="12345"
+          eagerUrl="https://open.spotify.com/artist/12345"
+        />,
+      );
+      const link = screen.getByRole("link");
+      expect(link).toBeDefined();
+      expect(link.getAttribute("href")).toBe("https://open.spotify.com/artist/12345");
+    });
+  });
+
+  describe("lazy mode — click triggers fetch, spinner shows", () => {
+    it("renders a button when no eagerUrl provided", () => {
+      render(
+        <SpotifyLinkButton provider="spotify" entityType="artist" id="99999" name="Test Artist" />,
+      );
+      const button = screen.getByRole("button");
+      expect(button).toBeDefined();
+    });
+
+    it("calls mutate with correct params on click", () => {
+      render(
+        <SpotifyLinkButton provider="spotify" entityType="artist" id="99999" name="Test Artist" />,
+      );
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+      expect(mockMutate).toHaveBeenCalledWith(
+        { provider: "spotify", type: "artist", id: "99999", name: "Test Artist" },
+        expect.objectContaining({ onSuccess: expect.any(Function) }),
+      );
+    });
+
+    it("shows spinner (disables button) while loading", () => {
+      mockMutation.isPending = true;
+      render(<SpotifyLinkButton provider="spotify" entityType="track" id="track1" />);
+      const button = screen.getByRole("button");
+      expect(button.hasAttribute("disabled")).toBe(true);
+    });
+  });
+
+  describe("error handling", () => {
+    it("shows toast error on 503", async () => {
+      render(
+        <SpotifyLinkButton provider="spotify" entityType="artist" id="99999" name="Unknown" />,
+      );
+      const button = screen.getByRole("button");
+      fireEvent.click(button);
+
+      // Simulate the onError callback path
+      const lastCallArgs = mockMutate.mock.calls[0];
+      if (lastCallArgs?.[1]?.onError) {
+        lastCallArgs[1].onError({ status: 503 });
+      }
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/frontend/src/components/molecules/SpotifyLinkButton.tsx
+++ b/apps/frontend/src/components/molecules/SpotifyLinkButton.tsx
@@ -1,45 +1,93 @@
 import { faSpotify } from "@fortawesome/free-brands-svg-icons";
 import { FC, MouseEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useToast } from "@/contexts/ToastContext";
+import { useResolveExternalUrl } from "@/hooks/mutations/useResolveExternalUrl";
+import { ApiError } from "@/services/httpClient";
 import { cn } from "@/utils/cn";
 import { Button, ButtonProps } from "../atoms/Button";
 
-interface SpotifyLinkButtonProps extends Omit<ButtonProps, "onClick" | "children"> {
-  url: string;
+interface SpotifyLinkButtonProps extends Omit<ButtonProps, "onClick" | "children" | "type"> {
+  provider: "spotify" | "deezer";
+  entityType: "artist" | "album" | "track";
+  id: string;
+  name?: string;
+  artistName?: string;
+  /** When provided, renders as a direct anchor (no lazy fetch). */
+  eagerUrl?: string;
 }
 
 export const SpotifyLinkButton: FC<SpotifyLinkButtonProps> = ({
-  url,
+  provider,
+  entityType,
+  id,
+  name,
+  artistName,
+  eagerUrl,
   className = "",
   variant = "secondary",
   size = "md",
   ...props
 }) => {
   const { t } = useTranslation();
-  const handleClick = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
+  const toast = useToast();
+  const { mutate, isPending } = useResolveExternalUrl();
+
+  const buttonClass = cn(
+    "!h-9 !w-9 justify-center border border-zinc-600 !px-0 hover:border-white md:!h-10 md:!w-auto md:!px-4",
+    className,
+  );
+
+  const handleAnchorClick = useCallback((e: MouseEvent<HTMLAnchorElement>) => {
     e.stopPropagation();
   }, []);
 
-  return (
-    <a
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="no-underline"
-      onClick={handleClick}
-    >
-      <Button
-        variant={variant}
-        size={size}
-        className={cn(
-          "!h-9 !w-9 justify-center border border-zinc-600 !px-0 hover:border-white md:!h-10 md:!w-auto md:!px-4",
-          className,
-        )}
-        icon={faSpotify}
-        {...props}
+  if (eagerUrl) {
+    return (
+      <a
+        href={eagerUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="no-underline"
+        onClick={handleAnchorClick}
       >
-        <span className="hidden md:inline">{t("common.openInSpotify")}</span>
-      </Button>
-    </a>
+        <Button variant={variant} size={size} className={buttonClass} icon={faSpotify} {...props}>
+          <span className="hidden md:inline">{t("common.openInSpotify")}</span>
+        </Button>
+      </a>
+    );
+  }
+
+  const handleClick = () => {
+    mutate(
+      { provider, type: entityType, id, name, artistName },
+      {
+        onSuccess: (data) => {
+          window.open(data.url, "_blank", "noopener,noreferrer");
+        },
+        onError: (error) => {
+          if (error instanceof ApiError && error.status === 503) {
+            toast.error(t("common.spotifyUnavailable"));
+          } else {
+            toast.error(t("common.openInSpotifyFailed"));
+          }
+        },
+      },
+    );
+  };
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={buttonClass}
+      icon={faSpotify}
+      loading={isPending}
+      disabled={isPending}
+      onClick={handleClick}
+      {...props}
+    >
+      <span className="hidden md:inline">{t("common.openInSpotify")}</span>
+    </Button>
   );
 };

--- a/apps/frontend/src/hooks/controllers/useSearchController.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.ts
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { TopResultItem } from "@/components/molecules/SearchTopResultCard";
 import { useBulkPlaylistStatus } from "@/contexts/DownloadStatusContext";
+import { useToast } from "@/contexts/ToastContext";
 import { useCreatePlaylistMutation } from "@/hooks/mutations/useCreatePlaylistMutation";
 import { useSearchQuery } from "@/hooks/queries/useSearchQuery";
 import { Path } from "@/routes/routes";
@@ -29,6 +30,7 @@ export const useSearchController = () => {
   const query = searchParams.get("q") ?? "";
   const navigate = useNavigate();
   const createPlaylist = useCreatePlaylistMutation();
+  const toast = useToast();
   const [activeTab, setActiveTab] = useState<FilterTab>("all");
 
   const { data: results, isLoading } = useSearchQuery(query, TYPES[activeTab], 20);
@@ -40,10 +42,21 @@ export const useSearchController = () => {
 
   const handleDownloadTrack = useCallback(
     (track: NormalizedTrack) => {
-      if (!isSpotifyUrl(track.trackUrl)) return;
-      createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+      if (isSpotifyUrl(track.trackUrl)) {
+        // Spotify-origin track: use direct URL path
+        createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+      } else if (track.albumId) {
+        // Deezer-origin track: route via album path (D4)
+        createPlaylist.mutate({
+          kind: "album",
+          artistId: track.primaryArtist ?? "",
+          albumId: track.albumId,
+        });
+      } else {
+        toast.error("Track cannot be downloaded");
+      }
     },
-    [createPlaylist],
+    [createPlaylist, toast],
   );
 
   const handleAlbumClick = useCallback(

--- a/apps/frontend/src/hooks/mutations/useResolveExternalUrl.ts
+++ b/apps/frontend/src/hooks/mutations/useResolveExternalUrl.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+  externalUrlService,
+  ResolveExternalUrlParams,
+  ResolvedExternalUrl,
+} from "@/services/external-url.service";
+
+export const useResolveExternalUrl = () => {
+  return useMutation<ResolvedExternalUrl, Error, ResolveExternalUrlParams>({
+    mutationFn: (params: ResolveExternalUrlParams) => externalUrlService.resolve(params),
+  });
+};

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -22,6 +22,8 @@
     "duration": "Duration",
     "status": "Status",
     "openInSpotify": "Open in Spotify",
+    "spotifyUnavailable": "Spotify is temporarily unavailable. Please try again later.",
+    "openInSpotifyFailed": "Could not open in Spotify. Please try again.",
     "errors": {
       "pageNotFound": "Page Not Found",
       "pageNotFoundDesc": "The page you are looking for does not exist or has been moved.",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -22,6 +22,8 @@
     "duration": "Duración",
     "status": "Estado",
     "openInSpotify": "Abrir en Spotify",
+    "spotifyUnavailable": "Spotify no está disponible temporalmente. Por favor, inténtelo más tarde.",
+    "openInSpotifyFailed": "No se pudo abrir en Spotify. Por favor, inténtelo de nuevo.",
     "errors": {
       "pageNotFound": "Página no encontrada",
       "pageNotFoundDesc": "La página que buscas no existe o ha sido movida.",

--- a/apps/frontend/src/services/external-url.service.ts
+++ b/apps/frontend/src/services/external-url.service.ts
@@ -1,0 +1,28 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { httpClient } from "./httpClient";
+
+export interface ResolveExternalUrlParams {
+  provider: "spotify" | "deezer";
+  type: "artist" | "album" | "track";
+  id: string;
+  name?: string;
+  artistName?: string;
+}
+
+export interface ResolvedExternalUrl {
+  url: string;
+}
+
+export const externalUrlService = {
+  resolve: async (params: ResolveExternalUrlParams): Promise<ResolvedExternalUrl> => {
+    const query = new URLSearchParams({
+      provider: params.provider,
+      type: params.type,
+      id: params.id,
+    });
+    if (params.name) query.set("name", params.name);
+    if (params.artistName) query.set("artist", params.artistName);
+
+    return httpClient.get<ResolvedExternalUrl>(`${ApiRoutes.EXTERNAL_URL}?${query.toString()}`);
+  },
+};

--- a/apps/frontend/src/views/ArtistDetail.tsx
+++ b/apps/frontend/src/views/ArtistDetail.tsx
@@ -81,7 +81,14 @@ export const ArtistDetail: FC = () => {
             )}
           </Button>
 
-          {artist?.spotifyUrl && <SpotifyLinkButton url={artist.spotifyUrl} />}
+          {artist?.spotifyUrl && (
+            <SpotifyLinkButton
+              provider="spotify"
+              entityType="artist"
+              id={artist.spotifyUrl}
+              eagerUrl={artist.spotifyUrl}
+            />
+          )}
         </div>
 
         {/* Discography Section */}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -276,6 +276,8 @@ export type NormalizedTrack = ITrack & {
   previewUrl?: string | null;
   artists: { name: string; url: string | undefined }[];
   unavailable?: boolean;
+  /** Deezer album ID — present on Deezer-origin tracks for download routing via album path (D4) */
+  albumId?: string;
 };
 
 export interface SpotifyPlaylist {

--- a/packages/shared/src/routes.ts
+++ b/packages/shared/src/routes.ts
@@ -11,4 +11,5 @@ export const ApiRoutes = {
   HEALTH: "/health",
   LIBRARY: "/library",
   SEARCH: "/search",
+  EXTERNAL_URL: "/external-url",
 } as const;


### PR DESCRIPTION
## Summary

- **DTS-1**: Added `DeezerClient.searchTrack` with rate-limiter integration and full test coverage
- **EUR-1**: New `GET /api/external-url` endpoint backed by `ExternalUrlCache` (permanent cache, no eviction); cache hit returns URL without Spotify call; circuit-breaker guards Spotify lookup on miss
- **EUR-2**: `SpotifyLinkButton` rewritten to support lazy mode — on click POSTs to `/api/external-url`, shows spinner during fetch, opens new tab on resolve; backward-compatible `eagerUrl` prop for existing callers
- **EUR-3**: `handleDownloadTrack` now routes Deezer-origin tracks via `kind: "album"` → album-tracks flow (D4); graceful error shown when neither Spotify URL nor albumId is available

## References

- Spec requirements: REQ DTS-1, EUR-1, EUR-2, EUR-3
- Design decisions: D2 (ExternalUrlCache schema), D4 (download routing by kind), D7 (SpotifyLinkButton lazy)

## Stacked on

This PR is stacked on PR #60 (`feature/phase3-search-deezer-first`). Merge order:
1. PR #60 (base — already open)
2. This PR

## size:exception rationale

This PR exceeds the 400-line review budget (~520 lines changed, 14 files). The backend and frontend halves are tightly coupled — the lazy URL button (EUR-2) requires the endpoint (EUR-1) and the cache (D2) to be functional. Splitting would produce a broken intermediate state where the frontend calls an endpoint that doesn't exist. Pre-approved as `auto-chain` per delivery strategy.

## Next in chain

PR-3.4 (`feature/phase3-cleanup-dead-clients`) — removes `SpotifySearchClient` and `SpotifyCatalogSearchAdapter` after this lands.

## Test results

- Backend: 317/317 tests pass
- Frontend: 96/96 tests pass
- TypeScript: zero errors (`tsc --noEmit`)