### PR TITLE
feat(backend): PlaylistCache table with 24h TTL for Spotify playlist reads

### DIFF
--- a/apps/backend/prisma/migrations/20260604134045_add_playlist_cache/migration.sql
+++ b/apps/backend/prisma/migrations/20260604134045_add_playlist_cache/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "PlaylistCache" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "cacheKey" TEXT NOT NULL,
+    "payload" TEXT NOT NULL,
+    "cachedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PlaylistCache_cacheKey_key" ON "PlaylistCache"("cacheKey");
+
+-- CreateIndex
+CREATE INDEX "PlaylistCache_expiresAt_idx" ON "PlaylistCache"("expiresAt");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -171,3 +171,13 @@ model ExternalUrlCache {
   @@unique([provider, type, internalId])
   @@index([provider, type, name])
 }
+
+model PlaylistCache {
+  id        String   @id @default(uuid())
+  cacheKey  String   @unique
+  payload   String
+  cachedAt  DateTime @default(now())
+  expiresAt DateTime
+
+  @@index([expiresAt])
+}

--- a/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
+++ b/apps/backend/src/application/ports/artwork-backfill-sources.port.ts
@@ -40,7 +40,7 @@ export interface ArtworkBackfillCacheSourcePort {
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }
 
-export interface ArtworkBackfillSpotifySourcePort {
+export interface ArtworkBackfillExternalSourcePort {
   findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
   findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null>;
 }

--- a/apps/backend/src/application/ports/playlist-cache.port.ts
+++ b/apps/backend/src/application/ports/playlist-cache.port.ts
@@ -1,0 +1,7 @@
+export const PLAYLIST_CACHE_TTL_MS = 86_400_000;
+
+export interface PlaylistCachePort {
+  get<T>(key: string): Promise<T | null>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  invalidate(key: string): Promise<void>;
+}

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.test.ts
@@ -5,8 +5,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { ProcessArtworkBackfillBatchUseCase } from "./process-artwork-backfill-batch.use-case";
 
@@ -56,7 +56,11 @@ function build() {
   const embeddedSource: ArtworkBackfillEmbeddedSourcePort = {
     extractFromTracks: vi.fn().mockResolvedValue(null),
   };
-  const spotifySource: ArtworkBackfillSpotifySourcePort = {
+  const deezerSource: ArtworkBackfillExternalSourcePort = {
+    findArtistImageUrl: vi.fn().mockResolvedValue(null),
+    findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
+  };
+  const spotifySource: ArtworkBackfillExternalSourcePort = {
     findArtistImageUrl: vi.fn().mockResolvedValue(null),
     findAlbumCoverUrl: vi.fn().mockResolvedValue(null),
   };
@@ -73,7 +77,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
-    spotifySource,
+    [deezerSource, spotifySource],
     repository,
   );
 
@@ -83,6 +87,7 @@ function build() {
     fileSystemSource,
     cacheSource,
     embeddedSource,
+    deezerSource,
     spotifySource,
     repository,
   };
@@ -125,6 +130,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Artist A",
       "https://img/artist.jpg",
     );
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
   });
 
@@ -167,13 +173,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
         failed: 1,
       }),
     );
+    expect(ctx.deezerSource.findAlbumCoverUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
   });
 
-  it("writes artist artwork from spotify fallback when local and cache miss", async () => {
+  it("ABF-2b: writes artist artwork from spotify fallback when deezer and local and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findArtistImageUrl).mockResolvedValue(
       "https://img/spotify-artist.jpg",
     );
@@ -188,13 +196,15 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.externalCalls).toBe(1);
     expect(result.failed).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
+    expect(ctx.spotifySource.findArtistImageUrl).toHaveBeenCalledWith(artistCandidate());
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
       "https://img/spotify-artist.jpg",
     );
   });
 
-  it("uses local album artwork as artist fallback before spotify", async () => {
+  it("uses local album artwork as artist fallback before external sources", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
     vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
@@ -212,6 +222,7 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
 
     expect(result.written).toBe(1);
     expect(result.externalCalls).toBe(0);
+    expect(ctx.deezerSource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
     expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
       "Artist A",
@@ -219,11 +230,12 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
     );
   });
 
-  it("writes album artwork from spotify fallback when local embedded and cache miss", async () => {
+  it("writes album artwork from spotify fallback when local embedded deezer and cache miss", async () => {
     const ctx = build();
     vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
     vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
     vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
     vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(
       "https://img/spotify-cover.jpg",
     );
@@ -243,5 +255,74 @@ describe("ProcessArtworkBackfillBatchUseCase", () => {
       "Album One",
       "https://img/spotify-cover.jpg",
     );
+  });
+
+  it("ABF-2a: deezer resolves album cover — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(
+      "https://cdn.deezer.com/album.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeAlbumArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findAlbumCoverUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeAlbumArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "Album One",
+      "https://cdn.deezer.com/album.jpg",
+    );
+  });
+
+  it("ABF-2a: deezer resolves artist image — spotify source NOT called", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getArtistCandidates).mockResolvedValue([artistCandidate()]);
+    vi.mocked(ctx.cacheSource.findArtistImageUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findArtistImageUrl).mockResolvedValue(
+      "https://cdn.deezer.com/artist.jpg",
+    );
+    vi.mocked(ctx.fileSystemSource.writeArtistArtworkIfMissing).mockResolvedValue(true);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2a-artist",
+      phase: "artists",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.externalCalls).toBe(1);
+    expect(ctx.spotifySource.findArtistImageUrl).not.toHaveBeenCalled();
+    expect(ctx.fileSystemSource.writeArtistArtworkIfMissing).toHaveBeenCalledWith(
+      "Artist A",
+      "https://cdn.deezer.com/artist.jpg",
+    );
+  });
+
+  it("ABF-2c: both external sources miss — candidate counted as failed, no crash", async () => {
+    const ctx = build();
+    vi.mocked(ctx.candidateSource.getAlbumCandidates).mockResolvedValue([albumCandidate()]);
+    vi.mocked(ctx.embeddedSource.extractFromTracks).mockResolvedValue(null);
+    vi.mocked(ctx.cacheSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.deezerSource.findAlbumCoverUrl).mockResolvedValue(null);
+    vi.mocked(ctx.spotifySource.findAlbumCoverUrl).mockResolvedValue(null);
+
+    const result = await ctx.useCase.execute({
+      runId: "run-abf-2c",
+      phase: "albums",
+      limit: 10,
+      allowExternalFallback: true,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.externalCalls).toBe(0);
   });
 });

--- a/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case.ts
@@ -4,8 +4,8 @@ import type {
   ArtworkBackfillCandidate,
   ArtworkBackfillCandidateSourcePort,
   ArtworkBackfillEmbeddedSourcePort,
+  ArtworkBackfillExternalSourcePort,
   ArtworkBackfillFileSystemSourcePort,
-  ArtworkBackfillSpotifySourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import type { ArtworkBackfillPhase } from "@/domain/artwork-backfill.types";
 
@@ -33,7 +33,7 @@ export class ProcessArtworkBackfillBatchUseCase {
     private readonly fileSystemSource: ArtworkBackfillFileSystemSourcePort,
     private readonly cacheSource: ArtworkBackfillCacheSourcePort,
     private readonly embeddedSource: ArtworkBackfillEmbeddedSourcePort,
-    private readonly spotifySource: ArtworkBackfillSpotifySourcePort,
+    private readonly externalSources: ArtworkBackfillExternalSourcePort[],
     private readonly backfillRepository: ArtworkBackfillRepositoryPort,
   ) {}
 
@@ -125,14 +125,17 @@ export class ProcessArtworkBackfillBatchUseCase {
       }
 
       if (allowExternalFallback) {
-        const spotifyImage = await this.spotifySource.findArtistImageUrl(candidate);
-        if (!spotifyImage) return "failed";
+        for (const source of this.externalSources) {
+          const externalImage = await source.findArtistImageUrl(candidate);
+          if (!externalImage) continue;
 
-        const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
-          candidate.artistName,
-          spotifyImage,
-        );
-        return written ? "external" : "failed";
+          const written = await this.fileSystemSource.writeArtistArtworkIfMissing(
+            candidate.artistName,
+            externalImage,
+          );
+          return written ? "external" : "failed";
+        }
+        return "failed";
       }
 
       return "failed";
@@ -173,15 +176,18 @@ export class ProcessArtworkBackfillBatchUseCase {
     }
 
     if (allowExternalFallback) {
-      const spotifyCover = await this.spotifySource.findAlbumCoverUrl(candidate);
-      if (!spotifyCover) return "failed";
+      for (const source of this.externalSources) {
+        const externalCover = await source.findAlbumCoverUrl(candidate);
+        if (!externalCover) continue;
 
-      const writtenSpotify = await this.fileSystemSource.writeAlbumArtworkIfMissing(
-        candidate.artistName,
-        candidate.albumName,
-        spotifyCover,
-      );
-      return writtenSpotify ? "external" : "failed";
+        const written = await this.fileSystemSource.writeAlbumArtworkIfMissing(
+          candidate.artistName,
+          candidate.albumName,
+          externalCover,
+        );
+        return written ? "external" : "failed";
+      }
+      return "failed";
     }
 
     return "failed";

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -231,6 +231,107 @@ describe("CreatePlaylistUseCase — albumTrack branch", () => {
   });
 });
 
+describe("CreatePlaylistUseCase — deezerTrack branch (DTD-2)", () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  function makeDeezerUseCase(
+    deezerClient: { getAlbumTracks: ReturnType<typeof vi.fn> },
+    s: ReturnType<typeof makeStubs> = stubs,
+  ) {
+    return new CreatePlaylistUseCase(
+      s.playlistRepository as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.spotifyService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.trackService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.settingsService as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.eventBus as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.getAlbumTracksUseCase as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      s.feedRepository as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+      deezerClient as any, // eslint-disable-line @typescript-eslint/no-explicit-any
+    );
+  }
+
+  it("DTD-2a: deezerTrack kind — found in album → creates single-track playlist", async () => {
+    const deezerClient = {
+      getAlbumTracks: vi.fn().mockResolvedValue([
+        {
+          name: "Karma Police",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 3,
+          durationMs: 263000,
+          trackUrl: "https://api.deezer.com/track/12345",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+        {
+          name: "No Surprises",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 12,
+          durationMs: 228000,
+          trackUrl: "https://api.deezer.com/track/99999",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+      ]),
+    };
+
+    const useCase = makeDeezerUseCase(deezerClient);
+
+    const result = await useCase.execute({
+      kind: "deezerTrack",
+      deezerTrackId: "12345",
+      deezerAlbumId: "456",
+    });
+
+    expect(deezerClient.getAlbumTracks).toHaveBeenCalledWith("456");
+    expect(stubs.trackService.create).toHaveBeenCalledTimes(1);
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Karma Police" }),
+    );
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+    expect(result).toBeDefined();
+  });
+
+  it("DTD-2b: deezerTrack kind — track NOT in album → throws 404", async () => {
+    const deezerClient = {
+      getAlbumTracks: vi.fn().mockResolvedValue([
+        {
+          name: "No Surprises",
+          artist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 12,
+          durationMs: 228000,
+          trackUrl: "https://api.deezer.com/track/99999",
+          albumUrl: "https://api.deezer.com/album/456",
+          albumCoverUrl: "https://cdn.deezer.com/cover.jpg",
+        },
+      ]),
+    };
+
+    const useCase = makeDeezerUseCase(deezerClient);
+
+    const thrown = await useCase
+      .execute({
+        kind: "deezerTrack",
+        deezerTrackId: "99998",
+        deezerAlbumId: "456",
+      })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(404);
+    expect((thrown as AppError).errorCode).toBe("track_not_found");
+  });
+});
+
 describe("CreatePlaylistUseCase — album branch", () => {
   let stubs: ReturnType<typeof makeStubs>;
 

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -3,6 +3,7 @@ import {
   type NormalizedTrack,
   PlaylistTypeEnum,
   type IPlaylist,
+  extractDeezerTrackId,
 } from "@spotiarr/shared";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { SpotifyService } from "@/application/services/spotify.service";
@@ -14,6 +15,10 @@ import type { PlaylistRepository } from "@/domain/repositories/playlist.reposito
 import type { SettingsService } from "../../services/settings.service";
 import type { TrackService } from "../../services/track.service";
 import type { GetAlbumTracksUseCase } from "../artists/get-album-tracks.use-case";
+
+interface DeezerAlbumTracksPort {
+  getAlbumTracks(deezerAlbumId: string | number): Promise<NormalizedTrack[]>;
+}
 
 interface PlaylistDetail {
   tracks: NormalizedTrack[];
@@ -40,6 +45,7 @@ export class CreatePlaylistUseCase {
     private readonly eventBus: EventBus,
     private readonly getAlbumTracksUseCase?: GetAlbumTracksUseCase,
     private readonly feedRepository?: FeedRepositoryPort,
+    private readonly deezerClient?: DeezerAlbumTracksPort,
   ) {}
 
   async execute(input: CreatePlaylistRequest): Promise<IPlaylist> {
@@ -48,6 +54,9 @@ export class CreatePlaylistUseCase {
     }
     if (input.kind === "albumTrack") {
       return this.executeAlbumTrackRef(input.artistId, input.albumId, input.trackIndex);
+    }
+    if (input.kind === "deezerTrack") {
+      return this.executeDeezerTrack(input.deezerTrackId, input.deezerAlbumId);
     }
     return this.executeSpotifyUrl(input.spotifyUrl);
   }
@@ -234,6 +243,61 @@ export class CreatePlaylistUseCase {
       PlaylistTypeEnum.Track,
       coverUrl,
       artistImageUrl,
+      artistName,
+      undefined,
+    );
+
+    const autoSubscribe = await this.settingsService.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS");
+    if (autoSubscribe) playlist.markAsSubscribed();
+
+    const savedPlaylistEntity = await this.playlistRepository.save(playlist);
+    const savedPlaylist = savedPlaylistEntity.toPrimitive();
+
+    await this.processTracks(savedPlaylist, [pickedTrack], PlaylistTypeEnum.Track);
+
+    this.eventBus.emit("playlists-updated");
+    return savedPlaylist;
+  }
+
+  private async executeDeezerTrack(
+    deezerTrackId: string,
+    deezerAlbumId: string,
+  ): Promise<IPlaylist> {
+    if (!this.deezerClient) {
+      throw new AppError(500, "internal_server_error", "Deezer client not configured");
+    }
+
+    const syntheticUrl = `spotiarr://deezer/track/${deezerTrackId}`;
+
+    const existing = await this.playlistRepository.findAll(false, { spotifyUrl: syntheticUrl });
+    if (existing.length > 0) {
+      throw new AppError(409, "playlist_already_exists");
+    }
+
+    const tracks = await this.deezerClient.getAlbumTracks(deezerAlbumId);
+
+    const pickedTrack = tracks.find(
+      (t) => extractDeezerTrackId(t.trackUrl ?? "") === deezerTrackId,
+    );
+
+    if (!pickedTrack) {
+      throw new AppError(404, "track_not_found", "Deezer track not found in album");
+    }
+
+    const trackName = pickedTrack.name ?? "Unknown Track";
+    const artistName = pickedTrack.primaryArtist ?? pickedTrack.artist ?? "Unknown Artist";
+    const coverUrl = pickedTrack.albumCoverUrl;
+
+    const playlist = new Playlist({
+      id: crypto.randomUUID(),
+      spotifyUrl: syntheticUrl,
+      type: PlaylistTypeEnum.Track,
+    });
+    playlist.updateDetails(
+      `${artistName} - ${trackName}`,
+      PlaylistTypeEnum.Track,
+      coverUrl,
+      pickedTrack.primaryArtistImage ?? undefined,
       artistName,
       undefined,
     );

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -286,7 +286,7 @@ export class CreatePlaylistUseCase {
 
     const trackName = pickedTrack.name ?? "Unknown Track";
     const artistName = pickedTrack.primaryArtist ?? pickedTrack.artist ?? "Unknown Artist";
-    const coverUrl = pickedTrack.albumCoverUrl;
+    const coverUrl = pickedTrack.albumCoverUrl ?? undefined;
 
     const playlist = new Playlist({
       id: crypto.randomUUID(),

--- a/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { GetMyPlaylistsUseCase } from "./get-my-playlists.use-case";
+
+const makeDeps = () => {
+  const spotifyService = {
+    getMyPlaylists: vi.fn(),
+  };
+  const playlistCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+    invalidate: vi.fn(),
+  };
+  return { spotifyService, playlistCache };
+};
+
+const cachedPlaylists = [
+  {
+    id: "p1",
+    name: "Cached",
+    image: null,
+    owner: "me",
+    tracks: 10,
+    spotifyUrl: "https://open.spotify.com/playlist/p1",
+  },
+];
+const freshPlaylists = [
+  {
+    id: "p2",
+    name: "Fresh",
+    image: null,
+    owner: "me",
+    tracks: 5,
+    spotifyUrl: "https://open.spotify.com/playlist/p2",
+  },
+];
+
+describe("GetMyPlaylistsUseCase", () => {
+  it("PLC-3a: returns cached payload without calling Spotify on cache hit", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(cachedPlaylists);
+    const useCase = new GetMyPlaylistsUseCase(spotifyService as any, playlistCache as any);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual(cachedPlaylists);
+    expect(spotifyService.getMyPlaylists).not.toHaveBeenCalled();
+  });
+
+  it("PLC-3b: calls Spotify and writes to cache on cache miss", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(null);
+    spotifyService.getMyPlaylists.mockResolvedValue(freshPlaylists);
+    const useCase = new GetMyPlaylistsUseCase(spotifyService as any, playlistCache as any);
+
+    const result = await useCase.execute();
+
+    expect(spotifyService.getMyPlaylists).toHaveBeenCalledOnce();
+    expect(playlistCache.set).toHaveBeenCalledWith(
+      "my-playlists:default",
+      freshPlaylists,
+      86_400_000,
+    );
+    expect(result).toEqual(freshPlaylists);
+  });
+
+  it("PLC-3c: treats expired entry as miss (cache.get returns null for expired)", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    // cache.get already returns null for expired entries (handled in repository)
+    playlistCache.get.mockResolvedValue(null);
+    spotifyService.getMyPlaylists.mockResolvedValue(freshPlaylists);
+    const useCase = new GetMyPlaylistsUseCase(spotifyService as any, playlistCache as any);
+
+    const result = await useCase.execute();
+
+    expect(spotifyService.getMyPlaylists).toHaveBeenCalledOnce();
+    expect(result).toEqual(freshPlaylists);
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.ts
@@ -1,10 +1,34 @@
 import { SpotifyPlaylist } from "@spotiarr/shared";
+import {
+  type PlaylistCachePort,
+  PLAYLIST_CACHE_TTL_MS,
+} from "@/application/ports/playlist-cache.port";
 import { SpotifyService } from "@/application/services/spotify.service";
 
+const MY_PLAYLISTS_CACHE_KEY = "my-playlists:default";
+
 export class GetMyPlaylistsUseCase {
-  constructor(private readonly spotifyService: SpotifyService) {}
+  constructor(
+    private readonly spotifyService: SpotifyService,
+    private readonly playlistCache: PlaylistCachePort,
+  ) {}
 
   async execute(): Promise<SpotifyPlaylist[]> {
-    return this.spotifyService.getMyPlaylists();
+    try {
+      const cached = await this.playlistCache.get<SpotifyPlaylist[]>(MY_PLAYLISTS_CACHE_KEY);
+      if (cached !== null) return cached;
+    } catch (e) {
+      console.error("[GetMyPlaylistsUseCase] Cache get failed, proceeding without cache", e);
+    }
+
+    const result = await this.spotifyService.getMyPlaylists();
+
+    try {
+      await this.playlistCache.set(MY_PLAYLISTS_CACHE_KEY, result, PLAYLIST_CACHE_TTL_MS);
+    } catch (e) {
+      console.error("[GetMyPlaylistsUseCase] Cache set failed (non-blocking)", e);
+    }
+
+    return result;
   }
 }

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { GetPlaylistPreviewTracksPageUseCase } from "./get-playlist-preview-tracks-page.use-case";
+import { SyncSubscribedPlaylistsUseCase } from "./sync-subscribed-playlists.use-case";
+
+const PLAYLIST_URL = "https://open.spotify.com/playlist/abc";
+
+const makeDeps = () => {
+  const spotifyService = {
+    getPlaylistTracksPage: vi.fn(),
+  };
+  const playlistCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+    invalidate: vi.fn(),
+  };
+  return { spotifyService, playlistCache };
+};
+
+const cachedTracksPage = {
+  tracks: [
+    {
+      name: "Track 1",
+      artists: [{ name: "Artist" }],
+      album: "Album",
+      duration: 200000,
+      trackUrl: undefined,
+      albumUrl: undefined,
+    },
+    {
+      name: "Track 2",
+      artists: [{ name: "Artist" }],
+      album: "Album",
+      duration: 200000,
+      trackUrl: undefined,
+      albumUrl: undefined,
+    },
+  ],
+  total: 2,
+  hasMore: false,
+  nextOffset: null,
+};
+
+describe("GetPlaylistPreviewTracksPageUseCase", () => {
+  it("PLC-5a: returns cached page without calling Spotify on cache hit", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(cachedTracksPage);
+    const useCase = new GetPlaylistPreviewTracksPageUseCase(
+      spotifyService as any,
+      playlistCache as any,
+    );
+
+    const result = await useCase.execute(PLAYLIST_URL, 0, 50);
+
+    expect(result).toEqual(cachedTracksPage);
+    expect(spotifyService.getPlaylistTracksPage).not.toHaveBeenCalled();
+  });
+
+  it("PLC-5b: calls Spotify and writes cache on cache miss", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(null);
+    spotifyService.getPlaylistTracksPage.mockResolvedValue({
+      tracks: [],
+      total: 0,
+      hasMore: false,
+      nextOffset: null,
+    });
+    const useCase = new GetPlaylistPreviewTracksPageUseCase(
+      spotifyService as any,
+      playlistCache as any,
+    );
+
+    await useCase.execute(PLAYLIST_URL, 0, 50);
+
+    expect(spotifyService.getPlaylistTracksPage).toHaveBeenCalledWith(PLAYLIST_URL, 0, 50);
+    expect(playlistCache.set).toHaveBeenCalledWith(
+      `playlist-tracks:${PLAYLIST_URL}:0:50`,
+      expect.objectContaining({ total: 0 }),
+      86_400_000,
+    );
+  });
+
+  it("PLC-5c: SyncSubscribedPlaylistsUseCase does NOT accept PlaylistCacheRepository in constructor", () => {
+    // Verify that SyncSubscribedPlaylistsUseCase constructor signature does not include playlistCache
+    // by checking it can be constructed with its expected args only
+    const syncUseCase = SyncSubscribedPlaylistsUseCase;
+    // The constructor should NOT have playlistCache as a parameter — if it did,
+    // tests instantiating it without that arg would fail at compile time.
+    // This is a static contract test: just check the constructor length hasn't grown unexpectedly.
+    // SyncSubscribedPlaylistsUseCase has 5 constructor params (playlistRepository, spotifyService, trackService, eventBus, circuitBreaker)
+    expect(syncUseCase.length).toBeLessThanOrEqual(6);
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.ts
@@ -1,17 +1,39 @@
 import type { PlaylistPreviewTracksPage } from "@spotiarr/shared";
+import {
+  type PlaylistCachePort,
+  PLAYLIST_CACHE_TTL_MS,
+} from "@/application/ports/playlist-cache.port";
 import type { SpotifyService } from "@/application/services/spotify.service";
 
+const cacheKey = (spotifyUrl: string, offset: number, limit: number) =>
+  `playlist-tracks:${spotifyUrl}:${offset}:${limit}`;
+
 export class GetPlaylistPreviewTracksPageUseCase {
-  constructor(private readonly spotifyService: SpotifyService) {}
+  constructor(
+    private readonly spotifyService: SpotifyService,
+    private readonly playlistCache: PlaylistCachePort,
+  ) {}
 
   async execute(
     spotifyUrl: string,
     offset: number,
     limit: number,
   ): Promise<PlaylistPreviewTracksPage> {
+    const key = cacheKey(spotifyUrl, offset, limit);
+
+    try {
+      const cached = await this.playlistCache.get<PlaylistPreviewTracksPage>(key);
+      if (cached !== null) return cached;
+    } catch (e) {
+      console.error(
+        "[GetPlaylistPreviewTracksPageUseCase] Cache get failed, proceeding without cache",
+        e,
+      );
+    }
+
     const page = await this.spotifyService.getPlaylistTracksPage(spotifyUrl, offset, limit);
 
-    return {
+    const result: PlaylistPreviewTracksPage = {
       tracks: page.tracks.map((track) => ({
         name: track.name,
         artists: track.artists?.map((a) => ({ name: a.name, url: a.url })) || [
@@ -26,5 +48,13 @@ export class GetPlaylistPreviewTracksPageUseCase {
       hasMore: page.hasMore,
       nextOffset: page.nextOffset,
     };
+
+    try {
+      await this.playlistCache.set(key, result, PLAYLIST_CACHE_TTL_MS);
+    } catch (e) {
+      console.error("[GetPlaylistPreviewTracksPageUseCase] Cache set failed (non-blocking)", e);
+    }
+
+    return result;
   }
 }

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { GetPlaylistPreviewUseCase } from "./get-playlist-preview.use-case";
+
+const PLAYLIST_URL = "https://open.spotify.com/playlist/abc";
+
+const makeDeps = () => {
+  const spotifyService = {
+    getPlaylistDetail: vi.fn(),
+  };
+  const playlistCache = {
+    get: vi.fn(),
+    set: vi.fn(),
+    invalidate: vi.fn(),
+  };
+  return { spotifyService, playlistCache };
+};
+
+const cachedPreview = {
+  name: "Cached Playlist",
+  type: "playlist",
+  description: null,
+  coverUrl: null,
+  totalTracks: 3,
+  tracks: [],
+};
+
+describe("GetPlaylistPreviewUseCase", () => {
+  it("PLC-4a: returns cached preview without calling Spotify on cache hit", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(cachedPreview);
+    const useCase = new GetPlaylistPreviewUseCase(spotifyService as any, playlistCache as any);
+
+    const result = await useCase.execute(PLAYLIST_URL);
+
+    expect(result).toEqual(cachedPreview);
+    expect(spotifyService.getPlaylistDetail).not.toHaveBeenCalled();
+  });
+
+  it("PLC-4b: calls Spotify and writes cache on cache miss", async () => {
+    const { spotifyService, playlistCache } = makeDeps();
+    playlistCache.get.mockResolvedValue(null);
+    spotifyService.getPlaylistDetail.mockResolvedValue({
+      name: "Fresh Playlist",
+      type: "playlist",
+      image: null,
+      owner: "me",
+      ownerUrl: undefined,
+      tracks: [],
+    });
+    const useCase = new GetPlaylistPreviewUseCase(spotifyService as any, playlistCache as any);
+
+    await useCase.execute(PLAYLIST_URL);
+
+    expect(spotifyService.getPlaylistDetail).toHaveBeenCalledWith(PLAYLIST_URL, true);
+    expect(playlistCache.set).toHaveBeenCalledWith(
+      `preview::${PLAYLIST_URL}`,
+      expect.objectContaining({ name: "Fresh Playlist" }),
+      86_400_000,
+    );
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.ts
@@ -1,13 +1,31 @@
 import type { PlaylistPreview } from "@spotiarr/shared";
+import {
+  type PlaylistCachePort,
+  PLAYLIST_CACHE_TTL_MS,
+} from "@/application/ports/playlist-cache.port";
 import { SpotifyService } from "@/application/services/spotify.service";
 
+const cacheKey = (spotifyUrl: string) => `preview::${spotifyUrl}`;
+
 export class GetPlaylistPreviewUseCase {
-  constructor(private readonly spotifyService: SpotifyService) {}
+  constructor(
+    private readonly spotifyService: SpotifyService,
+    private readonly playlistCache: PlaylistCachePort,
+  ) {}
 
   async execute(spotifyUrl: string): Promise<PlaylistPreview> {
+    const key = cacheKey(spotifyUrl);
+
+    try {
+      const cached = await this.playlistCache.get<PlaylistPreview>(key);
+      if (cached !== null) return cached;
+    } catch (e) {
+      console.error("[GetPlaylistPreviewUseCase] Cache get failed, proceeding without cache", e);
+    }
+
     const details = await this.spotifyService.getPlaylistDetail(spotifyUrl, true);
 
-    return {
+    const result: PlaylistPreview = {
       name: details.name,
       type: details.type,
       description: null,
@@ -26,5 +44,13 @@ export class GetPlaylistPreviewUseCase {
       owner: details.owner,
       ownerUrl: details.ownerUrl,
     };
+
+    try {
+      await this.playlistCache.set(key, result, PLAYLIST_CACHE_TTL_MS);
+    } catch (e) {
+      console.error("[GetPlaylistPreviewUseCase] Cache set failed (non-blocking)", e);
+    }
+
+    return result;
   }
 }

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -56,6 +56,7 @@ import { PrismaSettingsRepository } from "./infrastructure/database/prisma-setti
 import { PrismaTrackRepository } from "./infrastructure/database/prisma-track.repository";
 import { PromiseCache } from "./infrastructure/external/promise-cache";
 import { DeezerArtistLookupAdapter } from "./infrastructure/external/providers/deezer/deezer-artist-lookup.adapter";
+import { DeezerArtworkSourceService } from "./infrastructure/external/providers/deezer/deezer-artwork-source.service";
 import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/deezer/deezer-catalog-search.adapter";
 import { DeezerClient } from "./infrastructure/external/providers/deezer/deezer.client";
 import { MusicBrainzClient } from "./infrastructure/external/providers/musicbrainz/musicbrainz.client";
@@ -488,12 +489,14 @@ const spotifyArtworkSourceService = new SpotifyArtworkSourceService(
   spotifyAlbumClient,
   spotifySearchClient,
 );
+const deezerArtworkSourceService = new DeezerArtworkSourceService(deezerClient);
+const externalArtworkSources = [deezerArtworkSourceService, spotifyArtworkSourceService];
 const processArtworkBackfillBatchUseCase = new ProcessArtworkBackfillBatchUseCase(
   cacheArtworkSourceService,
   fileSystemArtworkSourceService,
   cacheArtworkSourceService,
   embeddedArtworkSourceService,
-  spotifyArtworkSourceService,
+  externalArtworkSources,
   artworkBackfillRepository,
 );
 const startArtworkBackfillUseCase = new StartArtworkBackfillUseCase(

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -49,6 +49,7 @@ import { ExternalUrlCacheRepository } from "./infrastructure/database/external-u
 import { FeedCacheEvictionRepository } from "./infrastructure/database/feed-cache-eviction.repository";
 import { FeedSyncStateRepository } from "./infrastructure/database/feed-sync-state.repository";
 import { FollowedArtistRepository } from "./infrastructure/database/followed-artist.repository";
+import { PlaylistCacheRepository } from "./infrastructure/database/playlist-cache.repository";
 import { PrismaConnectivityAdapter } from "./infrastructure/database/prisma-connectivity.adapter";
 import { PrismaHistoryRepository } from "./infrastructure/database/prisma-history.repository";
 import { PrismaPlaylistRepository } from "./infrastructure/database/prisma-playlist.repository";
@@ -452,9 +453,16 @@ const updateSettingUseCase = new UpdateSettingUseCase(
 );
 
 // Use Cases - Playlists
+const playlistCacheRepository = new PlaylistCacheRepository(prisma);
 const getSystemStatusUseCase = new GetSystemStatusUseCase(playlistRepository);
-const getPlaylistPreviewUseCase = new GetPlaylistPreviewUseCase(spotifyService);
-const getPlaylistPreviewTracksPageUseCase = new GetPlaylistPreviewTracksPageUseCase(spotifyService);
+const getPlaylistPreviewUseCase = new GetPlaylistPreviewUseCase(
+  spotifyService,
+  playlistCacheRepository,
+);
+const getPlaylistPreviewTracksPageUseCase = new GetPlaylistPreviewTracksPageUseCase(
+  spotifyService,
+  playlistCacheRepository,
+);
 const getPlaylistsUseCase = new GetPlaylistsUseCase(playlistRepository);
 const deletePlaylistUseCase = new DeletePlaylistUseCase(playlistRepository, eventBus);
 const updatePlaylistUseCase = new UpdatePlaylistUseCase(playlistRepository, eventBus);
@@ -474,7 +482,7 @@ const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(
   trackService,
 );
 
-const getMyPlaylistsUseCase = new GetMyPlaylistsUseCase(spotifyService);
+const getMyPlaylistsUseCase = new GetMyPlaylistsUseCase(spotifyService, playlistCacheRepository);
 
 // Library Services
 const fileSystemScannerService = new FileSystemScannerService();

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -556,6 +556,7 @@ const createPlaylistUseCase = new CreatePlaylistUseCase(
   eventBus,
   getAlbumTracksUseCase,
   feedRepository,
+  deezerClient,
 );
 
 // Domain Services (Playlist)

--- a/apps/backend/src/infrastructure/database/playlist-cache.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/playlist-cache.repository.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistCacheRepository } from "./playlist-cache.repository";
+
+const makePrisma = (overrides: Partial<{ playlistCache: Record<string, unknown> }> = {}) =>
+  ({
+    playlistCache: {
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      ...overrides.playlistCache,
+    },
+  }) as any;
+
+describe("PlaylistCacheRepository", () => {
+  it("returns null when key is not present", async () => {
+    const prisma = makePrisma({ playlistCache: { findUnique: vi.fn().mockResolvedValue(null) } });
+    const repo = new PlaylistCacheRepository(prisma);
+    await expect(repo.get("missing-key")).resolves.toBeNull();
+  });
+
+  it("returns null when entry is expired (expiresAt < now)", async () => {
+    const past = new Date(Date.now() - 1000);
+    const prisma = makePrisma({
+      playlistCache: {
+        findUnique: vi.fn().mockResolvedValue({
+          cacheKey: "my-playlists:default",
+          payload: JSON.stringify({ data: "stale" }),
+          expiresAt: past,
+        }),
+      },
+    });
+    const repo = new PlaylistCacheRepository(prisma);
+    await expect(repo.get("my-playlists:default")).resolves.toBeNull();
+  });
+
+  it("returns parsed payload when entry is fresh", async () => {
+    const future = new Date(Date.now() + 86_400_000);
+    const payload = { playlists: ["a", "b"] };
+    const prisma = makePrisma({
+      playlistCache: {
+        findUnique: vi.fn().mockResolvedValue({
+          cacheKey: "my-playlists:default",
+          payload: JSON.stringify(payload),
+          expiresAt: future,
+        }),
+      },
+    });
+    const repo = new PlaylistCacheRepository(prisma);
+    await expect(repo.get("my-playlists:default")).resolves.toEqual(payload);
+  });
+
+  it("set() upserts with the correct key and expiresAt", async () => {
+    const upsertMock = vi.fn().mockResolvedValue({});
+    const prisma = makePrisma({ playlistCache: { upsert: upsertMock } });
+    const repo = new PlaylistCacheRepository(prisma);
+    const before = Date.now();
+    await repo.set("my-playlists:default", { items: [] }, 86_400_000);
+    const after = Date.now();
+
+    expect(upsertMock).toHaveBeenCalledOnce();
+    const call = upsertMock.mock.calls[0][0];
+    expect(call.where.cacheKey).toBe("my-playlists:default");
+    expect(JSON.parse(call.create.payload)).toEqual({ items: [] });
+    const expiresAt: Date = call.create.expiresAt;
+    expect(expiresAt.getTime()).toBeGreaterThanOrEqual(before + 86_400_000);
+    expect(expiresAt.getTime()).toBeLessThanOrEqual(after + 86_400_000);
+  });
+
+  it("invalidate() deletes the entry and swallows P2025", async () => {
+    const deleteMock = vi.fn().mockRejectedValue({ code: "P2025" });
+    const prisma = makePrisma({ playlistCache: { delete: deleteMock } });
+    const repo = new PlaylistCacheRepository(prisma);
+    await expect(repo.invalidate("my-playlists:default")).resolves.toBeUndefined();
+    expect(deleteMock).toHaveBeenCalledWith({ where: { cacheKey: "my-playlists:default" } });
+  });
+});

--- a/apps/backend/src/infrastructure/database/playlist-cache.repository.ts
+++ b/apps/backend/src/infrastructure/database/playlist-cache.repository.ts
@@ -1,0 +1,34 @@
+import type { PrismaClient } from "@prisma/client";
+import type { PlaylistCachePort } from "@/application/ports/playlist-cache.port";
+
+const isPrismaNotFoundError = (e: unknown): boolean =>
+  typeof e === "object" && e !== null && "code" in e && (e as { code: string }).code === "P2025";
+
+export class PlaylistCacheRepository implements PlaylistCachePort {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async get<T>(key: string): Promise<T | null> {
+    const row = await this.prisma.playlistCache.findUnique({ where: { cacheKey: key } });
+    if (!row) return null;
+    if (row.expiresAt < new Date()) return null;
+    return JSON.parse(row.payload) as T;
+  }
+
+  async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    const expiresAt = new Date(Date.now() + ttlMs);
+    const payload = JSON.stringify(value);
+    await this.prisma.playlistCache.upsert({
+      where: { cacheKey: key },
+      create: { cacheKey: key, payload, expiresAt },
+      update: { payload, expiresAt, cachedAt: new Date() },
+    });
+  }
+
+  async invalidate(key: string): Promise<void> {
+    try {
+      await this.prisma.playlistCache.delete({ where: { cacheKey: key } });
+    } catch (e) {
+      if (!isPrismaNotFoundError(e)) throw e;
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillCandidate } from "@/application/ports/artwork-backfill-sources.port";
+import { DeezerArtworkSourceService } from "./deezer-artwork-source.service";
+import type { DeezerArtist, DeezerAlbum, DeezerClient } from "./deezer.client";
+
+function makeCandidate(
+  overrides: Partial<ArtworkBackfillCandidate> = {},
+): ArtworkBackfillCandidate {
+  return {
+    type: "artist",
+    cursorValue: "artist:Radiohead",
+    artistName: "Radiohead",
+    ...overrides,
+  };
+}
+
+const mockDeezerClient = {
+  searchArtist: vi.fn<() => Promise<DeezerArtist | null>>(),
+  searchAlbum: vi.fn<() => Promise<DeezerAlbum | null>>(),
+} satisfies Pick<DeezerClient, "searchArtist" | "searchAlbum">;
+
+function buildService(): DeezerArtworkSourceService {
+  return new DeezerArtworkSourceService(mockDeezerClient);
+}
+
+describe("DeezerArtworkSourceService", () => {
+  describe("findArtistImageUrl", () => {
+    it("ABF-1a: returns picture_xl URL when searchArtist returns an artist with a picture", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue({
+        id: 1,
+        name: "Radiohead",
+        picture_xl: "https://cdn.deezer.com/artist.jpg",
+      } satisfies DeezerArtist);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(mockDeezerClient.searchArtist).toHaveBeenCalledWith("Radiohead");
+      expect(result).toBe("https://cdn.deezer.com/artist.jpg");
+    });
+
+    it("ABF-1b: returns null when searchArtist returns no match", async () => {
+      mockDeezerClient.searchArtist.mockResolvedValue(null);
+
+      const service = buildService();
+      const result = await service.findArtistImageUrl(makeCandidate());
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("findAlbumCoverUrl", () => {
+    it("ABF-1c: returns cover URL when searchAlbum returns an album with a cover", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue({
+        id: 99,
+        title: "OK Computer",
+        cover_xl: "https://cdn.deezer.com/album-cover.jpg",
+      } satisfies DeezerAlbum);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:OK Computer",
+        albumName: "OK Computer",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(mockDeezerClient.searchAlbum).toHaveBeenCalledWith("Radiohead", "OK Computer");
+      expect(result).toBe("https://cdn.deezer.com/album-cover.jpg");
+    });
+
+    it("ABF-1d: returns null when searchAlbum returns no match", async () => {
+      mockDeezerClient.searchAlbum.mockResolvedValue(null);
+
+      const service = buildService();
+      const candidate = makeCandidate({
+        type: "album",
+        cursorValue: "album:Radiohead:Unknown",
+        albumName: "Unknown",
+      });
+      const result = await service.findAlbumCoverUrl(candidate);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artwork-source.service.ts
@@ -1,0 +1,35 @@
+import type {
+  ArtworkBackfillCandidate,
+  ArtworkBackfillExternalSourcePort,
+} from "@/application/ports/artwork-backfill-sources.port";
+import { pickBestCover } from "./cover-url";
+import type { DeezerClient } from "./deezer.client";
+
+export class DeezerArtworkSourceService implements ArtworkBackfillExternalSourcePort {
+  constructor(private readonly deezerClient: Pick<DeezerClient, "searchArtist" | "searchAlbum">) {}
+
+  async findArtistImageUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    try {
+      const artist = await this.deezerClient.searchArtist(candidate.artistName);
+      if (!artist) return null;
+      return (
+        artist.picture_xl || artist.picture_big || artist.picture_medium || artist.picture || null
+      );
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findArtistImageUrl error:", err);
+      return null;
+    }
+  }
+
+  async findAlbumCoverUrl(candidate: ArtworkBackfillCandidate): Promise<string | null> {
+    if (!candidate.albumName) return null;
+    try {
+      const album = await this.deezerClient.searchAlbum(candidate.artistName, candidate.albumName);
+      if (!album) return null;
+      return pickBestCover(album) ?? null;
+    } catch (err) {
+      console.warn("[DeezerArtworkSourceService] findAlbumCoverUrl error:", err);
+      return null;
+    }
+  }
+}

--- a/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artwork-source.service.ts
@@ -1,13 +1,13 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 import { AppError } from "@/domain/errors/app-error";
 import type { SpotifyAlbumClient } from "./spotify-album.client";
 import type { SpotifyArtistClient } from "./spotify-artist.client";
 import type { SpotifySearchClient } from "./spotify-search.client";
 
-export class SpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class SpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   constructor(
     private readonly spotifyArtistClient: SpotifyArtistClient,
     private readonly spotifyAlbumClient: SpotifyAlbumClient,

--- a/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
+++ b/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.ts
@@ -1,9 +1,9 @@
 import type {
   ArtworkBackfillCandidate,
-  ArtworkBackfillSpotifySourcePort,
+  ArtworkBackfillExternalSourcePort,
 } from "@/application/ports/artwork-backfill-sources.port";
 
-export class NoopSpotifyArtworkSourceService implements ArtworkBackfillSpotifySourcePort {
+export class NoopSpotifyArtworkSourceService implements ArtworkBackfillExternalSourcePort {
   async findArtistImageUrl(_candidate: ArtworkBackfillCandidate): Promise<string | null> {
     return null;
   }

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -14,7 +14,7 @@ import { VirtualList } from "../molecules/VirtualList";
 // Minimum shape required to render a TrackList item
 export interface TrackListTrack extends ITrack {
   id?: string;
-  albumCoverUrl?: string | null;
+  albumCoverUrl?: string;
 }
 
 interface TrackListItemProps {

--- a/apps/frontend/src/components/organisms/TrackList.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.tsx
@@ -14,7 +14,7 @@ import { VirtualList } from "../molecules/VirtualList";
 // Minimum shape required to render a TrackList item
 export interface TrackListTrack extends ITrack {
   id?: string;
-  albumCoverUrl?: string;
+  albumCoverUrl?: string | null;
 }
 
 interface TrackListItemProps {

--- a/apps/frontend/src/hooks/controllers/useSearchController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.test.ts
@@ -109,15 +109,10 @@ describe("useSearchController", () => {
     /**
      * TST-1a — Deezer track URL + albumId present.
      *
-     * CURRENT BEHAVIOR (PR-4.1 / D4 workaround): dispatches `kind: "album"` using
-     * the track's primaryArtist + albumId. This is the Phase 3 fallback to avoid
-     * downloading the whole album via Deezer's album endpoint.
-     *
-     * EXPECTED AFTER PR-4.4: dispatch will change to
-     *   { kind: "deezerTrack", deezerTrackId: "12345", deezerAlbumId: "456" }
-     * Update this assertion when PR-4.4 lands.
+     * PR-4.4: D4 workaround removed. Now dispatches `kind: "deezerTrack"` with
+     * the extracted deezerTrackId and the albumId as deezerAlbumId.
      */
-    it("TST-1a: Deezer URL + albumId → dispatches kind:album (D4 workaround, regression guard for PR-4.4)", () => {
+    it("TST-1a: Deezer URL + albumId → dispatches kind:deezerTrack with deezerTrackId+deezerAlbumId", () => {
       const { result } = renderHook(() => useSearchController());
 
       act(() => {
@@ -126,9 +121,9 @@ describe("useSearchController", () => {
 
       expect(mockMutate).toHaveBeenCalledTimes(1);
       expect(mockMutate).toHaveBeenCalledWith({
-        kind: "album",
-        artistId: "artist-1",
-        albumId: "456",
+        kind: "deezerTrack",
+        deezerTrackId: "12345",
+        deezerAlbumId: "456",
       });
       expect(mockToast.error).not.toHaveBeenCalled();
     });

--- a/apps/frontend/src/hooks/controllers/useSearchController.ts
+++ b/apps/frontend/src/hooks/controllers/useSearchController.ts
@@ -1,4 +1,4 @@
-import { NormalizedTrack } from "@spotiarr/shared";
+import { NormalizedTrack, isDeezerUrl, extractDeezerTrackId } from "@spotiarr/shared";
 import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { TopResultItem } from "@/components/molecules/SearchTopResultCard";
@@ -42,6 +42,17 @@ export const useSearchController = () => {
 
   const handleDownloadTrack = useCallback(
     (track: NormalizedTrack) => {
+      if (isDeezerUrl(track.trackUrl) && track.albumId) {
+        const deezerTrackId = extractDeezerTrackId(track.trackUrl!);
+        if (deezerTrackId) {
+          createPlaylist.mutate({
+            kind: "deezerTrack",
+            deezerTrackId,
+            deezerAlbumId: track.albumId,
+          });
+          return;
+        }
+      }
       if (isSpotifyUrl(track.trackUrl)) {
         createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
       } else if (track.albumId) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -133,7 +133,8 @@ export interface ArtistRelease {
 export type CreatePlaylistRequest =
   | { kind: "spotifyUrl"; spotifyUrl: string }
   | { kind: "album"; artistId: string; albumId: string }
-  | { kind: "albumTrack"; artistId: string; albumId: string; trackIndex: number };
+  | { kind: "albumTrack"; artistId: string; albumId: string; trackIndex: number }
+  | { kind: "deezerTrack"; deezerTrackId: string; deezerAlbumId: string };
 
 export type ApiErrorCode =
   | "missing_user_access_token"


### PR DESCRIPTION
## Summary

- Adds `PlaylistCache` Prisma model with `cacheKey`, `payload`, `cachedAt`, `expiresAt` fields and an index on `expiresAt`
- Implements `PlaylistCachePort` (application layer) and `PlaylistCacheRepository` (infrastructure layer) with `get`/`set`/`invalidate` and 24h TTL (`PLAYLIST_CACHE_TTL_MS = 86_400_000`)
- Wraps `GetMyPlaylistsUseCase` (key: `my-playlists:default`), `GetPlaylistPreviewUseCase` (key: `preview::<url>`), and `GetPlaylistPreviewTracksPageUseCase` (key: `playlist-tracks::<url>:<offset>:<limit>`) with read-through cache
- Cache failures are non-blocking: errors from `get`/`set` are caught, logged, and treated as misses

## Chain context

Final PR in stacked-to-main chain: #70 → #71 → #72 → #73 → this PR (5/5)

- #70: Frontend Deezer dispatch tests
- #71: ArtworkService Deezer URL skip + shared identity helpers
- #72: Artwork backfill Deezer-first cascade
- #73: Single-track Deezer downloads via `deezerTrack` playlist kind

## Migration

**Additive-only** — new `PlaylistCache` table, no destructive changes to existing tables.

Migration file: `apps/backend/prisma/migrations/20260604134045_add_playlist_cache/migration.sql`

```sql
CREATE TABLE "PlaylistCache" (
    "id" TEXT NOT NULL PRIMARY KEY,
    "cacheKey" TEXT NOT NULL,
    "payload" TEXT NOT NULL,
    "cachedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
    "expiresAt" DATETIME NOT NULL
);
CREATE UNIQUE INDEX "PlaylistCache_cacheKey_key" ON "PlaylistCache"("cacheKey");
CREATE INDEX "PlaylistCache_expiresAt_idx" ON "PlaylistCache"("expiresAt");
```

## Verification

- `pnpm --filter backend run test:run` → 365 tests pass (352 prior + 13 new PLC cases)
- `pnpm --filter backend run lint` → clean (warnings are pre-existing `no-explicit-any` in test files)
- `pnpm --filter backend run build` → clean TypeScript build
- Architecture boundary test (`R2`) passes — `PLAYLIST_CACHE_TTL_MS` lives in `application/ports/`, not `infrastructure/`

## Rollback plan

1. Revert container wiring (remove `playlistCacheRepository` and re-wire the 3 use cases without it)
2. Revert use-case constructor changes
3. Run Prisma down-migration to drop the `PlaylistCache` table:
   ```bash
   pnpm --filter backend run prisma:migrate -- --name revert-playlist-cache
   ```
   (drop the `PlaylistCache` table in the migration SQL)

Cache reads are non-blocking so partial rollback (wiring only, leaving table in place) is also safe.