### PR TITLE
feat(backend): Deezer-first cascade for artwork backfill worker

### DIFF
--- a/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
+++ b/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
@@ -40,7 +40,7 @@ export interface ArtworkBackfillCacheSourcePort {
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }
 
-export interface ArtworkBackfillSpotifySourcePort {
+export interface ArtworkBackfillExternalSourcePort {
   findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
@@ -5,8 +5,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { ProcessArtworkBackfillBatchUseCase } from "./process-artwork-backfill-batch.use-case";
 
@@ -56,7 +56,11 @@ function build() {
   const embeddedSource: ArtworkBackfillEmbeddedSourcePort = {
     extractFromTracks: vi.fn().mockResolvedValue(null),
   };
-  const spotifySource: ArtworkBackfillSpotifySourcePort = {
+  const deezerSource: ArtworkBackfillExternalSourcePort = {
+    findArtistImageUrl: vi.fn().mockResolvedValue(null),
+    findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
+  };
+  const spotifySource: ArtworkBackfillExternalSourcePort = {
     findArtistImageUrl: vi.fn().mockResolvedValue(null),
     findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
   };
@@ -73,7 +77,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
-    spotifySource,
+    [deezerSource, spotifySource],
     repository,
   );
 
@@ -83,6 +87,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
+    deezerSource,
     spotifySource,
     repository,
   };
@@ -125,6 +130,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Artist A",
       "https://img/artist.jpg",
     );
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
   });
 
@@ -167,13 +173,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
         failed: 1,
       }),
     );
+    expect(ctx.deezerSource.findAlbumCoverUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
   });
 
-  it("writes artist artwork from spotify fallback when local and cache miss", async () => {
+  it("ABF-2b: writes artist artwork from spotify fallback when deezer and local and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findArtistImageUrl).mockResolvedValue(
       "https://img/spotify-artist.jpg",
     );
@@ -188,13 +196,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.externalCalls).toBe(1);
     expect(result.failed).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
+    expect(ctx.spotifySource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
       "https://img/spotify-artist.jpg",
     );
   });
 
-  it("uses local album artwork as artist fallback before spotify", async () => {
+  it("uses local album artwork as artist fallback before external sources", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
@@ -212,6 +222,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.written).toBe(1);
     expect(result.externalCalls).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
@@ -219,11 +230,12 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
     );
   });
 
-  it("writes album artwork from spotify fallback when local embedded and cache miss", async () => {
+  it("writes album artwork from spotify fallback when local embedded deezer and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
     vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
     vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(
       "https://img/spotify-cover.jpg",
     );
@@ -243,5 +255,74 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Album One",
       "https://img/spotify-cover.jpg",
     );
+  });
+
+  it("ABF-2a: deezer resolves album cover — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(
+      "https://cdn.deezer.com/album.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeAlbumArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeAlbumArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "Album One",
+      "https://cdn.deezer.com/album.jpg",
+    );
+  });
+
+  it("ABF-2a: deezer resolves artist image — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
+    vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(
+      "https://cdn.deezer.com/artist.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeArtistArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a-artist",
+      phase: "artists",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "https://cdn.deezer.com/artist.jpg",
+    );
+  });
+
+  it("ABF-2c: both external sources miss — candidate counted as failed, no crash", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(null);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2c",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.externalCalls).toBe(0);
   });
 });

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
@@ -4,8 +4,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import type { ArtworkBackfillPhase } from "@/domain/artwork-backfill.types";
 
@@ -33,7 +33,7 @@ export class ProcessArtworkBackfillBatchUseCase {
     private readonly fileSystemSource: ArtworkBackfillFileSystemSourcePort,
     private readonly cacheSource: ArtworkBackfillCacheSourcePort,
     private readonly embeddedSource: ArtworkBackfillEmbeddedSourcePort,
-    private readonly spotifySource: ArtworkBackfillSpotifySourcePort,
+    private readonly externalSources: ArtworkBackfillExternalSourcePort[],
     private readonly backfillRepository: ArtworkBackfillRepositoryPort,
   ) {}
 
@@ -125,14 +125,17 @@ export class ProcessArtworkBackfillBatchUseCase {
       }
 
       if (allowExternalFallback) {
-        const spotifyImage = await this.spotifySource.findArtistImageUrl(candidate);
-        if (!spotifyImage) return "failed";
+        for (const source of this.externalSources) {
+          const externalImage = await source.findArtistImageUrl(candidate);
+          if (!externalImage) continue;
 
-        const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
-          candidate.artistName,
-          spotifyImage,
-        );
-        return written ? "external" : "failed";
+          const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
+            candidate.artistName,
+            externalImage,
+          );
+          return written ? "external" : "failed";
+        }
+        return "failed";
       }
 
       return "failed";
@@ -173,15 +176,18 @@ export class ProcessArtworkBackfillBatchUseCase {
     }
 
     if (allowExternalFallback) {
-      const spotifyCover = await this.spotifySource.findAlbumCoverUrl(candidate);
-      if (!spotifyCover) return "failed";
+      for (const source of this.externalSources) {
+        const externalCover = await source.findAlbumCoverUrl(candidate);
+        if (!externalCover) continue;
 
-      const writtenSpotify = await this.fileSystemSource.writeAlbumArtworkIfMissing(
-        candidate.artistName,
-        candidate.albumName,
-        spotifyCover,
-      );
-      return writtenSpotify ? "external" : "failed";
+        const written = await this.fileSystemSource.writeAlbumArtworkIfMissing(
+          candidate.artistName,
+          candidate.albumName,
+          externalCover,
+        );
+        return written ? "external" : "failed";
+      }
+      return "failed";
     }
 
     return "failed";

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -56,6 +56,7 @@ import { PrismaSettingsRepository } from "./infrastructure/database/prisma-setti
 import { PrismaTrackRepository } from "./infrastructure/database/prisma-track.repository";
 import { PromiseCache } from "./infrastructure/external/promise-cache";
 import { DeezerArtistLookupAdapter } from "./infrastructure/external/providers/deezer/deezer-artist-lookup.adapter";
+import { DeezerArtworkSourceService } from "./infrastructure/external/providers/deezer/deezer-artwork-source.service";
 import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/deezer/deezer-catalog-search.adapter";
 import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.client";
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
@@ -488,12 +489,14 @@ const spotifyArtworkSourceService = new SpotifyArtworkSourceService(
   spotifyAlbumClient,
   spotifySearchClient,
 );
+const deezerArtworkSourceService = new DeezerArtworkSourceService(deezerClient);
+const externalArtworkSources = [deezerArtworkSourceService, spotifyArtworkSourceService];
 const processArtworkBackfillBatchUseCase = new ProcessArtworkBackfillBatchUseCase(
   cacheArtworkSourceService,
   fileSystemArtworkSourceService,
   cacheArtworkSourceService,
   embeddedArtworkSourceService,
-  spotifyArtworkSourceService,
+  externalArtworkSources,
   artworkBackfillRepository,
 );
 const startArtworkBackfillUseCase = new StartArtworkBackfillUseCase(

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillCandidate } from "@/application/ports/artwork-backfill-sources.port";
+import { DeezerArtworkSourceService } from "./deezer-artwork-source.service";
+import type { DeezerArtist, DeezerAlbum, DeezerClient } from "./deezer.client";
+
+function makeCandidate(
+  overrides: Partial<ArtworkBackfillCandidate> = {},
+): ArtworkBackfillCandidate {
+  return {
+    type: "artist",
+    cursorValue: "artist:Radiohead",
+    artistName: "Radiohead",
+    ...overrides,
+  };
+}
+
+const mockDeezerClient = {
+  searchArtist: vi.fn<() => Promise<DeezerArtist | null>>(),
+  searchAlbum: vi.fn<() => Promise<DeezerAlbum | null>>(),
+} satisfies Pick<DeezerClient, "searchArtist" | "searchAlbum">;
+
+function buildService(): DeezerArtworkSourceService {
+  return new DeezerArtworkSourceService(mockDeezerClient);
+}
+
+describe("DeezerArtworkSourceService", () => {
+  describe("findArtistImageUrl", () => {
+    it("ABF-1a: returns picture_xl URL when searchArtist returns an artist with a picture", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue({
+        id: 1,
+        name: "Radiohead",
+        picture_xl: "https://cdn.deezer.com/artist.jpg",
+      } satisfies DeezerArtist);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(mockDeezerClient.searchArtist).toHaveBeenCalledWith("Radiohead");
+      expect(result).toBe("https://cdn.deezer.com/artist.jpg");
+    });
+
+    it("ABF-1b: returns null when searchArtist returns no match", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue(null);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("findAlbumCoverUrl", () => {
+    it("ABF-1c: returns cover URL when searchAlbum returns an album with a cover", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue({
+        id: 99,
+        title: "OK Computer",
+        cover_xl: "https://cdn.deezer.com/album-cover.jpg",
+      } satisfies DeezerAlbum);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:OK Computer",
+        albumName: "OK Computer",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(mockDeezerClient.searchAlbum).toHaveBeenCalledWith("Radiohead", "OK Computer");
+      expect(result).toBe("https://cdn.deezer.com/album-cover.jpg");
+    });
+
+    it("ABF-1d: returns null when searchAlbum returns no match", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue(null);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:Unknown",
+        albumName: "Unknown",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
@@ -1,0 +1,35 @@
+import type {
+  ArtworkBackfillCandidate,
+  ArtworkBackfillExternalSourcePort,
+} from "@/application/ports/artwork-backfill-sources.port";
+import { pickBestCover } from "./cover-url";
+import type { DeezerClient } from "./deezer.client";
+
+export class DeezerArtworkSourceService implements ArtworkBackfillExternalSourcePort {
+  constructor(private readonly deezerClient: Pick<DeezerClient, "searchArtist" | "searchAlbum">) {}
+
+  async findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    try {
+      const artist = await this.deezerClient.searchArtist(candidate.artistName);
+      if (!artist) return null;
+      return (
+        artist.picture_xl || artist.picture_big || artist.picture_medium || artist.picture || null
+      );
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findArtistImageUrl error:", err);
+      return null;
+    }
+  }
+
+  async findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    if (!candidate.albumName) return null;
+    try {
+      const album = await this.deezerClient.searchAlbum(candidate.artistName, candidate.albumName);
+      if (!album) return null;
+      return pickBestCover(album) ?? null;
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findAlbumCoverUrl error:", err);
+      return null;
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
@@ -1,13 +1,13 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { AppError } from "@/domain/errors/app-error";
 import type { SpotifyAlbumClient } from "./spotify-album.client";
 import type { SpotifyArtistClient } from "./spotify-artist.client";
 import type { SpotifySearchClient } from "./spotify-search.client";
 
-export class SpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class SpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   constructor(
     private readonly spotifyArtistClient: SpotifyArtistClient,
     private readonly spotifyAlbumClient: SpotifyAlbumClient,

--- a/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
@@ -1,9 +1,9 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 
-export class NoopSpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class NoopSpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   async findArtistImageUrl(_candidate: ArtworkBackfillCandidate): Promise<string | null> {
     return null;
   }


### PR DESCRIPTION
## Summary

- Renames `ArtworkBackfillSpotifySourcePort` → `ArtworkBackfillExternalSourcePort` across 5 files (port definition, use-case, test, Spotify adapter, noop service)
- Adds `DeezerArtworkSourceService` implementing the renamed port — resolves `picture_xl` via `DeezerClient.searchArtist` and `cover_xl` via `DeezerClient.searchAlbum`
- Updates `ProcessArtworkBackfillBatchUseCase` constructor to accept `externalSources: ArtworkBackfillExternalSourcePort[]`; iterates in order so first non-null result wins
- Wires `[deezerArtworkSourceService, spotifyArtworkSourceService]` in `container.ts` — Deezer is tried first, Spotify is the fallback

## Test plan

- [x] 4 unit tests for `DeezerArtworkSourceService` (ABF-1a/1b/1c/1d)
- [x] 3 ABF cascade order tests: Deezer wins → Spotify skipped (ABF-2a); Deezer miss → Spotify fallback (ABF-2b); both miss → no crash (ABF-2c)
- [x] All existing 343 tests remain GREEN → 350 total
- [x] `pnpm --filter backend run lint` — clean (no new errors)
- [x] `pnpm --filter backend run build` — TypeScript clean
- [x] `rg "ArtworkBackfillSpotifySourcePort"` in `*.ts` source files → 0 matches

## Rollback

```bash
# Revert container wiring
git revert <sha>
# Or manually: delete DeezerArtworkSourceService, rename port back, restore single-port constructor
```

## Chain context

PR 3/5 — stacked-to-main chain for `spotify-deezer-first-phase-4`
- Prior: PR-4.1 #70 (`feature/phase4-frontend-dispatch-tests`)
- Prior: PR-4.2 #71 (`feature/phase4-artwork-deezer-skip`)
- Next: PR-4.4 `kind: "deezerTrack"` single-track Deezer download