### PR TITLE
feat(library): add saved playlist detail playback

### DIFF
--- a/apps/backend/src/application/ports/file-system.port.ts
+++ b/apps/backend/src/application/ports/file-system.port.ts
@@ -14,6 +14,7 @@ export interface TrackTags {
 
 export interface FileSystemTrackPathPort {
   getMusicLibraryPath(): string;
+  getTrackFileName(track: ITrack, playlistName?: string): Promise<string>;
   getFolderName(track: ITrack, playlistName?: string): Promise<string>;
   getPlaylistFolderPath(name: string): string;
   getArtistFolderPath(artist: string): string;

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
@@ -1,0 +1,117 @@
+import { ApiRoutes, TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import { Track } from "@/domain/entities/track.entity";
+import { GetTracksUseCase } from "./get-tracks.use-case";
+
+function makeTrack(input: Partial<ITrack> = {}): Track {
+  return new Track({
+    id: "track-1",
+    name: "Track 01",
+    artist: "Artist",
+    trackUrl: "https://open.spotify.com/track/1",
+    status: TrackStatusEnum.Completed,
+    playlistId: "playlist-1",
+    playlistIndex: 1,
+    ...input,
+  });
+}
+
+describe("GetTracksUseCase", () => {
+  const trackRepository = {
+    findAll: vi.fn(),
+    findAllByPlaylist: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteAll: vi.fn(),
+    findStuckTracks: vi.fn(),
+    findAllByStatuses: vi.fn(),
+  };
+
+  const playlistRepository = {
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const trackPathService = {
+    getMusicLibraryPath: vi.fn(),
+    getTrackFileName: vi.fn(),
+    getFolderName: vi.fn(),
+    getPlaylistFolderPath: vi.fn(),
+    getArtistFolderPath: vi.fn(),
+    getAlbumFolderPath: vi.fn(),
+    ensureParentDirectory: vi.fn(),
+  };
+
+  let useCase: GetTracksUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetTracksUseCase(
+      trackRepository as never,
+      playlistRepository as never,
+      trackPathService as never,
+    );
+  });
+
+  it("adds audioUrl for completed playlist tracks and preserves trackUrl", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([makeTrack()]);
+    playlistRepository.findOne.mockResolvedValue(
+      new Playlist({ id: "playlist-1", name: "Road Trip" }),
+    );
+    trackPathService.getTrackFileName.mockResolvedValue(
+      "/tmp/Playlists/Road Trip/01 - Artist - Track 01.mp3",
+    );
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("playlist-1");
+    expect(trackPathService.getTrackFileName).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "track-1", playlistId: "playlist-1" }),
+      "Road Trip",
+    );
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "track-1",
+        trackUrl: "https://open.spotify.com/track/1",
+        audioUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(
+          "/tmp/Playlists/Road Trip/01 - Artist - Track 01.mp3",
+        )}`,
+      }),
+    ]);
+  });
+
+  it("does not add audioUrl for tracks that are not completed", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Downloading }),
+    ]);
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).not.toHaveBeenCalled();
+    expect(trackPathService.getTrackFileName).not.toHaveBeenCalled();
+    expect(result[0]).toMatchObject({
+      id: "track-2",
+      trackUrl: "https://open.spotify.com/track/1",
+    });
+    expect(result[0]).not.toHaveProperty("audioUrl");
+  });
+
+  it("does not add audioUrl when the playlist cannot be resolved", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([makeTrack()]);
+    playlistRepository.findOne.mockResolvedValue(null);
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("playlist-1");
+    expect(trackPathService.getTrackFileName).not.toHaveBeenCalled();
+    expect(result[0]).toMatchObject({ id: "track-1" });
+    expect(result[0]).not.toHaveProperty("audioUrl");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
@@ -1,8 +1,14 @@
-import type { ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import { ApiRoutes, type ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
 
 export class GetTracksUseCase {
-  constructor(private readonly trackRepository: TrackRepository) {}
+  constructor(
+    private readonly trackRepository: TrackRepository,
+    private readonly playlistRepository: PlaylistRepository,
+    private readonly trackPathService: FileSystemTrackPathPort,
+  ) {}
 
   async getAll(where?: Partial<ITrack>): Promise<ITrack[]> {
     const tracks = await this.trackRepository.findAll(where);
@@ -11,7 +17,34 @@ export class GetTracksUseCase {
 
   async getAllByPlaylist(id: string): Promise<ITrack[]> {
     const tracks = await this.trackRepository.findAllByPlaylist(id);
-    return tracks.map((t) => t.toPrimitive());
+    const items = tracks.map((track) => track.toPrimitive());
+    const hasPlayableTrack = items.some((track) => track.status === TrackStatusEnum.Completed);
+
+    if (!hasPlayableTrack) {
+      return items;
+    }
+
+    const playlist = await this.playlistRepository.findOne(id);
+    const playlistName = playlist?.name;
+
+    if (!playlistName) {
+      return items;
+    }
+
+    return Promise.all(
+      items.map(async (track) => {
+        if (track.status !== TrackStatusEnum.Completed) {
+          return track;
+        }
+
+        const filePath = await this.trackPathService.getTrackFileName(track, playlistName);
+
+        return {
+          ...track,
+          audioUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(filePath)}`,
+        };
+      }),
+    );
   }
 
   async get(id: string): Promise<ITrack | null> {

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -380,7 +380,7 @@ const trackPostProcessingService = new TrackPostProcessingService(
 // Use Cases - Tracks
 const createTrackUseCase = new CreateTrackUseCase(trackRepository, queueService);
 const deleteTrackUseCase = new DeleteTrackUseCase(trackRepository);
-const getTracksUseCase = new GetTracksUseCase(trackRepository);
+const getTracksUseCase = new GetTracksUseCase(trackRepository, playlistRepository, trackFileHelper);
 const updateTrackUseCase = new UpdateTrackUseCase(trackRepository);
 const searchTrackOnYoutubeUseCase = new SearchTrackOnYoutubeUseCase(
   trackRepository,

--- a/apps/frontend/src/components/atoms/Button.tsx
+++ b/apps/frontend/src/components/atoms/Button.tsx
@@ -18,6 +18,7 @@ export interface ButtonProps {
   className?: string;
   type?: "button" | "submit" | "reset";
   title?: string;
+  ariaLabel?: string;
 }
 
 const VARIANT_STYLES: Record<ButtonVariant, string> = {
@@ -46,6 +47,7 @@ export const Button: FC<ButtonProps> = ({
   className = "",
   type = "button",
   title,
+  ariaLabel,
 }) => {
   const isDisabled = disabled || loading;
 
@@ -64,6 +66,7 @@ export const Button: FC<ButtonProps> = ({
       type={type}
       onClick={onClick}
       disabled={isDisabled}
+      aria-label={ariaLabel}
       className={cn(
         BASE_STYLES,
         VARIANT_STYLES[variant],

--- a/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
+++ b/apps/frontend/src/components/molecules/AlbumPageLayout.tsx
@@ -24,6 +24,7 @@ export interface AlbumPageLayoutProps {
   onLoadMoreTracks?: () => void;
   onPlayTrack?: (trackId: string) => void;
   onPauseTrack?: () => void;
+  canPlayTrack?: (track: Track) => boolean;
   currentTrackId?: string | null;
   isPlaying?: boolean;
 }
@@ -46,6 +47,7 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
   onLoadMoreTracks,
   onPlayTrack,
   onPauseTrack,
+  canPlayTrack,
   currentTrackId,
   isPlaying = false,
 }) => {
@@ -80,6 +82,7 @@ export const AlbumPageLayout: FC<AlbumPageLayoutProps> = ({
             isLoadingMoreTracks={isLoadingMoreTracks}
             onPlayTrack={onPlayTrack}
             onPauseTrack={onPauseTrack}
+            canPlayTrack={canPlayTrack}
             currentTrackId={currentTrackId}
             isPlaying={isPlaying}
           />

--- a/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistActions } from "./PlaylistActions";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("PlaylistActions playback", () => {
+  it("renders a primary play control for saved playlists with playable tracks", () => {
+    const onPlayPlaylist = vi.fn();
+
+    render(
+      <PlaylistActions
+        isSubscribed={true}
+        hasFailed={false}
+        isRetrying={false}
+        isDownloading={false}
+        isDownloaded={true}
+        isSaved={true}
+        hasPlayableTracks={true}
+        isPlaying={false}
+        onPlayPlaylist={onPlayPlaylist}
+        onPausePlaylist={vi.fn()}
+        onToggleSubscription={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onDelete={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
+    expect(onPlayPlaylist).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches the primary control to pause while playback is active", () => {
+    const onPausePlaylist = vi.fn();
+
+    render(
+      <PlaylistActions
+        isSubscribed={true}
+        hasFailed={false}
+        isRetrying={false}
+        isDownloading={false}
+        isDownloaded={true}
+        isSaved={true}
+        hasPlayableTracks={true}
+        isPlaying={true}
+        onPlayPlaylist={vi.fn()}
+        onPausePlaylist={onPausePlaylist}
+        onToggleSubscription={vi.fn()}
+        onRetryFailed={vi.fn()}
+        onDelete={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "library.album.pauseTrack" }));
+    expect(onPausePlaylist).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -1,5 +1,13 @@
 import { faBell as faBellRegular } from "@fortawesome/free-regular-svg-icons";
-import { faBell, faCheck, faDownload, faRepeat, faTrash } from "@fortawesome/free-solid-svg-icons";
+import {
+  faBell,
+  faCheck,
+  faDownload,
+  faPause,
+  faPlay,
+  faRepeat,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,6 +23,10 @@ interface PlaylistActionsProps {
   isDownloading: boolean;
   isDownloaded: boolean;
   isSaved: boolean;
+  hasPlayableTracks?: boolean;
+  isPlaying?: boolean;
+  onPlayPlaylist?: () => void;
+  onPausePlaylist?: () => void;
   onToggleSubscription: () => void;
   onRetryFailed: () => void;
   onDelete: () => void;
@@ -28,6 +40,10 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   isDownloading,
   isDownloaded,
   isSaved,
+  hasPlayableTracks = false,
+  isPlaying = false,
+  onPlayPlaylist,
+  onPausePlaylist,
   onToggleSubscription,
   onRetryFailed,
   onDelete,
@@ -38,6 +54,22 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
 
   return (
     <div className="flex items-center gap-3 md:gap-4">
+      {hasPlayableTracks ? (
+        <Button
+          variant="primary"
+          size="lg"
+          className="!h-12 !w-12 justify-center !rounded-full !p-0 shadow-lg transition-transform hover:scale-105 md:!h-14 md:!w-14"
+          onClick={isPlaying ? onPausePlaylist : onPlayPlaylist}
+          title={isPlaying ? t("library.album.pauseTrack") : t("library.album.playTrack")}
+          ariaLabel={isPlaying ? t("library.album.pauseTrack") : t("library.album.playTrack")}
+          icon={isPlaying ? faPause : faPlay}
+        >
+          <span className="sr-only">
+            {isPlaying ? t("library.album.pause") : t("library.album.play")}
+          </span>
+        </Button>
+      ) : null}
+
       <Button
         variant="primary"
         size="lg"

--- a/apps/frontend/src/components/organisms/Playlist.test.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.test.tsx
@@ -127,6 +127,13 @@ describe("Playlist", () => {
         onDownloadOrRetry={onDownloadOrRetry}
         onDownloadTrack={onDownloadTrack}
         onRetryTrack={onRetryTrack}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+        onPlayPlaylist={vi.fn()}
+        onPausePlaylist={vi.fn()}
+        currentTrackId="track-1"
+        isPlaying={true}
+        hasPlayableTracks={true}
         onConfirmDelete={onConfirmDelete}
         onRetryFailed={onRetryFailed}
         onToggleSubscription={onToggleSubscription}
@@ -159,5 +166,13 @@ describe("Playlist", () => {
     expect(screen.queryByRole("dialog", { name: "confirm-delete" })).toBeNull();
 
     expect(albumPageLayoutSpy).toHaveBeenCalled();
+    expect(albumPageLayoutSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onPlayTrack: expect.any(Function),
+        onPauseTrack: expect.any(Function),
+        currentTrackId: "track-1",
+        isPlaying: true,
+      }),
+    );
   });
 });

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -24,6 +24,13 @@ interface PlaylistProps {
   onRetryTrack?: (trackId: string) => void;
   onDownloadTrack?: (track: Track) => void;
   onLoadMoreTracks?: () => void;
+  onPlayTrack?: (trackId: string) => void;
+  onPauseTrack?: () => void;
+  onPlayPlaylist?: () => void;
+  onPausePlaylist?: () => void;
+  currentTrackId?: string | null;
+  isPlaying?: boolean;
+  hasPlayableTracks?: boolean;
   onConfirmDelete: (() => void) | undefined;
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
@@ -45,6 +52,13 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryTrack,
   onDownloadTrack,
   onLoadMoreTracks,
+  onPlayTrack,
+  onPauseTrack,
+  onPlayPlaylist,
+  onPausePlaylist,
+  currentTrackId = null,
+  isPlaying = false,
+  hasPlayableTracks = false,
   onConfirmDelete,
   onRetryFailed,
   onToggleSubscription,
@@ -101,6 +115,10 @@ export const Playlist: FC<PlaylistProps> = ({
               isDownloading={isDownloading}
               isDownloaded={isDownloaded ?? false}
               isSaved={isSaved}
+              hasPlayableTracks={hasPlayableTracks}
+              isPlaying={isPlaying}
+              onPlayPlaylist={onPlayPlaylist}
+              onPausePlaylist={onPausePlaylist}
               onToggleSubscription={onToggleSubscription}
               onRetryFailed={onRetryFailed}
               onDelete={handleDelete}
@@ -120,6 +138,11 @@ export const Playlist: FC<PlaylistProps> = ({
         onLoadMoreTracks={onLoadMoreTracks}
         hasMoreTracks={hasMoreTracks}
         isLoadingMoreTracks={isLoadingMoreTracks}
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+        currentTrackId={currentTrackId}
+        isPlaying={isPlaying}
       />
 
       <ConfirmModal

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
@@ -43,6 +43,7 @@ const tracks: Track[] = [
     album: "Album 1",
     durationMs: 120000,
     status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
     trackUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
   },
 ];
@@ -56,6 +57,7 @@ describe("PlaylistTracksList playback", () => {
         isPlaying={true}
         onPlayTrack={vi.fn()}
         onPauseTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
       />,
     );
 
@@ -71,10 +73,31 @@ describe("PlaylistTracksList playback", () => {
         currentTrackId={null}
         isPlaying={false}
         onPlayTrack={onPlayTrack}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
     expect(onPlayTrack).toHaveBeenCalledWith("track-1");
+  });
+
+  it("hides playback controls for tracks without a playable audioUrl", () => {
+    render(
+      <PlaylistTracksList
+        tracks={[
+          {
+            ...tracks[0],
+            id: "track-2",
+            audioUrl: undefined,
+          },
+        ]}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "library.album.playTrack" })).toBeNull();
   });
 });

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
@@ -18,6 +18,7 @@ interface PlaylistTrackItemProps {
   track: Track;
   index: number;
   status?: TrackStatusEnum;
+  isPlayable: boolean;
   onRetryTrack?: (trackId: string) => void;
   onDownloadTrack?: (track: Track) => void;
   onPlayTrack?: (trackId: string) => void;
@@ -31,6 +32,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
     track,
     index,
     status,
+    isPlayable,
     onRetryTrack,
     onDownloadTrack,
     onPlayTrack,
@@ -66,12 +68,13 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
     }, []);
 
     const isCurrent = currentTrackId === track.id;
+    const canPlayTrack = isPlayable && Boolean(onPlayTrack);
 
     const handleTogglePlayback = useCallback(
       (e: MouseEvent) => {
         e.stopPropagation();
 
-        if (!onPlayTrack) {
+        if (!canPlayTrack || !onPlayTrack) {
           return;
         }
 
@@ -82,7 +85,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
 
         onPlayTrack(track.id);
       },
-      [isCurrent, isPlaying, onPauseTrack, onPlayTrack, track.id],
+      [canPlayTrack, isCurrent, isPlaying, onPauseTrack, onPlayTrack, track.id],
     );
 
     return (
@@ -138,7 +141,7 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
         {/* Duration & Actions */}
         <div className="flex items-center justify-end gap-4">
           <div className="text-text-secondary flex min-w-[40px] items-center justify-end gap-2 text-right text-sm tabular-nums">
-            {onPlayTrack ? (
+            {canPlayTrack ? (
               <button
                 type="button"
                 onClick={handleTogglePlayback}
@@ -176,6 +179,7 @@ interface PlaylistTracksListProps {
   isLoadingMoreTracks?: boolean;
   onPlayTrack?: (trackId: string) => void;
   onPauseTrack?: () => void;
+  canPlayTrack?: (track: Track) => boolean;
   currentTrackId?: string | null;
   isPlaying?: boolean;
 }
@@ -189,6 +193,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
   isLoadingMoreTracks = false,
   onPlayTrack,
   onPauseTrack,
+  canPlayTrack,
   currentTrackId,
   isPlaying = false,
 }) => {
@@ -209,6 +214,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
           track={track}
           index={index + 1}
           status={status}
+          isPlayable={canPlayTrack ? canPlayTrack(track) : Boolean(track.trackUrl)}
           onRetryTrack={onRetryTrack}
           onDownloadTrack={onDownloadTrack}
           onPlayTrack={onPlayTrack}
@@ -223,6 +229,7 @@ export const PlaylistTracksList: FC<PlaylistTracksListProps> = ({
       onDownloadTrack,
       onPlayTrack,
       onPauseTrack,
+      canPlayTrack,
       currentTrackId,
       isPlaying,
       trackStatusesMap,

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -1,15 +1,15 @@
 import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
-import { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { generatePath, useParams } from "react-router-dom";
 import { Path } from "@/routes/routes";
 import { Track } from "@/types";
 import { useLibraryArtistQuery } from "../queries/useLibraryArtistQuery";
+import {
+  LocalTrackPlaybackErrorKey,
+  useLocalTrackPlaybackController,
+} from "./useLocalTrackPlaybackController";
 
-export type LibraryPlaybackErrorKey =
-  | "library.album.playbackBlocked"
-  | "library.album.playbackFailed"
-  | "library.album.playbackUnavailable"
-  | "library.album.playbackUnsupported";
+export type LibraryPlaybackErrorKey = LocalTrackPlaybackErrorKey<"library.album">;
 
 const safeDecodeURIComponent = (value: string | undefined): string => {
   if (!value) {
@@ -52,145 +52,23 @@ export const useLibraryAlbumDetailController = () => {
     }));
   }, [album, artistName]);
 
-  const tracksRef = useRef<Track[]>(tracks);
-  tracksRef.current = tracks;
-
-  const [audioElement, setAudioElementState] = useState<HTMLAudioElement | null>(null);
-  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [playbackError, setPlaybackError] = useState<LibraryPlaybackErrorKey | null>(null);
-  const loadedSrcRef = useRef<string | null>(null);
-  const playAttemptRef = useRef(0);
-  const playbackScopeKeyRef = useRef(`${artistName}::${selectedAlbumName}`);
-
-  const currentTrack = useMemo(
-    () => tracks.find((track) => track.id === currentTrackId) ?? null,
-    [tracks, currentTrackId],
-  );
-
-  const audioSrc = currentTrack?.trackUrl ?? null;
-
-  const setAudioElement = useCallback((element: HTMLAudioElement | null) => {
-    loadedSrcRef.current = element ? loadedSrcRef.current : null;
-    setAudioElementState(element);
-  }, []);
-
-  const playOnElement = useCallback(
-    async (element: HTMLAudioElement | null, src: string | null, attemptId: number) => {
-      if (!element || !src) {
-        return;
-      }
-
-      if (loadedSrcRef.current !== src) {
-        element.src = src;
-        loadedSrcRef.current = src;
-      }
-
-      try {
-        const result = element.play();
-
-        if (result && typeof (result as Promise<void>).then === "function") {
-          await result;
-        }
-      } catch (error) {
-        if (playAttemptRef.current !== attemptId || loadedSrcRef.current !== src) {
-          return;
-        }
-
-        if (error instanceof DOMException) {
-          if (error.name === "AbortError") {
-            return;
-          }
-
-          if (error.name === "NotAllowedError") {
-            setIsPlaying(false);
-            setPlaybackError("library.album.playbackBlocked");
-            return;
-          }
-
-          if (error.name === "NotSupportedError") {
-            setIsPlaying(false);
-            setPlaybackError("library.album.playbackUnsupported");
-            return;
-          }
-        }
-
-        setIsPlaying(false);
-        setPlaybackError("library.album.playbackFailed");
-      }
-    },
-    [],
-  );
-
-  const onPlayTrack = useCallback(
-    (trackId: string) => {
-      const targetTrack = tracksRef.current.find((track) => track.id === trackId);
-      const targetSrc = targetTrack?.trackUrl ?? null;
-      const attemptId = playAttemptRef.current + 1;
-
-      playAttemptRef.current = attemptId;
-
-      setPlaybackError(null);
-      setCurrentTrackId(trackId);
-
-      if (audioElement) {
-        void playOnElement(audioElement, targetSrc, attemptId);
-      }
-    },
-    [audioElement, playOnElement],
-  );
-
-  const onPauseTrack = useCallback(() => {
-    audioElement?.pause();
-    setIsPlaying(false);
-  }, [audioElement]);
-
-  const onAudioPlay = useCallback(() => {
-    setIsPlaying(true);
-  }, []);
-
-  const onAudioPause = useCallback(() => {
-    setIsPlaying(false);
-  }, []);
-
-  const onAudioError = useCallback((event?: SyntheticEvent<HTMLAudioElement>) => {
-    const mediaErrorCode = event?.currentTarget.error?.code;
-
-    setIsPlaying(false);
-
-    if (mediaErrorCode === 4) {
-      setPlaybackError("library.album.playbackUnavailable");
-      return;
-    }
-
-    setPlaybackError("library.album.playbackFailed");
-  }, []);
-
-  useEffect(() => {
-    if (!audioElement) {
-      return;
-    }
-
-    return () => {
-      audioElement.pause();
-    };
-  }, [audioElement]);
-
-  useEffect(() => {
-    const nextScopeKey = `${artistName}::${selectedAlbumName}`;
-
-    if (playbackScopeKeyRef.current === nextScopeKey) {
-      return;
-    }
-
-    playbackScopeKeyRef.current = nextScopeKey;
-    playAttemptRef.current += 1;
-    loadedSrcRef.current = null;
-    audioElement?.pause();
-    setCurrentTrackId(null);
-    setIsPlaying(false);
-    setPlaybackError(null);
-  }, [artistName, selectedAlbumName, audioElement]);
+  const {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  } = useLocalTrackPlaybackController({
+    tracks,
+    scopeKey: `${artistName}::${selectedAlbumName}`,
+    errorKeyPrefix: "library.album",
+    getAudioUrl: (track) => track.trackUrl,
+  });
 
   const coverUrl = album?.image
     ? `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/image?path=${encodeURIComponent(album.image)}`
@@ -214,7 +92,7 @@ export const useLibraryAlbumDetailController = () => {
     audioSrc,
     currentTrackId,
     isPlaying,
-    playbackError,
+    playbackError: playbackError as LibraryPlaybackErrorKey | null,
     setAudioElement,
     onPlayTrack,
     onPauseTrack,

--- a/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.test.tsx
@@ -1,0 +1,318 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Track } from "@/types";
+import { useLocalTrackPlaybackController } from "./useLocalTrackPlaybackController";
+
+const tracks: Track[] = [
+  {
+    id: "track-1",
+    name: "Track 1",
+    artist: "Artist 1",
+    album: "Album 1",
+    durationMs: 180000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/1",
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F01.mp3",
+  },
+  {
+    id: "track-2",
+    name: "Track 2",
+    artist: "Artist 2",
+    album: "Album 2",
+    durationMs: 200000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/2",
+    audioUrl: "/api/library/audio?path=%2Ftmp%2F02.mp3",
+  },
+  {
+    id: "track-3",
+    name: "Track 3",
+    artist: "Artist 3",
+    album: "Album 3",
+    durationMs: 210000,
+    status: TrackStatusEnum.Completed,
+    trackUrl: "https://open.spotify.com/track/3",
+  },
+];
+
+const instrumentAudioElement = (audio: HTMLAudioElement) => {
+  let srcValue = "";
+  let currentTimeValue = 0;
+  let mediaError: MediaError | null = null;
+
+  Object.defineProperty(audio, "src", {
+    configurable: true,
+    get: () => srcValue,
+    set: (value: string) => {
+      srcValue = value;
+      currentTimeValue = 0;
+    },
+  });
+
+  Object.defineProperty(audio, "currentTime", {
+    configurable: true,
+    get: () => currentTimeValue,
+    set: (value: number) => {
+      currentTimeValue = value;
+    },
+  });
+
+  Object.defineProperty(audio, "error", {
+    configurable: true,
+    get: () => mediaError,
+    set: (value: MediaError | null) => {
+      mediaError = value;
+    },
+  });
+};
+
+describe("useLocalTrackPlaybackController", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("plays, pauses, and resumes the same track without resetting progress", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    expect(result.current.currentTrackId).toBe("track-1");
+    expect(result.current.audioSrc).toBe(tracks[0]?.audioUrl);
+
+    act(() => {
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      audioElement.currentTime = 42;
+      result.current.onPauseTrack();
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.isPlaying).toBe(false);
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+    expect(audioElement.currentTime).toBe(42);
+  });
+
+  it("switches tracks, ignores stale AbortError rejections, and resets when the scope changes", async () => {
+    const firstPlayController: { reject: null | ((reason?: unknown) => void) } = { reject: null };
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            firstPlayController.reject = reject;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result, rerender, unmount } = renderHook(
+      ({ scopeKey }) =>
+        useLocalTrackPlaybackController({
+          tracks,
+          scopeKey,
+          errorKeyPrefix: "library.album",
+          getAudioUrl: (track) => track.audioUrl,
+        }),
+      {
+        initialProps: { scopeKey: "album-1" },
+      },
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onPlayTrack("track-2");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      firstPlayController.reject?.(new DOMException("Interrupted", "AbortError"));
+    });
+
+    await waitFor(() => expect(audioElement.src).toContain("%2Ftmp%2F02.mp3"));
+    expect(result.current.playbackError).toBeNull();
+
+    rerender({ scopeKey: "album-2" });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+
+    unmount();
+
+    expect(pauseMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps unavailable and blocked playback failures to scoped error keys", async () => {
+    const playMock = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockRejectedValueOnce(new DOMException("Playback blocked", "NotAllowedError"))
+      .mockResolvedValue(undefined);
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.playbackError).toBe("library.album.playbackBlocked"));
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.audioSrc).toBeNull();
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+  });
+
+  it("stops and clears active playback when selecting a track without audio", async () => {
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.currentTrackId).toBe("track-1");
+    expect(result.current.isPlaying).toBe(true);
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.audioSrc).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+  });
+
+  it("keeps unavailable error when a stale pending playback later rejects", async () => {
+    const firstPlayController: { reject: null | ((reason?: unknown) => void) } = { reject: null };
+    const playMock = vi.spyOn(HTMLMediaElement.prototype, "play").mockImplementationOnce(
+      () =>
+        new Promise<void>((_, reject) => {
+          firstPlayController.reject = reject;
+        }),
+    );
+    const pauseMock = vi.spyOn(HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+    const audioElement = document.createElement("audio");
+
+    instrumentAudioElement(audioElement);
+
+    const { result } = renderHook(() =>
+      useLocalTrackPlaybackController({
+        tracks,
+        scopeKey: "album-1",
+        errorKeyPrefix: "library.album",
+        getAudioUrl: (track) => track.audioUrl,
+      }),
+    );
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+    });
+
+    act(() => {
+      result.current.onPlayTrack("track-1");
+    });
+
+    await waitFor(() => expect(playMock).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(pauseMock).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+
+    await act(async () => {
+      firstPlayController.reject?.(new DOMException("Playback blocked", "NotAllowedError"));
+      await Promise.resolve();
+    });
+
+    expect(result.current.playbackError).toBe("library.album.playbackUnavailable");
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.ts
+++ b/apps/frontend/src/hooks/controllers/useLocalTrackPlaybackController.ts
@@ -1,0 +1,214 @@
+import { SyntheticEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const PLAYBACK_ERROR_SUFFIX = {
+  BLOCKED: "playbackBlocked",
+  FAILED: "playbackFailed",
+  UNAVAILABLE: "playbackUnavailable",
+  UNSUPPORTED: "playbackUnsupported",
+} as const;
+
+type PlaybackErrorSuffix = (typeof PLAYBACK_ERROR_SUFFIX)[keyof typeof PLAYBACK_ERROR_SUFFIX];
+
+export type LocalTrackPlaybackErrorKey<TPrefix extends string> =
+  `${TPrefix}.${PlaybackErrorSuffix}`;
+
+interface LocalTrackPlaybackTrack {
+  id: string;
+}
+
+interface UseLocalTrackPlaybackControllerParams<
+  TTrack extends LocalTrackPlaybackTrack,
+  TPrefix extends string,
+> {
+  tracks: TTrack[];
+  scopeKey: string;
+  errorKeyPrefix: TPrefix;
+  getAudioUrl: (track: TTrack) => string | null | undefined;
+}
+
+const createPlaybackErrorKey = <TPrefix extends string>(
+  prefix: TPrefix,
+  suffix: PlaybackErrorSuffix,
+): LocalTrackPlaybackErrorKey<TPrefix> =>
+  `${prefix}.${suffix}` as LocalTrackPlaybackErrorKey<TPrefix>;
+
+export const useLocalTrackPlaybackController = <
+  TTrack extends LocalTrackPlaybackTrack,
+  TPrefix extends string,
+>({
+  tracks,
+  scopeKey,
+  errorKeyPrefix,
+  getAudioUrl,
+}: UseLocalTrackPlaybackControllerParams<TTrack, TPrefix>) => {
+  const tracksRef = useRef<TTrack[]>(tracks);
+  tracksRef.current = tracks;
+
+  const getAudioUrlRef = useRef(getAudioUrl);
+  getAudioUrlRef.current = getAudioUrl;
+
+  const [audioElement, setAudioElementState] = useState<HTMLAudioElement | null>(null);
+  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackError, setPlaybackError] = useState<LocalTrackPlaybackErrorKey<TPrefix> | null>(
+    null,
+  );
+  const loadedSrcRef = useRef<string | null>(null);
+  const playAttemptRef = useRef(0);
+  const playbackScopeKeyRef = useRef(scopeKey);
+
+  const currentTrack = useMemo(
+    () => tracks.find((track) => track.id === currentTrackId) ?? null,
+    [tracks, currentTrackId],
+  );
+
+  const audioSrc = currentTrack ? (getAudioUrl(currentTrack) ?? null) : null;
+
+  const stopAndClearPlayback = useCallback((element: HTMLAudioElement | null) => {
+    loadedSrcRef.current = null;
+    element?.pause();
+    setCurrentTrackId(null);
+    setIsPlaying(false);
+  }, []);
+
+  const setAudioElement = useCallback((element: HTMLAudioElement | null) => {
+    loadedSrcRef.current = element ? loadedSrcRef.current : null;
+    setAudioElementState(element);
+  }, []);
+
+  const playOnElement = useCallback(
+    async (element: HTMLAudioElement | null, src: string | null, attemptId: number) => {
+      if (!element || !src) {
+        return;
+      }
+
+      if (loadedSrcRef.current !== src) {
+        element.src = src;
+        loadedSrcRef.current = src;
+      }
+
+      try {
+        const result = element.play();
+
+        if (result && typeof (result as Promise<void>).then === "function") {
+          await result;
+        }
+      } catch (error) {
+        if (playAttemptRef.current !== attemptId || loadedSrcRef.current !== src) {
+          return;
+        }
+
+        if (error instanceof DOMException) {
+          if (error.name === "AbortError") {
+            return;
+          }
+
+          if (error.name === "NotAllowedError") {
+            setIsPlaying(false);
+            setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.BLOCKED));
+            return;
+          }
+
+          if (error.name === "NotSupportedError") {
+            setIsPlaying(false);
+            setPlaybackError(
+              createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNSUPPORTED),
+            );
+            return;
+          }
+        }
+
+        setIsPlaying(false);
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.FAILED));
+      }
+    },
+    [errorKeyPrefix],
+  );
+
+  const onPlayTrack = useCallback(
+    (trackId: string) => {
+      const targetTrack = tracksRef.current.find((track) => track.id === trackId);
+      const targetSrc = targetTrack ? (getAudioUrlRef.current(targetTrack) ?? null) : null;
+      const attemptId = playAttemptRef.current + 1;
+
+      playAttemptRef.current = attemptId;
+
+      if (!targetSrc) {
+        stopAndClearPlayback(audioElement);
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNAVAILABLE));
+        return;
+      }
+
+      setPlaybackError(null);
+      setCurrentTrackId(trackId);
+
+      if (audioElement) {
+        void playOnElement(audioElement, targetSrc, attemptId);
+      }
+    },
+    [audioElement, errorKeyPrefix, playOnElement, stopAndClearPlayback],
+  );
+
+  const onPauseTrack = useCallback(() => {
+    audioElement?.pause();
+    setIsPlaying(false);
+  }, [audioElement]);
+
+  const onAudioPlay = useCallback(() => {
+    setIsPlaying(true);
+  }, []);
+
+  const onAudioPause = useCallback(() => {
+    setIsPlaying(false);
+  }, []);
+
+  const onAudioError = useCallback(
+    (event?: SyntheticEvent<HTMLAudioElement>) => {
+      const mediaErrorCode = event?.currentTarget.error?.code;
+
+      setIsPlaying(false);
+
+      if (mediaErrorCode === 4) {
+        setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.UNAVAILABLE));
+        return;
+      }
+
+      setPlaybackError(createPlaybackErrorKey(errorKeyPrefix, PLAYBACK_ERROR_SUFFIX.FAILED));
+    },
+    [errorKeyPrefix],
+  );
+
+  useEffect(() => {
+    if (!audioElement) {
+      return;
+    }
+
+    return () => {
+      audioElement.pause();
+    };
+  }, [audioElement]);
+
+  useEffect(() => {
+    if (playbackScopeKeyRef.current === scopeKey) {
+      return;
+    }
+
+    playbackScopeKeyRef.current = scopeKey;
+    playAttemptRef.current += 1;
+    stopAndClearPlayback(audioElement);
+    setPlaybackError(null);
+  }, [audioElement, scopeKey, stopAndClearPlayback]);
+
+  return {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  };
+};

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -1,0 +1,162 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePlaylistDetailController } from "./usePlaylistDetailController";
+
+const mockUseParams = vi.fn();
+const mockUsePlaylistsQuery = vi.fn();
+const mockUseTracksQuery = vi.fn();
+const mockUseNavigationHelpers = vi.fn();
+const mockUsePlaylistController = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+  };
+});
+
+vi.mock("../queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: () => mockUsePlaylistsQuery(),
+}));
+
+vi.mock("../queries/useTracksQuery", () => ({
+  useTracksQuery: (playlistId: string | undefined) => mockUseTracksQuery(playlistId),
+}));
+
+vi.mock("../useNavigationHelpers", () => ({
+  useNavigationHelpers: () => mockUseNavigationHelpers(),
+}));
+
+vi.mock("./usePlaylistController", () => ({
+  usePlaylistController: (params: unknown) => mockUsePlaylistController(params),
+}));
+
+const playlist = {
+  id: "playlist-1",
+  name: "Road Trip",
+  type: PlaylistTypeEnum.Playlist,
+  spotifyUrl: "https://open.spotify.com/playlist/playlist-1",
+  subscribed: true,
+  stats: {
+    completedCount: 2,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 0,
+    activeCount: 0,
+    errorCount: 0,
+    totalCount: 3,
+    progress: 100,
+    isDownloading: false,
+    hasErrors: false,
+    isCompleted: true,
+  },
+};
+
+const tracks = [
+  {
+    id: "track-1",
+    name: "Intro",
+    artist: "Artist 1",
+    status: TrackStatusEnum.Completed,
+    audioUrl: undefined,
+    trackUrl: "https://open.spotify.com/track/1",
+  },
+  {
+    id: "track-2",
+    name: "Main Theme",
+    artist: "Artist 2",
+    status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Fmusic%2Fmain-theme.mp3",
+    trackUrl: "https://open.spotify.com/track/2",
+  },
+  {
+    id: "track-3",
+    name: "Finale",
+    artist: "Artist 3",
+    status: TrackStatusEnum.Completed,
+    audioUrl: "/api/library/audio?path=%2Fmusic%2Ffinale.mp3",
+    trackUrl: "https://open.spotify.com/track/3",
+  },
+];
+
+describe("usePlaylistDetailController", () => {
+  it("starts playlist playback from the first playable track and exposes local playback state", () => {
+    mockUseParams.mockReturnValue({ id: "playlist-1" });
+    mockUseNavigationHelpers.mockReturnValue({ handleGoHome: vi.fn() });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
+    mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
+    mockUsePlaylistController.mockReturnValue({
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 2,
+      displayTitle: "Road Trip",
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      mutations: { retryFailedTracks: { isPending: false } },
+    });
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(result.current.hasPlayableTracks).toBe(true);
+    expect(result.current.currentTrackId).toBe("track-2");
+    expect(result.current.audioSrc).toBe(tracks[1]?.audioUrl);
+    expect(typeof result.current.onPlayTrack).toBe("function");
+    expect(typeof result.current.onPauseTrack).toBe("function");
+  });
+
+  it("resets scoped playback when the playlist route changes", () => {
+    mockUseNavigationHelpers.mockReturnValue({ handleGoHome: vi.fn() });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
+    mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
+    mockUsePlaylistController.mockReturnValue({
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 2,
+      displayTitle: "Road Trip",
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      mutations: { retryFailedTracks: { isPending: false } },
+    });
+
+    const pause = vi.fn();
+    const audioElement = { pause } as unknown as HTMLAudioElement;
+
+    mockUseParams.mockReturnValue({ id: "playlist-1" });
+    const { result, rerender } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.setAudioElement(audioElement);
+      result.current.onPlayTrack("track-2");
+      result.current.onAudioPlay();
+    });
+
+    expect(result.current.currentTrackId).toBe("track-2");
+    expect(result.current.isPlaying).toBe(true);
+
+    mockUseParams.mockReturnValue({ id: "playlist-2" });
+    mockUsePlaylistsQuery.mockReturnValue({
+      data: [{ ...playlist, id: "playlist-2", name: "Night Drive" }],
+      isLoading: false,
+    });
+    mockUseTracksQuery.mockReturnValue({ data: tracks.slice(1), isLoading: false });
+
+    rerender();
+
+    expect(pause).toHaveBeenCalledTimes(1);
+    expect(result.current.currentTrackId).toBeNull();
+    expect(result.current.isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -1,9 +1,15 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useTracksQuery } from "../queries/useTracksQuery";
 import { useNavigationHelpers } from "../useNavigationHelpers";
+import {
+  LocalTrackPlaybackErrorKey,
+  useLocalTrackPlaybackController,
+} from "./useLocalTrackPlaybackController";
 import { usePlaylistController } from "./usePlaylistController";
+
+export type PlaylistPlaybackErrorKey = LocalTrackPlaybackErrorKey<"library.album">;
 
 export const usePlaylistDetailController = () => {
   const { handleGoHome } = useNavigationHelpers();
@@ -13,6 +19,41 @@ export const usePlaylistDetailController = () => {
   const { data: tracks = [], isLoading: isTracksLoading } = useTracksQuery(id);
 
   const playlist = useMemo(() => playlists.find((p) => p.id === id), [playlists, id]);
+
+  const {
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+  } = useLocalTrackPlaybackController({
+    tracks,
+    scopeKey: id ?? "playlist-detail",
+    errorKeyPrefix: "library.album",
+    getAudioUrl: (track) => track.audioUrl,
+  });
+
+  const firstPlayableTrackId = useMemo(
+    () => tracks.find((track) => track.audioUrl)?.id ?? null,
+    [tracks],
+  );
+
+  const hasPlayableTracks = firstPlayableTrackId !== null;
+
+  const onPlayPlaylist = useCallback(() => {
+    const targetTrackId = currentTrackId ?? firstPlayableTrackId;
+
+    if (!targetTrackId) {
+      return;
+    }
+
+    onPlayTrack(targetTrackId);
+  }, [currentTrackId, firstPlayableTrackId, onPlayTrack]);
 
   const {
     isDownloading,
@@ -48,5 +89,18 @@ export const usePlaylistDetailController = () => {
     handleRetryFailed,
     handleRetryTrack,
     handleGoHome,
+    audioSrc,
+    currentTrackId,
+    isPlaying,
+    playbackError: playbackError as PlaylistPlaybackErrorKey | null,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onPlayPlaylist,
+    onPausePlaylist: onPauseTrack,
+    onAudioPlay,
+    onAudioPause,
+    onAudioError,
+    hasPlayableTracks,
   };
 };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -199,6 +199,7 @@
     },
     "emptyTracksTitle": "No tracks in this playlist yet",
     "emptyTracksDescription": "Tracks you download or sync will appear here.",
+    "noPlayableTracks": "Download tracks in this playlist to start local playback.",
     "deleteModal": {
       "title": "Delete {{name}}?",
       "description": "This will remove the playlist from your library. Downloaded files will NOT be deleted."

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -199,6 +199,7 @@
     },
     "emptyTracksTitle": "Lista vacía",
     "emptyTracksDescription": "Las canciones que descargues o sincronices aparecerán aquí.",
+    "noPlayableTracks": "Descarga canciones de esta lista para iniciar la reproducción local.",
     "deleteModal": {
       "title": "¿Eliminar {{name}}?",
       "description": "Esto eliminará la lista de tu biblioteca. Los archivos descargados NO se borrarán."

--- a/apps/frontend/src/views/PlaylistDetail.test.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistDetail } from "./PlaylistDetail";
+
+const mockUsePlaylistDetailController = vi.fn();
+
+vi.mock("@/hooks/controllers/usePlaylistDetailController", () => ({
+  usePlaylistDetailController: () => mockUsePlaylistDetailController(),
+}));
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("@/components/organisms/Playlist", () => ({
+  Playlist: () => <div data-testid="playlist-view" />,
+}));
+
+describe("PlaylistDetail", () => {
+  it("renders local playback audio element and assertive playback errors for saved playlists", () => {
+    mockUsePlaylistDetailController.mockReturnValue({
+      playlist: { id: "playlist-1", name: "Road Trip" },
+      tracks: [],
+      isPlaylistsLoading: false,
+      isTracksLoading: false,
+      isDownloading: false,
+      isDownloaded: true,
+      hasFailed: false,
+      completedCount: 0,
+      displayTitle: "Road Trip",
+      retryFailedTracks: { isPending: false },
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      handleGoHome: vi.fn(),
+      audioSrc: "/api/library/audio?path=%2Fmusic%2Ftrack.mp3",
+      playbackError: "library.album.playbackUnavailable",
+      setAudioElement: vi.fn(),
+      onPlayTrack: vi.fn(),
+      onPauseTrack: vi.fn(),
+      onPlayPlaylist: vi.fn(),
+      onPausePlaylist: vi.fn(),
+      onAudioError: vi.fn(),
+      onAudioPlay: vi.fn(),
+      onAudioPause: vi.fn(),
+      currentTrackId: "track-1",
+      isPlaying: true,
+      hasPlayableTracks: true,
+    });
+
+    const { container } = render(<PlaylistDetail />);
+
+    expect(screen.getByTestId("playlist-view")).toBeTruthy();
+    expect(container.querySelector("audio")).toBeTruthy();
+    expect(screen.getByRole("alert").textContent).toBe("library.album.playbackUnavailable");
+  });
+
+  it("renders a passive no-playable-tracks message when tracks exist but none are playable yet", () => {
+    mockUsePlaylistDetailController.mockReturnValue({
+      playlist: { id: "playlist-1", name: "Road Trip" },
+      tracks: [{ id: "track-1", title: "First Track" }],
+      isPlaylistsLoading: false,
+      isTracksLoading: false,
+      isDownloading: false,
+      isDownloaded: false,
+      hasFailed: false,
+      completedCount: 0,
+      displayTitle: "Road Trip",
+      retryFailedTracks: { isPending: false },
+      handleToggleSubscription: vi.fn(),
+      handleDelete: vi.fn(),
+      handleRetryFailed: vi.fn(),
+      handleRetryTrack: vi.fn(),
+      handleGoHome: vi.fn(),
+      playbackError: null,
+      setAudioElement: vi.fn(),
+      onPlayTrack: vi.fn(),
+      onPauseTrack: vi.fn(),
+      onPlayPlaylist: vi.fn(),
+      onPausePlaylist: vi.fn(),
+      onAudioError: vi.fn(),
+      onAudioPlay: vi.fn(),
+      onAudioPause: vi.fn(),
+      currentTrackId: null,
+      isPlaying: false,
+      hasPlayableTracks: false,
+    });
+
+    render(<PlaylistDetail />);
+
+    expect(screen.getByRole("status").textContent).toBe("playlist.noPlayableTracks");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -1,10 +1,12 @@
 import { FC } from "react";
+import { useTranslation } from "react-i18next";
 import { PlaylistNotFound } from "@/components/molecules/PlaylistNotFound";
 import { Playlist } from "@/components/organisms/Playlist";
 import { PlaylistSkeleton } from "@/components/skeletons/PlaylistSkeleton";
 import { usePlaylistDetailController } from "@/hooks/controllers/usePlaylistDetailController";
 
 export const PlaylistDetail: FC = () => {
+  const { t } = useTranslation();
   const {
     playlist,
     tracks,
@@ -21,6 +23,18 @@ export const PlaylistDetail: FC = () => {
     handleRetryFailed,
     handleRetryTrack,
     handleGoHome,
+    playbackError,
+    setAudioElement,
+    onPlayTrack,
+    onPauseTrack,
+    onPlayPlaylist,
+    onPausePlaylist,
+    onAudioError,
+    onAudioPlay,
+    onAudioPause,
+    currentTrackId,
+    isPlaying,
+    hasPlayableTracks,
   } = usePlaylistDetailController();
 
   if (isPlaylistsLoading || isTracksLoading) {
@@ -32,24 +46,50 @@ export const PlaylistDetail: FC = () => {
   }
 
   return (
-    <Playlist
-      playlist={playlist}
-      tracks={tracks}
-      isDownloading={isDownloading}
-      isDownloaded={isDownloaded}
-      displayTitle={displayTitle}
-      completedCount={completedCount}
-      onRetryTrack={(trackId) => {
-        const track = tracks.find((t) => t.id === trackId);
-        if (track) handleRetryTrack(track);
-      }}
-      onConfirmDelete={handleDelete}
-      onRetryFailed={handleRetryFailed}
-      hasFailed={hasFailed}
-      isRetrying={retryFailedTracks.isPending}
-      onToggleSubscription={handleToggleSubscription}
-      onDownloadTrack={(track) => handleRetryTrack(track)}
-      onDownloadOrRetry={handleRetryFailed}
-    />
+    <main className="flex flex-1 flex-col">
+      <Playlist
+        playlist={playlist}
+        tracks={tracks}
+        isDownloading={isDownloading}
+        isDownloaded={isDownloaded}
+        displayTitle={displayTitle}
+        completedCount={completedCount}
+        onRetryTrack={(trackId) => {
+          const track = tracks.find((t) => t.id === trackId);
+          if (track) handleRetryTrack(track);
+        }}
+        onConfirmDelete={handleDelete}
+        onRetryFailed={handleRetryFailed}
+        hasFailed={hasFailed}
+        isRetrying={retryFailedTracks.isPending}
+        onToggleSubscription={handleToggleSubscription}
+        onDownloadTrack={(track) => handleRetryTrack(track)}
+        onDownloadOrRetry={handleRetryFailed}
+        onPlayTrack={onPlayTrack}
+        onPauseTrack={onPauseTrack}
+        onPlayPlaylist={onPlayPlaylist}
+        onPausePlaylist={onPausePlaylist}
+        currentTrackId={currentTrackId}
+        isPlaying={isPlaying}
+        hasPlayableTracks={hasPlayableTracks}
+      />
+      <audio
+        ref={setAudioElement}
+        className="sr-only"
+        onError={onAudioError}
+        onPlay={onAudioPlay}
+        onPause={onAudioPause}
+      />
+      {playbackError ? (
+        <p className="text-text-secondary px-6 py-3 text-sm" role="alert" aria-live="assertive">
+          {t(playbackError)}
+        </p>
+      ) : null}
+      {!hasPlayableTracks && tracks.length > 0 ? (
+        <p className="text-text-secondary px-6 py-3 text-sm" role="status" aria-live="polite">
+          {t("playlist.noPlayableTracks")}
+        </p>
+      ) : null}
+    </main>
   );
 };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -82,6 +82,7 @@ export interface ITrack {
   totalTracks?: number;
   spotifyUrl?: string;
   trackUrl?: string;
+  audioUrl?: string;
   albumUrl?: string;
   durationMs?: number;
   artists?: TrackArtist[];


### PR DESCRIPTION
Closes #66

## What
Merge the completed `library-playlist-playback` tracker branch into `main`. This ships the full saved playlist playback feature that was delivered in three chained slices: backend/shared `audioUrl` support, reusable local playback hook extraction, and saved playlist detail playback wiring.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Docs / chore

## Scope
- [ ] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [x] Cross-workspace

## Checklist
- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change

## Changes
- Add backend/shared `audioUrl` support for completed saved playlist tracks
- Extract reusable local playback controller hook for page-local audio behavior
- Enable saved playlist detail playback with playlist-level and row-level controls
- Add passive empty-state messaging for playlists without downloaded playable tracks yet

## Verification
- `pnpm --filter @spotiarr/shared run lint`
- `pnpm --filter @spotiarr/shared run build`
- `pnpm --filter backend run lint`
- `pnpm --filter backend run test:run`
- `pnpm --filter backend run build`
- `pnpm --filter frontend exec vitest run src/hooks/controllers/usePlaylistDetailController.test.ts src/views/PlaylistDetail.test.tsx src/components/molecules/PlaylistActions.test.tsx src/components/organisms/Playlist.test.tsx src/components/organisms/PlaylistTracksList.test.tsx`
- `pnpm --filter frontend run test:run`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run build`
- `pnpm lint`
- `pnpm test`
- `pnpm build`

## Chain history
- PR1: #59
- PR2: #62
- PR3: #64
- SDD verify: PASS WITH WARNINGS
- SDD archive: completed