### PR TITLE
feat(player): quick wins — queue artwork, meta nav, Media Session

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -3,7 +3,8 @@
  *
  * Covers: null render, track meta render, transport interactions,
  * ARIA assertions, keyboard Space toggle, error state auto-clear,
- * single audio element in DOM.
+ * single audio element in DOM, TrackMeta navigation (Win 2),
+ * MediaSession integration (Win 3).
  *
  * REQ-PLAYER-BAR-001, 002, 003, 005, 007, 009, 011.
  */
@@ -11,6 +12,20 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { GlobalPlayerBar } from "./GlobalPlayerBar";
+
+// ---------------------------------------------------------------------------
+// react-router-dom mock (useNavigate)
+// ---------------------------------------------------------------------------
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -370,5 +385,117 @@ describe("volume control", () => {
     fireEvent.change(volumeSlider, { target: { value: "0.5" } });
 
     expect(usePlayerStore.getState().volume).toBe(0.5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TrackMeta navigation (Win 2 — T2.6 / T2.7)
+// ---------------------------------------------------------------------------
+
+const makeItemWithContext = (id: string, contextPath: string) => ({
+  ...makeItem(id),
+  contextPath,
+});
+
+describe("TrackMeta navigation", () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it("[T2.6] renders as button with aria-label when contextPath is set", () => {
+    const item = makeItemWithContext("x", "/playlist/abc?mode=library");
+    usePlayerStore.getState().playQueue([item], 0);
+
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: /Open Track x by Artist x/ });
+    expect(btn).not.toBeNull();
+  });
+
+  it("[T2.6] clicking the TrackMeta button calls navigate with contextPath", () => {
+    const item = makeItemWithContext("x", "/playlist/abc?mode=library");
+    usePlayerStore.getState().playQueue([item], 0);
+
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: /Open Track x by Artist x/ });
+    fireEvent.click(btn);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/playlist/abc?mode=library");
+  });
+
+  it("[T2.7] renders as non-interactive div when contextPath is absent", () => {
+    const item = makeItem("y"); // no contextPath
+    usePlayerStore.getState().playQueue([item], 0);
+
+    render(<GlobalPlayerBar />);
+
+    // No button with navigate aria-label
+    expect(screen.queryByRole("button", { name: /Open Track y/ })).toBeNull();
+    // Track name still visible
+    expect(screen.getByText("Track y")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MediaSession integration (Win 3 — T3.10)
+// ---------------------------------------------------------------------------
+
+function setupMediaSessionStub() {
+  const setActionHandler = vi.fn();
+  const stub = {
+    metadata: null as unknown,
+    playbackState: "none" as string,
+    setActionHandler,
+  };
+  Object.defineProperty(navigator, "mediaSession", {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+  vi.stubGlobal(
+    "MediaMetadata",
+    class {
+      title: string;
+      artist: string;
+      album: string;
+      artwork: unknown[];
+      constructor(init: { title: string; artist: string; album: string; artwork: unknown[] }) {
+        this.title = init.title;
+        this.artist = init.artist;
+        this.album = init.album;
+        this.artwork = init.artwork;
+      }
+    },
+  );
+
+  function restore() {
+    Object.defineProperty(navigator, "mediaSession", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    vi.unstubAllGlobals();
+  }
+
+  return { stub, setActionHandler, restore };
+}
+
+describe("MediaSession integration", () => {
+  it("[T3.10] GlobalPlayerBar sets navigator.mediaSession.metadata when a track is playing", () => {
+    const { stub, restore } = setupMediaSessionStub();
+
+    const item = { ...makeItem("z"), album: "Album Z" };
+    usePlayerStore.getState().playQueue([item], 0);
+
+    render(<GlobalPlayerBar />);
+
+    // After render the metadata effect should have run
+    const meta = stub.metadata as { title: string; artist: string };
+    expect(meta).not.toBeNull();
+    expect(meta.title).toBe("Track z");
+    expect(meta.artist).toBe("Artist z");
+
+    restore();
   });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
@@ -93,8 +94,8 @@ const VolumeSection: FC = () => {
   );
 };
 
-const TrackMeta: FC<{ item: QueueItem }> = ({ item }) => (
-  <div className="flex min-w-0 items-center gap-3">
+const TrackMetaContent: FC<{ item: QueueItem }> = ({ item }) => (
+  <>
     <div className="h-10 w-10 shrink-0 overflow-hidden rounded shadow-sm">
       <Image src={item.artworkUrl} alt={item.name} className="rounded" />
     </div>
@@ -102,11 +103,36 @@ const TrackMeta: FC<{ item: QueueItem }> = ({ item }) => (
       <span className="truncate text-sm font-semibold text-white">{item.name}</span>
       <span className="text-text-secondary truncate text-xs">{item.artist}</span>
     </div>
-  </div>
+  </>
 );
+
+const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = ({
+  item,
+  onNavigate,
+}) => {
+  if (item.contextPath) {
+    return (
+      <button
+        type="button"
+        aria-label={`Open ${item.name} by ${item.artist}`}
+        onClick={() => onNavigate(item.contextPath!)}
+        className="flex min-w-0 cursor-pointer items-center gap-3 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+      >
+        <TrackMetaContent item={item} />
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-3">
+      <TrackMetaContent item={item} />
+    </div>
+  );
+};
 
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const navigate = useNavigate();
 
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
@@ -219,7 +245,7 @@ export const GlobalPlayerBar: FC = () => {
               {error ? (
                 <span className="text-sm text-red-400">{error}</span>
               ) : currentItem ? (
-                <TrackMeta item={currentItem} />
+                <TrackMeta item={currentItem} onNavigate={navigate} />
               ) : null}
             </div>
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -9,6 +9,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
+import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
@@ -143,12 +144,27 @@ export const GlobalPlayerBar: FC = () => {
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
   const prev = usePlayerStore((s) => s.prev);
+  const seek = usePlayerStore((s) => s.seek);
   const _onLoadedMetadata = usePlayerStore((s) => s._onLoadedMetadata);
   const _onTimeUpdate = usePlayerStore((s) => s._onTimeUpdate);
   const _onEnded = usePlayerStore((s) => s._onEnded);
   const _onError = usePlayerStore((s) => s._onError);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
+
+  // Media Session API integration — delegates to store actions
+  const mediaSessionActions = {
+    play: () => {
+      if (!usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
+    },
+    pause: () => {
+      if (usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
+    },
+    next,
+    previous: prev,
+    seek,
+  };
+  useMediaSession(currentItem, isPlaying, mediaSessionActions);
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -7,7 +7,7 @@ import {
   faVolumeXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import React, { FC, useEffect, useRef } from "react";
+import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
@@ -152,18 +152,20 @@ export const GlobalPlayerBar: FC = () => {
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
-  // Media Session API integration — delegates to store actions
-  const mediaSessionActions = {
-    play: () => {
-      if (!usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
-    },
-    pause: () => {
-      if (usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
-    },
-    next,
-    previous: prev,
-    seek,
-  };
+  const mediaSessionActions = useMemo(
+    () => ({
+      play: () => {
+        if (!usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
+      },
+      pause: () => {
+        if (usePlayerStore.getState().isPlaying) usePlayerStore.getState().togglePlay();
+      },
+      next,
+      previous: prev,
+      seek,
+    }),
+    [next, prev, seek],
+  );
   useMediaSession(currentItem, isPlaying, mediaSessionActions);
 
   useEffect(() => {

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -260,6 +260,44 @@ describe("useLibraryAlbumDetailController", () => {
     });
   });
 
+  // T2.4 — contextPath on library album queue items
+  it("[T2.4] every dispatched QueueItem carries contextPath equal to the library album route", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayTrack(result.current.tracks[0]!.id);
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; contextPath?: string }>,
+      number,
+    ];
+
+    const expectedPath = generatePath(Path.LIBRARY_ALBUM, {
+      name: "Sigur Rós",
+      albumName: "( )",
+    });
+
+    items.forEach((item) => {
+      expect(item.contextPath).toBe(expectedPath);
+    });
+  });
+
   it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
     mockUseParams.mockReturnValue({
       name: "Sigur%20R%C3%B3s",

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -225,6 +225,41 @@ describe("useLibraryAlbumDetailController", () => {
     expect(startIndex).toBe(0);
   });
 
+  // T1.3 — artworkUrl regression: library album controller is unaffected
+  it("[T1.3] dispatched QueueItems carry artworkUrl equal to coverUrl", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayTrack(result.current.tracks[0]!.id);
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; artworkUrl?: string }>,
+      number,
+    ];
+
+    // All items should carry artworkUrl equal to the album's coverUrl
+    const expectedCoverUrl = result.current.coverUrl;
+    items.forEach((item) => {
+      expect(item.artworkUrl).toBe(expectedCoverUrl);
+    });
+  });
+
   it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
     mockUseParams.mockReturnValue({
       name: "Sigur%20R%C3%B3s",

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -68,7 +68,7 @@ export const useLibraryAlbumDetailController = () => {
         albumName: selectedAlbumName,
       }),
     }));
-  }, [album, artistName, coverUrl]);
+  }, [album, artistName, coverUrl, selectedAlbumName]);
 
   const {
     currentIndex,

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -63,6 +63,10 @@ export const useLibraryAlbumDetailController = () => {
       artworkUrl: coverUrl,
       audioUrl: `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent(track.filePath)}`,
       durationMs: track.duration ? track.duration * 1000 : undefined,
+      contextPath: generatePath(Path.LIBRARY_ALBUM, {
+        name: artistName,
+        albumName: selectedAlbumName,
+      }),
     }));
   }, [album, artistName, coverUrl]);
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -323,4 +323,26 @@ describe("usePlaylistDetailController", () => {
     const track3Item = items.find((i) => i.id === "track-3");
     expect(track3Item?.artworkUrl).toBeUndefined();
   });
+
+  // T2.2 — contextPath on playlist queue items
+  it("[T2.2] every dispatched QueueItem carries contextPath equal to /playlist/id?mode=library", () => {
+    setupDefaults("library");
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayTrack("track-2");
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; contextPath?: string }>,
+      number,
+    ];
+
+    items.forEach((item) => {
+      expect(item.contextPath).toBe("/playlist/playlist-1?mode=library");
+    });
+  });
 });

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -83,6 +83,7 @@ const tracks = [
     status: TrackStatusEnum.Completed,
     audioUrl: undefined,
     trackUrl: "https://open.spotify.com/track/1",
+    albumCoverUrl: undefined,
   },
   {
     id: "track-2",
@@ -91,6 +92,7 @@ const tracks = [
     status: TrackStatusEnum.Completed,
     audioUrl: "/api/library/audio?path=%2Fmusic%2Fmain-theme.mp3",
     trackUrl: "https://open.spotify.com/track/2",
+    albumCoverUrl: "https://example.com/album-cover-track2.jpg",
   },
   {
     id: "track-3",
@@ -99,8 +101,14 @@ const tracks = [
     status: TrackStatusEnum.Completed,
     audioUrl: "/api/library/audio?path=%2Fmusic%2Ffinale.mp3",
     trackUrl: "https://open.spotify.com/track/3",
+    albumCoverUrl: undefined,
   },
 ];
+
+const playlistWithCover = {
+  ...playlist,
+  coverUrl: "https://example.com/playlist-cover.jpg",
+};
 
 const defaultPlaylistController = {
   isDownloading: false,
@@ -249,5 +257,70 @@ describe("usePlaylistDetailController", () => {
     });
 
     expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  // T1.1 — artworkUrl resolution
+  it("[T1.1-A] uses track.albumCoverUrl when present", () => {
+    setupDefaults("library");
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlistWithCover], isLoading: false });
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayTrack("track-2");
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; artworkUrl?: string }>,
+      number,
+    ];
+    // track-2 has albumCoverUrl set
+    const track2Item = items.find((i) => i.id === "track-2");
+    expect(track2Item?.artworkUrl).toBe("https://example.com/album-cover-track2.jpg");
+  });
+
+  it("[T1.1-B] falls back to playlist.coverUrl when track.albumCoverUrl is absent", () => {
+    setupDefaults("library");
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlistWithCover], isLoading: false });
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; artworkUrl?: string }>,
+      number,
+    ];
+    // track-3 has no albumCoverUrl → falls back to playlist.coverUrl
+    const track3Item = items.find((i) => i.id === "track-3");
+    expect(track3Item?.artworkUrl).toBe("https://example.com/playlist-cover.jpg");
+  });
+
+  it("[T1.1-C] artworkUrl is undefined when both track and playlist have no cover", () => {
+    setupDefaults("library");
+    // playlist has no coverUrl (use the original playlist fixture)
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayTrack("track-3");
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [items] = mockPlayQueue.mock.calls[0] as [
+      Array<{ id: string; artworkUrl?: string }>,
+      number,
+    ];
+    // track-3 has no albumCoverUrl; playlist has no coverUrl → undefined
+    const track3Item = items.find((i) => i.id === "track-3");
+    expect(track3Item?.artworkUrl).toBeUndefined();
   });
 });

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -35,7 +35,7 @@ export const usePlaylistDetailController = () => {
         durationMs: track.durationMs,
         contextPath: `/playlist/${id}?mode=library`,
       }));
-  }, [mode, tracks]);
+  }, [mode, tracks, playlist, id]);
 
   const { currentTrackId, isPlaying, hasPlayableTracks, playFromIndex, onPlayTrack, onPauseTrack } =
     usePlayerQueueBinding(queueItems);

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -33,6 +33,7 @@ export const usePlaylistDetailController = () => {
         artworkUrl: track.albumCoverUrl ?? playlist?.coverUrl ?? undefined,
         audioUrl: track.audioUrl!,
         durationMs: track.durationMs,
+        contextPath: `/playlist/${id}?mode=library`,
       }));
   }, [mode, tracks]);
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -30,7 +30,7 @@ export const usePlaylistDetailController = () => {
         name: track.name,
         artist: track.artist ?? "",
         album: track.album,
-        artworkUrl: undefined,
+        artworkUrl: track.albumCoverUrl ?? playlist?.coverUrl ?? undefined,
         audioUrl: track.audioUrl!,
         durationMs: track.durationMs,
       }));

--- a/apps/frontend/src/hooks/useMediaSession.test.ts
+++ b/apps/frontend/src/hooks/useMediaSession.test.ts
@@ -1,0 +1,304 @@
+/**
+ * useMediaSession unit tests — Strict TDD (Win 3).
+ *
+ * Tests T3.1–T3.8 cover:
+ * - no-op in unsupported environments
+ * - metadata set/cleared when currentItem changes
+ * - artwork array shape
+ * - playbackState sync
+ * - action handler registration and seekto guard
+ * - cleanup on unmount
+ */
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { QueueItem } from "@/store/usePlayerStore";
+import { type MediaSessionActions, useMediaSession } from "./useMediaSession";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeItem = (overrides: Partial<QueueItem> = {}): QueueItem => ({
+  id: "track-1",
+  name: "Vaka",
+  artist: "Sigur Rós",
+  album: "( )",
+  artworkUrl: "https://example.com/art.jpg",
+  audioUrl: "/api/library/audio?id=1",
+  ...overrides,
+});
+
+const makeActions = (): MediaSessionActions & {
+  play: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  next: ReturnType<typeof vi.fn>;
+  previous: ReturnType<typeof vi.fn>;
+  seek: ReturnType<typeof vi.fn>;
+} => ({
+  play: vi.fn(),
+  pause: vi.fn(),
+  next: vi.fn(),
+  previous: vi.fn(),
+  seek: vi.fn(),
+});
+
+// ---------------------------------------------------------------------------
+// MediaSession stub factory
+// ---------------------------------------------------------------------------
+
+function setupMediaSessionStub() {
+  const setActionHandler = vi.fn();
+  const stub = {
+    metadata: null as unknown,
+    playbackState: "none" as string,
+    setActionHandler,
+  };
+
+  Object.defineProperty(navigator, "mediaSession", {
+    value: stub,
+    configurable: true,
+    writable: true,
+  });
+
+  vi.stubGlobal(
+    "MediaMetadata",
+    class {
+      title: string;
+      artist: string;
+      album: string;
+      artwork: unknown[];
+      constructor(init: { title: string; artist: string; album: string; artwork: unknown[] }) {
+        this.title = init.title;
+        this.artist = init.artist;
+        this.album = init.album;
+        this.artwork = init.artwork;
+      }
+    },
+  );
+
+  function restore() {
+    Object.defineProperty(navigator, "mediaSession", {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    vi.unstubAllGlobals();
+  }
+
+  return { stub, setActionHandler, restore };
+}
+
+// ---------------------------------------------------------------------------
+// T3.1 — no-op when mediaSession is absent
+// ---------------------------------------------------------------------------
+
+describe("T3.1 — no-op in unsupported environments", () => {
+  beforeEach(() => {
+    // Make mediaSession unavailable by setting to null (different from undefined
+    // so that navigator.mediaSession != null guard catches it)
+    Object.defineProperty(navigator, "mediaSession", {
+      value: null,
+      configurable: true,
+      writable: true,
+    });
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(navigator, "mediaSession", {
+      value: null,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it("does not throw when navigator.mediaSession is absent", () => {
+    const actions = makeActions();
+    expect(() => {
+      renderHook(() => useMediaSession(makeItem(), false, actions));
+    }).not.toThrow();
+  });
+
+  it("does not call setActionHandler when mediaSession is absent", () => {
+    const actions = makeActions();
+    renderHook(() => useMediaSession(makeItem(), false, actions));
+    // No setActionHandler to call — just verify no side-effects happened
+    // (no throw, no global mutation)
+    expect(actions.play).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.2–T3.8 — behaviour with stubbed mediaSession
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession with stubbed navigator.mediaSession", () => {
+  let stub: ReturnType<typeof setupMediaSessionStub>["stub"];
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+
+  beforeEach(() => {
+    const result = setupMediaSessionStub();
+    stub = result.stub;
+    setActionHandler = result.setActionHandler;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  // T3.2 — metadata set when currentItem becomes non-null
+  it("[T3.2] sets metadata with correct title/artist/album/artwork when currentItem is provided", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    const meta = stub.metadata as {
+      title: string;
+      artist: string;
+      album: string;
+      artwork: { src: string }[];
+    };
+    expect(meta).not.toBeNull();
+    expect(meta.title).toBe("Vaka");
+    expect(meta.artist).toBe("Sigur Rós");
+    expect(meta.album).toBe("( )");
+    expect(meta.artwork).toEqual([{ src: "https://example.com/art.jpg" }]);
+  });
+
+  // T3.3 — artwork is empty when artworkUrl is undefined
+  it("[T3.3] artwork is [] when artworkUrl is undefined", () => {
+    const item = makeItem({ artworkUrl: undefined });
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    const meta = stub.metadata as { artwork: unknown[] };
+    expect(meta.artwork).toHaveLength(0);
+  });
+
+  // T3.4 — metadata clears to null when currentItem becomes null
+  it("[T3.4] clears metadata to null when currentItem becomes null", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    const { rerender } = renderHook(
+      ({ currentItem }: { currentItem: QueueItem | null }) =>
+        useMediaSession(currentItem, false, actions),
+      { initialProps: { currentItem: item as QueueItem | null } },
+    );
+
+    expect(stub.metadata).not.toBeNull();
+
+    rerender({ currentItem: null });
+
+    expect(stub.metadata).toBeNull();
+  });
+
+  // T3.5 — playbackState reflects isPlaying and currentItem
+  it("[T3.5] playbackState is 'playing' when isPlaying and currentItem is set", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, true, actions));
+
+    expect(stub.playbackState).toBe("playing");
+  });
+
+  it("[T3.5] playbackState is 'paused' when not isPlaying and currentItem is set", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    expect(stub.playbackState).toBe("paused");
+  });
+
+  it("[T3.5] playbackState is 'none' when currentItem is null", () => {
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(null, false, actions));
+
+    expect(stub.playbackState).toBe("none");
+  });
+
+  // T3.6 — all five action handlers registered on mount
+  it("[T3.6] registers all five action handlers on mount", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    const registeredActions = (setActionHandler.mock.calls as unknown[][]).map((call) => call[0]);
+    expect(registeredActions).toContain("play");
+    expect(registeredActions).toContain("pause");
+    expect(registeredActions).toContain("previoustrack");
+    expect(registeredActions).toContain("nexttrack");
+    expect(registeredActions).toContain("seekto");
+
+    // All handlers are non-null functions
+    (setActionHandler.mock.calls as unknown[][]).forEach((call) => {
+      expect(typeof call[1]).toBe("function");
+    });
+  });
+
+  // T3.7 — seekto handler guards seekTime != null
+  it("[T3.7] seekto handler calls actions.seek when seekTime is provided", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    const seektoCall = (setActionHandler.mock.calls as unknown[][]).find(
+      (call) => call[0] === "seekto",
+    );
+    const seektoHandler = seektoCall?.[1] as (details: { seekTime?: number }) => void;
+
+    seektoHandler({ seekTime: 42 });
+
+    expect(actions.seek).toHaveBeenCalledWith(42);
+  });
+
+  it("[T3.7] seekto handler does NOT call actions.seek when seekTime is absent", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(item, false, actions));
+
+    const seektoCall = (setActionHandler.mock.calls as unknown[][]).find(
+      (call) => call[0] === "seekto",
+    );
+    const seektoHandler = seektoCall?.[1] as (details: { seekTime?: number }) => void;
+
+    seektoHandler({});
+
+    expect(actions.seek).not.toHaveBeenCalled();
+  });
+
+  // T3.8 — cleanup clears all handlers on unmount
+  it("[T3.8] clears all five action handlers and nullifies metadata on unmount", () => {
+    const item = makeItem();
+    const actions = makeActions();
+
+    const { unmount } = renderHook(() => useMediaSession(item, false, actions));
+
+    setActionHandler.mockClear();
+
+    unmount();
+
+    // Five setActionHandler(name, null) calls expected
+    const nullCalls = (setActionHandler.mock.calls as unknown[][]).filter(
+      (call) => call[1] === null,
+    );
+    const clearedActions = nullCalls.map((call) => call[0]);
+    expect(clearedActions).toContain("play");
+    expect(clearedActions).toContain("pause");
+    expect(clearedActions).toContain("previoustrack");
+    expect(clearedActions).toContain("nexttrack");
+    expect(clearedActions).toContain("seekto");
+
+    expect(stub.metadata).toBeNull();
+  });
+});

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -1,0 +1,104 @@
+import { useEffect } from "react";
+import type { QueueItem } from "@/store/usePlayerStore";
+
+export interface MediaSessionActions {
+  play: () => void;
+  pause: () => void;
+  next: () => void;
+  previous: () => void;
+  /** Seek to position in seconds from the start of the current track. */
+  seek: (timeSec: number) => void;
+}
+
+function isMediaSessionSupported(): boolean {
+  return typeof navigator !== "undefined" && navigator.mediaSession != null;
+}
+
+/**
+ * Thin imperative bridge between player store state and the browser's
+ * Media Session API. No-ops silently when the API is unavailable (e.g. jsdom,
+ * older browsers). Three separate effects keep metadata, playback state, and
+ * action handlers independently updated.
+ *
+ * @param currentItem - The currently playing queue item, or null when idle.
+ * @param isPlaying   - Whether playback is active.
+ * @param actions     - Stable references to store transport actions.
+ */
+export function useMediaSession(
+  currentItem: QueueItem | null,
+  isPlaying: boolean,
+  actions: MediaSessionActions,
+): void {
+  // Effect 1: metadata — keyed on currentItem identity
+  useEffect(() => {
+    if (!isMediaSessionSupported()) return;
+
+    if (!currentItem) {
+      navigator.mediaSession.metadata = null;
+      return;
+    }
+
+    const artwork = currentItem.artworkUrl ? [{ src: currentItem.artworkUrl }] : [];
+
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: currentItem.name,
+      artist: currentItem.artist,
+      album: currentItem.album ?? "",
+      artwork,
+    });
+  }, [currentItem]);
+
+  // Effect 2: playbackState — keyed on isPlaying + currentItem presence
+  useEffect(() => {
+    if (!isMediaSessionSupported()) return;
+
+    if (!currentItem) {
+      navigator.mediaSession.playbackState = "none";
+    } else {
+      navigator.mediaSession.playbackState = isPlaying ? "playing" : "paused";
+    }
+  }, [isPlaying, currentItem]);
+
+  // Effect 3: action handlers — keyed on actions identity; cleanup clears all on unmount
+  useEffect(() => {
+    if (!isMediaSessionSupported()) return;
+
+    const handlers: [MediaSessionAction, MediaSessionActionHandler | null][] = [
+      ["play", () => actions.play()],
+      ["pause", () => actions.pause()],
+      ["previoustrack", () => actions.previous()],
+      ["nexttrack", () => actions.next()],
+      [
+        "seekto",
+        (details: MediaSessionActionDetails) => {
+          if (details.seekTime != null) {
+            actions.seek(details.seekTime);
+          }
+        },
+      ],
+    ];
+
+    handlers.forEach(([name, handler]) => {
+      try {
+        navigator.mediaSession.setActionHandler(name, handler);
+      } catch (e) {
+        if (import.meta.env.DEV) {
+          console.warn(`[useMediaSession] setActionHandler("${name}") failed:`, e);
+        }
+      }
+    });
+
+    return () => {
+      if (!isMediaSessionSupported()) return;
+      // Cleanup: clear all handlers and nullify metadata
+      handlers.forEach(([name]) => {
+        try {
+          navigator.mediaSession.setActionHandler(name, null);
+        } catch {
+          // Silently ignore on cleanup
+        }
+      });
+      navigator.mediaSession.metadata = null;
+    };
+  }, [actions]);
+}

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -6,7 +6,6 @@ export interface MediaSessionActions {
   pause: () => void;
   next: () => void;
   previous: () => void;
-  /** Seek to position in seconds from the start of the current track. */
   seek: (timeSec: number) => void;
 }
 
@@ -14,22 +13,11 @@ function isMediaSessionSupported(): boolean {
   return typeof navigator !== "undefined" && navigator.mediaSession != null;
 }
 
-/**
- * Thin imperative bridge between player store state and the browser's
- * Media Session API. No-ops silently when the API is unavailable (e.g. jsdom,
- * older browsers). Three separate effects keep metadata, playback state, and
- * action handlers independently updated.
- *
- * @param currentItem - The currently playing queue item, or null when idle.
- * @param isPlaying   - Whether playback is active.
- * @param actions     - Stable references to store transport actions.
- */
 export function useMediaSession(
   currentItem: QueueItem | null,
   isPlaying: boolean,
   actions: MediaSessionActions,
 ): void {
-  // Effect 1: metadata — keyed on currentItem identity
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
 
@@ -48,7 +36,6 @@ export function useMediaSession(
     });
   }, [currentItem]);
 
-  // Effect 2: playbackState — keyed on isPlaying + currentItem presence
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
 
@@ -59,7 +46,6 @@ export function useMediaSession(
     }
   }, [isPlaying, currentItem]);
 
-  // Effect 3: action handlers — keyed on actions identity; cleanup clears all on unmount
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
 
@@ -90,12 +76,11 @@ export function useMediaSession(
 
     return () => {
       if (!isMediaSessionSupported()) return;
-      // Cleanup: clear all handlers and nullify metadata
       handlers.forEach(([name]) => {
         try {
           navigator.mediaSession.setActionHandler(name, null);
         } catch {
-          // Silently ignore on cleanup
+          // ignore
         }
       });
       navigator.mediaSession.metadata = null;

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -15,6 +15,13 @@ export interface QueueItem {
   artworkUrl?: string;
   audioUrl: string;
   durationMs?: number;
+  /**
+   * Pre-built absolute route to the surface that queued this track
+   * (e.g. `/playlist/abc?mode=library`). When present, GlobalPlayerBar
+   * renders track meta as a navigable button. Each controller is responsible
+   * for building the canonical path for its own page.
+   */
+  contextPath?: string;
 }
 
 export interface PlayerState {


### PR DESCRIPTION
## Summary
- **Win 1 — Queue artwork**: `usePlaylistDetailController` now populates `artworkUrl` via `track.albumCoverUrl ?? playlist.coverUrl ?? undefined` instead of `undefined`.
- **Win 2 — Meta click navigation**: `QueueItem` gains optional `contextPath`; `TrackMeta` renders as a `<button>` when present and navigates to the source playlist/library album via `useNavigate`. Falls back to a non-interactive `<div>` when absent.
- **Win 3 — Media Session API**: new `useMediaSession(currentItem, isPlaying, actions)` hook wires `navigator.mediaSession` metadata + `play`/`pause`/`previoustrack`/`nexttrack`/`seekto` handlers for lock-screen and media-key control. Guarded by `navigator.mediaSession != null`; `MediaMetadata.artwork` is `[]` when `artworkUrl` is absent; `seekto` handler null-guards `details.seekTime`.
- **Perf fix**: `mediaSessionActions` wrapped in `useMemo` to avoid handler re-registration at every render (no React Compiler in repo).

## Scope
Single PR, ~115 LOC. Built on top of the shipped global-player-bar (PRs #84 + #85). Spotify-browse `useAlbumDetailController` has no player integration yet — explicitly out of scope. Shuffle/repeat, queue side-panel, and mobile fullscreen now-playing are deferred to next slices.

## SDD
Engram artifacts under `sdd/player-quick-wins/*` (proposal #3177 → archive #3196). Strict TDD throughout — 23 tasks, RED→GREEN per win.

## Test plan
- [x] `pnpm --filter frontend test:run` — 237/237 pass, 33 files
- [x] `pnpm --filter frontend lint` — oxlint clean
- [x] `pnpm --filter frontend build` — ✓ built
- [ ] Manual: play a playlist track → queue items show artwork; click track meta → routes to playlist; play in Chrome → lock-screen card shows; media keys (prev/play-pause/next/seek) work