### PR TITLE
test(frontend): add Playwright E2E smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,23 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Install Playwright browsers
+        run: pnpm --filter frontend exec playwright install --with-deps chromium
+
+      - name: Run frontend Playwright runtime tests
+        run: pnpm --filter frontend run test:e2e:runtime
+
+      - name: Run frontend Playwright E2E tests
+        run: pnpm --filter frontend run test:e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: apps/frontend/playwright-report/
+          if-no-files-found: ignore
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,31 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build shared package
+        run: pnpm --filter @spotiarr/shared run build
+
       - name: Install Playwright browsers
         run: pnpm --filter frontend exec playwright install --with-deps chromium
 

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ pids/
 
 # Reports
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+**/playwright-report/
+**/test-results/
 
 # OS files
 .DS_Store

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -11,7 +11,10 @@
     "lint": "oxlint src --fix --ignore-path ../../.gitignore",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:runtime": "vitest run --config vitest.playwright.config.ts",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.1.0",
@@ -34,6 +37,7 @@
     "zustand": "^5.0.9"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
     "@spotiarr/tsconfig": "workspace:*",
     "@tailwindcss/vite": "^4.1.17",
     "@tanstack/react-query-devtools": "^5.91.1",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+import { fileURLToPath } from "node:url";
+
+const PORT = 4173;
+const HOST = "127.0.0.1";
+const BASE_URL = `http://${HOST}:${PORT}`;
+const ROOT_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: `pnpm run build && vite preview --host ${HOST} --port ${PORT} --strictPort`,
+    cwd: ROOT_DIR,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 120_000,
+  },
+});

--- a/apps/frontend/tests/base-page.ts
+++ b/apps/frontend/tests/base-page.ts
@@ -1,0 +1,17 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export class BasePage {
+  readonly headerSearchInput: Locator;
+
+  constructor(protected readonly page: Page) {
+    this.headerSearchInput = page.getByPlaceholder("Search or paste link...");
+  }
+
+  async goto(path: string): Promise<void> {
+    await this.page.goto(path, { waitUntil: "domcontentloaded" });
+  }
+
+  async expectShellReady(): Promise<void> {
+    await expect(this.headerSearchInput).toBeVisible();
+  }
+}

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -1,0 +1,108 @@
+import { type Page } from "@playwright/test";
+
+interface AppShellMockOptions {
+  mockPlaylistStatus?: boolean;
+}
+
+interface AppShellMockGuard {
+  assertNoUnhandledRequests(timeoutMs?: number): Promise<void>;
+  waitForUnhandledRequest(timeoutMs?: number): Promise<string>;
+}
+
+const SETTINGS_PAYLOAD = {
+  data: [{ key: "UI_LANGUAGE", value: "en", updatedAt: new Date(0).toISOString() }],
+};
+
+const DOWNLOAD_STATUS_PAYLOAD = {
+  playlistStatusMap: {},
+  trackStatusMap: {},
+  albumTrackCountMap: {},
+};
+
+const SSE_PAYLOAD = ": connected\n\n";
+
+export async function installAppShellMocks(
+  page: Page,
+  { mockPlaylistStatus = true }: AppShellMockOptions = {},
+): Promise<AppShellMockGuard> {
+  let unhandledRequestMessage: string | null = null;
+  let resolveUnhandledRequest: ((message: string) => void) | null = null;
+
+  const unhandledRequestPromise = new Promise<string>((resolve) => {
+    resolveUnhandledRequest = resolve;
+  });
+
+  await page.route("**/api/**", async (route) => {
+    const message = `Unhandled API request: ${route.request().method()} ${route.request().url()}`;
+
+    if (!unhandledRequestMessage) {
+      unhandledRequestMessage = message;
+      resolveUnhandledRequest?.(message);
+    }
+
+    await route.abort("failed");
+  });
+
+  await page.route("**/api/settings", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(SETTINGS_PAYLOAD),
+    });
+  });
+
+  await page.route("**/api/events", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      headers: {
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+      body: SSE_PAYLOAD,
+    });
+  });
+
+  if (mockPlaylistStatus) {
+    await page.route("**/api/playlist/status", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(DOWNLOAD_STATUS_PAYLOAD),
+      });
+    });
+  }
+
+  return {
+    async assertNoUnhandledRequests(timeoutMs = 250): Promise<void> {
+      if (unhandledRequestMessage) {
+        throw new Error(unhandledRequestMessage);
+      }
+
+      const outcome = await Promise.race([
+        unhandledRequestPromise.then((message) => ({ message })),
+        page.waitForTimeout(timeoutMs).then(() => null),
+      ]);
+
+      if (outcome?.message) {
+        throw new Error(outcome.message);
+      }
+    },
+    async waitForUnhandledRequest(timeoutMs = 5_000): Promise<string> {
+      if (unhandledRequestMessage) {
+        return unhandledRequestMessage;
+      }
+
+      const outcome = await Promise.race([
+        unhandledRequestPromise.then((message) => ({ message })),
+        page.waitForTimeout(timeoutMs).then(() => null),
+      ]);
+
+      if (!outcome?.message) {
+        throw new Error(`Timed out waiting for an unhandled API request after ${timeoutMs}ms`);
+      }
+
+      return outcome.message;
+    },
+  };
+}

--- a/apps/frontend/tests/not-found/not-found-page.ts
+++ b/apps/frontend/tests/not-found/not-found-page.ts
@@ -1,0 +1,26 @@
+import { type Locator, type Page } from "@playwright/test";
+import { BasePage } from "../base-page";
+
+export class NotFoundPage extends BasePage {
+  readonly title: Locator;
+  readonly description: Locator;
+  readonly goHomeButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.title = page.getByRole("heading", { name: "Page Not Found" });
+    this.description = page.getByText(
+      "The page you are looking for does not exist or has been moved.",
+    );
+    this.goHomeButton = page.getByRole("button", { name: "Go Home" });
+  }
+
+  async goto(): Promise<void> {
+    await super.goto("/does-not-exist");
+    await this.expectShellReady();
+  }
+
+  async goHome(): Promise<void> {
+    await this.goHomeButton.click();
+  }
+}

--- a/apps/frontend/tests/not-found/not-found.md
+++ b/apps/frontend/tests/not-found/not-found.md
@@ -1,0 +1,11 @@
+# Not found smoke tests
+
+## Coverage
+
+- Unknown routes render the embedded not-found view.
+- `Go Home` returns the browser to `/`.
+
+## Mocking
+
+- Starts with `installAppShellMocks(page)`.
+- Route-specific mocks may be layered on top when `/` needs explicit data.

--- a/apps/frontend/tests/not-found/not-found.spec.ts
+++ b/apps/frontend/tests/not-found/not-found.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type Page } from "@playwright/test";
+import { installAppShellMocks } from "../helpers/api-mocks";
+import { NotFoundPage } from "./not-found-page";
+
+const installHomeRouteMocks = async (page: Page) => {
+  await page.route("**/api/library/stats", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          totalArtists: 0,
+          totalAlbums: 0,
+          totalTracks: 0,
+          totalSize: 0,
+          lastScannedAt: null,
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/library/artists", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: [] }),
+    });
+  });
+
+  await page.route("**/api/library/artwork-backfill/status", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: {
+          runId: null,
+          status: "idle",
+          phase: null,
+          totals: 0,
+          processed: 0,
+          skippedExisting: 0,
+          written: 0,
+          failed: 0,
+          externalCalls: 0,
+          lastCheckpoint: null,
+          rateLimitUntil: null,
+          updatedAt: null,
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/playlist", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: [] }),
+    });
+  });
+};
+
+test.describe("Not found smoke", () => {
+  test("shows the embedded not found view for unknown routes", async ({ page }) => {
+    const appShellMocks = await installAppShellMocks(page);
+
+    const notFoundPage = new NotFoundPage(page);
+
+    await notFoundPage.goto();
+
+    await expect(notFoundPage.title).toBeVisible();
+    await expect(notFoundPage.description).toBeVisible();
+    await appShellMocks.assertNoUnhandledRequests();
+  });
+
+  test("recovers to the home route when Go Home is activated", async ({ page }) => {
+    const appShellMocks = await installAppShellMocks(page);
+    await installHomeRouteMocks(page);
+
+    const notFoundPage = new NotFoundPage(page);
+
+    await notFoundPage.goto();
+    await notFoundPage.goHome();
+
+    await expect(page).toHaveURL("/");
+    await expect(page.getByText("Your Library")).toBeVisible();
+    await appShellMocks.assertNoUnhandledRequests();
+  });
+});

--- a/apps/frontend/tests/runtime/playwright-runtime.test.ts
+++ b/apps/frontend/tests/runtime/playwright-runtime.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { runStartupFailureScenario } from "./playwright-runtime";
+
+describe.sequential("Playwright runtime guarantees", () => {
+  test("fails before route specs execute when preview startup fails", async () => {
+    const result = await runStartupFailureScenario();
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.markerExists).toBe(false);
+    expect(result.output).not.toContain("startup failure fixture executed");
+  });
+});

--- a/apps/frontend/tests/runtime/playwright-runtime.ts
+++ b/apps/frontend/tests/runtime/playwright-runtime.ts
@@ -1,0 +1,135 @@
+import { spawn } from "node:child_process";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FRONTEND_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const BASE_URL = "http://127.0.0.1:4173";
+const PLAYWRIGHT_TIMEOUT_MS = 120_000;
+
+export interface PlaywrightRuntimeResult {
+  exitCode: number | null;
+  markerExists: boolean;
+  output: string;
+}
+
+export async function runStartupFailureScenario(): Promise<PlaywrightRuntimeResult> {
+  return runFixture({
+    webServerCommand: `node -e "process.exit(1)"`,
+    specBody: `
+      import { test } from "@playwright/test";
+      import { writeFileSync } from "node:fs";
+
+      test("startup failure fixture executed", async () => {
+        writeFileSync(process.env.PLAYWRIGHT_SPEC_MARKER!, "executed");
+      });
+    `,
+  });
+}
+
+interface FixtureOptions {
+  specBody: string;
+  webServerCommand: string;
+}
+
+async function runFixture({
+  specBody,
+  webServerCommand,
+}: FixtureOptions): Promise<PlaywrightRuntimeResult> {
+  const tempDir = await mkdtemp(join(tmpdir(), "spotiarr-playwright-runtime-"));
+  const configPath = join(tempDir, "playwright.config.ts");
+  const specPath = join(tempDir, "fixture.spec.ts");
+  const markerPath = join(tempDir, "spec-executed.txt");
+
+  await writeFile(configPath, buildConfig(webServerCommand), "utf8");
+  await writeFile(specPath, specBody.trimStart(), "utf8");
+
+  try {
+    const { exitCode, stderr, stdout } = await runPlaywright(configPath, specPath, markerPath);
+
+    return {
+      exitCode,
+      markerExists: await fileExists(markerPath),
+      output: `${stdout}\n${stderr}`.trim(),
+    };
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+function buildConfig(webServerCommand: string): string {
+  return `
+    import { defineConfig, devices } from "@playwright/test";
+
+    export default defineConfig({
+      testDir: ${JSON.stringify(".")},
+      testMatch: "**/*.spec.ts",
+      fullyParallel: false,
+      retries: 0,
+      reporter: [["line"]],
+      use: {
+        baseURL: ${JSON.stringify(BASE_URL)},
+        trace: "off",
+        screenshot: "off",
+      },
+      projects: [
+        {
+          name: "chromium",
+          use: { ...devices["Desktop Chrome"] },
+        },
+      ],
+      webServer: {
+        command: ${JSON.stringify(webServerCommand)},
+        cwd: ${JSON.stringify(FRONTEND_ROOT)},
+        url: ${JSON.stringify(BASE_URL)},
+        reuseExistingServer: false,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: ${PLAYWRIGHT_TIMEOUT_MS},
+      },
+    });
+  `.trimStart();
+}
+
+async function runPlaywright(
+  configPath: string,
+  specPath: string,
+  markerPath: string,
+): Promise<{ exitCode: number | null; stderr: string; stdout: string }> {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn("pnpm", ["exec", "playwright", "test", "--config", configPath, specPath], {
+      cwd: FRONTEND_ROOT,
+      env: {
+        ...process.env,
+        PLAYWRIGHT_SPEC_MARKER: markerPath,
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    child.on("error", rejectPromise);
+    child.on("close", (exitCode) => {
+      resolvePromise({ exitCode, stderr, stdout });
+    });
+  });
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    await readFile(path, "utf8");
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/frontend/tests/search/search-page.ts
+++ b/apps/frontend/tests/search/search-page.ts
@@ -1,0 +1,20 @@
+import { type Locator, type Page } from "@playwright/test";
+import { BasePage } from "../base-page";
+
+export class SearchPage extends BasePage {
+  readonly emptyStateMessage: Locator;
+  readonly allTab: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.emptyStateMessage = page.getByText(
+      "Type something in the search bar to find tracks, albums, or artists",
+    );
+    this.allTab = page.getByRole("button", { name: "All" });
+  }
+
+  async goto(): Promise<void> {
+    await super.goto("/search");
+    await this.expectShellReady();
+  }
+}

--- a/apps/frontend/tests/search/search.md
+++ b/apps/frontend/tests/search/search.md
@@ -1,0 +1,11 @@
+# Search smoke tests
+
+## Coverage
+
+- Empty `/search` route renders the empty-state guidance.
+- Shared app shell remains visible with bootstrap mocks only.
+
+## Mocking
+
+- Uses `installAppShellMocks(page)` only.
+- Must not require catalog or search endpoint mocks.

--- a/apps/frontend/tests/search/search.spec.ts
+++ b/apps/frontend/tests/search/search.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { installAppShellMocks } from "../helpers/api-mocks";
+import { SearchPage } from "./search-page";
+
+test.describe("Search smoke", () => {
+  test("renders the empty search state with bootstrap mocks only", async ({ page }) => {
+    const appShellMocks = await installAppShellMocks(page);
+
+    const searchPage = new SearchPage(page);
+
+    await searchPage.goto();
+
+    await expect(searchPage.emptyStateMessage).toBeVisible();
+    await expect(searchPage.emptyStateMessage).toContainText(
+      "Type something in the search bar to find tracks, albums, or artists",
+    );
+    await appShellMocks.assertNoUnhandledRequests();
+  });
+
+  test("keeps the shared app shell available on the empty search route", async ({ page }) => {
+    const appShellMocks = await installAppShellMocks(page);
+
+    const searchPage = new SearchPage(page);
+
+    await searchPage.goto();
+
+    await expect(searchPage.headerSearchInput).toBeVisible();
+    await expect(searchPage.allTab).toBeVisible();
+    await appShellMocks.assertNoUnhandledRequests();
+  });
+
+  test("fails explicitly when a required bootstrap mock is missing", async ({ page }) => {
+    const appShellMocks = await installAppShellMocks(page, { mockPlaylistStatus: false });
+
+    await page.goto("/search", { waitUntil: "domcontentloaded" });
+
+    await expect(appShellMocks.waitForUnhandledRequest()).resolves.toContain(
+      "/api/playlist/status",
+    );
+    await expect(appShellMocks.assertNoUnhandledRequests()).rejects.toThrow(
+      /Unhandled API request: GET/,
+    );
+  });
+});

--- a/apps/frontend/vitest.playwright.config.ts
+++ b/apps/frontend/vitest.playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["tests/runtime/**/*.test.ts"],
+    testTimeout: 180_000,
+    hookTimeout: 180_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
         specifier: ^5.0.9
         version: 5.0.9(@types/react@19.2.7)(react@19.2.1)(use-sync-external-store@1.6.0(react@19.2.1))
     devDependencies:
+      "@playwright/test":
+        specifier: ^1.56.1
+        version: 1.60.0
       "@spotiarr/tsconfig":
         specifier: workspace:*
         version: link:../../packages/tsconfig
@@ -1017,6 +1020,14 @@ packages:
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [win32]
+
+  "@playwright/test@1.60.0":
+    resolution:
+      {
+        integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
 
   "@prisma/client@5.22.0":
     resolution:
@@ -2313,6 +2324,14 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  fsevents@2.3.2:
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution:
       {
@@ -3094,6 +3113,22 @@ packages:
         integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
       }
     engines: { node: ">=0.10" }
+    hasBin: true
+
+  playwright-core@1.60.0:
+    resolution:
+      {
+        integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution:
+      {
+        integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==,
+      }
+    engines: { node: ">=18" }
     hasBin: true
 
   plimit-lit@1.6.1:
@@ -4488,6 +4523,10 @@ snapshots:
   "@oxlint/binding-win32-x64-msvc@1.66.0":
     optional: true
 
+  "@playwright/test@1.60.0":
+    dependencies:
+      playwright: 1.60.0
+
   "@prisma/client@5.22.0(prisma@5.22.0)":
     optionalDependencies:
       prisma: 5.22.0
@@ -5249,6 +5288,9 @@ snapshots:
 
   fresh@2.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5677,6 +5719,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pidtree@0.6.0: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   plimit-lit@1.6.1:
     dependencies:


### PR DESCRIPTION
## What

Adds a Playwright E2E foundation for the frontend: preview-backed smoke tests, browser-level API/SSE mocks, runtime startup validation, CI execution, and ignored Playwright report artifacts.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / chore

## Scope

- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Checklist

- [x] Lint + build pass for affected scope (`pnpm --filter frontend run lint`, `pnpm --filter frontend run test:run`, `pnpm --filter frontend run build`)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change

## Verification

- `pnpm --filter frontend run test:e2e:runtime`
- `pnpm --filter frontend run test:e2e`
- `pnpm --filter frontend run lint`
- `pnpm --filter frontend run test:run`
- `pnpm --filter frontend run build`

## Notes

- SDD verify result: PASS WITH WARNINGS; no critical issues.
- Approved size exception: Playwright dependency lockfile churn.