### PR TITLE
feat(playlists): persist parent Spotify playlist when downloading a single preview track

### DIFF
--- a/apps/backend/prisma/migrations/20260605000000_add_playlist_spotify_url_unique/README.md
+++ b/apps/backend/prisma/migrations/20260605000000_add_playlist_spotify_url_unique/README.md
@@ -1,0 +1,50 @@
+# Migration: add_playlist_spotify_url_unique
+
+Adds a unique constraint on `Playlist.spotifyUrl` to enforce DB-level idempotency
+for playlist creation. This supports the `playlistTrack` download kind where
+concurrent requests may attempt to create the same parent playlist row.
+
+## Pre-flight check (REQUIRED before applying to existing databases)
+
+Run the following SQL to verify no duplicate `spotifyUrl` values exist:
+
+```sql
+SELECT spotifyUrl, COUNT(*) c
+FROM Playlist
+GROUP BY spotifyUrl
+HAVING c > 1;
+```
+
+### If the query returns no rows
+
+The migration is safe to apply. Proceed with:
+
+```bash
+pnpm --filter backend run prisma:migrate:deploy
+```
+
+### If the query returns one or more rows (duplicate spotifyUrl values)
+
+You must deduplicate before applying the migration. For each duplicated `spotifyUrl`,
+keep the oldest row (lowest `createdAt`) and delete the rest:
+
+```sql
+-- Identify the IDs to keep (oldest row per spotifyUrl)
+-- Example cleanup — adjust as needed for your data:
+DELETE FROM Playlist
+WHERE id NOT IN (
+  SELECT MIN(id)
+  FROM Playlist
+  GROUP BY spotifyUrl
+);
+```
+
+After deduplication, re-run the pre-flight query to confirm zero duplicates,
+then apply the migration.
+
+## Notes
+
+- This constraint is safe on fresh databases and on any database where
+  application-level dedup has been consistently enforced (the expected case).
+- Existing `Playlist` rows with `type="track"` created before this migration
+  are NOT retroactively re-parented. They continue to render correctly in the UI.

--- a/apps/backend/prisma/migrations/20260605000000_add_playlist_spotify_url_unique/migration.sql
+++ b/apps/backend/prisma/migrations/20260605000000_add_playlist_spotify_url_unique/migration.sql
@@ -1,0 +1,8 @@
+-- AddUniqueConstraint on Playlist.spotifyUrl
+-- Pre-flight: verify no duplicate spotifyUrl values exist before applying.
+-- Run the query below against your database first:
+--   SELECT spotifyUrl, COUNT(*) c FROM Playlist GROUP BY spotifyUrl HAVING c > 1;
+-- If empty: apply cleanly. If non-empty: deduplicate (delete or merge) before running this migration.
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Playlist_spotifyUrl_key" ON "Playlist"("spotifyUrl");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -22,6 +22,8 @@ model Playlist {
   ownerUrl         String?
   tracks           Track[]
   downloadHistory  DownloadHistory[]
+
+  @@unique([spotifyUrl])
 }
 
 model Track {

--- a/apps/backend/src/application/services/spotify.service.test.ts
+++ b/apps/backend/src/application/services/spotify.service.test.ts
@@ -110,6 +110,93 @@ describe("SpotifyService", () => {
     expect(result.tracks[1]?.primaryArtistImage).toBe("https://image.test/artist.jpg");
   });
 
+  describe("getPlaylistMetadata", () => {
+    it("delegates to playlistClient.getPlaylistMetadata with the same URL", async () => {
+      const metadata = {
+        name: "My Playlist",
+        image: "https://image.test/cover.jpg",
+        owner: "alex",
+        ownerUrl: "https://open.spotify.com/user/alex",
+        totalTracks: 20,
+      };
+      const playlistClient = {
+        getPlaylistMetadata: vi.fn().mockResolvedValue(metadata),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient,
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = "https://open.spotify.com/playlist/abc123";
+      const result = await service.getPlaylistMetadata(url);
+
+      expect(playlistClient.getPlaylistMetadata).toHaveBeenCalledWith(url);
+      expect(result).toEqual(metadata);
+    });
+
+    it("returns the metadata shape unchanged (name, image, owner, ownerUrl, totalTracks)", async () => {
+      const metadata = {
+        name: "Radio Alexander",
+        image: "https://image.test/playlist.jpg",
+        owner: "user1",
+        ownerUrl: "https://open.spotify.com/user/user1",
+        totalTracks: 75,
+      };
+      const playlistClient = {
+        getPlaylistMetadata: vi.fn().mockResolvedValue(metadata),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient,
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistMetadata(
+        "https://open.spotify.com/playlist/xyz",
+      );
+
+      expect(result).toMatchObject({
+        name: "Radio Alexander",
+        image: "https://image.test/playlist.jpg",
+        owner: "user1",
+        ownerUrl: "https://open.spotify.com/user/user1",
+        totalTracks: 75,
+      });
+    });
+
+    it("propagates errors from the client", async () => {
+      const clientError = new Error("Spotify API error");
+      const playlistClient = {
+        getPlaylistMetadata: vi.fn().mockRejectedValue(clientError),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient,
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      await expect(
+        service.getPlaylistMetadata("https://open.spotify.com/playlist/err"),
+      ).rejects.toThrow("Spotify API error");
+    });
+  });
+
   it("returns playlist totalTracks from metadata even when preview tracks are paged", async () => {
     const service = new SpotifyService({
       artistClient: {

--- a/apps/backend/src/application/services/spotify.service.ts
+++ b/apps/backend/src/application/services/spotify.service.ts
@@ -218,6 +218,16 @@ export class SpotifyService {
     }
   }
 
+  async getPlaylistMetadata(spotifyUrl: string): Promise<{
+    name: string;
+    image: string;
+    owner?: string;
+    ownerUrl?: string;
+    totalTracks?: number;
+  }> {
+    return this.deps.playlistClient.getPlaylistMetadata(spotifyUrl);
+  }
+
   async getMyPlaylists(): Promise<SpotifyPlaylist[]> {
     return this.deps.userLibraryService.getMyPlaylists();
   }

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -1,16 +1,16 @@
 import { PlaylistTypeEnum } from "@spotiarr/shared";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Playlist } from "@/domain/entities/playlist.entity";
 import { AppError } from "@/domain/errors/app-error";
 import { CreatePlaylistUseCase } from "./create-playlist.use-case";
 
 // Minimal in-memory stubs
-function makePlaylistEntity() {
+function makePlaylistEntity(overrides: Partial<{ id: string; spotifyUrl: string; type: PlaylistTypeEnum; name: string }> = {}) {
   return new Playlist({
-    id: "playlist-id",
-    spotifyUrl: "spotiarr://album/artist-1/album-1",
-    type: PlaylistTypeEnum.Album,
-    name: "Artist - Album",
+    id: overrides.id ?? "playlist-id",
+    spotifyUrl: overrides.spotifyUrl ?? "spotiarr://album/artist-1/album-1",
+    type: overrides.type ?? PlaylistTypeEnum.Album,
+    name: overrides.name ?? "Artist - Album",
   });
 }
 
@@ -32,6 +32,12 @@ function makeStubs() {
       name: "Playlist",
       image: "",
       type: "playlist",
+    }),
+    getPlaylistMetadata: vi.fn().mockResolvedValue({
+      name: "Parent Playlist",
+      image: "https://image.test/cover.jpg",
+      owner: "user1",
+      ownerUrl: "https://open.spotify.com/user/user1",
     }),
   };
 
@@ -521,5 +527,210 @@ describe("CreatePlaylistUseCase — album branch", () => {
       albumUrl: "https://open.spotify.com/album/album-1",
     });
     expect(createdTrack).not.toHaveProperty("spotifyUrl");
+  });
+});
+
+describe("CreatePlaylistUseCase — executePlaylistTrack branch", () => {
+  const PARENT_URL = "https://open.spotify.com/playlist/parent-id";
+  const TRACK_URL = "https://open.spotify.com/track/track-id";
+
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+
+    // Default: no existing parent found
+    stubs.playlistRepository.findAll.mockResolvedValue([]);
+
+    // Default: getPlaylistMetadata returns playlist metadata
+    stubs.spotifyService.getPlaylistMetadata.mockResolvedValue({
+      name: "Parent Playlist",
+      image: "https://image.test/cover.jpg",
+      owner: "user1",
+      ownerUrl: "https://open.spotify.com/user/user1",
+    });
+
+    // Default: getPlaylistDetail for track returns one track
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "My Track",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: "https://open.spotify.com/artist/art1" }],
+          album: "My Album",
+          trackUrl: TRACK_URL,
+          durationMs: 200000,
+        },
+      ],
+      name: "My Track",
+      image: "https://image.test/track.jpg",
+      type: "track",
+    });
+
+    // Default: savedEntity is a proper playlist entity
+    const parentEntity = makePlaylistEntity({
+      id: "parent-entity-id",
+      spotifyUrl: PARENT_URL,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Parent Playlist",
+    });
+    stubs.playlistRepository.save.mockResolvedValue(parentEntity);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("PT-1: creates parent on findAll cache miss — calls getPlaylistMetadata and saves with type=Playlist", async () => {
+    const useCase = makeUseCase(stubs);
+
+    await useCase.execute({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PARENT_URL,
+      trackUrl: TRACK_URL,
+    });
+
+    expect(stubs.playlistRepository.findAll).toHaveBeenCalledWith(false, {
+      spotifyUrl: PARENT_URL,
+    });
+    expect(stubs.spotifyService.getPlaylistMetadata).toHaveBeenCalledWith(PARENT_URL);
+    expect(stubs.playlistRepository.save).toHaveBeenCalled();
+
+    const savedArg = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedArg.toPrimitive()).toMatchObject({
+      spotifyUrl: PARENT_URL,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Parent Playlist",
+      coverUrl: "https://image.test/cover.jpg",
+      owner: "user1",
+      ownerUrl: "https://open.spotify.com/user/user1",
+    });
+  });
+
+  it("PT-2: reuses existing parent on cache hit — skips getPlaylistMetadata and save", async () => {
+    const existingParent = makePlaylistEntity({
+      id: "existing-parent-id",
+      spotifyUrl: PARENT_URL,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Existing Parent",
+    });
+    stubs.playlistRepository.findAll.mockResolvedValue([existingParent]);
+
+    const useCase = makeUseCase(stubs);
+
+    await useCase.execute({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PARENT_URL,
+      trackUrl: TRACK_URL,
+    });
+
+    expect(stubs.spotifyService.getPlaylistMetadata).not.toHaveBeenCalled();
+    expect(stubs.playlistRepository.save).not.toHaveBeenCalled();
+  });
+
+  it("PT-3: links the track to the parent via processTracks with correct playlistId", async () => {
+    const useCase = makeUseCase(stubs);
+
+    await useCase.execute({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PARENT_URL,
+      trackUrl: TRACK_URL,
+    });
+
+    expect(stubs.trackService.create).toHaveBeenCalledOnce();
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playlistId: "parent-entity-id",
+        name: "My Track",
+      }),
+    );
+  });
+
+  it("PT-4: P2002 race recovery — returns winner parent when save throws P2002 and re-read finds it", async () => {
+    const p2002Err = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+    const winnerParent = makePlaylistEntity({
+      id: "winner-parent-id",
+      spotifyUrl: PARENT_URL,
+      type: PlaylistTypeEnum.Playlist,
+      name: "Winner Parent",
+    });
+
+    // First call: no existing parent
+    // After P2002: re-read returns winner
+    stubs.playlistRepository.findAll
+      .mockResolvedValueOnce([]) // initial find
+      .mockResolvedValueOnce([winnerParent]); // re-read after P2002
+
+    stubs.playlistRepository.save.mockRejectedValueOnce(p2002Err);
+
+    const useCase = makeUseCase(stubs);
+
+    const result = await useCase.execute({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PARENT_URL,
+      trackUrl: TRACK_URL,
+    });
+
+    expect(result).toMatchObject({ id: "winner-parent-id" });
+    // Should not throw
+  });
+
+  it("PT-5: P2002 with no row on re-read — re-throws the original error", async () => {
+    const p2002Err = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+
+    stubs.playlistRepository.findAll
+      .mockResolvedValueOnce([]) // initial find
+      .mockResolvedValueOnce([]); // re-read after P2002 — still empty
+
+    stubs.playlistRepository.save.mockRejectedValueOnce(p2002Err);
+
+    const useCase = makeUseCase(stubs);
+
+    const thrown = await useCase
+      .execute({
+        kind: "playlistTrack",
+        parentSpotifyUrl: PARENT_URL,
+        trackUrl: TRACK_URL,
+      })
+      .catch((e) => e);
+
+    expect(thrown).toBe(p2002Err);
+  });
+
+  it("PT-6: track not found — throws track_not_found when getPlaylistDetail returns empty tracks", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [],
+      name: "",
+      image: "",
+      type: "track",
+    });
+
+    const useCase = makeUseCase(stubs);
+
+    const thrown = await useCase
+      .execute({
+        kind: "playlistTrack",
+        parentSpotifyUrl: PARENT_URL,
+        trackUrl: TRACK_URL,
+      })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).errorCode).toBe("track_not_found");
+  });
+
+  it("PT-7: auto-subscribe respected — new parent is marked subscribed when AUTO_SUBSCRIBE_NEW_PLAYLISTS=true", async () => {
+    stubs.settingsService.getBoolean.mockResolvedValue(true);
+
+    const useCase = makeUseCase(stubs);
+
+    await useCase.execute({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PARENT_URL,
+      trackUrl: TRACK_URL,
+    });
+
+    const savedArg = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedArg.toPrimitive().subscribed).toBe(true);
   });
 });

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -16,6 +16,11 @@ import type { SettingsService } from "../../services/settings.service";
 import type { TrackService } from "../../services/track.service";
 import type { GetAlbumTracksUseCase } from "../artists/get-album-tracks.use-case";
 
+// Inline type guard: keeps application layer free of infrastructure imports.
+// Same guard exists in infrastructure/database/prisma-errors.ts for infra-layer use.
+const isUniqueConstraintViolation = (e: unknown): boolean =>
+  e instanceof Error && "code" in e && (e as { code?: string }).code === "P2002";
+
 interface DeezerAlbumTracksPort {
   getAlbumTracks(deezerAlbumId: string | number): Promise<NormalizedTrack[]>;
 }
@@ -57,6 +62,9 @@ export class CreatePlaylistUseCase {
     }
     if (input.kind === "deezerTrack") {
       return this.executeDeezerTrack(input.deezerTrackId, input.deezerAlbumId);
+    }
+    if (input.kind === "playlistTrack") {
+      return this.executePlaylistTrack(input.parentSpotifyUrl, input.trackUrl);
     }
     return this.executeSpotifyUrl(input.spotifyUrl);
   }
@@ -312,6 +320,63 @@ export class CreatePlaylistUseCase {
 
     this.eventBus.emit("playlists-updated");
     return savedPlaylist;
+  }
+
+  private async executePlaylistTrack(
+    parentSpotifyUrl: string,
+    trackUrl: string,
+  ): Promise<IPlaylist> {
+    // 1. Find-or-create parent playlist (race-safe via unique constraint + P2002 recovery)
+    let parentRow = (await this.playlistRepository.findAll(false, { spotifyUrl: parentSpotifyUrl }))[0];
+
+    if (!parentRow) {
+      const meta = await this.spotifyService.getPlaylistMetadata(parentSpotifyUrl);
+
+      const newParent = new Playlist({
+        id: crypto.randomUUID(),
+        spotifyUrl: parentSpotifyUrl,
+        type: PlaylistTypeEnum.Playlist,
+      });
+      newParent.updateDetails(
+        meta.name,
+        PlaylistTypeEnum.Playlist,
+        meta.image,
+        undefined,
+        meta.owner,
+        meta.ownerUrl,
+      );
+
+      const autoSubscribe = await this.settingsService.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS");
+      if (autoSubscribe) newParent.markAsSubscribed();
+
+      try {
+        parentRow = await this.playlistRepository.save(newParent);
+      } catch (e) {
+        if (isUniqueConstraintViolation(e)) {
+          // Another concurrent request won the race — re-read the winner
+          parentRow = (
+            await this.playlistRepository.findAll(false, { spotifyUrl: parentSpotifyUrl })
+          )[0];
+          if (!parentRow) throw e; // truly unexpected: P2002 but no row found
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    // 2. Resolve the single track using the existing single-track Spotify path
+    const detail = await this.spotifyService.getPlaylistDetail(trackUrl);
+    const singleTrack = detail.tracks[0];
+    if (!singleTrack) {
+      throw new AppError(404, "track_not_found", "Spotify track resolution returned no track");
+    }
+
+    // 3. Link the track to the parent playlist
+    const parentPrimitive = parentRow.toPrimitive();
+    await this.processTracks(parentPrimitive, [singleTrack], PlaylistTypeEnum.Track);
+
+    this.eventBus.emit("playlists-updated");
+    return parentPrimitive;
   }
 
   private async resolveAlbumMetadata(

--- a/apps/backend/src/infrastructure/database/prisma-errors.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { isPrismaUniqueViolation } from "./prisma-errors";
+
+describe("isPrismaUniqueViolation", () => {
+  it("returns true when passed an Error with code P2002", () => {
+    const err = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+    expect(isPrismaUniqueViolation(err)).toBe(true);
+  });
+
+  it("returns false for P2025 (not found)", () => {
+    const err = Object.assign(new Error("Record not found"), { code: "P2025" });
+    expect(isPrismaUniqueViolation(err)).toBe(false);
+  });
+
+  it("returns false for a plain non-Error value", () => {
+    expect(isPrismaUniqueViolation("P2002")).toBe(false);
+    expect(isPrismaUniqueViolation({ code: "P2002" })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isPrismaUniqueViolation(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isPrismaUniqueViolation(undefined)).toBe(false);
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-errors.ts
+++ b/apps/backend/src/infrastructure/database/prisma-errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Type guard for Prisma unique constraint violation (P2002).
+ *
+ * Use this in application-layer code (use cases) to detect and handle
+ * concurrent-write races on unique-constrained columns.
+ * Do NOT use this to silently swallow errors in the repository layer —
+ * keep "find-or-create" semantics in the use case where intent is clear.
+ */
+export const isPrismaUniqueViolation = (e: unknown): e is { code: string } =>
+  e instanceof Error && "code" in e && (e as { code?: string }).code === "P2002";

--- a/apps/backend/src/presentation/routes/schemas/playlist.schema.test.ts
+++ b/apps/backend/src/presentation/routes/schemas/playlist.schema.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { createPlaylistSchema } from "./playlist.schema";
+
+describe("createPlaylistSchema — playlistTrack variant", () => {
+  it("parses a valid playlistTrack body", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "playlistTrack",
+        parentSpotifyUrl: "https://open.spotify.com/playlist/abc",
+        trackUrl: "https://open.spotify.com/track/xyz",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toMatchObject({
+        kind: "playlistTrack",
+        parentSpotifyUrl: "https://open.spotify.com/playlist/abc",
+        trackUrl: "https://open.spotify.com/track/xyz",
+      });
+    }
+  });
+
+  it("rejects playlistTrack body missing parentSpotifyUrl", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "playlistTrack",
+        trackUrl: "https://open.spotify.com/track/xyz",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects playlistTrack body missing trackUrl", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "playlistTrack",
+        parentSpotifyUrl: "https://open.spotify.com/playlist/abc",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects playlistTrack body with empty string for parentSpotifyUrl", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "playlistTrack",
+        parentSpotifyUrl: "",
+        trackUrl: "https://open.spotify.com/track/xyz",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects playlistTrack body with empty string for trackUrl", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "playlistTrack",
+        parentSpotifyUrl: "https://open.spotify.com/playlist/abc",
+        trackUrl: "",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("createPlaylistSchema — deezerTrack variant", () => {
+  it("parses a valid deezerTrack body", () => {
+    const result = createPlaylistSchema.safeParse({
+      body: {
+        kind: "deezerTrack",
+        deezerTrackId: "12345",
+        deezerAlbumId: "456",
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body).toMatchObject({
+        kind: "deezerTrack",
+        deezerTrackId: "12345",
+        deezerAlbumId: "456",
+      });
+    }
+  });
+});

--- a/apps/backend/src/presentation/routes/schemas/playlist.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/playlist.schema.ts
@@ -14,6 +14,16 @@ const discriminatedBody = z.discriminatedUnion("kind", [
     albumId: z.string().min(1),
     trackIndex: z.number().int().min(0),
   }),
+  z.object({
+    kind: z.literal("deezerTrack"),
+    deezerTrackId: z.string().min(1),
+    deezerAlbumId: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal("playlistTrack"),
+    parentSpotifyUrl: z.string().min(1),
+    trackUrl: z.string().min(1),
+  }),
 ]);
 
 const legacyBody = z

--- a/apps/frontend/src/hooks/controllers/usePlaylistController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/usePlaylistController.test.tsx
@@ -1,0 +1,199 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/types";
+import { usePlaylistController } from "./usePlaylistController";
+
+// Mock all mutation hooks
+const mockCreatePlaylistMutate = vi.fn();
+const mockRetryTrackMutate = vi.fn();
+const mockRetryFailedTracksMutate = vi.fn();
+const mockUpdatePlaylistMutate = vi.fn();
+const mockDeletePlaylistMutate = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+vi.mock("../mutations/useCreatePlaylistMutation", () => ({
+  useCreatePlaylistMutation: () => ({
+    mutate: mockCreatePlaylistMutate,
+    isPending: false,
+    isSuccess: false,
+  }),
+}));
+
+vi.mock("../mutations/useRetryTrackMutation", () => ({
+  useRetryTrackMutation: () => ({
+    mutate: mockRetryTrackMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../mutations/useRetryFailedTracksMutation", () => ({
+  useRetryFailedTracksMutation: () => ({
+    mutate: mockRetryFailedTracksMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../mutations/useUpdatePlaylistMutation", () => ({
+  useUpdatePlaylistMutation: () => ({
+    mutate: mockUpdatePlaylistMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("../mutations/useDeletePlaylistMutation", () => ({
+  useDeletePlaylistMutation: () => ({
+    mutate: mockDeletePlaylistMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/contexts/DownloadStatusContext", () => ({
+  usePlaylistDownloading: () => false,
+  usePlaylistDownloaded: () => false,
+}));
+
+function makeSyntheticTrack(overrides: Partial<Track> = {}): Track {
+  return {
+    id: "preview-track-1",
+    name: "Test Track",
+    artist: "Test Artist",
+    status: TrackStatusEnum.Error,
+    trackUrl: "https://open.spotify.com/track/track-id",
+    ...overrides,
+  };
+}
+
+describe("usePlaylistController — handleRetryTrack", () => {
+  const PLAYLIST_URL = "https://open.spotify.com/playlist/parent-id";
+  const ALBUM_URL = "https://open.spotify.com/album/album-id";
+  const TRACK_URL = "https://open.spotify.com/track/track-id";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PCT-1: synthetic track + playlist parent spotifyUrl → dispatches playlistTrack kind", () => {
+    const track = makeSyntheticTrack({ trackUrl: TRACK_URL });
+
+    const { result } = renderHook(() =>
+      usePlaylistController({
+        tracks: [track],
+        spotifyUrl: PLAYLIST_URL,
+      }),
+    );
+
+    act(() => {
+      result.current.handleRetryTrack(track);
+    });
+
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PLAYLIST_URL,
+      trackUrl: TRACK_URL,
+    });
+    expect(mockRetryTrackMutate).not.toHaveBeenCalled();
+  });
+
+  it("PCT-2: synthetic track + non-playlist parent (album URL) → dispatches spotifyUrl kind", () => {
+    const track = makeSyntheticTrack({ trackUrl: TRACK_URL });
+
+    const { result } = renderHook(() =>
+      usePlaylistController({
+        tracks: [track],
+        spotifyUrl: ALBUM_URL,
+      }),
+    );
+
+    act(() => {
+      result.current.handleRetryTrack(track);
+    });
+
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "spotifyUrl",
+      spotifyUrl: TRACK_URL,
+    });
+    expect(mockRetryTrackMutate).not.toHaveBeenCalled();
+  });
+
+  it("PCT-3: non-synthetic track → calls retryTrack(track.id), no createPlaylist", () => {
+    const track = makeSyntheticTrack({ id: "real-db-id-abc" });
+
+    const { result } = renderHook(() =>
+      usePlaylistController({
+        tracks: [track],
+        spotifyUrl: PLAYLIST_URL,
+      }),
+    );
+
+    act(() => {
+      result.current.handleRetryTrack(track);
+    });
+
+    expect(mockRetryTrackMutate).toHaveBeenCalledWith("real-db-id-abc");
+    expect(mockCreatePlaylistMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe("usePlaylistController — handleRetryFailed", () => {
+  const PLAYLIST_URL = "https://open.spotify.com/playlist/parent-id";
+  const TRACK_URL_1 = "https://open.spotify.com/track/track-1";
+  const TRACK_URL_2 = "https://open.spotify.com/track/track-2";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PCT-4: handleRetryFailed from playlist preview → each failed synthetic track dispatches playlistTrack with same parentSpotifyUrl", () => {
+    const failedTrack1 = makeSyntheticTrack({ id: "preview-1", trackUrl: TRACK_URL_1 });
+    const failedTrack2 = makeSyntheticTrack({ id: "preview-2", trackUrl: TRACK_URL_2 });
+
+    const { result } = renderHook(() =>
+      usePlaylistController({
+        tracks: [failedTrack1, failedTrack2],
+        spotifyUrl: PLAYLIST_URL,
+      }),
+    );
+
+    act(() => {
+      result.current.handleRetryFailed();
+    });
+
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledTimes(2);
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PLAYLIST_URL,
+      trackUrl: TRACK_URL_1,
+    });
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "playlistTrack",
+      parentSpotifyUrl: PLAYLIST_URL,
+      trackUrl: TRACK_URL_2,
+    });
+    expect(mockRetryFailedTracksMutate).not.toHaveBeenCalled();
+  });
+
+  it("PCT-5: handleRetryFailed with id && hasFailed → calls retryFailedTracks.mutate(id) only", () => {
+    const failedTrack = makeSyntheticTrack({ id: "preview-1", trackUrl: TRACK_URL_1 });
+
+    const { result } = renderHook(() =>
+      usePlaylistController({
+        id: "playlist-db-id",
+        tracks: [failedTrack],
+        spotifyUrl: PLAYLIST_URL,
+      }),
+    );
+
+    act(() => {
+      result.current.handleRetryFailed();
+    });
+
+    expect(mockRetryFailedTracksMutate).toHaveBeenCalledWith("playlist-db-id");
+    expect(mockCreatePlaylistMutate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/controllers/usePlaylistController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistController.ts
@@ -5,7 +5,7 @@ import { usePlaylistDownloaded, usePlaylistDownloading } from "@/contexts/Downlo
 import { Playlist, PlaylistWithStats } from "@/types";
 import { Track } from "@/types";
 import { formatPlaylistTitle } from "@/utils/playlist";
-import { isSpotifyUrl } from "@/utils/spotify";
+import { isSpotifyPlaylistUrl, isSpotifyUrl } from "@/utils/spotify";
 import { useCreatePlaylistMutation } from "../mutations/useCreatePlaylistMutation";
 import { useDeletePlaylistMutation } from "../mutations/useDeletePlaylistMutation";
 import { useRetryFailedTracksMutation } from "../mutations/useRetryFailedTracksMutation";
@@ -83,10 +83,18 @@ export const usePlaylistController = ({
 
     tracks.forEach((track) => {
       if (track.status === TrackStatusEnum.Error && isSpotifyUrl(track.trackUrl)) {
-        createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+        if (isSpotifyPlaylistUrl(spotifyUrl)) {
+          createPlaylist.mutate({
+            kind: "playlistTrack",
+            parentSpotifyUrl: spotifyUrl!,
+            trackUrl: track.trackUrl!,
+          });
+        } else {
+          createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+        }
       }
     });
-  }, [id, hasFailed, tracks, retryFailedTracks, createPlaylist]);
+  }, [id, hasFailed, tracks, retryFailedTracks, createPlaylist, spotifyUrl]);
 
   const handleRetryTrack = useCallback(
     (track: Track) => {
@@ -104,10 +112,18 @@ export const usePlaylistController = ({
       // Synthetic ids have no DB row yet. Only Spotify trackUrls can be
       // resolved via createPlaylist; Deezer/MB urls have no single-track path.
       if (isSpotifyUrl(track.trackUrl)) {
-        createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+        if (isSpotifyPlaylistUrl(spotifyUrl)) {
+          createPlaylist.mutate({
+            kind: "playlistTrack",
+            parentSpotifyUrl: spotifyUrl!,
+            trackUrl: track.trackUrl!,
+          });
+        } else {
+          createPlaylist.mutate({ kind: "spotifyUrl", spotifyUrl: track.trackUrl! });
+        }
       }
     },
-    [retryTrack, createPlaylist],
+    [retryTrack, createPlaylist, spotifyUrl],
   );
 
   const completedCount = useMemo(() => {

--- a/apps/frontend/src/utils/spotify.test.ts
+++ b/apps/frontend/src/utils/spotify.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { getSpotifyIdFromUrl, isSpotifyUrl, mapApiError, normalizeSpotifyUrl } from "./spotify";
+import {
+  getSpotifyIdFromUrl,
+  isSpotifyPlaylistUrl,
+  isSpotifyUrl,
+  mapApiError,
+  normalizeSpotifyUrl,
+} from "./spotify";
 
 describe("normalizeSpotifyUrl", () => {
   it("normalizes a valid open.spotify.com URL", () => {
@@ -75,6 +81,30 @@ describe("getSpotifyIdFromUrl", () => {
 
   it("returns null when path has fewer than 3 segments", () => {
     expect(getSpotifyIdFromUrl("https://open.spotify.com/playlist")).toBeNull();
+  });
+});
+
+describe("isSpotifyPlaylistUrl", () => {
+  it("returns true for a Spotify playlist URL", () => {
+    expect(isSpotifyPlaylistUrl("https://open.spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns false for a Spotify album URL", () => {
+    expect(isSpotifyPlaylistUrl("https://open.spotify.com/album/abc")).toBe(false);
+  });
+
+  it("returns false for a Spotify track URL", () => {
+    expect(isSpotifyPlaylistUrl("https://open.spotify.com/track/abc")).toBe(false);
+  });
+
+  it("returns false for null, undefined, or empty string", () => {
+    expect(isSpotifyPlaylistUrl(null)).toBe(false);
+    expect(isSpotifyPlaylistUrl(undefined)).toBe(false);
+    expect(isSpotifyPlaylistUrl("")).toBe(false);
+  });
+
+  it("returns false for a non-Spotify host with playlist path", () => {
+    expect(isSpotifyPlaylistUrl("https://google.com/playlist/abc")).toBe(false);
   });
 });
 

--- a/apps/frontend/src/utils/spotify.ts
+++ b/apps/frontend/src/utils/spotify.ts
@@ -56,6 +56,17 @@ export const isSpotifyUrl = (url: string | null | undefined): boolean => {
   }
 };
 
+export const isSpotifyPlaylistUrl = (url: string | null | undefined): boolean => {
+  if (!isSpotifyUrl(url)) return false;
+  try {
+    const parts = new URL(url!).pathname.split("/").filter(Boolean);
+    // Pathname is /playlist/{id} — type segment is always the first non-empty segment
+    return parts[0] === "playlist" && Boolean(parts[1]);
+  } catch {
+    return false;
+  }
+};
+
 export const getSpotifyIdFromUrl = (url: string): string | null => {
   try {
     const urlObj = new URL(url);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -134,7 +134,8 @@ export type CreatePlaylistRequest =
   | { kind: "spotifyUrl"; spotifyUrl: string }
   | { kind: "album"; artistId: string; albumId: string }
   | { kind: "albumTrack"; artistId: string; albumId: string; trackIndex: number }
-  | { kind: "deezerTrack"; deezerTrackId: string; deezerAlbumId: string };
+  | { kind: "deezerTrack"; deezerTrackId: string; deezerAlbumId: string }
+  | { kind: "playlistTrack"; parentSpotifyUrl: string; trackUrl: string };
 
 export type ApiErrorCode =
   | "missing_user_access_token"


### PR DESCRIPTION
## Summary

- New `kind: "playlistTrack"` variant in `CreatePlaylistRequest` (shared + Zod) carrying `{ parentSpotifyUrl, trackUrl }`.
- New `executePlaylistTrack` private method in `CreatePlaylistUseCase` that find-or-creates the parent Playlist row (type=playlist) via a new lightweight `SpotifyService.getPlaylistMetadata`, then links the resolved track via `Track.playlistId`. Subsequent downloads append to the same parent.
- New Prisma migration `add_playlist_spotify_url_unique` adds `@@unique([spotifyUrl])`. P2002 unique-violation race recovery is handled inside the use case (re-read parent and link to it) — keeps the architecture boundary clean (no infra import from application).
- Frontend `usePlaylistController.handleRetryTrack` and `handleRetryFailed` now branch via new `isSpotifyPlaylistUrl(parent)` helper: dispatch `playlistTrack` only when the parent URL is a Spotify playlist; track-URL paste path is untouched.
- Pre-existing `deezerTrack` Zod schema gap closed at the same time (low-cost cleanup in the same surface).

## Why

Closes the gap surfaced by PR #79: the Home Playlists section stayed empty for users whose downloads came only from individual playlist-preview tracks, because the parent playlist row was never persisted.

## Out of scope

- Filesystem subfolder reorganization (`<DOWNLOADS>/Playlists/<name>/...`) — separate concern with migration implications.
- Retroactive backfill of pre-existing `type="track"` orphan rows from past per-track downloads.

## Test plan

- [x] Backend `pnpm test --run` → 391 pass (was 370). 21 new tests across schema, prisma-errors, spotify.service, create-playlist.use-case.
- [x] Frontend `pnpm test --run` → 145 pass (was 135). 10 new tests across isSpotifyPlaylistUrl + usePlaylistController.
- [x] Backend `pnpm build` clean. Frontend `pnpm build` clean.
- [x] Lint clean both apps.
- [x] Prisma migration additive-only (only CREATE UNIQUE INDEX).

## Notes for reviewer

- Design D5 suggested importing the unique-violation guard from infrastructure. The architecture R2 rule forbids application → infrastructure imports, so the guard is inlined as `isUniqueConstraintViolation` in the use case. The standalone `prisma-errors.ts` is kept in infra for future infra-layer use.