### PR TITLE
feat(player): global player bar foundation (slice 1/2)

### DIFF
--- a/apps/frontend/src/components/layouts/AppLayout.tsx
+++ b/apps/frontend/src/components/layouts/AppLayout.tsx
@@ -3,6 +3,7 @@ import { Outlet } from "react-router-dom";
 import { Path } from "@/routes/routes";
 import { usePreferencesStore } from "@/store/usePreferencesStore";
 import { cn } from "@/utils/cn";
+import { GlobalPlayerBar } from "../organisms/GlobalPlayerBar";
 import { AppHeader } from "./AppHeader";
 import { BottomNavigation } from "./BottomNavigation";
 import { Sidebar } from "./Sidebar";
@@ -21,7 +22,9 @@ export const AppLayout: FC<AppLayoutProps> = ({ pathname, version }) => {
 
       <main
         className={cn(
-          "bg-background ml-0 flex flex-1 flex-col pb-20 transition-[margin-left] duration-300 md:pb-0",
+          // Mobile: pb-36 clears bottom-nav (h-16 = 64px) + player bar (~80px).
+          // Desktop: pb-24 clears player bar (~80px); no bottom nav on md+.
+          "bg-background ml-0 flex flex-1 flex-col pb-36 transition-[margin-left] duration-300 md:pb-24",
           isSidebarCollapsed ? "md:ml-20" : "md:ml-64",
         )}
       >
@@ -31,6 +34,10 @@ export const AppLayout: FC<AppLayoutProps> = ({ pathname, version }) => {
       </main>
 
       <BottomNavigation pathname={pathname} />
+
+      {/* GlobalPlayerBar is always mounted above BottomNavigation on mobile (bottom-16),
+          at bottom-0 on desktop. z-40 places it below z-50 nav. */}
+      <GlobalPlayerBar />
     </div>
   );
 };

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -38,14 +38,6 @@ function resetStore() {
   });
 }
 
-// jsdom does not implement HTMLMediaElement; stub the imperative API.
-function mockAudioElement(): HTMLAudioElement {
-  const el = document.createElement("audio");
-  el.play = vi.fn().mockResolvedValue(undefined);
-  el.pause = vi.fn();
-  return el;
-}
-
 beforeEach(() => {
   vi.useFakeTimers();
   resetStore();
@@ -130,11 +122,8 @@ describe("track metadata", () => {
 
     render(<GlobalPlayerBar />);
 
-    // The Image atom renders a FontAwesome icon placeholder when src is absent
-    // Confirm no broken img element (img with src would not be rendered)
-    const imgEl = screen.queryByRole("img", { name: /Track a/i });
-    // Either it's a placeholder div or the img is not rendered — either is correct
-    // What matters is no throw and the artwork container is present
+    // The Image atom renders a FontAwesome icon placeholder when src is absent.
+    // What matters is no throw and the artwork container is present.
     const region = screen.getByRole("region", { name: "Now playing" });
     expect(region).not.toBeNull();
   });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -316,6 +316,38 @@ describe("error state", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Keyboard Space toggle (REQ-PLAYER-BAR-009)
+// ---------------------------------------------------------------------------
+
+describe("keyboard space toggle", () => {
+  it("pressing Space on the region root toggles play", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    render(<GlobalPlayerBar />);
+
+    const region = screen.getByRole("region", { name: "Now playing" });
+    fireEvent.keyDown(region, { key: " " });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("pressing Space on the play button does NOT double-toggle", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    render(<GlobalPlayerBar />);
+
+    const playBtn = screen.getByRole("button", { name: "Play" });
+    fireEvent.keyDown(playBtn, { key: " " });
+
+    // The region onKeyDown should be a no-op when target is BUTTON
+    // so isPlaying remains unchanged from before the keyDown
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Volume control
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * GlobalPlayerBar unit tests — Strict TDD.
+ *
+ * Covers: null render, track meta render, transport interactions,
+ * ARIA assertions, keyboard Space toggle, error state auto-clear,
+ * single audio element in DOM.
+ *
+ * REQ-PLAYER-BAR-001, 002, 003, 005, 007, 009, 011.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { GlobalPlayerBar } from "./GlobalPlayerBar";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeItem = (id: string, audioUrl = `/api/library/audio?id=${id}`) => ({
+  id,
+  name: `Track ${id}`,
+  artist: `Artist ${id}`,
+  artworkUrl: `https://example.com/art/${id}.jpg`,
+  audioUrl,
+  durationMs: 180_000,
+});
+
+function resetStore() {
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: null,
+    isPlaying: false,
+    volume: 1,
+    isMuted: false,
+    currentTime: 0,
+    duration: 180,
+    error: null,
+  });
+}
+
+// jsdom does not implement HTMLMediaElement; stub the imperative API.
+function mockAudioElement(): HTMLAudioElement {
+  const el = document.createElement("audio");
+  el.play = vi.fn().mockResolvedValue(undefined);
+  el.pause = vi.fn();
+  return el;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetStore();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  resetStore();
+});
+
+// ---------------------------------------------------------------------------
+// Render guard
+// ---------------------------------------------------------------------------
+
+describe("render guard", () => {
+  it("returns null when queue is empty and no error", () => {
+    render(<GlobalPlayerBar />);
+
+    expect(screen.queryByRole("region", { name: "Now playing" })).toBeNull();
+  });
+
+  it("renders the region when a queue is loaded", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("region", { name: "Now playing" })).not.toBeNull();
+  });
+
+  it("renders the region when there is an error (even without a queue)", () => {
+    usePlayerStore.setState({ error: "Network error" });
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("region", { name: "Now playing" })).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single audio element
+// ---------------------------------------------------------------------------
+
+describe("audio element", () => {
+  it("renders exactly one hidden audio element", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audioEls = container.querySelectorAll("audio");
+    expect(audioEls).toHaveLength(1);
+    expect(audioEls[0]?.getAttribute("aria-label")).toBe("Audio player");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Track metadata display
+// ---------------------------------------------------------------------------
+
+describe("track metadata", () => {
+  it("displays track name and artist of the current track", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByText("Track a")).not.toBeNull();
+    expect(screen.getByText("Artist a")).not.toBeNull();
+  });
+
+  it("shows artwork when artworkUrl is provided", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    render(<GlobalPlayerBar />);
+
+    const img = screen.queryByRole("img", { name: /Track a/i });
+    expect(img).not.toBeNull();
+  });
+
+  it("shows placeholder when artworkUrl is missing", () => {
+    const item = { ...makeItem("a"), artworkUrl: undefined };
+    usePlayerStore.getState().playQueue([item], 0);
+
+    render(<GlobalPlayerBar />);
+
+    // The Image atom renders a FontAwesome icon placeholder when src is absent
+    // Confirm no broken img element (img with src would not be rendered)
+    const imgEl = screen.queryByRole("img", { name: /Track a/i });
+    // Either it's a placeholder div or the img is not rendered — either is correct
+    // What matters is no throw and the artwork container is present
+    const region = screen.getByRole("region", { name: "Now playing" });
+    expect(region).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transport controls — interactions
+// ---------------------------------------------------------------------------
+
+describe("transport controls", () => {
+  it("renders play button and calls togglePlay on click", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    render(<GlobalPlayerBar />);
+
+    const playBtn = screen.getByRole("button", { name: "Play" });
+    expect(playBtn).not.toBeNull();
+
+    fireEvent.click(playBtn);
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("renders pause button when playing", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    // isPlaying is true after playQueue
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.queryByRole("button", { name: "Pause" })).not.toBeNull();
+  });
+
+  it("renders previous button and calls prev on click", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    render(<GlobalPlayerBar />);
+
+    const prevBtn = screen.getByRole("button", { name: "Previous track" });
+    fireEvent.click(prevBtn);
+
+    expect(usePlayerStore.getState().currentIndex).toBe(0);
+  });
+
+  it("renders next button and calls next on click", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+
+    render(<GlobalPlayerBar />);
+
+    const nextBtn = screen.getByRole("button", { name: "Next track" });
+    fireEvent.click(nextBtn);
+
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("previous button is disabled at index 0", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+
+    render(<GlobalPlayerBar />);
+
+    const prevBtn = screen.getByRole("button", { name: "Previous track" });
+    expect(prevBtn).toHaveProperty("disabled", true);
+  });
+
+  it("next button is disabled at last index", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    render(<GlobalPlayerBar />);
+
+    const nextBtn = screen.getByRole("button", { name: "Next track" });
+    expect(nextBtn).toHaveProperty("disabled", true);
+  });
+
+  it("next at last index is a no-op (currentIndex unchanged)", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    render(<GlobalPlayerBar />);
+
+    const nextBtn = screen.getByRole("button", { name: "Next track" });
+    fireEvent.click(nextBtn);
+
+    // next() at boundary sets isPlaying=false but keeps currentIndex
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ARIA attributes
+// ---------------------------------------------------------------------------
+
+describe("ARIA", () => {
+  it("region has role=region and aria-label='Now playing'", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("region", { name: "Now playing" })).not.toBeNull();
+  });
+
+  it("play/pause button has aria-pressed reflecting isPlaying", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    render(<GlobalPlayerBar />);
+
+    const playBtn = screen.getByRole("button", { name: "Play" });
+    expect(playBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("mute button has aria-label Mute when not muted", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("button", { name: "Mute" })).not.toBeNull();
+  });
+
+  it("mute button has aria-label Unmute when muted", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isMuted: true });
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("button", { name: "Unmute" })).not.toBeNull();
+  });
+
+  it("seek slider has role=slider with aria-label Seek", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const seekSlider = screen.getByRole("slider", { name: "Seek" });
+    expect(seekSlider).not.toBeNull();
+    expect(seekSlider.getAttribute("aria-valuemin")).toBe("0");
+  });
+
+  it("volume slider has role=slider with aria-label Volume", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const volumeSlider = screen.getByRole("slider", { name: "Volume" });
+    expect(volumeSlider).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+describe("error state", () => {
+  it("shows error text when store has an error", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      isPlaying: false,
+      error: "Playback failed",
+    });
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByText("Playback failed")).not.toBeNull();
+  });
+
+  it("clears error after 3 seconds", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      isPlaying: false,
+      error: "Playback failed",
+    });
+
+    render(<GlobalPlayerBar />);
+    expect(screen.getByText("Playback failed")).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(usePlayerStore.getState().error).toBeNull();
+  });
+
+  it("renders bar region even with no currentIndex when error exists", () => {
+    usePlayerStore.setState({ error: "Some error", currentIndex: null });
+
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("region", { name: "Now playing" })).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Volume control
+// ---------------------------------------------------------------------------
+
+describe("volume control", () => {
+  it("calls toggleMute when mute button is clicked", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const muteBtn = screen.getByRole("button", { name: "Mute" });
+    fireEvent.click(muteBtn);
+
+    expect(usePlayerStore.getState().isMuted).toBe(true);
+  });
+
+  it("calls setVolume when volume slider changes", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const volumeSlider = screen.getByRole("slider", { name: "Volume" });
+    fireEvent.change(volumeSlider, { target: { value: "0.5" } });
+
+    expect(usePlayerStore.getState().volume).toBe(0.5);
+  });
+});

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -1,0 +1,321 @@
+/**
+ * GlobalPlayerBar — Persistent global audio player mounted in AppLayout.
+ *
+ * Owns the single <audio> element for the application. Subscribes to
+ * usePlayerStore via selectors to minimise re-renders on the ~4Hz currentTime
+ * tick. Never unmounts (returns null instead of being conditionally mounted)
+ * so the audio element survives client-side navigation.
+ *
+ * REQ-PLAYER-BAR-001, 002, 003, 004, 005, 007, 009, 010.
+ */
+import {
+  faBackwardStep,
+  faForwardStep,
+  faPause,
+  faPlay,
+  faVolumeHigh,
+  faVolumeXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC, useEffect, useRef } from "react";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import type { QueueItem } from "@/store/usePlayerStore";
+import { cn } from "@/utils/cn";
+import { Image } from "../atoms/Image";
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/** Format seconds as m:ss (e.g. 75 → "1:15"). */
+function formatSeconds(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return `${m}:${rem.toString().padStart(2, "0")}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components (selector-scoped for perf)
+// ---------------------------------------------------------------------------
+
+/** Only re-renders when currentTime or duration change. */
+const ProgressSection: FC = () => {
+  const currentTime = usePlayerStore((s) => s.currentTime);
+  const duration = usePlayerStore((s) => s.duration);
+  const seek = usePlayerStore((s) => s.seek);
+
+  const pct = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  return (
+    <div className="flex w-full items-center gap-2">
+      <span className="text-text-secondary w-8 shrink-0 text-right text-xs tabular-nums">
+        {formatSeconds(currentTime)}
+      </span>
+      <input
+        type="range"
+        role="slider"
+        aria-label="Seek"
+        aria-valuemin={0}
+        aria-valuemax={duration}
+        aria-valuenow={currentTime}
+        aria-valuetext={`${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
+        min={0}
+        max={duration || 1}
+        step={1}
+        value={currentTime}
+        onChange={(e) => seek(Number(e.target.value))}
+        className="h-1 flex-1 cursor-pointer accent-white"
+        style={{
+          background: `linear-gradient(to right, white ${pct}%, rgba(255,255,255,0.2) ${pct}%)`,
+        }}
+      />
+      <span className="text-text-secondary w-8 shrink-0 text-xs tabular-nums">
+        {formatSeconds(duration)}
+      </span>
+    </div>
+  );
+};
+
+/** Only re-renders when volume or isMuted change. */
+const VolumeSection: FC = () => {
+  const volume = usePlayerStore((s) => s.volume);
+  const isMuted = usePlayerStore((s) => s.isMuted);
+  const setVolume = usePlayerStore((s) => s.setVolume);
+  const toggleMute = usePlayerStore((s) => s.toggleMute);
+
+  return (
+    <div className="hidden items-center gap-2 md:flex">
+      <button
+        type="button"
+        aria-label={isMuted ? "Unmute" : "Mute"}
+        aria-pressed={isMuted}
+        onClick={toggleMute}
+        className="text-text-secondary hover:text-text-primary flex h-8 w-8 items-center justify-center rounded-full transition-colors"
+      >
+        <FontAwesomeIcon icon={isMuted ? faVolumeXmark : faVolumeHigh} className="text-sm" />
+      </button>
+      <input
+        type="range"
+        role="slider"
+        aria-label="Volume"
+        aria-valuemin={0}
+        aria-valuemax={1}
+        aria-valuenow={volume}
+        aria-valuetext={`${Math.round(volume * 100)}%`}
+        min={0}
+        max={1}
+        step={0.05}
+        value={isMuted ? 0 : volume}
+        onChange={(e) => setVolume(Number(e.target.value))}
+        className="h-1 w-20 cursor-pointer accent-white"
+      />
+    </div>
+  );
+};
+
+/** Track metadata — re-renders when the current queue item changes. */
+const TrackMeta: FC<{ item: QueueItem }> = ({ item }) => (
+  <div className="flex min-w-0 items-center gap-3">
+    <div className="h-10 w-10 shrink-0 overflow-hidden rounded shadow-sm">
+      <Image src={item.artworkUrl} alt={item.name} className="rounded" />
+    </div>
+    <div className="flex min-w-0 flex-col">
+      <span className="truncate text-sm font-semibold text-white">{item.name}</span>
+      <span className="text-text-secondary truncate text-xs">{item.artist}</span>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// GlobalPlayerBar
+// ---------------------------------------------------------------------------
+
+export const GlobalPlayerBar: FC = () => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Selector subscriptions
+  const queue = usePlayerStore((s) => s.queue);
+  const currentIndex = usePlayerStore((s) => s.currentIndex);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const error = usePlayerStore((s) => s.error);
+
+  // Store actions
+  const setAudioElement = usePlayerStore((s) => s.setAudioElement);
+  const togglePlay = usePlayerStore((s) => s.togglePlay);
+  const next = usePlayerStore((s) => s.next);
+  const prev = usePlayerStore((s) => s.prev);
+  const _onLoadedMetadata = usePlayerStore((s) => s._onLoadedMetadata);
+  const _onTimeUpdate = usePlayerStore((s) => s._onTimeUpdate);
+  const _onEnded = usePlayerStore((s) => s._onEnded);
+  const _onError = usePlayerStore((s) => s._onError);
+
+  const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
+
+  // --------------------------------------------------------------------------
+  // Effect 1: Bind / unbind audio element to store
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+    setAudioElement(el);
+    return () => {
+      setAudioElement(null);
+    };
+  }, [setAudioElement]);
+
+  // --------------------------------------------------------------------------
+  // Effect 2: Subscribe to audio events
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el) return;
+
+    const onTimeUpdate = () => _onTimeUpdate(el.currentTime);
+    const onLoadedMetadata = () => _onLoadedMetadata(el.duration);
+    const onEnded = () => _onEnded();
+    const onError = () => {
+      const msg = el.error?.message ?? "Playback error";
+      _onError(msg);
+    };
+
+    el.addEventListener("timeupdate", onTimeUpdate);
+    el.addEventListener("loadedmetadata", onLoadedMetadata);
+    el.addEventListener("ended", onEnded);
+    el.addEventListener("error", onError);
+
+    return () => {
+      el.removeEventListener("timeupdate", onTimeUpdate);
+      el.removeEventListener("loadedmetadata", onLoadedMetadata);
+      el.removeEventListener("ended", onEnded);
+      el.removeEventListener("error", onError);
+    };
+  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError]);
+
+  // --------------------------------------------------------------------------
+  // Effect 3: Sync audio src when current item changes
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el || !currentItem) return;
+    if (el.src !== currentItem.audioUrl) {
+      el.src = currentItem.audioUrl;
+    }
+  }, [currentItem]);
+
+  // --------------------------------------------------------------------------
+  // Effect 4: Sync isPlaying → play()/pause()
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el || !currentItem) return;
+    if (isPlaying) {
+      const playPromise = el.play();
+      if (playPromise && typeof playPromise.catch === "function") {
+        void playPromise.catch(() => {
+          // AbortError from rapid src changes is expected — swallow silently
+        });
+      }
+    } else {
+      el.pause();
+    }
+  }, [isPlaying, currentItem]);
+
+  // --------------------------------------------------------------------------
+  // Effect 5: Auto-clear error after 3 s
+  // --------------------------------------------------------------------------
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(() => {
+      usePlayerStore.setState({ error: null });
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [error]);
+
+  const isVisible = currentIndex !== null || !!error;
+  const isAtFirst = currentIndex === 0;
+  const isAtLast = currentIndex !== null && currentIndex === queue.length - 1;
+
+  return (
+    <>
+      {/* Audio element lives outside the conditional section so it is never
+          recreated when the bar toggles between hidden and visible states.
+          This is the load-bearing "never unmount" guarantee for navigation survivability. */}
+      <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
+
+      {isVisible && (
+        <section
+          role="region"
+          aria-label="Now playing"
+          className={cn(
+            "bg-surface/95 border-t border-white/10 backdrop-blur-lg",
+            "fixed right-0 bottom-16 left-0 z-40 md:bottom-0",
+            "px-4 py-2",
+          )}
+        >
+          {/* Mobile layout: two-row stack | Desktop: three-column flex */}
+          <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-4">
+            {/* Row 1 / Col 1: Track meta or error */}
+            <div className="flex min-w-0 flex-1 items-center">
+              {error ? (
+                <span className="text-sm text-red-400">{error}</span>
+              ) : currentItem ? (
+                <TrackMeta item={currentItem} />
+              ) : null}
+            </div>
+
+            {/* Row 2 / Col 2: Transport + progress */}
+            <div className="flex flex-1 flex-col items-center gap-1">
+              {/* Transport buttons */}
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  aria-label="Previous track"
+                  disabled={isAtFirst}
+                  onClick={prev}
+                  className={cn(
+                    "text-text-secondary hover:text-text-primary flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                    isAtFirst && "cursor-not-allowed opacity-40",
+                  )}
+                >
+                  <FontAwesomeIcon icon={faBackwardStep} className="text-base" />
+                </button>
+
+                <button
+                  type="button"
+                  aria-label={isPlaying ? "Pause" : "Play"}
+                  aria-pressed={isPlaying}
+                  onClick={togglePlay}
+                  className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105"
+                >
+                  <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className="text-sm" />
+                </button>
+
+                <button
+                  type="button"
+                  aria-label="Next track"
+                  disabled={isAtLast}
+                  onClick={next}
+                  className={cn(
+                    "text-text-secondary hover:text-text-primary flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                    isAtLast && "cursor-not-allowed opacity-40",
+                  )}
+                >
+                  <FontAwesomeIcon icon={faForwardStep} className="text-base" />
+                </button>
+              </div>
+
+              {/* Progress bar */}
+              <ProgressSection />
+            </div>
+
+            {/* Col 3 (desktop only): Volume */}
+            <div className="hidden flex-1 justify-end md:flex">
+              <VolumeSection />
+            </div>
+          </div>
+        </section>
+      )}
+    </>
+  );
+};

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -17,7 +17,7 @@ import {
   faVolumeXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useEffect, useRef } from "react";
+import React, { FC, useEffect, useRef } from "react";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
@@ -236,6 +236,14 @@ export const GlobalPlayerBar: FC = () => {
   const isAtFirst = currentIndex === 0;
   const isAtLast = currentIndex !== null && currentIndex === queue.length - 1;
 
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== " ") return;
+    const tag = (e.target as HTMLElement).tagName;
+    if (tag === "BUTTON" || tag === "INPUT") return;
+    e.preventDefault();
+    togglePlay();
+  };
+
   return (
     <>
       {/* Audio element lives outside the conditional section so it is never
@@ -247,6 +255,7 @@ export const GlobalPlayerBar: FC = () => {
         <section
           role="region"
           aria-label="Now playing"
+          onKeyDown={onKeyDown}
           className={cn(
             "bg-surface/95 border-t border-white/10 backdrop-blur-lg",
             "fixed right-0 bottom-16 left-0 z-40 md:bottom-0",

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -1,13 +1,3 @@
-/**
- * GlobalPlayerBar — Persistent global audio player mounted in AppLayout.
- *
- * Owns the single <audio> element for the application. Subscribes to
- * usePlayerStore via selectors to minimise re-renders on the ~4Hz currentTime
- * tick. Never unmounts (returns null instead of being conditionally mounted)
- * so the audio element survives client-side navigation.
- *
- * REQ-PLAYER-BAR-001, 002, 003, 004, 005, 007, 009, 010.
- */
 import {
   faBackwardStep,
   faForwardStep,
@@ -23,11 +13,6 @@ import type { QueueItem } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
 
-// ---------------------------------------------------------------------------
-// Utilities
-// ---------------------------------------------------------------------------
-
-/** Format seconds as m:ss (e.g. 75 → "1:15"). */
 function formatSeconds(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
   const m = Math.floor(s / 60);
@@ -35,11 +20,6 @@ function formatSeconds(seconds: number): string {
   return `${m}:${rem.toString().padStart(2, "0")}`;
 }
 
-// ---------------------------------------------------------------------------
-// Sub-components (selector-scoped for perf)
-// ---------------------------------------------------------------------------
-
-/** Only re-renders when currentTime or duration change. */
 const ProgressSection: FC = () => {
   const currentTime = usePlayerStore((s) => s.currentTime);
   const duration = usePlayerStore((s) => s.duration);
@@ -77,7 +57,6 @@ const ProgressSection: FC = () => {
   );
 };
 
-/** Only re-renders when volume or isMuted change. */
 const VolumeSection: FC = () => {
   const volume = usePlayerStore((s) => s.volume);
   const isMuted = usePlayerStore((s) => s.isMuted);
@@ -114,7 +93,6 @@ const VolumeSection: FC = () => {
   );
 };
 
-/** Track metadata — re-renders when the current queue item changes. */
 const TrackMeta: FC<{ item: QueueItem }> = ({ item }) => (
   <div className="flex min-w-0 items-center gap-3">
     <div className="h-10 w-10 shrink-0 overflow-hidden rounded shadow-sm">
@@ -127,20 +105,14 @@ const TrackMeta: FC<{ item: QueueItem }> = ({ item }) => (
   </div>
 );
 
-// ---------------------------------------------------------------------------
-// GlobalPlayerBar
-// ---------------------------------------------------------------------------
-
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
 
-  // Selector subscriptions
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const error = usePlayerStore((s) => s.error);
 
-  // Store actions
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
@@ -152,9 +124,6 @@ export const GlobalPlayerBar: FC = () => {
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
-  // --------------------------------------------------------------------------
-  // Effect 1: Bind / unbind audio element to store
-  // --------------------------------------------------------------------------
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
@@ -164,9 +133,6 @@ export const GlobalPlayerBar: FC = () => {
     };
   }, [setAudioElement]);
 
-  // --------------------------------------------------------------------------
-  // Effect 2: Subscribe to audio events
-  // --------------------------------------------------------------------------
   useEffect(() => {
     const el = audioRef.current;
     if (!el) return;
@@ -192,9 +158,6 @@ export const GlobalPlayerBar: FC = () => {
     };
   }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError]);
 
-  // --------------------------------------------------------------------------
-  // Effect 3: Sync audio src when current item changes
-  // --------------------------------------------------------------------------
   useEffect(() => {
     const el = audioRef.current;
     if (!el || !currentItem) return;
@@ -203,27 +166,19 @@ export const GlobalPlayerBar: FC = () => {
     }
   }, [currentItem]);
 
-  // --------------------------------------------------------------------------
-  // Effect 4: Sync isPlaying → play()/pause()
-  // --------------------------------------------------------------------------
   useEffect(() => {
     const el = audioRef.current;
     if (!el || !currentItem) return;
     if (isPlaying) {
       const playPromise = el.play();
       if (playPromise && typeof playPromise.catch === "function") {
-        void playPromise.catch(() => {
-          // AbortError from rapid src changes is expected — swallow silently
-        });
+        void playPromise.catch(() => {});
       }
     } else {
       el.pause();
     }
   }, [isPlaying, currentItem]);
 
-  // --------------------------------------------------------------------------
-  // Effect 5: Auto-clear error after 3 s
-  // --------------------------------------------------------------------------
   useEffect(() => {
     if (!error) return;
     const timer = setTimeout(() => {
@@ -246,9 +201,6 @@ export const GlobalPlayerBar: FC = () => {
 
   return (
     <>
-      {/* Audio element lives outside the conditional section so it is never
-          recreated when the bar toggles between hidden and visible states.
-          This is the load-bearing "never unmount" guarantee for navigation survivability. */}
       <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
 
       {isVisible && (
@@ -262,9 +214,7 @@ export const GlobalPlayerBar: FC = () => {
             "px-4 py-2",
           )}
         >
-          {/* Mobile layout: two-row stack | Desktop: three-column flex */}
           <div className="flex flex-col gap-1 md:flex-row md:items-center md:gap-4">
-            {/* Row 1 / Col 1: Track meta or error */}
             <div className="flex min-w-0 flex-1 items-center">
               {error ? (
                 <span className="text-sm text-red-400">{error}</span>
@@ -273,9 +223,7 @@ export const GlobalPlayerBar: FC = () => {
               ) : null}
             </div>
 
-            {/* Row 2 / Col 2: Transport + progress */}
             <div className="flex flex-1 flex-col items-center gap-1">
-              {/* Transport buttons */}
               <div className="flex items-center gap-4">
                 <button
                   type="button"
@@ -314,11 +262,9 @@ export const GlobalPlayerBar: FC = () => {
                 </button>
               </div>
 
-              {/* Progress bar */}
               <ProgressSection />
             </div>
 
-            {/* Col 3 (desktop only): Volume */}
             <div className="hidden flex-1 justify-end md:flex">
               <VolumeSection />
             </div>

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -180,6 +180,40 @@ describe("prev", () => {
     usePlayerStore.getState().prev();
     expect(usePlayerStore.getState().isPlaying).toBe(true);
   });
+
+  it("seeks to 0 and does not change currentIndex when currentTime > 3", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ currentTime: 5, duration: 200 });
+    const wasPlaying = usePlayerStore.getState().isPlaying;
+
+    usePlayerStore.getState().prev();
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(2);
+    expect(state.currentTime).toBe(0);
+    expect(state.isPlaying).toBe(wasPlaying);
+  });
+
+  it("decrements currentIndex when currentTime <= 3", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ currentTime: 3, duration: 200 });
+
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("stays at index 0 when currentTime <= 3 and already at first track", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ currentTime: 2, duration: 200 });
+
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1,0 +1,394 @@
+/**
+ * usePlayerStore unit tests — Strict TDD (RED phase authored first).
+ *
+ * These tests cover every action and internal reducer as per the design spec.
+ * REQ-PLAYER-BAR-002, 003, 004, 007, 011, 012.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// We import the store lazily after each reset to avoid cross-test state pollution.
+// Zustand stores are module-level singletons, so we reset state via the store's
+// own reset mechanism in beforeEach.
+
+let usePlayerStore: typeof import("./usePlayerStore").usePlayerStore;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import("./usePlayerStore");
+  usePlayerStore = mod.usePlayerStore;
+  // Reset to initial state before each test
+  usePlayerStore.getState().clear();
+  // Also reset volume/isMuted to defaults (clear preserves them, so set explicitly)
+  usePlayerStore.setState({ volume: 1, isMuted: false, error: null });
+});
+
+const makeItem = (id: string, audioUrl = `/api/library/audio?id=${id}`) => ({
+  id,
+  name: `Track ${id}`,
+  artist: "Artist",
+  audioUrl,
+  durationMs: 180_000,
+});
+
+// ---------------------------------------------------------------------------
+// playQueue
+// ---------------------------------------------------------------------------
+
+describe("playQueue", () => {
+  it("sets queue, currentIndex, isPlaying=true, currentTime=0", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.queue).toEqual(items);
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(0);
+    expect(state.error).toBeNull();
+  });
+
+  it("calls clear() when items array is empty", () => {
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState().playQueue([], 0);
+
+    const state = usePlayerStore.getState();
+    expect(state.queue).toHaveLength(0);
+    expect(state.currentIndex).toBeNull();
+    expect(state.isPlaying).toBe(false);
+  });
+
+  it("calls clear() when startIndex is out of range", () => {
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 5);
+
+    const state = usePlayerStore.getState();
+    expect(state.queue).toHaveLength(0);
+    expect(state.currentIndex).toBeNull();
+  });
+
+  it("clears any existing error on new playQueue call", () => {
+    usePlayerStore.setState({ error: "previous error" });
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    expect(usePlayerStore.getState().error).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// togglePlay
+// ---------------------------------------------------------------------------
+
+describe("togglePlay", () => {
+  it("is a no-op when currentIndex is null", () => {
+    usePlayerStore.getState().togglePlay();
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("flips isPlaying from false to true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    usePlayerStore.getState().togglePlay();
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("flips isPlaying from true to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+
+    usePlayerStore.getState().togglePlay();
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// next
+// ---------------------------------------------------------------------------
+
+describe("next", () => {
+  it("advances currentIndex when not at last track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState().next();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("resets currentTime to 0 when advancing", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ currentTime: 45 });
+    usePlayerStore.getState().next();
+
+    expect(usePlayerStore.getState().currentTime).toBe(0);
+  });
+
+  it("is a no-op at last index (does NOT wrap or clear)", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().next();
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.queue).toHaveLength(2);
+  });
+
+  it("keeps isPlaying state when advancing", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+
+    usePlayerStore.getState().next();
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prev
+// ---------------------------------------------------------------------------
+
+describe("prev", () => {
+  it("decrements currentIndex when not at first track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("resets currentTime to 0 when going to previous", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ currentTime: 60 });
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentTime).toBe(0);
+  });
+
+  it("is a no-op at first index (does NOT wrap)", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(0);
+  });
+
+  it("keeps isPlaying state when going previous", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().prev();
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// seek
+// ---------------------------------------------------------------------------
+
+describe("seek", () => {
+  it("sets currentTime to the requested value", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 200 });
+    usePlayerStore.getState().seek(90);
+
+    expect(usePlayerStore.getState().currentTime).toBe(90);
+  });
+
+  it("clamps to 0 when given a negative value", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 200 });
+    usePlayerStore.getState().seek(-10);
+
+    expect(usePlayerStore.getState().currentTime).toBe(0);
+  });
+
+  it("clamps to duration when value exceeds duration", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 200 });
+    usePlayerStore.getState().seek(999);
+
+    expect(usePlayerStore.getState().currentTime).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setVolume
+// ---------------------------------------------------------------------------
+
+describe("setVolume", () => {
+  it("sets volume within [0, 1] range", () => {
+    usePlayerStore.getState().setVolume(0.5);
+    expect(usePlayerStore.getState().volume).toBe(0.5);
+  });
+
+  it("clamps to 0 when given a negative value", () => {
+    usePlayerStore.getState().setVolume(-0.5);
+    expect(usePlayerStore.getState().volume).toBe(0);
+  });
+
+  it("clamps to 1 when given a value above 1", () => {
+    usePlayerStore.getState().setVolume(2);
+    expect(usePlayerStore.getState().volume).toBe(1);
+  });
+
+  it("does not change isMuted", () => {
+    usePlayerStore.setState({ isMuted: true });
+    usePlayerStore.getState().setVolume(0.7);
+
+    expect(usePlayerStore.getState().isMuted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleMute
+// ---------------------------------------------------------------------------
+
+describe("toggleMute", () => {
+  it("flips isMuted from false to true", () => {
+    usePlayerStore.setState({ isMuted: false });
+    usePlayerStore.getState().toggleMute();
+
+    expect(usePlayerStore.getState().isMuted).toBe(true);
+  });
+
+  it("flips isMuted from true to false", () => {
+    usePlayerStore.setState({ isMuted: true });
+    usePlayerStore.getState().toggleMute();
+
+    expect(usePlayerStore.getState().isMuted).toBe(false);
+  });
+
+  it("does not change volume when toggling mute", () => {
+    usePlayerStore.setState({ volume: 0.7, isMuted: false });
+    usePlayerStore.getState().toggleMute();
+
+    expect(usePlayerStore.getState().volume).toBe(0.7);
+
+    usePlayerStore.getState().toggleMute();
+    expect(usePlayerStore.getState().volume).toBe(0.7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clear
+// ---------------------------------------------------------------------------
+
+describe("clear", () => {
+  it("resets queue, currentIndex, isPlaying, currentTime, duration, error", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ currentTime: 30, duration: 200, error: "oops" });
+    usePlayerStore.getState().clear();
+
+    const state = usePlayerStore.getState();
+    expect(state.queue).toHaveLength(0);
+    expect(state.currentIndex).toBeNull();
+    expect(state.isPlaying).toBe(false);
+    expect(state.currentTime).toBe(0);
+    expect(state.duration).toBe(0);
+    expect(state.error).toBeNull();
+  });
+
+  it("preserves volume and isMuted after clear", () => {
+    usePlayerStore.setState({ volume: 0.4, isMuted: true });
+    usePlayerStore.getState().clear();
+
+    const state = usePlayerStore.getState();
+    expect(state.volume).toBe(0.4);
+    expect(state.isMuted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Internal reducers: _onLoadedMetadata, _onTimeUpdate, _onEnded, _onError
+// ---------------------------------------------------------------------------
+
+describe("_onLoadedMetadata", () => {
+  it("sets duration", () => {
+    usePlayerStore.getState()._onLoadedMetadata(240);
+    expect(usePlayerStore.getState().duration).toBe(240);
+  });
+});
+
+describe("_onTimeUpdate", () => {
+  it("updates currentTime", () => {
+    usePlayerStore.getState()._onTimeUpdate(42);
+    expect(usePlayerStore.getState().currentTime).toBe(42);
+  });
+});
+
+describe("_onEnded", () => {
+  it("calls next and keeps isPlaying true when not at last track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState()._onEnded();
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+  });
+
+  it("sets isPlaying=false at boundary (last track ended, next is no-op)", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState()._onEnded();
+
+    // next() is a no-op at last index — the store must explicitly set isPlaying=false
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+});
+
+describe("_onError", () => {
+  it("sets error and pauses playback", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState()._onError("Network error");
+
+    const state = usePlayerStore.getState();
+    expect(state.error).toBe("Network error");
+    expect(state.isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persist partialize: only volume and isMuted survive
+// ---------------------------------------------------------------------------
+
+describe("persist partialize", () => {
+  it("only serializes volume and isMuted", async () => {
+    const mod = await import("./usePlayerStore");
+    const partialize = mod.__partialize;
+
+    const state = {
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      isPlaying: true,
+      volume: 0.6,
+      isMuted: true,
+      currentTime: 55,
+      duration: 200,
+      error: null,
+      playQueue: vi.fn(),
+      togglePlay: vi.fn(),
+      next: vi.fn(),
+      prev: vi.fn(),
+      seek: vi.fn(),
+      setVolume: vi.fn(),
+      toggleMute: vi.fn(),
+      clear: vi.fn(),
+      setAudioElement: vi.fn(),
+      _onLoadedMetadata: vi.fn(),
+      _onTimeUpdate: vi.fn(),
+      _onEnded: vi.fn(),
+      _onError: vi.fn(),
+    };
+
+    const persisted = partialize(state as unknown as Parameters<typeof partialize>[0]);
+    const roundTripped = JSON.parse(JSON.stringify(persisted));
+
+    expect(roundTripped).toEqual({ volume: 0.6, isMuted: true });
+    expect("queue" in roundTripped).toBe(false);
+    expect("currentTime" in roundTripped).toBe(false);
+    expect("isPlaying" in roundTripped).toBe(false);
+  });
+});

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -1,34 +1,11 @@
 /**
- * usePlayerStore — Global audio playback store.
- *
- * @remarks
- * **3rd Zustand store — Approved Exception**
- *
- * This project conventionally uses exactly 2 Zustand stores
- * (`usePreferencesStore`, `useDownloadStatusStore`). `usePlayerStore` is an
- * explicitly documented exception approved during the SDD design phase
- * (decision record: `sdd/global-player-bar/proposal`).
- *
- * **Rationale:**
- * 1. **Navigation survivability** — the store must survive client-side route
- *    changes so that audio playback continues uninterrupted. React Context
- *    would require a provider above the router, but Zustand modules are
- *    singleton-scoped and never unmount.
- * 2. **Selector-based subscription necessity** — `currentTime` updates at
- *    ~4 Hz during playback. Zustand selectors confine re-renders to only the
- *    progress-bar sub-component; a Context value would re-render every
- *    consumer on every tick.
- * 3. **Bounded scope** — the store is exclusively consumed by
- *    `GlobalPlayerBar` (audio wiring) and page controllers (dispatch only).
- *    No further stores should be added without equivalent justification and
- *    documentation.
+ * 3rd Zustand store — approved exception to the "exactly 2 stores" convention.
+ * Singleton module survives client-side navigation so playback continues across
+ * route changes; selector subscriptions confine ~4Hz currentTime re-renders to
+ * the progress sub-component. See `sdd/global-player-bar/proposal`.
  */
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
 
 export interface QueueItem {
   id: string;
@@ -36,28 +13,20 @@ export interface QueueItem {
   artist: string;
   album?: string;
   artworkUrl?: string;
-  /** Normalized at the dispatch boundary inside each controller. */
   audioUrl: string;
   durationMs?: number;
 }
 
 export interface PlayerState {
-  // ---- Public state ----
   queue: QueueItem[];
   currentIndex: number | null;
   isPlaying: boolean;
-  /** Volume in range [0, 1]. Persisted. */
   volume: number;
-  /** Whether the audio is muted. Persisted. Does not change `volume`. */
   isMuted: boolean;
-  /** Current playback position in seconds. NOT persisted. */
   currentTime: number;
-  /** Total track duration in seconds. NOT persisted. */
   duration: number;
-  /** Inline error message shown in the bar; null when clear. NOT persisted. */
   error: string | null;
 
-  // ---- Public actions ----
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
   next: () => void;
@@ -67,7 +36,6 @@ export interface PlayerState {
   toggleMute: () => void;
   clear: () => void;
 
-  // ---- Internal wiring (called by GlobalPlayerBar only) ----
   setAudioElement: (el: HTMLAudioElement | null) => void;
   _onLoadedMetadata: (duration: number) => void;
   _onTimeUpdate: (currentTime: number) => void;
@@ -75,21 +43,11 @@ export interface PlayerState {
   _onError: (message: string) => void;
 }
 
-// ---------------------------------------------------------------------------
-// Partialize helper — exported for testability
-// ---------------------------------------------------------------------------
-
 export const __partialize = (state: PlayerState): Pick<PlayerState, "volume" | "isMuted"> => ({
   volume: state.volume,
   isMuted: state.isMuted,
 });
 
-// ---------------------------------------------------------------------------
-// Store
-// ---------------------------------------------------------------------------
-
-/** Reference to the bound HTMLAudioElement. Lives outside Zustand state so
- *  it does not trigger re-renders when the element is set/unset. */
 let _audioElement: HTMLAudioElement | null = null;
 
 const INITIAL_STATE = {
@@ -107,8 +65,6 @@ export const usePlayerStore = create<PlayerState>()(
   persist(
     (set, get) => ({
       ...INITIAL_STATE,
-
-      // ---- Actions ----
 
       playQueue(items, startIndex) {
         if (items.length === 0 || startIndex < 0 || startIndex >= items.length) {
@@ -134,11 +90,9 @@ export const usePlayerStore = create<PlayerState>()(
         const { currentIndex, queue } = get();
         if (currentIndex === null) return;
         if (currentIndex >= queue.length - 1) {
-          // Boundary — next is a no-op for the index, but playback stops
           set({ isPlaying: false });
           return;
         }
-        // Advance; isPlaying is unchanged (bar's effect calls play/pause accordingly)
         set({ currentIndex: currentIndex + 1, currentTime: 0 });
       },
 
@@ -146,7 +100,6 @@ export const usePlayerStore = create<PlayerState>()(
         const { currentIndex, currentTime } = get();
         if (currentIndex === null) return;
         if (currentTime > 3) {
-          // Seek to start of current track without changing index
           set({ currentTime: 0 });
           if (_audioElement) {
             _audioElement.currentTime = 0;
@@ -192,10 +145,7 @@ export const usePlayerStore = create<PlayerState>()(
           duration: 0,
           error: null,
         });
-        // volume and isMuted are intentionally preserved
       },
-
-      // ---- Internal wiring ----
 
       setAudioElement(el) {
         _audioElement = el;
@@ -213,11 +163,9 @@ export const usePlayerStore = create<PlayerState>()(
         const { currentIndex, queue } = get();
         if (currentIndex === null) return;
         if (currentIndex >= queue.length - 1) {
-          // Last track ended — stop playback (next() is a boundary no-op here)
           set({ isPlaying: false });
           return;
         }
-        // Advance to next track
         set({ currentIndex: currentIndex + 1, currentTime: 0 });
       },
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -1,0 +1,224 @@
+/**
+ * usePlayerStore — Global audio playback store.
+ *
+ * @remarks
+ * **3rd Zustand store — Approved Exception**
+ *
+ * This project conventionally uses exactly 2 Zustand stores
+ * (`usePreferencesStore`, `useDownloadStatusStore`). `usePlayerStore` is an
+ * explicitly documented exception approved during the SDD design phase
+ * (decision record: `sdd/global-player-bar/proposal`).
+ *
+ * **Rationale:**
+ * 1. **Navigation survivability** — the store must survive client-side route
+ *    changes so that audio playback continues uninterrupted. React Context
+ *    would require a provider above the router, but Zustand modules are
+ *    singleton-scoped and never unmount.
+ * 2. **Selector-based subscription necessity** — `currentTime` updates at
+ *    ~4 Hz during playback. Zustand selectors confine re-renders to only the
+ *    progress-bar sub-component; a Context value would re-render every
+ *    consumer on every tick.
+ * 3. **Bounded scope** — the store is exclusively consumed by
+ *    `GlobalPlayerBar` (audio wiring) and page controllers (dispatch only).
+ *    No further stores should be added without equivalent justification and
+ *    documentation.
+ */
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface QueueItem {
+  id: string;
+  name: string;
+  artist: string;
+  album?: string;
+  artworkUrl?: string;
+  /** Normalized at the dispatch boundary inside each controller. */
+  audioUrl: string;
+  durationMs?: number;
+}
+
+export interface PlayerState {
+  // ---- Public state ----
+  queue: QueueItem[];
+  currentIndex: number | null;
+  isPlaying: boolean;
+  /** Volume in range [0, 1]. Persisted. */
+  volume: number;
+  /** Whether the audio is muted. Persisted. Does not change `volume`. */
+  isMuted: boolean;
+  /** Current playback position in seconds. NOT persisted. */
+  currentTime: number;
+  /** Total track duration in seconds. NOT persisted. */
+  duration: number;
+  /** Inline error message shown in the bar; null when clear. NOT persisted. */
+  error: string | null;
+
+  // ---- Public actions ----
+  playQueue: (items: QueueItem[], startIndex: number) => void;
+  togglePlay: () => void;
+  next: () => void;
+  prev: () => void;
+  seek: (seconds: number) => void;
+  setVolume: (v: number) => void;
+  toggleMute: () => void;
+  clear: () => void;
+
+  // ---- Internal wiring (called by GlobalPlayerBar only) ----
+  setAudioElement: (el: HTMLAudioElement | null) => void;
+  _onLoadedMetadata: (duration: number) => void;
+  _onTimeUpdate: (currentTime: number) => void;
+  _onEnded: () => void;
+  _onError: (message: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Partialize helper — exported for testability
+// ---------------------------------------------------------------------------
+
+export const __partialize = (state: PlayerState): Pick<PlayerState, "volume" | "isMuted"> => ({
+  volume: state.volume,
+  isMuted: state.isMuted,
+});
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+/** Reference to the bound HTMLAudioElement. Lives outside Zustand state so
+ *  it does not trigger re-renders when the element is set/unset. */
+let _audioElement: HTMLAudioElement | null = null;
+
+const INITIAL_STATE = {
+  queue: [] as QueueItem[],
+  currentIndex: null as number | null,
+  isPlaying: false,
+  volume: 1,
+  isMuted: false,
+  currentTime: 0,
+  duration: 0,
+  error: null as string | null,
+};
+
+export const usePlayerStore = create<PlayerState>()(
+  persist(
+    (set, get) => ({
+      ...INITIAL_STATE,
+
+      // ---- Actions ----
+
+      playQueue(items, startIndex) {
+        if (items.length === 0 || startIndex < 0 || startIndex >= items.length) {
+          get().clear();
+          return;
+        }
+        set({
+          queue: items,
+          currentIndex: startIndex,
+          isPlaying: true,
+          currentTime: 0,
+          error: null,
+        });
+      },
+
+      togglePlay() {
+        const { currentIndex, isPlaying } = get();
+        if (currentIndex === null) return;
+        set({ isPlaying: !isPlaying });
+      },
+
+      next() {
+        const { currentIndex, queue } = get();
+        if (currentIndex === null) return;
+        if (currentIndex >= queue.length - 1) {
+          // Boundary — next is a no-op for the index, but playback stops
+          set({ isPlaying: false });
+          return;
+        }
+        // Advance; isPlaying is unchanged (bar's effect calls play/pause accordingly)
+        set({ currentIndex: currentIndex + 1, currentTime: 0 });
+      },
+
+      prev() {
+        const { currentIndex } = get();
+        if (currentIndex === null || currentIndex === 0) return;
+        set({ currentIndex: currentIndex - 1, currentTime: 0 });
+      },
+
+      seek(seconds) {
+        const { duration } = get();
+        const clamped = Math.max(0, Math.min(seconds, duration));
+        set({ currentTime: clamped });
+        if (_audioElement) {
+          _audioElement.currentTime = clamped;
+        }
+      },
+
+      setVolume(v) {
+        const clamped = Math.max(0, Math.min(1, v));
+        set({ volume: clamped });
+        if (_audioElement) {
+          _audioElement.volume = clamped;
+        }
+      },
+
+      toggleMute() {
+        const { isMuted } = get();
+        const next = !isMuted;
+        set({ isMuted: next });
+        if (_audioElement) {
+          _audioElement.muted = next;
+        }
+      },
+
+      clear() {
+        set({
+          queue: [],
+          currentIndex: null,
+          isPlaying: false,
+          currentTime: 0,
+          duration: 0,
+          error: null,
+        });
+        // volume and isMuted are intentionally preserved
+      },
+
+      // ---- Internal wiring ----
+
+      setAudioElement(el) {
+        _audioElement = el;
+      },
+
+      _onLoadedMetadata(duration) {
+        set({ duration });
+      },
+
+      _onTimeUpdate(currentTime) {
+        set({ currentTime });
+      },
+
+      _onEnded() {
+        const { currentIndex, queue } = get();
+        if (currentIndex === null) return;
+        if (currentIndex >= queue.length - 1) {
+          // Last track ended — stop playback (next() is a boundary no-op here)
+          set({ isPlaying: false });
+          return;
+        }
+        // Advance to next track
+        set({ currentIndex: currentIndex + 1, currentTime: 0 });
+      },
+
+      _onError(message) {
+        set({ error: message, isPlaying: false });
+      },
+    }),
+    {
+      name: "spotiarr-player",
+      partialize: __partialize,
+    },
+  ),
+);

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -143,8 +143,17 @@ export const usePlayerStore = create<PlayerState>()(
       },
 
       prev() {
-        const { currentIndex } = get();
-        if (currentIndex === null || currentIndex === 0) return;
+        const { currentIndex, currentTime } = get();
+        if (currentIndex === null) return;
+        if (currentTime > 3) {
+          // Seek to start of current track without changing index
+          set({ currentTime: 0 });
+          if (_audioElement) {
+            _audioElement.currentTime = 0;
+          }
+          return;
+        }
+        if (currentIndex === 0) return;
         set({ currentIndex: currentIndex - 1, currentTime: 0 });
       },
 


### PR DESCRIPTION
## Summary
Foundation slice for Spotify-style global player bar. Introduces `usePlayerStore` (3rd Zustand store — documented exception), `GlobalPlayerBar` organism, and mounts it in `AppLayout`. Page-local audio remains untouched in this slice — non-breaking by design.

- `usePlayerStore.ts` — Zustand store with persist (`{volume, isMuted}`), transport actions, queue management
- `GlobalPlayerBar.tsx` — organism with single `<audio>`, transport controls, progress bar, volume slider, ARIA region + Space-to-toggle
- `AppLayout.tsx` — mounts bar, adjusts padding cascade for `BottomNavigation`

Stacked-to-main: this is PR 1 of 2. Slice 2 (#follow-up) refactors controllers and removes page-local audio atomically.

## Spec compliance
REQ-PLAYER-BAR-001..005, 009..012 — PASS. REQ-006..008 deferred to slice 2.

## Test plan
- [x] `pnpm --filter frontend test --run` — 207 tests pass
- [x] `pnpm --filter frontend exec tsc --noEmit` — clean
- [x] `pnpm --filter frontend lint` — clean
- [ ] Manual: bar renders on all routes, transport controls visible, volume slider persists across reload
- [ ] Manual: page-local playback in `LibraryAlbumDetail` / `PlaylistDetail` still works (coexistence verified)