### PR TITLE
feat: single-track Deezer downloads via deezerTrack playlist kind

### DIFF
--- a/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
+++ b/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
@@ -40,7 +40,7 @@ export interface ArtworkBackfillCacheSourcePort {
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }
 
-export interface ArtworkBackfillSpotifySourcePort {
+export interface ArtworkBackfillExternalSourcePort {
   findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
@@ -5,8 +5,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { ProcessArtworkBackfillBatchUseCase } from "./process-artwork-backfill-batch.use-case";
 
@@ -56,7 +56,11 @@ function build() {
   const embeddedSource: ArtworkBackfillEmbeddedSourcePort = {
     extractFromTracks: vi.fn().mockResolvedValue(null),
   };
-  const spotifySource: ArtworkBackfillSpotifySourcePort = {
+  const deezerSource: ArtworkBackfillExternalSourcePort = {
+    findArtistImageUrl: vi.fn().mockResolvedValue(null),
+    findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
+  };
+  const spotifySource: ArtworkBackfillExternalSourcePort = {
     findArtistImageUrl: vi.fn().mockResolvedValue(null),
     findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
   };
@@ -73,7 +77,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
-    spotifySource,
+    [deezerSource, spotifySource],
     repository,
   );
 
@@ -83,6 +87,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
+    deezerSource,
     spotifySource,
     repository,
   };
@@ -125,6 +130,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Artist A",
       "https://img/artist.jpg",
     );
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
   });
 
@@ -167,13 +173,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
         failed: 1,
       }),
     );
+    expect(ctx.deezerSource.findAlbumCoverUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
   });
 
-  it("writes artist artwork from spotify fallback when local and cache miss", async () => {
+  it("ABF-2b: writes artist artwork from spotify fallback when deezer and local and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findArtistImageUrl).mockResolvedValue(
       "https://img/spotify-artist.jpg",
     );
@@ -188,13 +196,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.externalCalls).toBe(1);
     expect(result.failed).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
+    expect(ctx.spotifySource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
       "https://img/spotify-artist.jpg",
     );
   });
 
-  it("uses local album artwork as artist fallback before spotify", async () => {
+  it("uses local album artwork as artist fallback before external sources", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
@@ -212,6 +222,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.written).toBe(1);
     expect(result.externalCalls).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
@@ -219,11 +230,12 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
     );
   });
 
-  it("writes album artwork from spotify fallback when local embedded and cache miss", async () => {
+  it("writes album artwork from spotify fallback when local embedded deezer and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
     vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
     vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(
       "https://img/spotify-cover.jpg",
     );
@@ -243,5 +255,74 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Album One",
       "https://img/spotify-cover.jpg",
     );
+  });
+
+  it("ABF-2a: deezer resolves album cover — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(
+      "https://cdn.deezer.com/album.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeAlbumArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeAlbumArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "Album One",
+      "https://cdn.deezer.com/album.jpg",
+    );
+  });
+
+  it("ABF-2a: deezer resolves artist image — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
+    vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(
+      "https://cdn.deezer.com/artist.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeArtistArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a-artist",
+      phase: "artists",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "https://cdn.deezer.com/artist.jpg",
+    );
+  });
+
+  it("ABF-2c: both external sources miss — candidate counted as failed, no crash", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(null);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2c",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.externalCalls).toBe(0);
   });
 });

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
@@ -4,8 +4,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import type { ArtworkBackfillPhase } from "@/domain/artwork-backfill.types";
 
@@ -33,7 +33,7 @@ export class ProcessArtworkBackfillBatchUseCase {
     private readonly fileSystemSource: ArtworkBackfillFileSystemSourcePort,
     private readonly cacheSource: ArtworkBackfillCacheSourcePort,
     private readonly embeddedSource: ArtworkBackfillEmbeddedSourcePort,
-    private readonly spotifySource: ArtworkBackfillSpotifySourcePort,
+    private readonly externalSources: ArtworkBackfillExternalSourcePort[],
     private readonly backfillRepository: ArtworkBackfillRepositoryPort,
   ) {}
 
@@ -125,14 +125,17 @@ export class ProcessArtworkBackfillBatchUseCase {
       }
 
       if (allowExternalFallback) {
-        const spotifyImage = await this.spotifySource.findArtistImageUrl(candidate);
-        if (!spotifyImage) return "failed";
+        for (const source of this.externalSources) {
+          const externalImage = await source.findArtistImageUrl(candidate);
+          if (!externalImage) continue;
 
-        const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
-          candidate.artistName,
-          spotifyImage,
-        );
-        return written ? "external" : "failed";
+          const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
+            candidate.artistName,
+            externalImage,
+          );
+          return written ? "external" : "failed";
+        }
+        return "failed";
       }
 
       return "failed";
@@ -173,15 +176,18 @@ export class ProcessArtworkBackfillBatchUseCase {
     }
 
     if (allowExternalFallback) {
-      const spotifyCover = await this.spotifySource.findAlbumCoverUrl(candidate);
-      if (!spotifyCover) return "failed";
+      for (const source of this.externalSources) {
+        const externalCover = await source.findAlbumCoverUrl(candidate);
+        if (!externalCover) continue;
 
-      const writtenSpotify = await this.fileSystemSource.writeAlbumArtworkIfMissing(
-        candidate.artistName,
-        candidate.albumName,
-        spotifyCover,
-      );
-      return writtenSpotify ? "external" : "failed";
+        const written = await this.fileSystemSource.writeAlbumArtworkIfMissing(
+          candidate.artistName,
+          candidate.albumName,
+          externalCover,
+        );
+        return written ? "external" : "failed";
+      }
+      return "failed";
     }
 
     return "failed";

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -231,6 +231,107 @@ describe("CreatePlaylistUseCase — albumTrack branch", () => {
   });
 });
 
+describe("CreatePlaylistUseCase — deezerTrack branch (DTD-2)", () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  function makeDeezerUseCase(
+    deezerClient: { getAlbumTracks: ReturnType<typeof vi.fn> },
+    s: ReturnType<typeof makeStubs> = stubs,
+  ) {
+    return new CreatePlaylistUseCase(
+      s.playlistRepository as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.spotifyService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.trackService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.settingsService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.eventBus as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.getAlbumTracksUseCase as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.feedRepository as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      deezerClient as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+  }
+
+  it("DTD-2a: deezerTrack kind — found in album → creates single-track playlist", async () => {
+    const deezerClient = {
+      getAlbumTracks: vi.fn().mockResolvedValue([
+        {
+          name: "Karma Police",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 3,
+          durationMs: 263000,
+          trackUrl: "https://api.deezer.com/track/12345",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+        {
+          name: "No Surprises",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 12,
+          durationMs: 228000,
+          trackUrl: "https://api.deezer.com/track/99999",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+      ]),
+    };
+
+    const useCase = makeDeezerUseCase(deezerClient);
+
+    const result = await useCase.execute({
+      kind: "deezerTrack",
+      deezerTrackId: "12345",
+      deezerAlbumId: "456",
+    });
+
+    expect(deezerClient.getAlbumTracks).toHaveBeenCalledWith("456");
+    expect(stubs.trackService.create).toHaveBeenCalledTimes(1);
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Karma Police" }),
+    );
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+    expect(result).toBeDefined();
+  });
+
+  it("DTD-2b: deezerTrack kind — track NOT in album → throws 404", async () => {
+    const deezerClient = {
+      getAlbumTracks: vi.fn().mockResolvedValue([
+        {
+          name: "No Surprises",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 12,
+          durationMs: 228000,
+          trackUrl: "https://api.deezer.com/track/99999",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+      ]),
+    };
+
+    const useCase = makeDeezerUseCase(deezerClient);
+
+    const thrown = await useCase
+      .execute({
+        kind: "deezerTrack",
+        deezerTrackId: "99998",
+        deezerAlbumId: "456",
+      })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(404);
+    expect((thrown as AppError).errorCode).toBe("track_not_found");
+  });
+});
+
 describe("CreatePlaylistUseCase — album branch", () => {
   let stubs: ReturnType<typeof makeStubs>;
 

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -3,6 +3,7 @@ import {
   type NormalizedTrack,
   PlaylistTypeEnum,
   type IPlaylist,
+  extractDeezerTrackId,
 } from "@spotiarr/shared";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { SpotifyService } from "@/application/services/spotify.service";
@@ -14,6 +15,10 @@ import type { PlaylistRepository } from "@/domain/repositories/playlist.reposito
 import type { SettingsService } from "../../services/settings.service";
 import type { TrackService } from "../../services/track.service";
 import type { GetAlbumTracksUseCase } from "../artists/get-album-tracks.use-case";
+
+interface DeezerAlbumTracksPort {
+  getAlbumTracks(deezerAlbumId: string | number): Promise<NormalizedTrack[]>;
+}
 
 interface PlaylistDetail {
   tracks: NormalizedTrack[];
@@ -40,6 +45,7 @@ export class CreatePlaylistUseCase {
     private readonly eventBus: EventBus,
     private readonly getAlbumTracksUseCase?: GetAlbumTracksUseCase,
     private readonly feedRepository?: FeedRepositoryPort,
+    private readonly deezerClient?: DeezerAlbumTracksPort,
   ) {}
 
   async execute(input: CreatePlaylistRequest): Promise<IPlaylist> {
@@ -48,6 +54,9 @@ export class CreatePlaylistUseCase {
     }
     if (input.kind === "albumTrack") {
       return this.executeAlbumTrackRef(input.artistId, input.albumId, input.trackIndex);
+    }
+    if (input.kind === "deezerTrack") {
+      return this.executeDeezerTrack(input.deezerTrackId, input.deezerAlbumId);
     }
     return this.executeSpotifyUrl(input.spotifyUrl);
   }
@@ -234,6 +243,61 @@ export class CreatePlaylistUseCase {
       PlaylistTypeEnum.Track,
       coverUrl,
       artistImageUrl,
+      artistName,
+      undefined,
+    );
+
+    const autoSubscribe = await this.settingsService.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS");
+    if (autoSubscribe) playlist.markAsSubscribed();
+
+    const savedPlaylistEntity = await this.playlistRepository.save(playlist);
+    const savedPlaylist = savedPlaylistEntity.toPrimitive();
+
+    await this.processTracks(savedPlaylist, [pickedTrack], PlaylistTypeEnum.Track);
+
+    this.eventBus.emit("playlists-updated");
+    return savedPlaylist;
+  }
+
+  private async executeDeezerTrack(
+    deezerTrackId: string,
+    deezerAlbumId: string,
+  ): Promise<IPlaylist> {
+    if (!this.deezerClient) {
+      throw new AppError(500, "internal_server_error", "Deezer client not configured");
+    }
+
+    const syntheticUrl = `spotiarr://deezer/track/${deezerTrackId}`;
+
+    const existing = await this.playlistRepository.findAll(false, { spotifyUrl: syntheticUrl });
+    if (existing.length > 0) {
+      throw new AppError(409, "playlist_already_exists");
+    }
+
+    const tracks = await this.deezerClient.getAlbumTracks(deezerAlbumId);
+
+    const pickedTrack = tracks.find(
+      (t) => extractDeezerTrackId(t.trackUrl ?? "") === deezerTrackId,
+    );
+
+    if (!pickedTrack) {
+      throw new AppError(404, "track_not_found", "Deezer track not found in album");
+    }
+
+    const trackName = pickedTrack.name ?? "Unknown Track";
+    const artistName = pickedTrack.primaryArtist ?? pickedTrack.artist ?? "Unknown Artist";
+    const coverUrl = pickedTrack.albumCoverUrl;
+
+    const playlist = new Playlist({
+      id: crypto.randomUUID(),
+      spotifyUrl: syntheticUrl,
+      type: PlaylistTypeEnum.Track,
+    });
+    playlist.updateDetails(
+      `${artistName} - ${trackName}`,
+      PlaylistTypeEnum.Track,
+      coverUrl,
+      pickedTrack.primaryArtistImage ?? undefined,
       artistName,
       undefined,
     );

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -286,7 +286,7 @@ export class CreatePlaylistUseCase {
 
     const trackName = pickedTrack.name ?? "Unknown Track";
     const artistName = pickedTrack.primaryArtist ?? pickedTrack.artist ?? "Unknown Artist";
-    const coverUrl = pickedTrack.albumCoverUrl;
+    const coverUrl = pickedTrack.albumCoverUrl ?? undefined;
 
     const playlist = new Playlist({
       id: crypto.randomUUID(),

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -56,6 +56,7 @@ import { PrismaSettingsRepository } from "./infrastructure/database/prisma-setti
 import { PrismaTrackRepository } from "./infrastructure/database/prisma-track.repository";
 import { PromiseCache } from "./infrastructure/external/promise-cache";
 import { DeezerArtistLookupAdapter } from "./infrastructure/external/providers/deezer/deezer-artist-lookup.adapter";
+import { DeezerArtworkSourceService } from "./infrastructure/external/providers/deezer/deezer-artwork-source.service";
 import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/deezer/deezer-catalog-search.adapter";
 import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.client";
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
@@ -488,12 +489,14 @@ const spotifyArtworkSourceService = new SpotifyArtworkSourceService(
   spotifyAlbumClient,
   spotifySearchClient,
 );
+const deezerArtworkSourceService = new DeezerArtworkSourceService(deezerClient);
+const externalArtworkSources = [deezerArtworkSourceService, spotifyArtworkSourceService];
 const processArtworkBackfillBatchUseCase = new ProcessArtworkBackfillBatchUseCase(
   cacheArtworkSourceService,
   fileSystemArtworkSourceService,
   cacheArtworkSourceService,
   embeddedArtworkSourceService,
-  spotifyArtworkSourceService,
+  externalArtworkSources,
   artworkBackfillRepository,
 );
 const startArtworkBackfillUseCase = new StartArtworkBackfillUseCase(

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -556,6 +556,7 @@ const createPlaylistUseCase = new CreatePlaylistUseCase(
   eventBus,
   getAlbumTracksUseCase,
   feedRepository,
+  deezerClient,
 );
 
 // Domain Services (Playlist)

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillCandidate } from "@/application/ports/artwork-backfill-sources.port";
+import { DeezerArtworkSourceService } from "./deezer-artwork-source.service";
+import type { DeezerArtist, DeezerAlbum, DeezerClient } from "./deezer.client";
+
+function makeCandidate(
+  overrides: Partial<ArtworkBackfillCandidate> = {},
+): ArtworkBackfillCandidate {
+  return {
+    type: "artist",
+    cursorValue: "artist:Radiohead",
+    artistName: "Radiohead",
+    ...overrides,
+  };
+}
+
+const mockDeezerClient = {
+  searchArtist: vi.fn<() => Promise<DeezerArtist | null>>(),
+  searchAlbum: vi.fn<() => Promise<DeezerAlbum | null>>(),
+} satisfies Pick<DeezerClient, "searchArtist" | "searchAlbum">;
+
+function buildService(): DeezerArtworkSourceService {
+  return new DeezerArtworkSourceService(mockDeezerClient);
+}
+
+describe("DeezerArtworkSourceService", () => {
+  describe("findArtistImageUrl", () => {
+    it("ABF-1a: returns picture_xl URL when searchArtist returns an artist with a picture", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue({
+        id: 1,
+        name: "Radiohead",
+        picture_xl: "https://cdn.deezer.com/artist.jpg",
+      } satisfies DeezerArtist);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(mockDeezerClient.searchArtist).toHaveBeenCalledWith("Radiohead");
+      expect(result).toBe("https://cdn.deezer.com/artist.jpg");
+    });
+
+    it("ABF-1b: returns null when searchArtist returns no match", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue(null);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("findAlbumCoverUrl", () => {
+    it("ABF-1c: returns cover URL when searchAlbum returns an album with a cover", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue({
+        id: 99,
+        title: "OK Computer",
+        cover_xl: "https://cdn.deezer.com/album-cover.jpg",
+      } satisfies DeezerAlbum);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:OK Computer",
+        albumName: "OK Computer",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(mockDeezerClient.searchAlbum).toHaveBeenCalledWith("Radiohead", "OK Computer");
+      expect(result).toBe("https://cdn.deezer.com/album-cover.jpg");
+    });
+
+    it("ABF-1d: returns null when searchAlbum returns no match", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue(null);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:Unknown",
+        albumName: "Unknown",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
@@ -1,0 +1,35 @@
+import type {
+  ArtworkBackfillCandidate,
+  ArtworkBackfillExternalSourcePort,
+} from "@/application/ports/artwork-backfill-sources.port";
+import { pickBestCover } from "./cover-url";
+import type { DeezerClient } from "./deezer.client";
+
+export class DeezerArtworkSourceService implements ArtworkBackfillExternalSourcePort {
+  constructor(private readonly deezerClient: Pick<DeezerClient, "searchArtist" | "searchAlbum">) {}
+
+  async findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    try {
+      const artist = await this.deezerClient.searchArtist(candidate.artistName);
+      if (!artist) return null;
+      return (
+        artist.picture_xl || artist.picture_big || artist.picture_medium || artist.picture || null
+      );
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findArtistImageUrl error:", err);
+      return null;
+    }
+  }
+
+  async findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    if (!candidate.albumName) return null;
+    try {
+      const album = await this.deezerClient.searchAlbum(candidate.artistName, candidate.albumName);
+      if (!album) return null;
+      return pickBestCover(album) ?? null;
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findAlbumCoverUrl error:", err);
+      return null;
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
@@ -1,13 +1,13 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { AppError } from "@/domain/errors/app-error";
 import type { SpotifyAlbumClient } from "./spotify-album.client";
 import type { SpotifyArtistClient } from "./spotify-artist.client";
 import type { SpotifySearchClient } from "./spotify-search.client";
 
-export class SpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class SpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   constructor(
     private readonly spotifyArtistClient: SpotifyArtistClient,
     private readonly spotifyAlbumClient: SpotifyAlbumClient,

--- a/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
@@ -1,9 +1,9 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 
-export class NoopSpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class NoopSpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   async findArtistImageUrl(_candidate: ArtworkBackfillCandidate): Promise<string | null> {
     return null;
   }

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -14,7 +14,7 @@ import { VirtualList } from "../molecules/VirtualList";
 // Minimum shape required to render a TrackList item
 export interface TrackListTrack extends ITrack {
   id?: string;
-  albumCoverUrl?: string | null;
+  albumCoverUrl?: string;
 }
 
 interface TrackListItemProps {

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -14,7 +14,7 @@ import { VirtualList } from "../molecules/VirtualList";
 // Minimum shape required to render a TrackList item
 export interface TrackListTrack extends ITrack {
   id?: string;
-  albumCoverUrl?: string;
+  albumCoverUrl?: string | null;
 }
 
 interface TrackListItemProps {

--- a/apps/frontend/src/hooks/controllers/useSearchController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.test.ts
@@ -109,15 +109,10 @@ describe("useSearchController", () => {
     /**
      * TST-1a — Deezer track URL + albumId present.
      *
-     * CURRENT BEHAVIOR (PR-4.1 / D4 workaround): dispatches `kind: "album"` using
-     * the track's primaryArtist + albumId. This is the Phase 3 fallback to avoid
-     * downloading the whole album via Deezer's album endpoint.
-     *
-     * EXPECTED AFTER PR-4.4: dispatch will change to
-     *   { kind: "deezerTrack", deezerTrackId: "12345", deezerAlbumId: "456" }
-     * Update this assertion when PR-4.4 lands.
+     * PR-4.4: D4 workaround removed. Now dispatches `kind: "deezerTrack"` with
+     * the extracted deezerTrackId and the albumId as deezerAlbumId.
      */
-    it("TST-1a: Deezer URL + albumId → dispatches kind:album (D4 workaround, regression guard for PR-4.4)", () => {
+    it("TST-1a: Deezer URL + albumId → dispatches kind:deezerTrack with deezerTrackId+deezerAlbumId", () => {
       const { result } = renderHook(() => useSearchController());
 
       act(() => {
@@ -126,9 +121,9 @@ describe("useSearchController", () => {
 
       expect(mockMutate).toHaveBeenCalledTimes(1);
       expect(mockMutate).toHaveBeenCalledWith({
-        kind: "album",
-        artistId: "artist-1",
-        albumId: "456",
+        kind: "deezerTrack",
+        deezerTrackId: "12345",
+        deezerAlbumId: "456",
       });
       expect(mockToast.error).not.toHaveBeenCalled();
     });

--- a/apps/frontend/src/hooks/controllers/useSearchController.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.ts
@@ -1,4 +1,4 @@
-import { NormalizedTrack } from "@spotiarr/shared";
+import { NormalizedTrack, isDeezerUrl, extractDeezerTrackId } from "@spotiarr/shared";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { TopResultItem } from "@/components/molecules/SearchTopResultCard";
@@ -42,6 +42,17 @@ export const useSearchController = () => {
 
   const handleDownloadTrack = useCallback(
     (track: NormalizedTrack) => {
+      if (isDeezerUrl(track.trackUrl) && track.albumId) {
+        const deezerTrackId = extractDeezerTrackId(track.trackUrl!);
+        if (deezerTrackId) {
+          createPlaylist.mutate({
+            kind: "deezerTrack",
+            deezerTrackId,
+            deezerAlbumId: track.albumId,
+          });
+          return;
+        }
+      }
       if (isSpotifyUrl(track.trackUrl)) {
         createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
       } else if (track.albumId) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,7 +133,8 @@ export interface ArtistRelease {
 export type CreatePlaylistRequest =
   | { kind: "spotifyUrl"; spotifyUrl: string }
   | { kind: "album"; artistId: string; albumId: string }
-  | { kind: "albumTrack"; artistId: string; albumId: string; trackIndex: number };
+  | { kind: "albumTrack"; artistId: string; albumId: string; trackIndex: number }
+  | { kind: "deezerTrack"; deezerTrackId: string; deezerAlbumId: string };
 
 export type ApiErrorCode =
   | "missing_user_access_token"


### PR DESCRIPTION
## Summary

Chain PR 4/5 — stacked-to-main. Depends on #72 (PR-4.3) being merged first.

**CRITICAL — lockstep deploy**: this PR lands a shared DTO change (`CreatePlaylistRequest` union), frontend dispatch update, and backend use-case implementation atomically. All three must be in the same deploy; partial state is a TypeScript error.

- Extends `CreatePlaylistRequest` union in `packages/shared/src/index.ts` with `{ kind: "deezerTrack"; deezerTrackId: string; deezerAlbumId: string }`
- Implements `executeDeezerTrack` in `CreatePlaylistUseCase`: calls `DeezerClient.getAlbumTracks(deezerAlbumId)`, finds matching track via `extractDeezerTrackId`, creates a **single-track** playlist entry (previously the D4 workaround queued the entire album)
- Removes the D4 album-download workaround from `useSearchController.handleDownloadTrack` — Deezer search-result track clicks now correctly download only that track
- Injects `deezerClient` into `CreatePlaylistUseCase` constructor in `container.ts`
- Fixes `TrackListTrack.albumCoverUrl` type mismatch (`string | null` → `string`) introduced by PR-4.2's `ITrack` extension

## Chain context

| PR | Branch | Status |
|---|---|---|
| 4.1 | feature/phase4-frontend-dispatch-tests | #70 |
| 4.2 | feature/phase4-artwork-deezer-skip | #71 |
| 4.3 | feature/phase4-artwork-backfill-deezer | #72 |
| **4.4 (this PR)** | feature/phase4-deezer-track-download | — |
| 4.5 | feature/phase4-playlist-cache | pending |

## D4 workaround removal (Phase 3 PR-3.1b)

The Phase 3 migration introduced a workaround where clicking a Deezer track in search results would dispatch `kind: "album"` (downloading the whole album). This PR removes that workaround and replaces it with a proper single-track download path.

## Verification

- Backend: 352 tests pass (`pnpm --filter backend run test:run`) — DTD-2a (track found), DTD-2b (track not found → 404) pass
- Frontend: 115 tests pass (`pnpm --filter frontend run test:run`) — TST-1a now asserts `deezerTrack` dispatch
- `pnpm --filter @spotiarr/shared run build` — clean
- `pnpm --filter backend run build` — clean
- `pnpm --filter frontend run build` — clean
- `useAlbumDetailController.handleDownloadTrack` unchanged — still dispatches `kind: "albumTrack"` with `trackIndex`

## Rollback

Revert this PR in lockstep (frontend + backend + shared). Removing the union variant is a typed breaking change requiring all three reverted together.