### PR TITLE
feat(frontend): playlists section + search bar in Home

### DIFF
--- a/apps/frontend/src/components/molecules/HomePlaylistCard.test.tsx
+++ b/apps/frontend/src/components/molecules/HomePlaylistCard.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistWithStats } from "@/types";
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { HomePlaylistCard } from "./HomePlaylistCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const makePlaylist = (overrides: Partial<PlaylistWithStats> = {}): PlaylistWithStats => ({
+  id: "playlist-1",
+  name: "Test Playlist",
+  owner: "John Doe",
+  coverUrl: "https://example.com/cover.jpg",
+  tracks: [
+    {
+      id: "t1",
+      name: "Track 1",
+      artist: "Artist 1",
+      status: TrackStatusEnum.Completed,
+      playlistId: "playlist-1",
+    },
+  ],
+  stats: {
+    completedCount: 1,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 0,
+    activeCount: 0,
+    errorCount: 0,
+    totalCount: 100,
+    progress: 1,
+    isDownloading: false,
+    hasErrors: false,
+    isCompleted: false,
+  },
+  ...overrides,
+});
+
+describe("HomePlaylistCard", () => {
+  it("renders the playlist name", () => {
+    const playlist = makePlaylist({ name: "Road Trip Vibes" });
+    render(
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={5}
+        totalCount={50}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Road Trip Vibes")).not.toBeNull();
+  });
+
+  it("renders the owner", () => {
+    const playlist = makePlaylist({ owner: "Jane Smith" });
+    render(
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={5}
+        totalCount={50}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Jane Smith/)).not.toBeNull();
+  });
+
+  it("renders downloaded/total count badge", () => {
+    const playlist = makePlaylist();
+    render(
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={12}
+        totalCount={187}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("12/187")).not.toBeNull();
+  });
+
+  it("renders cover image when coverUrl is provided", () => {
+    const playlist = makePlaylist({ coverUrl: "https://example.com/img.jpg" });
+    render(
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={1}
+        totalCount={10}
+        onClick={vi.fn()}
+      />,
+    );
+    const img = document.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("https://example.com/img.jpg");
+  });
+
+  it("fires onClick with the playlist id when clicked", () => {
+    const onClick = vi.fn();
+    const playlist = makePlaylist({ id: "my-id" });
+    render(
+      <HomePlaylistCard playlist={playlist} downloadedCount={1} totalCount={10} onClick={onClick} />,
+    );
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledWith("my-id");
+  });
+});

--- a/apps/frontend/src/components/molecules/HomePlaylistCard.tsx
+++ b/apps/frontend/src/components/molecules/HomePlaylistCard.tsx
@@ -1,0 +1,60 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { FC, memo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { PlaylistWithStats } from "@/types";
+import { Image } from "../atoms/Image";
+
+interface HomePlaylistCardProps {
+  playlist: PlaylistWithStats;
+  downloadedCount: number;
+  totalCount: number;
+  onClick: (id: string) => void;
+}
+
+export const HomePlaylistCard: FC<HomePlaylistCardProps> = memo(
+  ({ playlist, downloadedCount, totalCount, onClick }) => {
+    const { t } = useTranslation();
+
+    const handleClick = useCallback(() => {
+      onClick(playlist.id);
+    }, [onClick, playlist.id]);
+
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-label={t("library.playlistCardAriaLabel", {
+          name: playlist.name ?? "",
+          downloaded: downloadedCount,
+          total: totalCount,
+        })}
+        className="bg-background-elevated hover:bg-background-hover focus-visible:ring-primary group w-full cursor-pointer rounded-md p-4 text-left transition-all focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <div className="bg-background-hover relative mb-4 aspect-square overflow-hidden rounded-md shadow-lg">
+          <Image
+            src={playlist.coverUrl ?? undefined}
+            alt={playlist.name ?? ""}
+            loading="lazy"
+            fallbackIcon={faMusic}
+            className="group-hover:scale-105"
+          />
+        </div>
+
+        <h3
+          className="text-text-primary mb-1 truncate text-base font-semibold"
+          title={playlist.name ?? ""}
+        >
+          {playlist.name ?? t("common.cards.unnamedPlaylist", "Unnamed Playlist")}
+        </h3>
+        <p className="text-text-secondary truncate text-sm">
+          {t("common.by", "By")} {playlist.owner ?? ""}
+        </p>
+        <span className="bg-background-hover text-text-secondary mt-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
+          {downloadedCount}/{totalCount}
+        </span>
+      </button>
+    );
+  },
+);
+
+HomePlaylistCard.displayName = "HomePlaylistCard";

--- a/apps/frontend/src/components/organisms/HomePlaylistList.test.tsx
+++ b/apps/frontend/src/components/organisms/HomePlaylistList.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { PlaylistWithStats } from "@/types";
+import { HomePlaylistList } from "./HomePlaylistList";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+// HomePlaylistList uses a simple grid, not VirtualGrid, so we don't need to mock Virtuoso
+const makeItem = (id: string, name: string): { playlist: PlaylistWithStats; downloadedCount: number; totalCount: number } => ({
+  playlist: {
+    id,
+    name,
+    owner: "test-owner",
+    coverUrl: undefined,
+    tracks: [
+      {
+        id: `${id}-t1`,
+        name: "Track 1",
+        artist: "Artist",
+        status: TrackStatusEnum.Completed,
+        playlistId: id,
+      },
+    ],
+    stats: {
+      completedCount: 1,
+      downloadingCount: 0,
+      searchingCount: 0,
+      queuedCount: 0,
+      activeCount: 0,
+      errorCount: 0,
+      totalCount: 10,
+      progress: 10,
+      isDownloading: false,
+      hasErrors: false,
+      isCompleted: false,
+    },
+  },
+  downloadedCount: 1,
+  totalCount: 10,
+});
+
+describe("HomePlaylistList", () => {
+  it("renders one card per item in the list", () => {
+    const items = [makeItem("p1", "Playlist One"), makeItem("p2", "Playlist Two")];
+    render(<HomePlaylistList items={items} onPlaylistClick={vi.fn()} />);
+
+    expect(screen.getByText("Playlist One")).not.toBeNull();
+    expect(screen.getByText("Playlist Two")).not.toBeNull();
+  });
+
+  it("calls onPlaylistClick with the correct id when a card is clicked", () => {
+    const onClick = vi.fn();
+    const items = [makeItem("p1", "Clickable Playlist")];
+    render(<HomePlaylistList items={items} onPlaylistClick={onClick} />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledWith("p1");
+  });
+
+  it("renders nothing when items list is empty", () => {
+    const { container } = render(<HomePlaylistList items={[]} onPlaylistClick={vi.fn()} />);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+});

--- a/apps/frontend/src/components/organisms/HomePlaylistList.tsx
+++ b/apps/frontend/src/components/organisms/HomePlaylistList.tsx
@@ -1,0 +1,41 @@
+import { FC, memo, useCallback } from "react";
+import { HomePlaylistCard } from "../molecules/HomePlaylistCard";
+import { PlaylistWithStats } from "@/types";
+
+interface HomePlaylistListItem {
+  playlist: PlaylistWithStats;
+  downloadedCount: number;
+  totalCount: number;
+}
+
+interface HomePlaylistListProps {
+  items: HomePlaylistListItem[];
+  onPlaylistClick: (id: string) => void;
+}
+
+export const HomePlaylistList: FC<HomePlaylistListProps> = memo(({ items, onPlaylistClick }) => {
+  const handleClick = useCallback(
+    (id: string) => {
+      onPlaylistClick(id);
+    },
+    [onPlaylistClick],
+  );
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+      {items.map(({ playlist, downloadedCount, totalCount }) => (
+        <HomePlaylistCard
+          key={playlist.id}
+          playlist={playlist}
+          downloadedCount={downloadedCount}
+          totalCount={totalCount}
+          onClick={handleClick}
+        />
+      ))}
+    </div>
+  );
+});
+
+HomePlaylistList.displayName = "HomePlaylistList";

--- a/apps/frontend/src/hooks/controllers/useHomeController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useHomeController.test.tsx
@@ -1,6 +1,8 @@
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError } from "@/services/httpClient";
+import { PlaylistWithStats } from "@/types";
 import { useHomeController } from "./useHomeController";
 
 const mockNavigate = vi.fn();
@@ -11,6 +13,46 @@ const mockToast = {
   warning: vi.fn(),
   error: vi.fn(),
 };
+
+const makePlaylist = (overrides: Partial<PlaylistWithStats> = {}): PlaylistWithStats => ({
+  id: "playlist-1",
+  name: "My Playlist",
+  type: PlaylistTypeEnum.Playlist,
+  owner: "test-user",
+  coverUrl: "https://example.com/cover.jpg",
+  tracks: [
+    {
+      id: "track-1",
+      name: "Track 1",
+      artist: "Artist 1",
+      status: TrackStatusEnum.Completed,
+      playlistId: "playlist-1",
+    },
+    {
+      id: "track-2",
+      name: "Track 2",
+      artist: "Artist 2",
+      status: TrackStatusEnum.Queued,
+      playlistId: "playlist-1",
+    },
+  ],
+  stats: {
+    completedCount: 1,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 1,
+    activeCount: 1,
+    errorCount: 0,
+    totalCount: 2,
+    progress: 50,
+    isDownloading: true,
+    hasErrors: false,
+    isCompleted: false,
+  },
+  ...overrides,
+});
+
+let mockPlaylistsData: PlaylistWithStats[] = [];
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -33,6 +75,10 @@ vi.mock("../queries/useLibraryStatsQuery", () => ({
 
 vi.mock("../queries/useLibraryArtistsQuery", () => ({
   useLibraryArtistsQuery: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("../queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: () => ({ data: mockPlaylistsData }),
 }));
 
 vi.mock("../queries/useArtworkBackfillStatusQuery", () => ({
@@ -58,6 +104,7 @@ vi.mock("../mutations/useStartArtworkBackfillMutation", () => ({
 describe("useHomeController", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPlaylistsData = [];
   });
 
   it("starts scan first and then starts artwork backfill", async () => {
@@ -206,5 +253,176 @@ describe("useHomeController", () => {
 
     expect(mockToast.success).toHaveBeenLastCalledWith("Artwork backfill is already running.");
     expect(result.current.isScanModalOpen).toBe(false);
+  });
+
+  describe("playlists with downloads", () => {
+    it("returns downloadedPlaylists with only playlists that have at least one completed track", () => {
+      const playlistWithDownloads = makePlaylist({ id: "p1", name: "Has Downloads" });
+      const playlistWithoutDownloads = makePlaylist({
+        id: "p2",
+        name: "No Downloads",
+        tracks: [
+          {
+            id: "track-x",
+            name: "Track X",
+            artist: "Artist X",
+            status: TrackStatusEnum.Queued,
+            playlistId: "p2",
+          },
+        ],
+        stats: {
+          completedCount: 0,
+          downloadingCount: 0,
+          searchingCount: 0,
+          queuedCount: 1,
+          activeCount: 1,
+          errorCount: 0,
+          totalCount: 1,
+          progress: 0,
+          isDownloading: true,
+          hasErrors: false,
+          isCompleted: false,
+        },
+      });
+
+      mockPlaylistsData = [playlistWithDownloads, playlistWithoutDownloads];
+
+      const { result } = renderHook(() => useHomeController());
+
+      expect(result.current.downloadedPlaylists).toHaveLength(1);
+      expect(result.current.downloadedPlaylists[0].playlist.id).toBe("p1");
+    });
+
+    it("excludes album/track/artist synthetic playlists from downloadedPlaylists", () => {
+      const realPlaylist = makePlaylist({ id: "real", name: "Real Playlist" });
+      const albumPlaylist = makePlaylist({
+        id: "album-1",
+        name: "Quevedo - BUENAS NOCHES",
+        type: PlaylistTypeEnum.Album,
+      });
+      const trackPlaylist = makePlaylist({
+        id: "track-1",
+        name: "Single Track",
+        type: PlaylistTypeEnum.Track,
+      });
+      const artistPlaylist = makePlaylist({
+        id: "artist-1",
+        name: "Some Artist",
+        type: PlaylistTypeEnum.Artist,
+      });
+
+      mockPlaylistsData = [realPlaylist, albumPlaylist, trackPlaylist, artistPlaylist];
+
+      const { result } = renderHook(() => useHomeController());
+
+      expect(result.current.downloadedPlaylists).toHaveLength(1);
+      expect(result.current.downloadedPlaylists[0].playlist.id).toBe("real");
+    });
+
+    it("returns correct downloadedCount and totalCount per playlist", () => {
+      const playlist = makePlaylist({
+        id: "p1",
+        tracks: [
+          {
+            id: "t1",
+            name: "T1",
+            artist: "A",
+            status: TrackStatusEnum.Completed,
+            playlistId: "p1",
+          },
+          {
+            id: "t2",
+            name: "T2",
+            artist: "A",
+            status: TrackStatusEnum.Completed,
+            playlistId: "p1",
+          },
+          {
+            id: "t3",
+            name: "T3",
+            artist: "A",
+            status: TrackStatusEnum.Queued,
+            playlistId: "p1",
+          },
+        ],
+        stats: {
+          completedCount: 2,
+          downloadingCount: 0,
+          searchingCount: 0,
+          queuedCount: 1,
+          activeCount: 1,
+          errorCount: 0,
+          totalCount: 3,
+          progress: 67,
+          isDownloading: true,
+          hasErrors: false,
+          isCompleted: false,
+        },
+      });
+      mockPlaylistsData = [playlist];
+
+      const { result } = renderHook(() => useHomeController());
+
+      expect(result.current.downloadedPlaylists[0].downloadedCount).toBe(2);
+      expect(result.current.downloadedPlaylists[0].totalCount).toBe(3);
+    });
+
+    it("filters playlists by search term (case-insensitive)", async () => {
+      vi.useFakeTimers();
+      const p1 = makePlaylist({ id: "p1", name: "Rock Anthems" });
+      const p2 = makePlaylist({ id: "p2", name: "Jazz Classics" });
+      mockPlaylistsData = [p1, p2];
+
+      const { result } = renderHook(() => useHomeController());
+
+      act(() => {
+        result.current.handleSearchChange("rock");
+      });
+      await act(async () => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.filteredPlaylists).toHaveLength(1);
+      expect(result.current.filteredPlaylists[0].playlist.name).toBe("Rock Anthems");
+      vi.useRealTimers();
+    });
+
+    it("filters artists by search term", async () => {
+      vi.useFakeTimers();
+      const { result } = renderHook(() => useHomeController());
+
+      act(() => {
+        result.current.handleSearchChange("anything");
+      });
+      await act(async () => {
+        vi.runAllTimers();
+      });
+
+      expect(result.current.filteredArtists).toHaveLength(0);
+      vi.useRealTimers();
+    });
+
+    it("returns search state and handleSearchChange", () => {
+      const { result } = renderHook(() => useHomeController());
+
+      expect(result.current.search).toBe("");
+      act(() => {
+        result.current.handleSearchChange("hello");
+      });
+      expect(result.current.search).toBe("hello");
+    });
+
+    it("navigates to playlist detail on handlePlaylistClick", () => {
+      const playlist = makePlaylist({ id: "playlist-nav" });
+      mockPlaylistsData = [playlist];
+
+      const { result } = renderHook(() => useHomeController());
+
+      act(() => {
+        result.current.handlePlaylistClick("playlist-nav");
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith("/playlist/playlist-nav");
+    });
   });
 });

--- a/apps/frontend/src/hooks/controllers/useHomeController.ts
+++ b/apps/frontend/src/hooks/controllers/useHomeController.ts
@@ -1,15 +1,19 @@
-import { ArtworkBackfillRunStatus, LibraryArtist } from "@spotiarr/shared";
+import { ArtworkBackfillRunStatus, LibraryArtist, PlaylistTypeEnum } from "@spotiarr/shared";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useToast } from "@/contexts/ToastContext";
 import { Path } from "@/routes/routes";
 import { ApiError } from "@/services/httpClient";
+import { PlaylistWithStats } from "@/types";
 import { useScanLibraryMutation } from "../mutations/useScanLibraryMutation";
 import { useStartArtworkBackfillMutation } from "../mutations/useStartArtworkBackfillMutation";
 import { useArtworkBackfillStatusQuery } from "../queries/useArtworkBackfillStatusQuery";
 import { useLibraryArtistsQuery } from "../queries/useLibraryArtistsQuery";
 import { useLibraryStatsQuery } from "../queries/useLibraryStatsQuery";
+import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
+import { useDebounce } from "../useDebounce";
+import { APP_CONFIG } from "@/config/app";
 
 const ACTIVE_BACKFILL_STATUSES = new Set<ArtworkBackfillRunStatus>([
   "running",
@@ -24,9 +28,12 @@ export const useHomeController = () => {
   const toast = useToast();
   const [isScanModalOpen, setIsScanModalOpen] = useState(false);
   const [isRetryBackfillOnly, setIsRetryBackfillOnly] = useState(false);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, APP_CONFIG.DEBOUNCE.SEARCH_DELAY);
   const { data: stats, isLoading: isStatsLoading } = useLibraryStatsQuery();
   const { data: artists, isLoading: isArtistsLoading } = useLibraryArtistsQuery();
   const { data: artworkBackfillStatus } = useArtworkBackfillStatusQuery();
+  const { data: playlists = [] } = usePlaylistsQuery();
   const { mutateAsync: scanLibrary, isPending: isScanning } = useScanLibraryMutation();
   const { mutateAsync: startArtworkBackfill, isPending: isStartingArtworkBackfill } =
     useStartArtworkBackfillMutation();
@@ -111,11 +118,22 @@ export const useHomeController = () => {
     [handleBackfillStartError, isRetryBackfillOnly, scanLibrary, startArtworkBackfill, t, toast],
   );
 
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value);
+  }, []);
+
   const handleArtistClick = useCallback(
     (artist: LibraryArtist) => {
       if (artist.name) {
         navigate(Path.LIBRARY_ARTIST.replace(":name", encodeURIComponent(artist.name)));
       }
+    },
+    [navigate],
+  );
+
+  const handlePlaylistClick = useCallback(
+    (id: string) => {
+      navigate(Path.PLAYLIST_DETAIL.replace(":id", id));
     },
     [navigate],
   );
@@ -141,6 +159,35 @@ export const useHomeController = () => {
     return [...artists].sort((a, b) => a.name.localeCompare(b.name));
   }, [artists]);
 
+  // Playlists that have at least one completed track, enriched with counts
+  const downloadedPlaylists = useMemo(() => {
+    return playlists
+      .filter(
+        (p: PlaylistWithStats) =>
+          p.type === PlaylistTypeEnum.Playlist && p.stats.completedCount > 0,
+      )
+      .map((p: PlaylistWithStats) => ({
+        playlist: p,
+        downloadedCount: p.stats.completedCount,
+        totalCount: p.stats.totalCount,
+      }));
+  }, [playlists]);
+
+  // Filtered by debounced search
+  const filteredPlaylists = useMemo(() => {
+    if (!debouncedSearch) return downloadedPlaylists;
+    const lower = debouncedSearch.toLowerCase();
+    return downloadedPlaylists.filter((item) =>
+      (item.playlist.name ?? "").toLowerCase().includes(lower),
+    );
+  }, [downloadedPlaylists, debouncedSearch]);
+
+  const filteredArtists = useMemo(() => {
+    if (!debouncedSearch) return sortedArtists;
+    const lower = debouncedSearch.toLowerCase();
+    return sortedArtists.filter((a) => a.name.toLowerCase().includes(lower));
+  }, [sortedArtists, debouncedSearch]);
+
   return {
     t,
     stats: statsData,
@@ -154,6 +201,12 @@ export const useHomeController = () => {
     handleCloseScanModal,
     handleConfirmScan,
     handleArtistClick,
+    handlePlaylistClick,
+    handleSearchChange,
     formatSize,
+    search,
+    downloadedPlaylists,
+    filteredPlaylists,
+    filteredArtists,
   };
 };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -122,10 +122,13 @@
     "emptyTitle": "Library is empty",
     "emptyDescription": "Scan or rescan your downloads folder to populate your library and artwork.",
     "scanNow": "Scan Now",
+    "searchPlaceholder": "Search playlists and artists...",
+    "playlistsSection": "Playlists",
     "artistNotFound": "Artist not found",
     "artistNotFoundDescription": "Could not load artist details.",
     "artistCardAriaLabel": "Artist {{name}}, {{albums}} albums, {{tracks}} tracks",
     "albumCardAriaLabel": "Album {{name}} by {{artist}}, {{year}}, {{tracks}} tracks",
+    "playlistCardAriaLabel": "Playlist {{name}}, {{downloaded}} of {{total}} downloaded",
     "album": {
       "notFound": "Album not found",
       "notFoundDescription": "Could not find this album in your library.",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -122,10 +122,13 @@
     "emptyTitle": "La biblioteca está vacía",
     "emptyDescription": "Escanea o vuelve a escanear tu carpeta de descargas para rellenar tu biblioteca y las carátulas.",
     "scanNow": "Escanear Ahora",
+    "searchPlaceholder": "Buscar listas y artistas...",
+    "playlistsSection": "Listas",
     "artistNotFound": "Artista no encontrado",
     "artistNotFoundDescription": "No se pudieron cargar los detalles del artista.",
     "artistCardAriaLabel": "Artista {{name}}, {{albums}} álbumes, {{tracks}} canciones",
     "albumCardAriaLabel": "Álbum {{name}} de {{artist}}, {{year}}, {{tracks}} canciones",
+    "playlistCardAriaLabel": "Lista {{name}}, {{downloaded}} de {{total}} descargadas",
     "album": {
       "notFound": "Álbum no encontrado",
       "notFoundDescription": "No se pudo encontrar este álbum en tu biblioteca.",

--- a/apps/frontend/src/views/Home.test.tsx
+++ b/apps/frontend/src/views/Home.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { PlaylistWithStats } from "@/types";
+import { Home } from "./Home";
+
+const mockUseHomeController = vi.fn();
+
+vi.mock("@/hooks/controllers/useHomeController", () => ({
+  useHomeController: () => mockUseHomeController(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string | Record<string, unknown>) =>
+      typeof fallback === "string" ? fallback : key,
+  }),
+}));
+
+vi.mock("@/components/organisms/ScanLibraryModal", () => ({
+  ScanLibraryModal: () => null,
+}));
+
+vi.mock("@/components/organisms/ArtworkBackfillStatusIndicator", () => ({
+  ArtworkBackfillStatusIndicator: () => null,
+}));
+
+vi.mock("@/components/organisms/LibraryArtistList", () => ({
+  LibraryArtistList: ({ artists }: { artists: unknown[] }) => (
+    <div data-testid="artist-list" data-count={artists.length} />
+  ),
+}));
+
+vi.mock("@/components/organisms/HomePlaylistList", () => ({
+  HomePlaylistList: ({ items }: { items: unknown[] }) => (
+    <div data-testid="home-playlist-list" data-count={items.length} />
+  ),
+}));
+
+const makePlaylist = (id: string, name: string): PlaylistWithStats => ({
+  id,
+  name,
+  owner: "test-owner",
+  coverUrl: undefined,
+  tracks: [
+    {
+      id: `${id}-t1`,
+      name: "Track 1",
+      artist: "Artist",
+      status: TrackStatusEnum.Completed,
+      playlistId: id,
+    },
+  ],
+  stats: {
+    completedCount: 1,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 0,
+    activeCount: 0,
+    errorCount: 0,
+    totalCount: 10,
+    progress: 10,
+    isDownloading: false,
+    hasErrors: false,
+    isCompleted: false,
+  },
+});
+
+const defaultController = {
+  t: (key: string, fallback?: string) => fallback ?? key,
+  stats: null,
+  artists: [],
+  isLoading: false,
+  isScanning: false,
+  isScanModalOpen: false,
+  artworkBackfillStatus: { status: "idle" },
+  isArtworkBackfillActive: false,
+  handleOpenScanModal: vi.fn(),
+  handleCloseScanModal: vi.fn(),
+  handleConfirmScan: vi.fn(),
+  handleArtistClick: vi.fn(),
+  handlePlaylistClick: vi.fn(),
+  handleSearchChange: vi.fn(),
+  formatSize: vi.fn(),
+  search: "",
+  downloadedPlaylists: [],
+  filteredPlaylists: [],
+  filteredArtists: [],
+};
+
+describe("Home", () => {
+  it("renders the playlists section before the artists list when playlists with downloads exist", () => {
+    const p = makePlaylist("p1", "Chill Vibes");
+    mockUseHomeController.mockReturnValue({
+      ...defaultController,
+      artists: [{ name: "Artist A", path: "/a", albumCount: 1, trackCount: 5, totalSize: 0, albums: [] }],
+      filteredArtists: [{ name: "Artist A", path: "/a", albumCount: 1, trackCount: 5, totalSize: 0, albums: [] }],
+      downloadedPlaylists: [{ playlist: p, downloadedCount: 1, totalCount: 10 }],
+      filteredPlaylists: [{ playlist: p, downloadedCount: 1, totalCount: 10 }],
+    });
+
+    render(<Home />);
+
+    const playlistList = screen.getByTestId("home-playlist-list");
+    const artistList = screen.getByTestId("artist-list");
+    expect(playlistList).not.toBeNull();
+    expect(artistList).not.toBeNull();
+
+    // Playlist section should appear before artists in DOM
+    const allElements = document.querySelectorAll("[data-testid]");
+    const playlistIndex = Array.from(allElements).findIndex(
+      (el) => el.getAttribute("data-testid") === "home-playlist-list",
+    );
+    const artistIndex = Array.from(allElements).findIndex(
+      (el) => el.getAttribute("data-testid") === "artist-list",
+    );
+    expect(playlistIndex).toBeLessThan(artistIndex);
+  });
+
+  it("hides the playlists section when filteredPlaylists is empty", () => {
+    mockUseHomeController.mockReturnValue({
+      ...defaultController,
+      artists: [{ name: "Artist A", path: "/a", albumCount: 1, trackCount: 5, totalSize: 0, albums: [] }],
+      filteredArtists: [{ name: "Artist A", path: "/a", albumCount: 1, trackCount: 5, totalSize: 0, albums: [] }],
+      downloadedPlaylists: [],
+      filteredPlaylists: [],
+    });
+
+    render(<Home />);
+
+    expect(screen.queryByTestId("home-playlist-list")).toBeNull();
+  });
+
+  it("renders search bar", () => {
+    mockUseHomeController.mockReturnValue(defaultController);
+
+    render(<Home />);
+
+    const input = document.querySelector("input[type='text']");
+    expect(input).not.toBeNull();
+  });
+
+  it("calls handleSearchChange when user types in search bar", () => {
+    const handleSearchChange = vi.fn();
+    mockUseHomeController.mockReturnValue({
+      ...defaultController,
+      handleSearchChange,
+    });
+
+    render(<Home />);
+
+    const input = document.querySelector("input[type='text']") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "rock" } });
+    expect(handleSearchChange).toHaveBeenCalledWith("rock");
+  });
+
+  it("shows filtered artists list when artists are present", () => {
+    const artist = { name: "Rock Band", path: "/rb", albumCount: 2, trackCount: 20, totalSize: 0, albums: [] };
+    mockUseHomeController.mockReturnValue({
+      ...defaultController,
+      artists: [artist],
+      filteredArtists: [artist],
+    });
+
+    render(<Home />);
+
+    const artistList = screen.getByTestId("artist-list");
+    expect(artistList.getAttribute("data-count")).toBe("1");
+  });
+});

--- a/apps/frontend/src/views/Home.tsx
+++ b/apps/frontend/src/views/Home.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/components/atoms/Button";
 import { Loading } from "@/components/atoms/Loading";
 import { EmptyState } from "@/components/molecules/EmptyState";
 import { PageHeader } from "@/components/molecules/PageHeader";
+import { SearchInput } from "@/components/molecules/SearchInput";
 import { StatCard } from "@/components/molecules/StatCard";
 import { ArtworkBackfillStatusIndicator } from "@/components/organisms/ArtworkBackfillStatusIndicator";
+import { HomePlaylistList } from "@/components/organisms/HomePlaylistList";
 import { LibraryArtistList } from "@/components/organisms/LibraryArtistList";
 import { ScanLibraryModal } from "@/components/organisms/ScanLibraryModal";
 import { useHomeController } from "@/hooks/controllers/useHomeController";
@@ -14,7 +16,6 @@ export const Home: FC = () => {
   const {
     t,
     stats,
-    artists,
     isLoading,
     isScanning,
     isScanModalOpen,
@@ -23,16 +24,28 @@ export const Home: FC = () => {
     handleCloseScanModal,
     handleConfirmScan,
     handleArtistClick,
+    handlePlaylistClick,
+    handleSearchChange,
+    search,
+    filteredPlaylists,
+    filteredArtists,
   } = useHomeController();
 
   return (
     <section className="bg-background w-full px-4 py-6 md:px-8">
       <div className="max-w-full">
-        <PageHeader
-          title={t("library.title", "Library")}
-          description={t("library.description", "Your downloaded music collection")}
-          className="mb-6"
-          action={
+        <div className="bg-background/95 sticky top-[60px] z-30 -mx-4 mb-6 flex flex-col gap-3 border-b border-white/10 px-4 py-4 shadow-md backdrop-blur-md md:-mx-8 md:flex-row md:items-center md:justify-between md:px-8">
+          <PageHeader
+            title={t("library.title", "Library")}
+            description={t("library.description", "Your downloaded music collection")}
+          />
+          <div className="flex flex-col gap-3 md:flex-row md:items-center">
+            <SearchInput
+              value={search}
+              onChange={handleSearchChange}
+              placeholder={t("library.searchPlaceholder", "Search playlists and artists...")}
+              className="w-full md:w-64"
+            />
             <Button
               variant="primary"
               size="md"
@@ -45,8 +58,8 @@ export const Home: FC = () => {
                 ? t("library.scanning", "Scanning...")
                 : t("library.scan", "Scan Library")}
             </Button>
-          }
-        />
+          </div>
+        </div>
 
         <ArtworkBackfillStatusIndicator status={artworkBackfillStatus} />
 
@@ -61,22 +74,35 @@ export const Home: FC = () => {
 
         {isLoading ? (
           <Loading />
-        ) : !artists || artists.length === 0 ? (
-          <EmptyState
-            icon={faFolderOpen}
-            title={t("library.emptyTitle", "Library is empty")}
-            description={t(
-              "library.emptyDescription",
-              "Scan your downloads folder to populate your library.",
-            )}
-            action={
-              <Button onClick={handleOpenScanModal} icon={faRotate} variant="primary">
-                {t("library.scanNow", "Scan Now")}
-              </Button>
-            }
-          />
         ) : (
-          <LibraryArtistList artists={artists} onArtistClick={handleArtistClick} />
+          <>
+            {filteredPlaylists.length > 0 && (
+              <div className="mb-8">
+                <h2 className="text-text-primary mb-4 text-lg font-semibold">
+                  {t("library.playlistsSection", "Playlists")}
+                </h2>
+                <HomePlaylistList items={filteredPlaylists} onPlaylistClick={handlePlaylistClick} />
+              </div>
+            )}
+
+            {filteredArtists.length === 0 && filteredPlaylists.length === 0 ? (
+              <EmptyState
+                icon={faFolderOpen}
+                title={t("library.emptyTitle", "Library is empty")}
+                description={t(
+                  "library.emptyDescription",
+                  "Scan your downloads folder to populate your library.",
+                )}
+                action={
+                  <Button onClick={handleOpenScanModal} icon={faRotate} variant="primary">
+                    {t("library.scanNow", "Scan Now")}
+                  </Button>
+                }
+              />
+            ) : filteredArtists.length > 0 ? (
+              <LibraryArtistList artists={filteredArtists} onArtistClick={handleArtistClick} />
+            ) : null}
+          </>
         )}
 
         <ScanLibraryModal


### PR DESCRIPTION
## Summary

- Add a **Playlists section** to the Home/Library view listing local DB playlists (`type === "playlist"`) that have at least one downloaded track. Cards show cover, name, owner, and a `downloaded/total` badge; click navigates to `PLAYLIST_DETAIL`.
- Add a **search input** in the sticky Home header (same pattern as `MyPlaylists`) that filters both the new playlists section and the artists list in-memory with a debounced value.
- Filter excludes synthetic album/track/artist playlist rows (`type !== "playlist"`) so only real Spotify playlists surface.
- i18n: EN + ES keys added (`library.searchPlaceholder`, `library.playlistsSection`, `library.playlistCardAriaLabel`).

## Follow-up (not in this PR)

Today, downloading a single track from a Spotify playlist preview only persists the track row (with `type: "track"`), not the parent playlist. Until that is fixed in a follow-up SDD, the section will look empty for users whose only downloads come from playlist previews. The UI is ready for when parent playlists are persisted on track download.

## Test plan

- [x] `pnpm --filter frontend test --run` → 135/135 pass (20 new tests across controller / card / list / view)
- [x] `pnpm --filter frontend run lint` clean
- [x] `pnpm --filter frontend run build` clean
- [x] Backend untouched: 370/370 pass