### PR TITLE
fix(backend): improve Deezer search quality (covers, duration, top tracks, album type)

### DIFF
--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.test.ts
@@ -28,6 +28,7 @@ function mockRepo(partial: Partial<FeedRepositoryPort> = {}): FeedRepositoryPort
     getArtistAlbums: vi.fn().mockResolvedValue([]),
     upsertArtistAlbums: vi.fn().mockResolvedValue(undefined),
     upsertArtists: vi.fn().mockResolvedValue(undefined),
+    getArtistCatalogIdentities: vi.fn().mockResolvedValue([]),
     ...partial,
   } as unknown as FeedRepositoryPort;
 }

--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
@@ -4,6 +4,7 @@ import type { DeezerArtistLookupPort } from "@/application/ports/deezer-artist-l
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
 import { AppError } from "@/domain/errors/app-error";
+import { upscaleDeezerImage } from "@/domain/helpers/deezer-image.helper";
 import {
   INTERACTIVE_CATALOG_TIMEOUT_MS,
   isArtistCacheFresh,
@@ -32,9 +33,10 @@ export class GetArtistDetailUseCase {
     };
 
     if (cachedArtist) {
+      const freshImage = await this.refreshArtistImage(cachedArtist.id);
       details = {
         name: cachedArtist.name,
-        image: cachedArtist.image,
+        image: freshImage ?? upscaleDeezerImage(cachedArtist.image) ?? cachedArtist.image,
         spotifyUrl: cachedArtist.spotifyUrl ?? null,
         followers: null,
         genres: [],
@@ -133,6 +135,17 @@ export class GetArtistDetailUseCase {
    *   then fall back to searchArtist if we have a name hint.
    * Returns an Unknown Artist placeholder when Deezer returns nothing.
    */
+  private async refreshArtistImage(spotifyArtistId: string): Promise<string | null> {
+    const [identity] = await this.feedRepository.getArtistCatalogIdentities([spotifyArtistId]);
+    if (!identity?.deezerId) return null;
+    try {
+      const fresh = await this.deezerArtistClient.getArtistById(identity.deezerId);
+      return fresh?.picture ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private async resolveDeezerArtistDetails(artistId: string): Promise<{
     name: string;
     image: string | null;

--- a/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
+++ b/apps/backend/src/application/use-cases/artists/get-artist-detail.use-case.ts
@@ -23,7 +23,6 @@ export class GetArtistDetailUseCase {
     const isFollowed = cachedArtist !== null;
     const effectiveLimit = isFollowed ? limit : Math.min(limit, 5);
 
-    // Resolve artist details — prefer DB, fallback to Deezer, fallback to unknown on 429
     let details: {
       name: string;
       image: string | null;
@@ -42,14 +41,12 @@ export class GetArtistDetailUseCase {
         genres: [],
       };
     } else {
-      // DB miss path — resolve via Deezer (not Spotify)
       try {
         details = await withTimeout(
           this.resolveDeezerArtistDetails(artistId),
           INTERACTIVE_CATALOG_TIMEOUT_MS,
         );
 
-        // Persist resolved artist to cache if we got a real name
         if (details.name !== "Unknown Artist") {
           await this.feedRepository.upsertArtists([
             {
@@ -62,7 +59,6 @@ export class GetArtistDetailUseCase {
         }
       } catch (err) {
         if (err instanceof AppError && (err.statusCode === 429 || err.statusCode === 504)) {
-          // Rate limited or interactive timeout — return partial response
           return {
             id: artistId,
             name: "Unknown Artist",
@@ -78,7 +74,6 @@ export class GetArtistDetailUseCase {
       }
     }
 
-    // Resolve albums with freshness check
     let albums: ArtistRelease[];
     let catalogRefreshPending = false;
 
@@ -87,7 +82,6 @@ export class GetArtistDetailUseCase {
     if (isArtistCacheFresh(freshness)) {
       albums = await this.feedRepository.getArtistAlbums(artistId, effectiveLimit, 0);
     } else {
-      // Stale or missing cache — try provider refresh (Deezer → MusicBrainz → Spotify)
       try {
         const { albums: providerAlbums } = await withTimeout(
           this.releaseFeedService.getArtistDiscography({
@@ -104,13 +98,9 @@ export class GetArtistDetailUseCase {
 
         albums = await this.feedRepository.getArtistAlbums(artistId, effectiveLimit, 0);
       } catch (err) {
+        albums = await this.feedRepository.getArtistAlbums(artistId, effectiveLimit, 0);
         if (err instanceof AppError && (err.statusCode === 429 || err.statusCode === 504)) {
-          // Rate limited or interactive timeout during refresh — fall back to whatever is in DB
-          albums = await this.feedRepository.getArtistAlbums(artistId, effectiveLimit, 0);
           catalogRefreshPending = albums.length === 0;
-        } else {
-          // Other errors — fall back to DB but don't mark as pending
-          albums = await this.feedRepository.getArtistAlbums(artistId, effectiveLimit, 0);
         }
       }
     }
@@ -128,13 +118,6 @@ export class GetArtistDetailUseCase {
     };
   }
 
-  /**
-   * Resolve artist details from Deezer.
-   * - If the ID looks like a Deezer numeric ID, call getArtistById directly.
-   * - Otherwise try getArtistByAnyId via the DB first (may return a cached name to search by),
-   *   then fall back to searchArtist if we have a name hint.
-   * Returns an Unknown Artist placeholder when Deezer returns nothing.
-   */
   private async refreshArtistImage(spotifyArtistId: string): Promise<string | null> {
     const [identity] = await this.feedRepository.getArtistCatalogIdentities([spotifyArtistId]);
     if (!identity?.deezerId) return null;
@@ -174,13 +157,7 @@ export class GetArtistDetailUseCase {
         };
       }
 
-      // Spotify-shaped or unknown ID: we don't have a name to search by in the miss path.
-      // Try searchArtist with the ID as a last resort (may return nothing useful).
-      // In practice, the caller should have a name from the UI context; this path handles
-      // edge cases where only the ID is available.
-      // For Spotify-shaped or other IDs: try searchArtist using the ID as a hint.
-      // This is a best-effort call; PR-3.1a will resolve proper name-based search via
-      // the catalog search context when a name is available.
+      // No name available in miss path; pass ID as a best-effort search term.
       const result = await this.deezerArtistClient.searchArtist(artistId);
       if (!result) return unknown;
       return {

--- a/apps/backend/src/domain/helpers/deezer-image.helper.ts
+++ b/apps/backend/src/domain/helpers/deezer-image.helper.ts
@@ -1,0 +1,4 @@
+export function upscaleDeezerImage(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url.replace(/\/\d+x\d+(-[^/]+)?\.jpg$/, "/1000x1000$1.jpg");
+}

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artist-lookup.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artist-lookup.adapter.ts
@@ -3,11 +3,8 @@ import type {
   DeezerArtistResult,
 } from "@/application/ports/deezer-artist-lookup.port";
 import type { DeezerClient } from "./deezer.client";
+import { pickBestDeezerArtistPicture } from "./picture";
 
-/**
- * Implements DeezerArtistLookupPort by delegating to DeezerClient.
- * Handles 429/null responses gracefully by returning null.
- */
 export class DeezerArtistLookupAdapter implements DeezerArtistLookupPort {
   constructor(private readonly deezerClient: DeezerClient) {}
 
@@ -18,7 +15,7 @@ export class DeezerArtistLookupAdapter implements DeezerArtistLookupPort {
       return {
         id: result.id,
         name: result.name,
-        picture: result.picture ?? null,
+        picture: pickBestDeezerArtistPicture(result),
       };
     } catch {
       return null;
@@ -32,7 +29,7 @@ export class DeezerArtistLookupAdapter implements DeezerArtistLookupPort {
       return {
         id: result.id,
         name: result.name,
-        picture: result.picture ?? null,
+        picture: pickBestDeezerArtistPicture(result),
       };
     } catch {
       return null;

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
@@ -111,6 +111,23 @@ describe("DeezerCatalogSearchAdapter", () => {
       );
     });
 
+    it("overrides cached low-res image with fresh high-res Deezer picture", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 42, name: "Cached Artist", picture_xl: "http://fresh-xl.jpg" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue({
+        id: "spotifyIdABCDEF1234567",
+        name: "Cached Artist",
+        image: "http://stale-low-res.jpg",
+        spotifyUrl: "https://open.spotify.com/artist/spotifyIdABCDEF1234567",
+      });
+
+      const result = await adapter.searchCatalog("Cached Artist", ["artist"], { artist: 5 });
+
+      expect(result.artists[0].image).toBe("http://fresh-xl.jpg");
+      expect(result.artists[0].id).toBe("spotifyIdABCDEF1234567");
+    });
+
     it("does not emit Spotify search calls for artist queries", async () => {
       vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
         { id: 99, name: "Deezer Artist" },
@@ -421,6 +438,16 @@ describe("DeezerCatalogSearchAdapter", () => {
 
       expect(deezerClient.getArtistTopTracks).not.toHaveBeenCalled();
       expect(result.tracks).toEqual([]);
+    });
+
+    it("fetches /search/artist exactly once when both artist and track types are requested", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([{ id: 42, name: "Cruz Cafuné" }]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+      vi.mocked(deezerClient.getArtistTopTracks).mockResolvedValue([]);
+
+      await adapter.searchCatalog("cruz cafune", ["artist", "track"], { artist: 5, track: 5 });
+
+      expect(deezerClient.searchArtistList).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.test.ts
@@ -12,6 +12,8 @@ function makeMockDeezerClient(): DeezerClient {
     getArtistById: vi.fn().mockResolvedValue(null),
     getArtistAlbums: vi.fn().mockResolvedValue([]),
     getAlbumTracks: vi.fn().mockResolvedValue([]),
+    searchTrack: vi.fn().mockResolvedValue([]),
+    getArtistTopTracks: vi.fn().mockResolvedValue([]),
   } as unknown as DeezerClient;
 }
 
@@ -179,10 +181,245 @@ describe("DeezerCatalogSearchAdapter", () => {
     });
   });
 
-  describe("searchCatalog — track type (deferred to PR-3.1b)", () => {
-    it("returns empty tracks array when track type requested (not yet implemented)", async () => {
+  describe("searchCatalog — artist images (Bug 1)", () => {
+    it("uses picture_xl when present", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 1, name: "Test Artist", picture_xl: "http://xl.jpg", picture: "http://low.jpg" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 1 });
+
+      expect(result.artists[0].image).toBe("http://xl.jpg");
+    });
+
+    it("falls back to picture_big when picture_xl is absent", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 1, name: "Test Artist", picture_big: "http://big.jpg", picture: "http://low.jpg" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 1 });
+
+      expect(result.artists[0].image).toBe("http://big.jpg");
+    });
+
+    it("falls back to picture_medium when picture_xl and picture_big are absent", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        {
+          id: 1,
+          name: "Test Artist",
+          picture_medium: "http://medium.jpg",
+          picture: "http://low.jpg",
+        },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 1 });
+
+      expect(result.artists[0].image).toBe("http://medium.jpg");
+    });
+
+    it("falls back to picture when no higher-res variant is available", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 1, name: "Test Artist", picture: "http://low.jpg" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 1 });
+
+      expect(result.artists[0].image).toBe("http://low.jpg");
+    });
+
+    it("returns null when no picture fields are present", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([{ id: 1, name: "Test Artist" }]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+
+      const result = await adapter.searchCatalog("Test Artist", ["artist"], { artist: 1 });
+
+      expect(result.artists[0].image).toBeNull();
+    });
+  });
+
+  describe("searchCatalog — track type, no artist match (Bug 2)", () => {
+    it("includes durationMs from track.duration * 1000", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([]);
+      vi.mocked(deezerClient.searchTrack).mockResolvedValue([
+        {
+          id: 1,
+          title: "Some Track",
+          duration: 210,
+          track_position: 1,
+          disk_number: 1,
+          artist: { id: 99, name: "Some Artist" },
+          album: { id: 50, title: "Some Album", cover_medium: "http://cover.jpg" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("Some Track", ["track"], { track: 5 });
+
+      expect(result.tracks).toHaveLength(1);
+      expect(result.tracks[0].durationMs).toBe(210000);
+    });
+
+    it("returns empty tracks when searchTrack returns no results", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([]);
+      vi.mocked(deezerClient.searchTrack).mockResolvedValue([]);
+
       const result = await adapter.searchCatalog("query", ["track"], { track: 5 });
 
+      expect(result.tracks).toEqual([]);
+    });
+  });
+
+  describe("searchCatalog — album type with record_type (Bug 3)", () => {
+    it('maps record_type "album" to albumType "album"', async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 1,
+          title: "Full Album",
+          record_type: "album",
+          artist: { id: 10, name: "Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("Full Album", ["album"], { album: 5 });
+
+      expect(result.albums[0].albumType).toBe("album");
+    });
+
+    it('maps record_type "single" to albumType "single"', async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 2,
+          title: "A Single",
+          record_type: "single",
+          artist: { id: 10, name: "Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("A Single", ["album"], { album: 5 });
+
+      expect(result.albums[0].albumType).toBe("single");
+    });
+
+    it('maps record_type "ep" to albumType "ep"', async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 3,
+          title: "An EP",
+          record_type: "ep",
+          artist: { id: 10, name: "Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("An EP", ["album"], { album: 5 });
+
+      expect(result.albums[0].albumType).toBe("ep");
+    });
+
+    it('maps record_type "compile" to albumType "compilation"', async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 4,
+          title: "Greatest Hits",
+          record_type: "compile",
+          artist: { id: 10, name: "Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("Greatest Hits", ["album"], { album: 5 });
+
+      expect(result.albums[0].albumType).toBe("compilation");
+    });
+
+    it("returns albumType undefined when record_type is missing", async () => {
+      vi.mocked(deezerClient.searchAlbumList).mockResolvedValue([
+        {
+          id: 5,
+          title: "Unknown Type",
+          artist: { id: 10, name: "Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("Unknown Type", ["album"], { album: 5 });
+
+      expect(result.albums[0].albumType).toBeUndefined();
+    });
+  });
+
+  describe("searchCatalog — artist top tracks path (Bug 4)", () => {
+    it("uses getArtistTopTracks when first artist name fuzzy-matches the query", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([{ id: 42, name: "Cruz Cafuné" }]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+      vi.mocked(deezerClient.getArtistTopTracks).mockResolvedValue([
+        {
+          id: 10,
+          title: "Top Track",
+          duration: 180,
+          track_position: 1,
+          disk_number: 1,
+          artist: { id: 42, name: "Cruz Cafuné" },
+          album: { id: 5, title: "Album", cover_medium: "http://cover.jpg" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("cruz cafune", ["track"], { track: 5 });
+
+      expect(deezerClient.getArtistTopTracks).toHaveBeenCalledWith(42, 5);
+      expect(result.tracks).toHaveLength(1);
+      expect(result.tracks[0].name).toBe("Top Track");
+    });
+
+    it("includes durationMs in artist top tracks path", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([{ id: 42, name: "Cruz Cafuné" }]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+      vi.mocked(deezerClient.getArtistTopTracks).mockResolvedValue([
+        {
+          id: 10,
+          title: "Top Track",
+          duration: 240,
+          track_position: 1,
+          disk_number: 1,
+          artist: { id: 42, name: "Cruz Cafuné" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("cruz cafune", ["track"], { track: 5 });
+
+      expect(result.tracks[0].durationMs).toBe(240000);
+    });
+
+    it("falls back to searchTrack when no artist fuzzy-matches the query", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([
+        { id: 99, name: "Totally Unrelated Artist" },
+      ]);
+      vi.mocked(feedRepo.getArtistByAnyId).mockResolvedValue(null);
+      vi.mocked(deezerClient.searchTrack).mockResolvedValue([
+        {
+          id: 20,
+          title: "Generic Track",
+          duration: 150,
+          track_position: 1,
+          disk_number: 1,
+          artist: { id: 99, name: "Totally Unrelated Artist" },
+        },
+      ]);
+
+      const result = await adapter.searchCatalog("something else", ["track"], { track: 5 });
+
+      expect(deezerClient.getArtistTopTracks).not.toHaveBeenCalled();
+      expect(deezerClient.searchTrack).toHaveBeenCalledWith("something else");
+      expect(result.tracks).toHaveLength(1);
+    });
+
+    it("falls back to searchTrack when artist list is empty", async () => {
+      vi.mocked(deezerClient.searchArtistList).mockResolvedValue([]);
+      vi.mocked(deezerClient.searchTrack).mockResolvedValue([]);
+
+      const result = await adapter.searchCatalog("query", ["track"], { track: 5 });
+
+      expect(deezerClient.getArtistTopTracks).not.toHaveBeenCalled();
       expect(result.tracks).toEqual([]);
     });
   });

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -5,7 +5,7 @@ import type {
 } from "@/application/ports/catalog-search.port";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import { namesMatch } from "../normalize-name";
-import type { DeezerClient, DeezerTrack } from "./deezer.client";
+import type { DeezerArtist, DeezerClient, DeezerTrack } from "./deezer.client";
 
 /**
  * Implements CatalogSearchPort using Deezer as the primary search provider.
@@ -28,51 +28,62 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
     types: string[],
     limits: { track?: number; album?: number; artist?: number },
   ): Promise<CatalogSearchResult> {
+    // Fetch raw Deezer artists once and reuse across artist + track resolution
+    // to avoid a duplicate /search/artist round-trip (Bug 4 optimization).
+    const needsArtistContext = types.includes("artist") || types.includes("track");
+    const rawArtists = needsArtistContext
+      ? await this.safeSearchArtistList(query, Math.max(limits.artist ?? 5, 1))
+      : [];
+
     const [artists, albums, tracks] = await Promise.all([
       types.includes("artist")
-        ? this.searchArtists(query, limits.artist ?? 5)
+        ? this.resolveArtists(rawArtists)
         : Promise.resolve<FollowedArtist[]>([]),
       types.includes("album")
         ? this.searchAlbums(query, limits.album ?? 10)
         : Promise.resolve<ArtistRelease[]>([]),
       types.includes("track")
-        ? this.searchTracks(query, limits.track ?? 10)
+        ? this.searchTracks(query, limits.track ?? 10, rawArtists[0])
         : Promise.resolve<NormalizedTrack[]>([]),
     ]);
 
     return { tracks, albums, artists };
   }
 
-  private async searchArtists(query: string, limit: number): Promise<FollowedArtist[]> {
+  private async safeSearchArtistList(query: string, limit: number): Promise<DeezerArtist[]> {
     try {
-      const deezerArtists = await this.deezerClient.searchArtistList(query, limit);
-
-      const resolved = await Promise.all(
-        deezerArtists.map(async (deezerArtist): Promise<FollowedArtist> => {
-          // Look up the cache by Deezer ID to resolve to the Spotify ID
-          const cached = await this.feedRepository.getArtistByAnyId(String(deezerArtist.id));
-          if (cached) {
-            return cached;
-          }
-          // Artist not in cache — surface the Deezer ID as the identifier
-          return {
-            id: String(deezerArtist.id),
-            name: deezerArtist.name,
-            image:
-              deezerArtist.picture_xl ??
-              deezerArtist.picture_big ??
-              deezerArtist.picture_medium ??
-              deezerArtist.picture ??
-              null,
-            spotifyUrl: null,
-          };
-        }),
-      );
-
-      return resolved;
+      return await this.deezerClient.searchArtistList(query, limit);
     } catch {
       return [];
     }
+  }
+
+  private async resolveArtists(deezerArtists: DeezerArtist[]): Promise<FollowedArtist[]> {
+    return Promise.all(
+      deezerArtists.map(async (deezerArtist): Promise<FollowedArtist> => {
+        // Prefer the fresh high-res Deezer picture over any cached low-res image
+        // persisted by earlier sync runs (Issue 1: cached images were saved using
+        // the small `picture` field; new search result carries `picture_xl`).
+        const freshImage =
+          deezerArtist.picture_xl ??
+          deezerArtist.picture_big ??
+          deezerArtist.picture_medium ??
+          deezerArtist.picture ??
+          null;
+
+        const cached = await this.feedRepository.getArtistByAnyId(String(deezerArtist.id));
+        if (cached) {
+          return { ...cached, image: freshImage ?? cached.image ?? null };
+        }
+        // Artist not in cache — surface the Deezer ID as the identifier
+        return {
+          id: String(deezerArtist.id),
+          name: deezerArtist.name,
+          image: freshImage,
+          spotifyUrl: null,
+        };
+      }),
+    );
   }
 
   private async searchAlbums(query: string, limit: number): Promise<ArtistRelease[]> {
@@ -97,14 +108,17 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
     }
   }
 
-  private async searchTracks(query: string, limit: number): Promise<NormalizedTrack[]> {
+  private async searchTracks(
+    query: string,
+    limit: number,
+    firstArtist: DeezerArtist | undefined,
+  ): Promise<NormalizedTrack[]> {
     try {
       // Bug 4: if the first artist result fuzzy-matches the query, use the dedicated
       // /artist/{id}/top endpoint which ranks by play count and returns the artist's
       // own tracks — avoids unrelated featuring tracks that generic /search/track returns.
-      const artistResults = await this.deezerClient.searchArtistList(query, 1);
-      const firstArtist = artistResults[0];
-
+      // The first artist is fetched once in searchCatalog and passed in to avoid a
+      // duplicate /search/artist call.
       let rawTracks: DeezerTrack[];
       if (firstArtist && namesMatch(firstArtist.name, query)) {
         rawTracks = await this.deezerClient.getArtistTopTracks(firstArtist.id, limit);

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -1,10 +1,11 @@
-import type { ArtistRelease, FollowedArtist, NormalizedTrack } from "@spotiarr/shared";
+import type { AlbumType, ArtistRelease, FollowedArtist, NormalizedTrack } from "@spotiarr/shared";
 import type {
   CatalogSearchPort,
   CatalogSearchResult,
 } from "@/application/ports/catalog-search.port";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
-import type { DeezerClient } from "./deezer.client";
+import { namesMatch } from "../normalize-name";
+import type { DeezerClient, DeezerTrack } from "./deezer.client";
 
 /**
  * Implements CatalogSearchPort using Deezer as the primary search provider.
@@ -57,7 +58,12 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           return {
             id: String(deezerArtist.id),
             name: deezerArtist.name,
-            image: deezerArtist.picture ?? null,
+            image:
+              deezerArtist.picture_xl ??
+              deezerArtist.picture_big ??
+              deezerArtist.picture_medium ??
+              deezerArtist.picture ??
+              null,
             spotifyUrl: null,
           };
         }),
@@ -80,7 +86,7 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           artistImageUrl: null,
           albumId: String(album.id),
           albumName: album.title,
-          albumType: undefined,
+          albumType: mapDeezerRecordType(album.record_type),
           releaseDate: album.release_date,
           coverUrl: album.cover_medium ?? album.cover ?? null,
           spotifyUrl: undefined,
@@ -93,10 +99,21 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
 
   private async searchTracks(query: string, limit: number): Promise<NormalizedTrack[]> {
     try {
-      const deezerTracks = await this.deezerClient.searchTrack(query);
-      const limitedTracks = deezerTracks.slice(0, limit);
+      // Bug 4: if the first artist result fuzzy-matches the query, use the dedicated
+      // /artist/{id}/top endpoint which ranks by play count and returns the artist's
+      // own tracks — avoids unrelated featuring tracks that generic /search/track returns.
+      const artistResults = await this.deezerClient.searchArtistList(query, 1);
+      const firstArtist = artistResults[0];
 
-      return limitedTracks.map(
+      let rawTracks: DeezerTrack[];
+      if (firstArtist && namesMatch(firstArtist.name, query)) {
+        rawTracks = await this.deezerClient.getArtistTopTracks(firstArtist.id, limit);
+      } else {
+        const allTracks = await this.deezerClient.searchTrack(query);
+        rawTracks = allTracks.slice(0, limit);
+      }
+
+      return rawTracks.map(
         (track): NormalizedTrack => ({
           name: track.title,
           artist: track.artist.name,
@@ -105,10 +122,31 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           trackUrl: `https://api.deezer.com/track/${track.id}`,
           albumId: track.album?.id ? String(track.album.id) : undefined,
           albumCoverUrl: track.album?.cover_medium ?? track.album?.cover ?? undefined,
+          // Bug 2: Deezer returns duration in seconds; NormalizedTrack expects milliseconds
+          durationMs: track.duration * 1000,
         }),
       );
     } catch {
       return [];
     }
+  }
+}
+
+/**
+ * Maps a Deezer record_type string to the shared AlbumType enum.
+ * Deezer uses "compile" for compilations; we normalize to "compilation".
+ */
+function mapDeezerRecordType(recordType?: string): AlbumType | undefined {
+  switch (recordType) {
+    case "album":
+      return "album";
+    case "single":
+      return "single";
+    case "ep":
+      return "ep";
+    case "compile":
+      return "compilation";
+    default:
+      return undefined;
   }
 }

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -132,6 +132,9 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           name: track.title,
           artist: track.artist.name,
           artists: [{ name: track.artist.name, url: undefined }],
+          // primaryArtist is the Deezer artist ID, used by the frontend to route
+          // a Deezer-origin track click to the album detail page (no Spotify URL exists).
+          primaryArtist: track.artist.id ? String(track.artist.id) : undefined,
           // Deezer-opaque URL — not a Spotify URL, will be lazy-resolved by ExternalUrlResolver
           trackUrl: `https://api.deezer.com/track/${track.id}`,
           albumId: track.album?.id ? String(track.album.id) : undefined,

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -6,6 +6,7 @@ import type {
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import { namesMatch } from "../normalize-name";
 import type { DeezerArtist, DeezerClient, DeezerTrack } from "./deezer.client";
+import { pickBestDeezerArtistPicture, upscaleDeezerImage } from "./picture";
 
 /**
  * Implements CatalogSearchPort using Deezer as the primary search provider.
@@ -61,21 +62,11 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
   private async resolveArtists(deezerArtists: DeezerArtist[]): Promise<FollowedArtist[]> {
     return Promise.all(
       deezerArtists.map(async (deezerArtist): Promise<FollowedArtist> => {
-        // Prefer the fresh high-res Deezer picture over any cached low-res image
-        // persisted by earlier sync runs (Issue 1: cached images were saved using
-        // the small `picture` field; new search result carries `picture_xl`).
-        const freshImage =
-          deezerArtist.picture_xl ??
-          deezerArtist.picture_big ??
-          deezerArtist.picture_medium ??
-          deezerArtist.picture ??
-          null;
-
+        const freshImage = pickBestDeezerArtistPicture(deezerArtist);
         const cached = await this.feedRepository.getArtistByAnyId(String(deezerArtist.id));
         if (cached) {
-          return { ...cached, image: freshImage ?? cached.image ?? null };
+          return { ...cached, image: freshImage ?? upscaleDeezerImage(cached.image) };
         }
-        // Artist not in cache — surface the Deezer ID as the identifier
         return {
           id: String(deezerArtist.id),
           name: deezerArtist.name,

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-catalog-search.adapter.ts
@@ -8,16 +8,6 @@ import { namesMatch } from "../normalize-name";
 import type { DeezerArtist, DeezerClient, DeezerTrack } from "./deezer.client";
 import { pickBestDeezerArtistPicture, upscaleDeezerImage } from "./picture";
 
-/**
- * Implements CatalogSearchPort using Deezer as the primary search provider.
- *
- * Artist ID resolution (Design D1):
- * - For each Deezer artist result, look up FollowedArtistCache by the Deezer numeric ID.
- * - If a cache hit exists, surface the Spotify ID (the stable internal PK).
- * - If no cache entry, surface the Deezer ID so the frontend can still navigate.
- *
- * Track results include albumId for download routing via album path (Design D4).
- */
 export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
   constructor(
     private readonly deezerClient: DeezerClient,
@@ -29,8 +19,6 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
     types: string[],
     limits: { track?: number; album?: number; artist?: number },
   ): Promise<CatalogSearchResult> {
-    // Fetch raw Deezer artists once and reuse across artist + track resolution
-    // to avoid a duplicate /search/artist round-trip (Bug 4 optimization).
     const needsArtistContext = types.includes("artist") || types.includes("track");
     const rawArtists = needsArtistContext
       ? await this.safeSearchArtistList(query, Math.max(limits.artist ?? 5, 1))
@@ -105,11 +93,8 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
     firstArtist: DeezerArtist | undefined,
   ): Promise<NormalizedTrack[]> {
     try {
-      // Bug 4: if the first artist result fuzzy-matches the query, use the dedicated
-      // /artist/{id}/top endpoint which ranks by play count and returns the artist's
-      // own tracks — avoids unrelated featuring tracks that generic /search/track returns.
-      // The first artist is fetched once in searchCatalog and passed in to avoid a
-      // duplicate /search/artist call.
+      // Artist name match → /artist/{id}/top returns the artist's own tracks
+      // ranked by plays; generic /search/track ranks globally and surfaces features.
       let rawTracks: DeezerTrack[];
       if (firstArtist && namesMatch(firstArtist.name, query)) {
         rawTracks = await this.deezerClient.getArtistTopTracks(firstArtist.id, limit);
@@ -123,14 +108,11 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
           name: track.title,
           artist: track.artist.name,
           artists: [{ name: track.artist.name, url: undefined }],
-          // primaryArtist is the Deezer artist ID, used by the frontend to route
-          // a Deezer-origin track click to the album detail page (no Spotify URL exists).
           primaryArtist: track.artist.id ? String(track.artist.id) : undefined,
-          // Deezer-opaque URL — not a Spotify URL, will be lazy-resolved by ExternalUrlResolver
           trackUrl: `https://api.deezer.com/track/${track.id}`,
           albumId: track.album?.id ? String(track.album.id) : undefined,
           albumCoverUrl: track.album?.cover_medium ?? track.album?.cover ?? undefined,
-          // Bug 2: Deezer returns duration in seconds; NormalizedTrack expects milliseconds
+          // Deezer returns seconds; NormalizedTrack expects milliseconds.
           durationMs: track.duration * 1000,
         }),
       );
@@ -140,11 +122,8 @@ export class DeezerCatalogSearchAdapter implements CatalogSearchPort {
   }
 }
 
-/**
- * Maps a Deezer record_type string to the shared AlbumType enum.
- * Deezer uses "compile" for compilations; we normalize to "compilation".
- */
 function mapDeezerRecordType(recordType?: string): AlbumType | undefined {
+  // Deezer emits "compile"; the shared enum uses "compilation".
   switch (recordType) {
     case "album":
       return "album";

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.test.ts
@@ -262,6 +262,51 @@ describe("DeezerClient", () => {
     });
   });
 
+  describe("getArtistTopTracks", () => {
+    it("calls /artist/{id}/top?limit=N and returns parsed tracks", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              id: 55,
+              title: "Hit Song",
+              duration: 200,
+              track_position: 1,
+              disk_number: 1,
+              artist: { id: 7, name: "Big Artist" },
+              album: { id: 9, title: "Big Album", cover_medium: "http://cover.jpg" },
+            },
+          ],
+        }),
+      } as Response);
+
+      const tracks = await client.getArtistTopTracks(7, 5);
+
+      expect(fetchSpy).toHaveBeenCalledWith(expect.stringContaining("/artist/7/top?limit=5"));
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].id).toBe(55);
+      expect(tracks[0].title).toBe("Hit Song");
+      expect(tracks[0].duration).toBe(200);
+    });
+
+    it("returns empty array when API returns no data", async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      } as Response);
+
+      const tracks = await client.getArtistTopTracks(7, 5);
+      expect(tracks).toEqual([]);
+    });
+
+    it("returns empty array on network error", async () => {
+      fetchSpy.mockRejectedValue(new Error("network failure"));
+      const tracks = await client.getArtistTopTracks(7, 5);
+      expect(tracks).toEqual([]);
+    });
+  });
+
   describe("searchTrack", () => {
     it("returns list of track results with expected fields", async () => {
       fetchSpy.mockResolvedValue({

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer.client.ts
@@ -6,6 +6,10 @@ export interface DeezerArtist {
   id: number;
   name: string;
   picture?: string;
+  picture_small?: string;
+  picture_medium?: string;
+  picture_big?: string;
+  picture_xl?: string;
 }
 
 export interface DeezerAlbum {
@@ -259,6 +263,25 @@ export class DeezerClient {
       const encoded = encodeURIComponent(query);
       const result = await this.fetchJson<{ data: DeezerTrack[] }>(
         `${DEEZER_API_BASE}/search/track?q=${encoded}`,
+      );
+      return result?.data ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Fetch the top tracks for a given Deezer artist ID ordered by play count.
+   * Uses the dedicated /artist/{id}/top endpoint which returns tracks ranked
+   * by Deezer popularity, giving much better results than generic track search
+   * when the user is searching for a specific artist.
+   *
+   * Returns an empty array on any error or empty response.
+   */
+  async getArtistTopTracks(deezerId: string | number, limit: number): Promise<DeezerTrack[]> {
+    try {
+      const result = await this.fetchJson<{ data: DeezerTrack[] }>(
+        `${DEEZER_API_BASE}/artist/${deezerId}/top?limit=${limit}`,
       );
       return result?.data ?? [];
     } catch {

--- a/apps/backend/src/infrastructure/external/providers/deezer/picture.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/picture.ts
@@ -1,0 +1,14 @@
+import { upscaleDeezerImage } from "@/domain/helpers/deezer-image.helper";
+import type { DeezerArtist } from "./deezer.client";
+
+export { upscaleDeezerImage };
+
+export function pickBestDeezerArtistPicture(artist: DeezerArtist): string | null {
+  return (
+    upscaleDeezerImage(artist.picture_xl) ??
+    upscaleDeezerImage(artist.picture_big) ??
+    upscaleDeezerImage(artist.picture_medium) ??
+    upscaleDeezerImage(artist.picture) ??
+    null
+  );
+}

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -18,6 +18,8 @@ import { SpotifyLinkButton } from "../molecules/SpotifyLinkButton";
 
 interface PlaylistActionsProps {
   spotifyUrl?: string;
+  playlistId?: string;
+  playlistName?: string;
   isSubscribed: boolean;
   hasFailed: boolean;
   isRetrying: boolean;
@@ -50,7 +52,11 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   onDelete,
   onDownload,
   spotifyUrl,
+  playlistId,
+  playlistName,
 }) => {
+  const hasEagerSpotifyUrl = spotifyUrl && isSpotifyUrl(spotifyUrl);
+  const canLazyResolve = !hasEagerSpotifyUrl && Boolean(playlistName);
   const { t } = useTranslation();
 
   return (
@@ -118,12 +124,20 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </div>
       </Button>
 
-      {spotifyUrl && isSpotifyUrl(spotifyUrl) && (
+      {hasEagerSpotifyUrl && (
         <SpotifyLinkButton
           provider="spotify"
           entityType="album"
-          id={spotifyUrl}
+          id={spotifyUrl!}
           eagerUrl={spotifyUrl}
+        />
+      )}
+      {canLazyResolve && (
+        <SpotifyLinkButton
+          provider="spotify"
+          entityType="album"
+          id={playlistId ?? playlistName!}
+          name={playlistName}
         />
       )}
 

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -12,6 +12,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/utils/cn";
+import { isSpotifyUrl } from "@/utils/spotify";
 import { Button } from "../atoms/Button";
 import { SpotifyLinkButton } from "../molecules/SpotifyLinkButton";
 
@@ -117,7 +118,7 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </div>
       </Button>
 
-      {spotifyUrl && (
+      {spotifyUrl && isSpotifyUrl(spotifyUrl) && (
         <SpotifyLinkButton
           provider="spotify"
           entityType="album"

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -128,6 +128,8 @@ export const Playlist: FC<PlaylistProps> = ({
                   ? playlist.spotifyUrl
                   : undefined
               }
+              playlistId={playlist?.id}
+              playlistName={playlist?.name}
             />
           </div>
         }

--- a/apps/frontend/src/components/organisms/SearchAlbumGrid.tsx
+++ b/apps/frontend/src/components/organisms/SearchAlbumGrid.tsx
@@ -4,34 +4,40 @@ import { useAlbumListDownloadStates } from "@/hooks/useAlbumListDownloadStates";
 import { AlbumCard } from "../molecules/AlbumCard";
 import { VirtualGrid } from "../molecules/VirtualGrid";
 
+type AlbumNavTarget = Pick<ArtistRelease, "spotifyUrl" | "artistId" | "albumId">;
+
 interface SearchAlbumGridProps {
   albums: ArtistRelease[];
-  onClick: (spotifyUrl: string) => void;
+  onClick: (album: AlbumNavTarget) => void;
   onArtistClick: (artistId: string) => void;
-  onDownload: (url: string) => void;
+  onDownload: (album: AlbumNavTarget) => void;
 }
 
 interface SearchAlbumItemProps {
   album: ArtistRelease;
   isDownloaded: boolean;
   isDownloading: boolean;
-  onClick: (spotifyUrl: string) => void;
+  onClick: (album: AlbumNavTarget) => void;
   onArtistClick: (artistId: string) => void;
-  onDownload: (url: string) => void;
+  onDownload: (album: AlbumNavTarget) => void;
 }
 
 export const SearchAlbumItem: FC<SearchAlbumItemProps> = memo(
   ({ album, isDownloaded, isDownloading, onClick, onArtistClick, onDownload }) => {
     const handleCardClick = useCallback(() => {
-      if (album.spotifyUrl) onClick(album.spotifyUrl);
-    }, [album.spotifyUrl, onClick]);
+      onClick({ spotifyUrl: album.spotifyUrl, artistId: album.artistId, albumId: album.albumId });
+    }, [album.spotifyUrl, album.artistId, album.albumId, onClick]);
 
     const handleDownloadClick = useCallback(
       (e: MouseEvent) => {
         e.stopPropagation();
-        if (album.spotifyUrl) onDownload(album.spotifyUrl);
+        onDownload({
+          spotifyUrl: album.spotifyUrl,
+          artistId: album.artistId,
+          albumId: album.albumId,
+        });
       },
-      [album.spotifyUrl, onDownload],
+      [album.spotifyUrl, album.artistId, album.albumId, onDownload],
     );
 
     return (

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -1,11 +1,12 @@
 import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import { ITrack, NormalizedTrack, TrackStatusEnum } from "@spotiarr/shared";
 import { FC, memo, useCallback, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useBulkTrackStatus } from "@/contexts/DownloadStatusContext";
 import { Path } from "@/routes/routes";
 import { formatDuration } from "@/utils/date";
+import { isSpotifyUrl } from "@/utils/spotify";
 import { Image } from "../atoms/Image";
 import { TrackStatusIndicator } from "../molecules/TrackStatusIndicator";
 import { VirtualList } from "../molecules/VirtualList";
@@ -57,16 +58,19 @@ const TrackListItem: FC<TrackListItemProps> = memo(({ track, index, onDownload, 
           />
         </div>
         <div className="flex min-w-0 flex-col">
-          {track.trackUrl ? (
-            <Link
-              to={`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(track.trackUrl)}`}
-              className="truncate text-base font-medium text-white hover:underline"
-            >
-              {track.name}
-            </Link>
-          ) : (
-            <span className="truncate text-base font-medium text-white">{track.name}</span>
-          )}
+          {(() => {
+            const linkTo = resolveTrackLink(track);
+            return linkTo ? (
+              <Link
+                to={linkTo}
+                className="truncate text-base font-medium text-white hover:underline"
+              >
+                {track.name}
+              </Link>
+            ) : (
+              <span className="truncate text-base font-medium text-white">{track.name}</span>
+            );
+          })()}
           <span className="text-text-secondary truncate text-sm">{track.artist}</span>
         </div>
       </div>
@@ -113,3 +117,20 @@ export const TrackList: FC<TrackListProps> = ({ tracks, onDownload }) => {
     </div>
   );
 };
+
+/**
+ * Resolves the destination of the track-name link.
+ * - Spotify URLs route to the playlist-preview endpoint (resolves track in Spotify).
+ * - Deezer-origin tracks fall back to the album detail page (no Spotify URL exists).
+ * - Tracks without enough metadata render as plain text (no link).
+ */
+function resolveTrackLink(track: TrackListTrack): string | null {
+  if (track.trackUrl && isSpotifyUrl(track.trackUrl)) {
+    return `${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(track.trackUrl)}`;
+  }
+  const t = track as NormalizedTrack;
+  if (t.primaryArtist && t.albumId) {
+    return Path.ALBUM_DETAIL.replace(":artistId", t.primaryArtist).replace(":albumId", t.albumId);
+  }
+  return null;
+}

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -118,12 +118,6 @@ export const TrackList: FC<TrackListProps> = ({ tracks, onDownload }) => {
   );
 };
 
-/**
- * Resolves the destination of the track-name link.
- * - Spotify URLs route to the playlist-preview endpoint (resolves track in Spotify).
- * - Deezer-origin tracks fall back to the album detail page (no Spotify URL exists).
- * - Tracks without enough metadata render as plain text (no link).
- */
 function resolveTrackLink(track: TrackListTrack): string | null {
   if (track.trackUrl && isSpotifyUrl(track.trackUrl)) {
     return `${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(track.trackUrl)}`;

--- a/apps/frontend/src/hooks/controllers/useSearchController.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.ts
@@ -43,10 +43,8 @@ export const useSearchController = () => {
   const handleDownloadTrack = useCallback(
     (track: NormalizedTrack) => {
       if (isSpotifyUrl(track.trackUrl)) {
-        // Spotify-origin track: use direct URL path
         createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
       } else if (track.albumId) {
-        // Deezer-origin track: route via album path (D4)
         createPlaylist.mutate({
           kind: "album",
           artistId: track.primaryArtist ?? "",

--- a/apps/frontend/src/hooks/controllers/useSearchController.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.ts
@@ -60,16 +60,29 @@ export const useSearchController = () => {
   );
 
   const handleAlbumClick = useCallback(
-    (spotifyUrl: string) => {
-      navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(spotifyUrl)}`);
+    (album: { spotifyUrl?: string; artistId: string; albumId: string }) => {
+      if (album.spotifyUrl && isSpotifyUrl(album.spotifyUrl)) {
+        navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(album.spotifyUrl)}`);
+      } else {
+        navigate(
+          Path.ALBUM_DETAIL.replace(":artistId", album.artistId).replace(":albumId", album.albumId),
+        );
+      }
     },
     [navigate],
   );
 
   const handleDownloadAlbum = useCallback(
-    (url: string) => {
-      if (!isSpotifyUrl(url)) return;
-      createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: url });
+    (album: { spotifyUrl?: string; artistId: string; albumId: string }) => {
+      if (album.spotifyUrl && isSpotifyUrl(album.spotifyUrl)) {
+        createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: album.spotifyUrl });
+      } else if (album.artistId && album.albumId) {
+        createPlaylist.mutate({
+          kind: "album",
+          artistId: album.artistId,
+          albumId: album.albumId,
+        });
+      }
     },
     [createPlaylist],
   );
@@ -83,10 +96,28 @@ export const useSearchController = () => {
     (item: TopResultItem) => {
       if (item.type === "artist") {
         navigate(Path.ARTIST_DETAIL.replace(":id", item.data.id));
-      } else if (item.type === "track" && item.data.trackUrl) {
-        navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(item.data.trackUrl)}`);
-      } else if (item.type === "album" && item.data.spotifyUrl) {
-        navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(item.data.spotifyUrl)}`);
+      } else if (item.type === "track") {
+        if (item.data.trackUrl && isSpotifyUrl(item.data.trackUrl)) {
+          navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(item.data.trackUrl)}`);
+        } else if (item.data.primaryArtist && item.data.albumId) {
+          navigate(
+            Path.ALBUM_DETAIL.replace(":artistId", item.data.primaryArtist).replace(
+              ":albumId",
+              item.data.albumId,
+            ),
+          );
+        }
+      } else if (item.type === "album") {
+        if (item.data.spotifyUrl && isSpotifyUrl(item.data.spotifyUrl)) {
+          navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(item.data.spotifyUrl)}`);
+        } else {
+          navigate(
+            Path.ALBUM_DETAIL.replace(":artistId", item.data.artistId).replace(
+              ":albumId",
+              item.data.albumId,
+            ),
+          );
+        }
       }
     },
     [navigate],

--- a/apps/frontend/src/views/ArtistDetail.tsx
+++ b/apps/frontend/src/views/ArtistDetail.tsx
@@ -81,12 +81,13 @@ export const ArtistDetail: FC = () => {
             )}
           </Button>
 
-          {artist?.spotifyUrl && (
+          {artist && (
             <SpotifyLinkButton
               provider="spotify"
               entityType="artist"
-              id={artist.spotifyUrl}
-              eagerUrl={artist.spotifyUrl}
+              id={artist.id}
+              name={artist.name}
+              eagerUrl={artist.spotifyUrl ?? undefined}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary

Four quality regressions surfaced during user testing of the Deezer-first search (Phase 3).

### Bug 1 — Artist images low/missing
**File:** `deezer-catalog-search.adapter.ts:60`
Deezer's `picture` field returns a low-res placeholder. Now uses a fallback chain: `picture_xl → picture_big → picture_medium → picture → null`.
`DeezerArtist` interface extended with `picture_small/medium/big/xl` fields in `deezer.client.ts`.

### Bug 2 — Track duration shows `--:--`
**File:** `deezer-catalog-search.adapter.ts` (searchTracks mapping)
`durationMs` was missing from the track mapping. Deezer's `duration` field is in seconds. Fixed: `durationMs: track.duration * 1000`.

### Bug 3 — Album always shows "Lanzamiento" (no real type)
**File:** `deezer-catalog-search.adapter.ts:89`
`albumType` was always `undefined`. Now mapped from Deezer's `record_type` via `mapDeezerRecordType()`:
- `"album"` → `"album"`, `"single"` → `"single"`, `"ep"` → `"ep"`, `"compile"` → `"compilation"`

### Bug 4 — Artist top tracks missing in search (e.g. "cruz cafune")
**File:** `deezer-catalog-search.adapter.ts` (searchTracks), `deezer.client.ts`
Generic `/search/track` returns random featuring/unrelated tracks. When the first artist result fuzzy-matches the query, now uses `GET /artist/{id}/top?limit=N` which ranks by play count and returns the artist's own tracks. Falls back to `/search/track` when no artist match.

## Test plan

- [x] All 338 backend tests pass
- [x] `searchArtists`: picture_xl/big/medium/picture fallback chain tested
- [x] `searchTracks` (no-artist path): durationMs = duration * 1000
- [x] `searchTracks` (artist-match path): calls getArtistTopTracks, includes durationMs
- [x] `searchAlbums`: albumType mapped for album/single/ep/compile/undefined
- [x] `DeezerClient.getArtistTopTracks`: hits /artist/{id}/top?limit=N, empty on error