### PR TITLE
feat(frontend): library/managed mode for PlaylistDetail view

### DIFF
--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -16,6 +16,8 @@ import { isSpotifyUrl } from "@/utils/spotify";
 import { Button } from "../atoms/Button";
 import { SpotifyLinkButton } from "../molecules/SpotifyLinkButton";
 
+export type PlaylistActionsMode = "library" | "managed";
+
 interface PlaylistActionsProps {
   spotifyUrl?: string;
   playlistId?: string;
@@ -34,6 +36,7 @@ interface PlaylistActionsProps {
   onRetryFailed: () => void;
   onDelete: () => void;
   onDownload: () => void;
+  mode?: PlaylistActionsMode;
 }
 
 export const PlaylistActions: FC<PlaylistActionsProps> = ({
@@ -54,10 +57,12 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   spotifyUrl,
   playlistId,
   playlistName,
+  mode = "managed",
 }) => {
   const hasEagerSpotifyUrl = spotifyUrl && isSpotifyUrl(spotifyUrl);
   const canLazyResolve = !hasEagerSpotifyUrl && Boolean(playlistName);
   const { t } = useTranslation();
+  const isManaged = mode === "managed";
 
   return (
     <div className="flex items-center gap-3 md:gap-4">
@@ -77,52 +82,56 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </Button>
       ) : null}
 
-      <Button
-        variant="primary"
-        size="lg"
-        className={cn(
-          "!h-12 !w-12 justify-center !rounded-full !p-0 shadow-lg transition-transform md:!h-14 md:!w-14",
-          isDownloaded
-            ? "cursor-default bg-green-500 hover:bg-green-600"
-            : "bg-green-500 hover:scale-105 hover:bg-green-600",
-        )}
-        onClick={onDownload}
-        loading={isDownloading}
-        disabled={isDownloaded || isDownloading}
-        title={
-          isDownloaded
-            ? t("playlist.downloaded")
-            : isDownloading
-              ? t("playlist.actions.downloading")
-              : t("playlist.actions.download")
-        }
-      >
-        {isDownloaded ? (
-          <FontAwesomeIcon icon={faCheck} className="text-xl text-black" />
-        ) : !isDownloading ? (
-          <FontAwesomeIcon icon={faDownload} className="text-xl text-black" />
-        ) : null}
-      </Button>
+      {isManaged && (
+        <Button
+          variant="primary"
+          size="lg"
+          className={cn(
+            "!h-12 !w-12 justify-center !rounded-full !p-0 shadow-lg transition-transform md:!h-14 md:!w-14",
+            isDownloaded
+              ? "cursor-default bg-green-500 hover:bg-green-600"
+              : "bg-green-500 hover:scale-105 hover:bg-green-600",
+          )}
+          onClick={onDownload}
+          loading={isDownloading}
+          disabled={isDownloaded || isDownloading}
+          title={
+            isDownloaded
+              ? t("playlist.downloaded")
+              : isDownloading
+                ? t("playlist.actions.downloading")
+                : t("playlist.actions.download")
+          }
+        >
+          {isDownloaded ? (
+            <FontAwesomeIcon icon={faCheck} className="text-xl text-black" />
+          ) : !isDownloading ? (
+            <FontAwesomeIcon icon={faDownload} className="text-xl text-black" />
+          ) : null}
+        </Button>
+      )}
 
-      <Button
-        variant="secondary"
-        size="md"
-        className={cn(
-          "!h-9 !w-9 justify-center !rounded-full border-2 px-0 shadow-lg md:!h-10 md:!w-36 md:px-0",
-          isSubscribed
-            ? "border-green-500 bg-green-500 text-black hover:border-green-400 hover:bg-green-400"
-            : "border-white/30 bg-transparent text-white hover:border-white hover:bg-white/10",
-        )}
-        onClick={onToggleSubscription}
-        title={isSubscribed ? t("playlist.actions.unsubscribe") : t("playlist.actions.subscribe")}
-      >
-        <div className="flex items-center justify-center gap-2">
-          <FontAwesomeIcon icon={isSubscribed ? faBell : faBellRegular} className="text-sm" />
-          <span className="hidden text-xs font-bold tracking-wide uppercase md:inline">
-            {isSubscribed ? t("playlist.actions.subscribed") : t("playlist.actions.subscribe")}
-          </span>
-        </div>
-      </Button>
+      {isManaged && (
+        <Button
+          variant="secondary"
+          size="md"
+          className={cn(
+            "!h-9 !w-9 justify-center !rounded-full border-2 px-0 shadow-lg md:!h-10 md:!w-36 md:px-0",
+            isSubscribed
+              ? "border-green-500 bg-green-500 text-black hover:border-green-400 hover:bg-green-400"
+              : "border-white/30 bg-transparent text-white hover:border-white hover:bg-white/10",
+          )}
+          onClick={onToggleSubscription}
+          title={isSubscribed ? t("playlist.actions.unsubscribe") : t("playlist.actions.subscribe")}
+        >
+          <div className="flex items-center justify-center gap-2">
+            <FontAwesomeIcon icon={isSubscribed ? faBell : faBellRegular} className="text-sm" />
+            <span className="hidden text-xs font-bold tracking-wide uppercase md:inline">
+              {isSubscribed ? t("playlist.actions.subscribed") : t("playlist.actions.subscribe")}
+            </span>
+          </div>
+        </Button>
+      )}
 
       {hasEagerSpotifyUrl && (
         <SpotifyLinkButton
@@ -157,22 +166,24 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </Button>
       )}
 
-      <Button
-        variant="ghost"
-        size="lg"
-        icon={faTrash}
-        className={cn(
-          "text-text-secondary",
-          !isSaved ? "cursor-not-allowed opacity-30" : "hover:bg-red-500/10 hover:text-red-400",
-        )}
-        onClick={onDelete}
-        disabled={!isSaved}
-        title={
-          !isSaved ? t("playlist.actions.downloadToEnable") : t("playlist.actions.deleteTooltip")
-        }
-      >
-        <span className="hidden sm:inline">{t("playlist.actions.delete")}</span>
-      </Button>
+      {isManaged && (
+        <Button
+          variant="ghost"
+          size="lg"
+          icon={faTrash}
+          className={cn(
+            "text-text-secondary",
+            !isSaved ? "cursor-not-allowed opacity-30" : "hover:bg-red-500/10 hover:text-red-400",
+          )}
+          onClick={onDelete}
+          disabled={!isSaved}
+          title={
+            !isSaved ? t("playlist.actions.downloadToEnable") : t("playlist.actions.deleteTooltip")
+          }
+        >
+          <span className="hidden sm:inline">{t("playlist.actions.delete")}</span>
+        </Button>
+      )}
     </div>
   );
 };

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -9,6 +9,8 @@ import { PlaylistDescription } from "../molecules/PlaylistDescription";
 import { PlaylistMetadata } from "../molecules/PlaylistMetadata";
 import { ConfirmModal } from "../organisms/ConfirmModal";
 
+export type PlaylistMode = "library" | "managed";
+
 interface PlaylistProps {
   playlist: PlaylistWithStats;
   tracks: Track[];
@@ -36,6 +38,7 @@ interface PlaylistProps {
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
   onDownloadOrRetry: () => void;
+  mode?: PlaylistMode;
 }
 
 export const Playlist: FC<PlaylistProps> = ({
@@ -65,6 +68,7 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryFailed,
   onToggleSubscription,
   onDownloadOrRetry,
+  mode = "managed",
 }) => {
   const { t } = useTranslation();
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -132,6 +136,7 @@ export const Playlist: FC<PlaylistProps> = ({
               }
               playlistId={playlist?.id}
               playlistName={playlist?.name}
+              mode={mode}
             />
           </div>
         }

--- a/apps/frontend/src/hooks/controllers/useHomeController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useHomeController.test.tsx
@@ -422,7 +422,7 @@ describe("useHomeController", () => {
         result.current.handlePlaylistClick("playlist-nav");
       });
 
-      expect(mockNavigate).toHaveBeenCalledWith("/playlist/playlist-nav");
+      expect(mockNavigate).toHaveBeenCalledWith("/playlist/playlist-nav?mode=library");
     });
   });
 });

--- a/apps/frontend/src/hooks/controllers/useHomeController.ts
+++ b/apps/frontend/src/hooks/controllers/useHomeController.ts
@@ -133,7 +133,7 @@ export const useHomeController = () => {
 
   const handlePlaylistClick = useCallback(
     (id: string) => {
-      navigate(Path.PLAYLIST_DETAIL.replace(":id", id));
+      navigate(`${Path.PLAYLIST_DETAIL.replace(":id", id)}?mode=library`);
     },
     [navigate],
   );

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -15,6 +15,7 @@ vi.mock("react-router-dom", async () => {
   return {
     ...actual,
     useParams: () => mockUseParams(),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
   };
 });
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -1,5 +1,7 @@
 import { useCallback, useMemo } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
+
+export type PlaylistDetailMode = "library" | "managed";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useTracksQuery } from "../queries/useTracksQuery";
 import { useNavigationHelpers } from "../useNavigationHelpers";
@@ -14,6 +16,8 @@ export type PlaylistPlaybackErrorKey = LocalTrackPlaybackErrorKey<"library.album
 export const usePlaylistDetailController = () => {
   const { handleGoHome } = useNavigationHelpers();
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const mode: PlaylistDetailMode = searchParams.get("mode") === "library" ? "library" : "managed";
 
   const { data: playlists = [], isLoading: isPlaylistsLoading } = usePlaylistsQuery();
   const { data: tracks = [], isLoading: isTracksLoading } = useTracksQuery(id);
@@ -102,5 +106,6 @@ export const usePlaylistDetailController = () => {
     onAudioPause,
     onAudioError,
     hasPlayableTracks,
+    mode,
   };
 };

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -35,6 +35,7 @@ export const PlaylistDetail: FC = () => {
     currentTrackId,
     isPlaying,
     hasPlayableTracks,
+    mode,
   } = usePlaylistDetailController();
 
   if (isPlaylistsLoading || isTracksLoading) {
@@ -72,6 +73,7 @@ export const PlaylistDetail: FC = () => {
         currentTrackId={currentTrackId}
         isPlaying={isPlaying}
         hasPlayableTracks={hasPlayableTracks}
+        mode={mode}
       />
       <audio
         ref={setAudioElement}


### PR DESCRIPTION
## Summary

When the user opens a playlist from the new Home Playlists section (PR #79), the view represents **what is already downloaded** — subscribe, download-all-sync, and delete-row do not belong in that context. They stay in the MyPlaylists entry path.

- New `mode: "library" | "managed"` prop wired through `usePlaylistDetailController` → `PlaylistDetail` → `Playlist` → `PlaylistActions`.
- Controller reads `?mode=library` from URL search params, default `managed`.
- `useHomeController.handlePlaylistClick` now navigates with `?mode=library` suffix.
- MyPlaylists navigation unchanged → keeps managed mode by default.
- In library mode `PlaylistActions` hides: download/sync (✓), subscribe, delete. Play/pause + Spotify link remain.

## Test plan

- [x] Frontend `pnpm test --run` → 145/145
- [x] Frontend `pnpm lint` clean
- [x] Frontend `pnpm build` clean
- [x] Backend untouched