### PR TITLE
feat(frontend): polish library album/playlist detail views

### DIFF
--- a/apps/frontend/src/components/molecules/PlaylistDescription.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistDescription.tsx
@@ -6,6 +6,7 @@ interface PlaylistDescriptionProps {
   completedCount: number;
   totalCount: number;
   isDownloading?: boolean;
+  mode?: "library" | "managed";
 }
 
 export const PlaylistDescription: FC<PlaylistDescriptionProps> = ({
@@ -13,10 +14,11 @@ export const PlaylistDescription: FC<PlaylistDescriptionProps> = ({
   completedCount,
   totalCount,
   isDownloading,
+  mode = "managed",
 }) => {
   const { t } = useTranslation();
 
-  if (completedCount > 0 || (isDownloading && totalCount > 0)) {
+  if (mode !== "library" && (completedCount > 0 || (isDownloading && totalCount > 0))) {
     return (
       <div className="mt-4 w-full">
         <div className="text-text-secondary mb-1.5 flex items-center justify-between text-xs font-bold tracking-wider uppercase">

--- a/apps/frontend/src/components/molecules/PlaylistHeader.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistHeader.tsx
@@ -59,7 +59,7 @@ export const PlaylistHeader: FC<PlaylistHeaderProps> = ({
 
           <div className="text-text-primary mt-2 flex flex-wrap items-center justify-start gap-1 text-sm font-medium">
             {metadata}
-            <span className="text-text-secondary">•</span>
+            {metadata ? <span className="text-text-secondary">•</span> : null}
             <span className="text-text-secondary">
               {totalCount} {t("playlist.songs")}
             </span>

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -100,6 +100,7 @@ export const Playlist: FC<PlaylistProps> = ({
             completedCount={completedCount}
             totalCount={resolvedTotalCount}
             isDownloading={isDownloading}
+            mode={mode}
           />
         }
         metadata={

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -1,5 +1,5 @@
 import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { generatePath, useParams } from "react-router-dom";
 import { Path } from "@/routes/routes";
 import { Track } from "@/types";
@@ -70,6 +70,19 @@ export const useLibraryAlbumDetailController = () => {
     getAudioUrl: (track) => track.trackUrl,
   });
 
+  const firstPlayableTrackId = useMemo(
+    () => tracks.find((track) => track.trackUrl)?.id ?? null,
+    [tracks],
+  );
+
+  const hasPlayableTracks = firstPlayableTrackId !== null;
+
+  const onPlayPlaylist = useCallback(() => {
+    const targetTrackId = currentTrackId ?? firstPlayableTrackId;
+    if (!targetTrackId) return;
+    onPlayTrack(targetTrackId);
+  }, [currentTrackId, firstPlayableTrackId, onPlayTrack]);
+
   const coverUrl = album?.image
     ? `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/image?path=${encodeURIComponent(album.image)}`
     : undefined;
@@ -99,5 +112,8 @@ export const useLibraryAlbumDetailController = () => {
     onAudioPlay,
     onAudioPause,
     onAudioError,
+    hasPlayableTracks,
+    onPlayPlaylist,
+    onPausePlaylist: onPauseTrack,
   };
 };

--- a/apps/frontend/src/hooks/controllers/useMyPlaylistsController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useMyPlaylistsController.test.ts
@@ -92,6 +92,44 @@ describe("useMyPlaylistsController", () => {
     );
   });
 
+  it("routes partially-downloaded unsubscribed saved playlists to the preview, not detail", () => {
+    const partial: PlaylistWithStats = {
+      ...savedPlaylist,
+      subscribed: false,
+      stats: { ...savedPlaylist.stats, completedCount: 1, totalCount: 187 },
+    };
+    mockUsePlaylistsQuery.mockReturnValue({ data: [partial], isLoading: false });
+
+    const { result } = renderHook(() => useMyPlaylistsController());
+
+    act(() => {
+      result.current.handlePlaylistClick(spotifyPlaylist.id);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(spotifyPlaylist.spotifyUrl)}`,
+    );
+  });
+
+  it("routes fully-downloaded saved playlists to detail even when unsubscribed", () => {
+    const full: PlaylistWithStats = {
+      ...savedPlaylist,
+      subscribed: false,
+      stats: { ...savedPlaylist.stats, completedCount: 12, totalCount: 12 },
+    };
+    mockUsePlaylistsQuery.mockReturnValue({ data: [full], isLoading: false });
+
+    const { result } = renderHook(() => useMyPlaylistsController());
+
+    act(() => {
+      result.current.handlePlaylistClick(spotifyPlaylist.id);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Path.PLAYLIST_DETAIL.replace(":id", savedPlaylist.id),
+    );
+  });
+
   it("falls back to playlist preview when the playlist is not saved", () => {
     const { result } = renderHook(() => useMyPlaylistsController());
 

--- a/apps/frontend/src/hooks/controllers/useMyPlaylistsController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useMyPlaylistsController.test.ts
@@ -1,13 +1,11 @@
-import { PlaylistTypeEnum, SpotifyPlaylist } from "@spotiarr/shared";
+import { SpotifyPlaylist } from "@spotiarr/shared";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Path } from "@/routes/routes";
-import { PlaylistWithStats } from "@/types";
 import { useMyPlaylistsController } from "./useMyPlaylistsController";
 
 const mockNavigate = vi.fn();
 const mockUseMyPlaylistsQuery = vi.fn();
-const mockUsePlaylistsQuery = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -20,10 +18,6 @@ vi.mock("react-router-dom", async () => {
 
 vi.mock("@/hooks/queries/useMyPlaylistsQuery", () => ({
   useMyPlaylistsQuery: () => mockUseMyPlaylistsQuery(),
-}));
-
-vi.mock("@/hooks/queries/usePlaylistsQuery", () => ({
-  usePlaylistsQuery: () => mockUsePlaylistsQuery(),
 }));
 
 vi.mock("../useDebounce", () => ({
@@ -39,28 +33,6 @@ const spotifyPlaylist: SpotifyPlaylist = {
   spotifyUrl: "https://open.spotify.com/playlist/road-trip",
 };
 
-const savedPlaylist: PlaylistWithStats = {
-  id: "saved-playlist-1",
-  name: "Road Trip",
-  type: PlaylistTypeEnum.Playlist,
-  spotifyUrl: spotifyPlaylist.spotifyUrl,
-  subscribed: true,
-  tracks: [],
-  stats: {
-    completedCount: 0,
-    downloadingCount: 0,
-    searchingCount: 0,
-    queuedCount: 0,
-    activeCount: 0,
-    errorCount: 0,
-    totalCount: 0,
-    progress: 0,
-    isDownloading: false,
-    hasErrors: false,
-    isCompleted: false,
-  },
-};
-
 describe("useMyPlaylistsController", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -69,68 +41,9 @@ describe("useMyPlaylistsController", () => {
       isLoading: false,
       error: null,
     });
-    mockUsePlaylistsQuery.mockReturnValue({
-      data: [],
-      isLoading: false,
-    });
   });
 
-  it("navigates to saved playlist detail when the playlist already exists", () => {
-    mockUsePlaylistsQuery.mockReturnValue({
-      data: [savedPlaylist],
-      isLoading: false,
-    });
-
-    const { result } = renderHook(() => useMyPlaylistsController());
-
-    act(() => {
-      result.current.handlePlaylistClick(spotifyPlaylist.id);
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Path.PLAYLIST_DETAIL.replace(":id", savedPlaylist.id),
-    );
-  });
-
-  it("routes partially-downloaded unsubscribed saved playlists to the preview, not detail", () => {
-    const partial: PlaylistWithStats = {
-      ...savedPlaylist,
-      subscribed: false,
-      stats: { ...savedPlaylist.stats, completedCount: 1, totalCount: 187 },
-    };
-    mockUsePlaylistsQuery.mockReturnValue({ data: [partial], isLoading: false });
-
-    const { result } = renderHook(() => useMyPlaylistsController());
-
-    act(() => {
-      result.current.handlePlaylistClick(spotifyPlaylist.id);
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      `${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(spotifyPlaylist.spotifyUrl)}`,
-    );
-  });
-
-  it("routes fully-downloaded saved playlists to detail even when unsubscribed", () => {
-    const full: PlaylistWithStats = {
-      ...savedPlaylist,
-      subscribed: false,
-      stats: { ...savedPlaylist.stats, completedCount: 12, totalCount: 12 },
-    };
-    mockUsePlaylistsQuery.mockReturnValue({ data: [full], isLoading: false });
-
-    const { result } = renderHook(() => useMyPlaylistsController());
-
-    act(() => {
-      result.current.handlePlaylistClick(spotifyPlaylist.id);
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith(
-      Path.PLAYLIST_DETAIL.replace(":id", savedPlaylist.id),
-    );
-  });
-
-  it("falls back to playlist preview when the playlist is not saved", () => {
+  it("navigates to playlist preview regardless of saved/subscribed state", () => {
     const { result } = renderHook(() => useMyPlaylistsController());
 
     act(() => {

--- a/apps/frontend/src/hooks/controllers/useMyPlaylistsController.ts
+++ b/apps/frontend/src/hooks/controllers/useMyPlaylistsController.ts
@@ -2,13 +2,11 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { APP_CONFIG } from "@/config/app";
 import { useMyPlaylistsQuery } from "@/hooks/queries/useMyPlaylistsQuery";
-import { usePlaylistsQuery } from "@/hooks/queries/usePlaylistsQuery";
 import { Path } from "@/routes/routes";
 import { useDebounce } from "../useDebounce";
 
 export const useMyPlaylistsController = () => {
   const { data: playlists = [], isLoading, error } = useMyPlaylistsQuery();
-  const { data: savedPlaylists = [] } = usePlaylistsQuery();
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebounce(search, APP_CONFIG.DEBOUNCE.SEARCH_DELAY);
   const navigate = useNavigate();
@@ -20,28 +18,14 @@ export const useMyPlaylistsController = () => {
   const handlePlaylistClick = useCallback(
     (id: string) => {
       const playlist = playlists.find((p) => p.id === id);
-      if (playlist) {
-        const savedPlaylist = savedPlaylists.find((p) => p.spotifyUrl === playlist.spotifyUrl);
-
-        // Only route to PlaylistDetail when the user has explicitly committed
-        // to the playlist (subscribed or fully downloaded). Otherwise the saved
-        // row may only contain a few orphan single-track downloads, in which
-        // case the preview gives the complete Spotify catalogue with per-track
-        // download buttons.
-        if (
-          savedPlaylist &&
-          (savedPlaylist.subscribed ||
-            (savedPlaylist.stats.totalCount > 0 &&
-              savedPlaylist.stats.completedCount === savedPlaylist.stats.totalCount))
-        ) {
-          navigate(Path.PLAYLIST_DETAIL.replace(":id", savedPlaylist.id));
-          return;
-        }
-
-        navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(playlist.spotifyUrl)}`);
-      }
+      if (!playlist) return;
+      // Always show the live Spotify catalogue (PlaylistPreview) when coming
+      // from MyPlaylists. The DB row (savedPlaylist) only contains downloaded
+      // tracks, which would misrepresent the playlist when partially saved.
+      // PlaylistDetail (managed/library views) is reachable from Home Playlists.
+      navigate(`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(playlist.spotifyUrl)}`);
     },
-    [navigate, playlists, savedPlaylists],
+    [navigate, playlists],
   );
 
   const filteredPlaylists = useMemo(

--- a/apps/frontend/src/hooks/controllers/useMyPlaylistsController.ts
+++ b/apps/frontend/src/hooks/controllers/useMyPlaylistsController.ts
@@ -23,7 +23,17 @@ export const useMyPlaylistsController = () => {
       if (playlist) {
         const savedPlaylist = savedPlaylists.find((p) => p.spotifyUrl === playlist.spotifyUrl);
 
-        if (savedPlaylist) {
+        // Only route to PlaylistDetail when the user has explicitly committed
+        // to the playlist (subscribed or fully downloaded). Otherwise the saved
+        // row may only contain a few orphan single-track downloads, in which
+        // case the preview gives the complete Spotify catalogue with per-track
+        // download buttons.
+        if (
+          savedPlaylist &&
+          (savedPlaylist.subscribed ||
+            (savedPlaylist.stats.totalCount > 0 &&
+              savedPlaylist.stats.completedCount === savedPlaylist.stats.totalCount))
+        ) {
           navigate(Path.PLAYLIST_DETAIL.replace(":id", savedPlaylist.id));
           return;
         }

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -141,6 +141,8 @@
       "pause": "Pause",
       "playTrack": "Play track",
       "pauseTrack": "Pause track",
+      "playAlbum": "Play album",
+      "pauseAlbum": "Pause album",
       "playbackBlocked": "Your browser blocked playback. Try pressing play again or checking autoplay permissions.",
       "playbackFailed": "Playback failed for this track. Try again.",
       "playbackUnavailable": "This track could not be loaded for playback. The source may be unavailable or unsupported.",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -141,6 +141,8 @@
       "pause": "Pausar",
       "playTrack": "Reproducir canción",
       "pauseTrack": "Pausar canción",
+      "playAlbum": "Reproducir álbum",
+      "pauseAlbum": "Pausar álbum",
       "playbackBlocked": "Tu navegador bloqueó la reproducción. Probá reproducir de nuevo o revisá los permisos de autoplay.",
       "playbackFailed": "La reproducción falló para esta canción. Probá de nuevo.",
       "playbackUnavailable": "No se pudo cargar esta canción para reproducirla. La fuente puede no estar disponible o no ser compatible.",

--- a/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.test.tsx
@@ -22,6 +22,10 @@ vi.mock("react-i18next", async (importOriginal) => {
   };
 });
 
+vi.mock("@/components/molecules/SpotifyLinkButton", () => ({
+  SpotifyLinkButton: () => null,
+}));
+
 vi.mock("@/components/molecules/VirtualList", () => ({
   VirtualList: ({
     items,

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -1,10 +1,12 @@
-import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { faMusic, faPause, faPlay } from "@fortawesome/free-solid-svg-icons";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { Button } from "@/components/atoms/Button";
 import { Loading } from "@/components/atoms/Loading";
 import { AlbumPageLayout } from "@/components/molecules/AlbumPageLayout";
 import { EmptyState } from "@/components/molecules/EmptyState";
+import { SpotifyLinkButton } from "@/components/molecules/SpotifyLinkButton";
 import { useLibraryAlbumDetailController } from "@/hooks/controllers/useLibraryAlbumDetailController";
 
 export const LibraryAlbumDetail: FC = () => {
@@ -28,6 +30,9 @@ export const LibraryAlbumDetail: FC = () => {
     onAudioError,
     onAudioPlay,
     onAudioPause,
+    hasPlayableTracks,
+    onPlayPlaylist,
+    onPausePlaylist,
   } = useLibraryAlbumDetailController();
 
   if (isLoading) {
@@ -88,11 +93,6 @@ export const LibraryAlbumDetail: FC = () => {
         type={playlistType}
         coverUrl={coverUrl}
         description={artistName}
-        metadata={
-          <span>
-            {tracks.length} {t("library.album.tracks")}
-          </span>
-        }
         totalCount={tracks.length}
         tracks={tracks}
         onPlayTrack={onPlayTrack}
@@ -101,6 +101,35 @@ export const LibraryAlbumDetail: FC = () => {
         isPlaying={isPlaying}
         emptyTitle={t("library.album.emptyTracks")}
         emptyDescription={t("library.album.emptyTracks")}
+        actions={
+          <div className="to-background bg-gradient-to-b from-black/20 px-6 py-6 md:px-8">
+            <div className="flex items-center gap-3 md:gap-4">
+              {hasPlayableTracks ? (
+                <Button
+                  variant="primary"
+                  size="lg"
+                  className="!h-12 !w-12 justify-center !rounded-full !p-0 shadow-lg transition-transform hover:scale-105 md:!h-14 md:!w-14"
+                  onClick={isPlaying ? onPausePlaylist : onPlayPlaylist}
+                  title={isPlaying ? t("library.album.pauseAlbum") : t("library.album.playAlbum")}
+                  ariaLabel={
+                    isPlaying ? t("library.album.pauseAlbum") : t("library.album.playAlbum")
+                  }
+                  icon={isPlaying ? faPause : faPlay}
+                >
+                  <span className="sr-only">
+                    {isPlaying ? t("library.album.pause") : t("library.album.play")}
+                  </span>
+                </Button>
+              ) : null}
+              <SpotifyLinkButton
+                provider="spotify"
+                entityType="album"
+                id={`${artistName}::${album.name}`}
+                name={`${artistName} ${album.name}`}
+              />
+            </div>
+          </div>
+        }
       />
       <audio
         ref={setAudioElement}


### PR DESCRIPTION
## Summary

Three small fixes surfaced from #79/#81 after using the library views:

- **PlaylistDetail in \`?mode=library\`**: hide the "X / Y DESCARGADO" progress bar — tautological in library mode (everything visible is already downloaded).
- **LibraryAlbumDetail**: add Play/Pause album button + lazy "Open in Spotify" button in the actions slot, matching PlaylistDetail. Reuses existing \`useLocalTrackPlaybackController\` and \`SpotifyLinkButton\` (lazy mode resolves the Spotify URL on demand).
- **LibraryAlbumDetail**: drop the redundant \`metadata\` slot that rendered the track count twice ("1 canciones · 1 canciones"). \`PlaylistHeader\` already renders \`totalCount\`.

New i18n keys EN + ES: \`library.album.playAlbum\` / \`pauseAlbum\` to keep the album-level Play button distinguishable from the per-track Play action.

## Test plan

- [x] Frontend \`pnpm test --run\` → 145/145
- [x] Frontend \`pnpm lint\` + \`pnpm build\` clean
- [x] \`LibraryAlbumDetail.test.tsx\` mocks \`SpotifyLinkButton\` to keep its \`ToastProvider\`-less setup valid
- [x] Backend untouched