### PR TITLE
feat(player): shuffle and repeat modes

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -50,6 +50,10 @@ function resetStore() {
     currentTime: 0,
     duration: 180,
     error: null,
+    shuffleMode: false,
+    repeatMode: "off",
+    shuffleOrder: [],
+    shuffleOrderIndex: -1,
   });
 }
 
@@ -490,12 +494,137 @@ describe("MediaSession integration", () => {
 
     render(<GlobalPlayerBar />);
 
-    // After render the metadata effect should have run
     const meta = stub.metadata as { title: string; artist: string };
     expect(meta).not.toBeNull();
     expect(meta.title).toBe("Track z");
     expect(meta.artist).toBe("Artist z");
 
     restore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shuffle button (S4-1, S4-2, S4-7)
+// ---------------------------------------------------------------------------
+
+describe("shuffle button", () => {
+  it("S4-1: renders with aria-label 'Enable shuffle' when shuffleMode is false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("button", { name: "Enable shuffle" })).not.toBeNull();
+  });
+
+  it("S4-2: renders with aria-label 'Disable shuffle' when shuffleMode is true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ shuffleMode: true });
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("button", { name: "Disable shuffle" })).not.toBeNull();
+  });
+
+  it("S4-7: shuffle control element is a BUTTON", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Enable shuffle" });
+    expect(btn.tagName).toBe("BUTTON");
+  });
+
+  it("clicking shuffle button calls toggleShuffle", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Enable shuffle" });
+    fireEvent.click(btn);
+
+    expect(usePlayerStore.getState().shuffleMode).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repeat button (S4-3)
+// ---------------------------------------------------------------------------
+
+describe("repeat button", () => {
+  it("S4-3: cycles aria-label across 3 clicks", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Enable repeat" });
+
+    fireEvent.click(btn);
+    expect(screen.getByRole("button", { name: "Repeat all" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Repeat all" }));
+    expect(screen.getByRole("button", { name: "Repeat one" })).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Repeat one" }));
+    expect(screen.getByRole("button", { name: "Enable repeat" })).not.toBeNull();
+  });
+
+  it("badge <sup>1</sup> is visible when repeatMode is 'one'", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ repeatMode: "one" });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const sup = container.querySelector("sup");
+    expect(sup).not.toBeNull();
+    expect(sup?.textContent).toBe("1");
+  });
+
+  it("badge is absent when repeatMode is 'all'", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ repeatMode: "all" });
+    const { container } = render(<GlobalPlayerBar />);
+
+    expect(container.querySelector("sup")).toBeNull();
+  });
+
+  it("badge is absent when repeatMode is 'off'", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    const { container } = render(<GlobalPlayerBar />);
+
+    expect(container.querySelector("sup")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isAtFirst / isAtLast with modes (S4-4, S4-5, S4-6)
+// ---------------------------------------------------------------------------
+
+describe("isAtFirst / isAtLast with modes", () => {
+  it("S4-4: prev and next NOT disabled when shuffleMode is true", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ shuffleMode: true });
+    render(<GlobalPlayerBar />);
+
+    const prevBtn = screen.getByRole("button", { name: "Previous track" });
+    const nextBtn = screen.getByRole("button", { name: "Next track" });
+    expect(prevBtn).toHaveProperty("disabled", false);
+    expect(nextBtn).toHaveProperty("disabled", false);
+  });
+
+  it("S4-5: prev and next NOT disabled when repeatMode is 'all'", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ shuffleMode: false, repeatMode: "all" });
+    render(<GlobalPlayerBar />);
+
+    const prevBtn = screen.getByRole("button", { name: "Previous track" });
+    const nextBtn = screen.getByRole("button", { name: "Next track" });
+    expect(prevBtn).toHaveProperty("disabled", false);
+    expect(nextBtn).toHaveProperty("disabled", false);
+  });
+
+  it("S4-6: prev IS disabled with repeat off and shuffle off at index 0", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ shuffleMode: false, repeatMode: "off" });
+    render(<GlobalPlayerBar />);
+
+    const prevBtn = screen.getByRole("button", { name: "Previous track" });
+    expect(prevBtn).toHaveProperty("disabled", true);
   });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -3,6 +3,8 @@ import {
   faForwardStep,
   faPause,
   faPlay,
+  faRepeat,
+  faShuffle,
   faVolumeHigh,
   faVolumeXmark,
 } from "@fortawesome/free-solid-svg-icons";
@@ -139,12 +141,16 @@ export const GlobalPlayerBar: FC = () => {
   const currentIndex = usePlayerStore((s) => s.currentIndex);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const error = usePlayerStore((s) => s.error);
+  const shuffleMode = usePlayerStore((s) => s.shuffleMode);
+  const repeatMode = usePlayerStore((s) => s.repeatMode);
 
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
   const prev = usePlayerStore((s) => s.prev);
   const seek = usePlayerStore((s) => s.seek);
+  const toggleShuffle = usePlayerStore((s) => s.toggleShuffle);
+  const cycleRepeat = usePlayerStore((s) => s.cycleRepeat);
   const _onLoadedMetadata = usePlayerStore((s) => s._onLoadedMetadata);
   const _onTimeUpdate = usePlayerStore((s) => s._onTimeUpdate);
   const _onEnded = usePlayerStore((s) => s._onEnded);
@@ -232,8 +238,17 @@ export const GlobalPlayerBar: FC = () => {
   }, [error]);
 
   const isVisible = currentIndex !== null || !!error;
-  const isAtFirst = currentIndex === 0;
-  const isAtLast = currentIndex !== null && currentIndex === queue.length - 1;
+  const isAtFirst =
+    !shuffleMode && repeatMode !== "all" && (currentIndex === null || currentIndex <= 0);
+  const isAtLast =
+    !shuffleMode &&
+    repeatMode !== "all" &&
+    (currentIndex === null || currentIndex >= queue.length - 1);
+
+  const shuffleAriaLabel = shuffleMode ? "Disable shuffle" : "Enable shuffle";
+  const repeatAriaLabel =
+    repeatMode === "off" ? "Enable repeat" : repeatMode === "all" ? "Repeat all" : "Repeat one";
+  const isRepeatActive = repeatMode !== "off";
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== " ") return;
@@ -271,6 +286,18 @@ export const GlobalPlayerBar: FC = () => {
               <div className="flex items-center gap-4">
                 <button
                   type="button"
+                  aria-label={shuffleAriaLabel}
+                  onClick={toggleShuffle}
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                    shuffleMode ? "text-green-500" : "text-text-secondary hover:text-text-primary",
+                  )}
+                >
+                  <FontAwesomeIcon icon={faShuffle} className="text-sm" />
+                </button>
+
+                <button
+                  type="button"
                   aria-label="Previous track"
                   disabled={isAtFirst}
                   onClick={prev}
@@ -303,6 +330,25 @@ export const GlobalPlayerBar: FC = () => {
                   )}
                 >
                   <FontAwesomeIcon icon={faForwardStep} className="text-base" />
+                </button>
+
+                <button
+                  type="button"
+                  aria-label={repeatAriaLabel}
+                  onClick={cycleRepeat}
+                  className={cn(
+                    "relative flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                    isRepeatActive
+                      ? "text-green-500"
+                      : "text-text-secondary hover:text-text-primary",
+                  )}
+                >
+                  <FontAwesomeIcon icon={faRepeat} className="text-sm" />
+                  {repeatMode === "one" && (
+                    <sup className="absolute -top-1 -right-1 text-[0.55rem] leading-none font-bold">
+                      1
+                    </sup>
+                  )}
                 </button>
               </div>
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
+import { usePreferencesStore } from "@/store/usePreferencesStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
 
@@ -136,6 +137,7 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const navigate = useNavigate();
+  const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
 
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
@@ -269,7 +271,8 @@ export const GlobalPlayerBar: FC = () => {
           onKeyDown={onKeyDown}
           className={cn(
             "bg-surface/95 border-t border-white/10 backdrop-blur-lg",
-            "fixed right-0 bottom-16 left-0 z-40 md:bottom-0",
+            "fixed right-0 bottom-16 left-0 z-40 transition-[left] duration-300 md:bottom-0",
+            isSidebarCollapsed ? "md:left-20" : "md:left-64",
             "px-4 py-2",
           )}
         >

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -16,10 +16,16 @@ beforeEach(async () => {
   vi.resetModules();
   const mod = await import("./usePlayerStore");
   usePlayerStore = mod.usePlayerStore;
-  // Reset to initial state before each test
   usePlayerStore.getState().clear();
-  // Also reset volume/isMuted to defaults (clear preserves them, so set explicitly)
-  usePlayerStore.setState({ volume: 1, isMuted: false, error: null });
+  usePlayerStore.setState({
+    volume: 1,
+    isMuted: false,
+    error: null,
+    shuffleMode: false,
+    repeatMode: "off",
+    shuffleOrder: [],
+    shuffleOrderIndex: -1,
+  });
 });
 
 const makeItem = (id: string, audioUrl = `/api/library/audio?id=${id}`) => ({
@@ -385,11 +391,11 @@ describe("_onError", () => {
 });
 
 // ---------------------------------------------------------------------------
-// persist partialize: only volume and isMuted survive
+// persist partialize: only volume, isMuted, shuffleMode, repeatMode survive
 // ---------------------------------------------------------------------------
 
 describe("persist partialize", () => {
-  it("only serializes volume and isMuted", async () => {
+  it("serializes volume, isMuted, shuffleMode, repeatMode", async () => {
     const mod = await import("./usePlayerStore");
     const partialize = mod.__partialize;
 
@@ -402,6 +408,10 @@ describe("persist partialize", () => {
       currentTime: 55,
       duration: 200,
       error: null,
+      shuffleMode: true,
+      repeatMode: "one" as const,
+      shuffleOrder: [2, 0, 1],
+      shuffleOrderIndex: 1,
       playQueue: vi.fn(),
       togglePlay: vi.fn(),
       next: vi.fn(),
@@ -410,6 +420,8 @@ describe("persist partialize", () => {
       setVolume: vi.fn(),
       toggleMute: vi.fn(),
       clear: vi.fn(),
+      toggleShuffle: vi.fn(),
+      cycleRepeat: vi.fn(),
       setAudioElement: vi.fn(),
       _onLoadedMetadata: vi.fn(),
       _onTimeUpdate: vi.fn(),
@@ -420,9 +432,353 @@ describe("persist partialize", () => {
     const persisted = partialize(state as unknown as Parameters<typeof partialize>[0]);
     const roundTripped = JSON.parse(JSON.stringify(persisted));
 
-    expect(roundTripped).toEqual({ volume: 0.6, isMuted: true });
+    expect(roundTripped).toEqual({
+      volume: 0.6,
+      isMuted: true,
+      shuffleMode: true,
+      repeatMode: "one",
+    });
     expect("queue" in roundTripped).toBe(false);
     expect("currentTime" in roundTripped).toBe(false);
     expect("isPlaying" in roundTripped).toBe(false);
+    expect("shuffleOrder" in roundTripped).toBe(false);
+    expect("shuffleOrderIndex" in roundTripped).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shuffle state (S1-1, S1-3, S1-4, S5-1, S5-2)
+// ---------------------------------------------------------------------------
+
+describe("shuffle state", () => {
+  it("S1-1: initial defaults", () => {
+    const state = usePlayerStore.getState();
+    expect(state.shuffleMode).toBe(false);
+    expect(state.repeatMode).toBe("off");
+    expect(state.shuffleOrder).toEqual([]);
+    expect(state.shuffleOrderIndex).toBe(-1);
+  });
+
+  it("S1-3: toggleShuffle on builds order with currentIndex pinned at position 0", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().toggleShuffle();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleMode).toBe(true);
+    expect(state.shuffleOrder).toHaveLength(5);
+    expect(state.shuffleOrder[0]).toBe(2);
+    expect(state.shuffleOrderIndex).toBe(0);
+  });
+
+  it("S1-4: toggleShuffle off clears order and leaves currentIndex unchanged", () => {
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 4, 1, 3],
+      shuffleOrderIndex: 2,
+      currentIndex: 4,
+    });
+    usePlayerStore.getState().toggleShuffle();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleMode).toBe(false);
+    expect(state.shuffleOrder).toEqual([]);
+    expect(state.shuffleOrderIndex).toBe(-1);
+    expect(state.currentIndex).toBe(4);
+  });
+
+  it("S5-1: toggle on mid-queue pins current and discards old history", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ shuffleOrder: [0, 3, 2, 1], shuffleOrderIndex: 2 });
+    usePlayerStore.getState().toggleShuffle();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrder[0]).toBe(2);
+    expect(state.shuffleOrderIndex).toBe(0);
+  });
+
+  it("S5-2: toggle off leaves currentIndex intact", () => {
+    usePlayerStore.setState({
+      shuffleMode: true,
+      currentIndex: 3,
+      shuffleOrder: [3, 1, 0, 2],
+      shuffleOrderIndex: 0,
+    });
+    usePlayerStore.getState().toggleShuffle();
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(3);
+    expect(state.shuffleOrder).toEqual([]);
+    expect(state.shuffleOrderIndex).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repeat state (S1-5, S5-3)
+// ---------------------------------------------------------------------------
+
+describe("repeat state", () => {
+  it("S1-5: cycleRepeat rotates off → all → one → off", () => {
+    usePlayerStore.getState().cycleRepeat();
+    expect(usePlayerStore.getState().repeatMode).toBe("all");
+
+    usePlayerStore.getState().cycleRepeat();
+    expect(usePlayerStore.getState().repeatMode).toBe("one");
+
+    usePlayerStore.getState().cycleRepeat();
+    expect(usePlayerStore.getState().repeatMode).toBe("off");
+  });
+
+  it("S5-3: cycleRepeat does not touch audio state", () => {
+    usePlayerStore.setState({
+      isPlaying: true,
+      currentTime: 42,
+      currentIndex: 1,
+      repeatMode: "off",
+    });
+    usePlayerStore.getState().cycleRepeat();
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(42);
+    expect(state.currentIndex).toBe(1);
+    expect(state.repeatMode).toBe("all");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// partialize — S1-6 rehydration
+// ---------------------------------------------------------------------------
+
+describe("partialize S1-6", () => {
+  it("shuffleOrder and shuffleOrderIndex reset to defaults on rehydration", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      shuffleMode: true,
+      repeatMode: "one" as const,
+      shuffleOrder: [2, 0, 1],
+      shuffleOrderIndex: 1,
+      volume: 1,
+      isMuted: false,
+    } as unknown as Parameters<typeof p>[0];
+
+    const persisted = p(fakeState);
+    expect("shuffleOrder" in persisted).toBe(false);
+    expect("shuffleOrderIndex" in persisted).toBe(false);
+    expect(persisted.shuffleMode).toBe(true);
+    expect(persisted.repeatMode).toBe("one");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// next() with modes (S2-1 to S2-6)
+// ---------------------------------------------------------------------------
+
+describe("next() with modes", () => {
+  it("S2-1: stops at last track with repeat off", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().next();
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(2);
+    expect(state.isPlaying).toBe(false);
+  });
+
+  it("S2-2: wraps to 0 with repeat all", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ repeatMode: "all" });
+    usePlayerStore.getState().next();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(0);
+  });
+
+  it("S2-3: repeat-one still advances (user-triggered next)", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ repeatMode: "one" });
+    usePlayerStore.getState().next();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(2);
+  });
+
+  it("S2-4: shuffle on advances shuffleOrderIndex and sets currentIndex", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 4, 1, 3],
+      shuffleOrderIndex: 1,
+    });
+    usePlayerStore.getState().next();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrderIndex).toBe(2);
+    expect(state.currentIndex).toBe(4);
+  });
+
+  it("S2-5: shuffle wraps cursor with repeat all", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 4, 1, 3],
+      shuffleOrderIndex: 4,
+      repeatMode: "all",
+    });
+    usePlayerStore.getState().next();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrderIndex).toBe(0);
+    expect(state.currentIndex).toBe(2);
+  });
+
+  it("S2-6: shuffle stops at end with repeat off", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 4, 1, 3],
+      shuffleOrderIndex: 4,
+      repeatMode: "off",
+    });
+    usePlayerStore.getState().next();
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.shuffleOrderIndex).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prev() with modes (S2-7, S2-8, Decision #10)
+// ---------------------------------------------------------------------------
+
+describe("prev() with modes", () => {
+  it("S2-7: repeat all wraps at index 0", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ currentTime: 1, repeatMode: "all" });
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(3);
+  });
+
+  it("S2-8: shuffle walks cursor back", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 4);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 4],
+      shuffleOrderIndex: 2,
+      currentTime: 1,
+      repeatMode: "off",
+    });
+    usePlayerStore.getState().prev();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrderIndex).toBe(1);
+    expect(state.currentIndex).toBe(0);
+  });
+
+  it("Decision #10: shuffle on + shuffleOrderIndex=0 + repeat off is a no-op", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [2, 0, 1],
+      shuffleOrderIndex: 0,
+      currentIndex: 2,
+      currentTime: 1,
+      repeatMode: "off",
+    });
+    usePlayerStore.getState().prev();
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrderIndex).toBe(0);
+    expect(state.currentIndex).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _onEnded() with modes (S2-9 to S2-12)
+// ---------------------------------------------------------------------------
+
+describe("_onEnded() with modes", () => {
+  it("S2-9: repeat one replays (seek 0 + play), does not advance", () => {
+    const mockAudio = { currentTime: 5, play: vi.fn().mockResolvedValue(undefined) };
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ repeatMode: "one", isPlaying: true });
+    usePlayerStore.getState().setAudioElement(mockAudio as unknown as HTMLAudioElement);
+
+    usePlayerStore.getState()._onEnded();
+
+    expect(mockAudio.currentTime).toBe(0);
+    expect(mockAudio.play).toHaveBeenCalledOnce();
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("S2-10: repeat off at last track stops playback", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ repeatMode: "off" });
+    usePlayerStore.getState()._onEnded();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+    expect(usePlayerStore.getState().currentIndex).toBe(2);
+  });
+
+  it("S2-11: single-track repeat one replays", () => {
+    const mockAudio = { currentTime: 5, play: vi.fn().mockResolvedValue(undefined) };
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ repeatMode: "one", isPlaying: true });
+    usePlayerStore.getState().setAudioElement(mockAudio as unknown as HTMLAudioElement);
+
+    usePlayerStore.getState()._onEnded();
+
+    expect(mockAudio.currentTime).toBe(0);
+    expect(mockAudio.play).toHaveBeenCalledOnce();
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("S2-12: single-track repeat off stops", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ repeatMode: "off" });
+    usePlayerStore.getState()._onEnded();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// playQueue() with shuffle (S3-1, S3-2)
+// ---------------------------------------------------------------------------
+
+describe("playQueue() with shuffle", () => {
+  it("S3-1: rebuilds shuffleOrder when shuffle on, pins startIndex at 0", () => {
+    usePlayerStore.setState({ shuffleMode: true });
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrder).toHaveLength(3);
+    expect(state.shuffleOrder[0]).toBe(1);
+    expect(state.shuffleOrderIndex).toBe(0);
+    expect(state.currentIndex).toBe(1);
+  });
+
+  it("S3-2: no shuffleOrder side effects when shuffle off", () => {
+    usePlayerStore.setState({ shuffleMode: false });
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.shuffleOrder).toEqual([]);
+    expect(state.shuffleOrderIndex).toBe(-1);
   });
 });

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -24,6 +24,8 @@ export interface QueueItem {
   contextPath?: string;
 }
 
+export type RepeatMode = "off" | "all" | "one";
+
 export interface PlayerState {
   queue: QueueItem[];
   currentIndex: number | null;
@@ -33,6 +35,10 @@ export interface PlayerState {
   currentTime: number;
   duration: number;
   error: string | null;
+  shuffleMode: boolean;
+  repeatMode: RepeatMode;
+  shuffleOrder: number[];
+  shuffleOrderIndex: number;
 
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
@@ -42,6 +48,8 @@ export interface PlayerState {
   setVolume: (v: number) => void;
   toggleMute: () => void;
   clear: () => void;
+  toggleShuffle: () => void;
+  cycleRepeat: () => void;
 
   setAudioElement: (el: HTMLAudioElement | null) => void;
   _onLoadedMetadata: (duration: number) => void;
@@ -50,12 +58,35 @@ export interface PlayerState {
   _onError: (message: string) => void;
 }
 
-export const __partialize = (state: PlayerState): Pick<PlayerState, "volume" | "isMuted"> => ({
+export const __partialize = (
+  state: PlayerState,
+): Pick<PlayerState, "volume" | "isMuted" | "shuffleMode" | "repeatMode"> => ({
   volume: state.volume,
   isMuted: state.isMuted,
+  shuffleMode: state.shuffleMode,
+  repeatMode: state.repeatMode,
 });
 
 let _audioElement: HTMLAudioElement | null = null;
+
+function shuffleIndices(length: number, pin: number): number[] {
+  if (length === 0) return [];
+  if (length === 1) return [pin];
+  const arr = Array.from({ length }, (_, i) => i);
+  for (let i = arr.length - 1; i > 1; i--) {
+    const j = 1 + Math.floor(Math.random() * i);
+    const tmp = arr[i]!;
+    arr[i] = arr[j]!;
+    arr[j] = tmp;
+  }
+  const pinPos = arr.indexOf(pin);
+  if (pinPos !== 0) {
+    const tmp = arr[0]!;
+    arr[0] = arr[pinPos]!;
+    arr[pinPos] = tmp;
+  }
+  return arr;
+}
 
 const INITIAL_STATE = {
   queue: [] as QueueItem[],
@@ -66,120 +97,213 @@ const INITIAL_STATE = {
   currentTime: 0,
   duration: 0,
   error: null as string | null,
+  shuffleMode: false,
+  repeatMode: "off" as RepeatMode,
+  shuffleOrder: [] as number[],
+  shuffleOrderIndex: -1,
 };
+
+type AdvanceSource = "user" | "ended";
 
 export const usePlayerStore = create<PlayerState>()(
   persist(
-    (set, get) => ({
-      ...INITIAL_STATE,
-
-      playQueue(items, startIndex) {
-        if (items.length === 0 || startIndex < 0 || startIndex >= items.length) {
-          get().clear();
-          return;
-        }
-        set({
-          queue: items,
-          currentIndex: startIndex,
-          isPlaying: true,
-          currentTime: 0,
-          error: null,
-        });
-      },
-
-      togglePlay() {
-        const { currentIndex, isPlaying } = get();
+    (set, get) => {
+      function advance(source: AdvanceSource): void {
+        const { currentIndex, queue, shuffleMode, shuffleOrder, shuffleOrderIndex, repeatMode } =
+          get();
         if (currentIndex === null) return;
-        set({ isPlaying: !isPlaying });
-      },
-
-      next() {
-        const { currentIndex, queue } = get();
-        if (currentIndex === null) return;
-        if (currentIndex >= queue.length - 1) {
-          set({ isPlaying: false });
-          return;
-        }
-        set({ currentIndex: currentIndex + 1, currentTime: 0 });
-      },
-
-      prev() {
-        const { currentIndex, currentTime } = get();
-        if (currentIndex === null) return;
-        if (currentTime > 3) {
-          set({ currentTime: 0 });
+        if (source === "ended" && repeatMode === "one") {
           if (_audioElement) {
             _audioElement.currentTime = 0;
+            void _audioElement.play();
           }
           return;
         }
-        if (currentIndex === 0) return;
-        set({ currentIndex: currentIndex - 1, currentTime: 0 });
-      },
-
-      seek(seconds) {
-        const { duration } = get();
-        const clamped = Math.max(0, Math.min(seconds, duration));
-        set({ currentTime: clamped });
-        if (_audioElement) {
-          _audioElement.currentTime = clamped;
+        if (shuffleMode) {
+          if (shuffleOrderIndex >= shuffleOrder.length - 1) {
+            if (repeatMode === "all") {
+              set({ shuffleOrderIndex: 0, currentIndex: shuffleOrder[0]!, currentTime: 0 });
+            } else {
+              set({ isPlaying: false });
+            }
+            return;
+          }
+          const nextOrderIndex = shuffleOrderIndex + 1;
+          set({
+            shuffleOrderIndex: nextOrderIndex,
+            currentIndex: shuffleOrder[nextOrderIndex]!,
+            currentTime: 0,
+          });
+          return;
         }
-      },
-
-      setVolume(v) {
-        const clamped = Math.max(0, Math.min(1, v));
-        set({ volume: clamped });
-        if (_audioElement) {
-          _audioElement.volume = clamped;
-        }
-      },
-
-      toggleMute() {
-        const { isMuted } = get();
-        const next = !isMuted;
-        set({ isMuted: next });
-        if (_audioElement) {
-          _audioElement.muted = next;
-        }
-      },
-
-      clear() {
-        set({
-          queue: [],
-          currentIndex: null,
-          isPlaying: false,
-          currentTime: 0,
-          duration: 0,
-          error: null,
-        });
-      },
-
-      setAudioElement(el) {
-        _audioElement = el;
-      },
-
-      _onLoadedMetadata(duration) {
-        set({ duration });
-      },
-
-      _onTimeUpdate(currentTime) {
-        set({ currentTime });
-      },
-
-      _onEnded() {
-        const { currentIndex, queue } = get();
-        if (currentIndex === null) return;
         if (currentIndex >= queue.length - 1) {
-          set({ isPlaying: false });
+          if (repeatMode === "all") {
+            set({ currentIndex: 0, currentTime: 0 });
+          } else {
+            set({ isPlaying: false });
+          }
           return;
         }
         set({ currentIndex: currentIndex + 1, currentTime: 0 });
-      },
+      }
 
-      _onError(message) {
-        set({ error: message, isPlaying: false });
-      },
-    }),
+      return {
+        ...INITIAL_STATE,
+
+        playQueue(items, startIndex) {
+          if (items.length === 0 || startIndex < 0 || startIndex >= items.length) {
+            get().clear();
+            return;
+          }
+          set({
+            queue: items,
+            currentIndex: startIndex,
+            isPlaying: true,
+            currentTime: 0,
+            error: null,
+          });
+          if (get().shuffleMode && items.length > 0) {
+            const order = shuffleIndices(items.length, startIndex);
+            set({ shuffleOrder: order, shuffleOrderIndex: 0 });
+          } else {
+            set({ shuffleOrder: [], shuffleOrderIndex: -1 });
+          }
+        },
+
+        togglePlay() {
+          const { currentIndex, isPlaying } = get();
+          if (currentIndex === null) return;
+          set({ isPlaying: !isPlaying });
+        },
+
+        next() {
+          advance("user");
+        },
+
+        prev() {
+          const {
+            currentIndex,
+            currentTime,
+            shuffleMode,
+            shuffleOrder,
+            shuffleOrderIndex,
+            queue,
+            repeatMode,
+          } = get();
+          if (currentIndex === null) return;
+          if (currentTime > 3) {
+            set({ currentTime: 0 });
+            if (_audioElement) {
+              _audioElement.currentTime = 0;
+            }
+            return;
+          }
+          if (shuffleMode) {
+            if (shuffleOrderIndex > 0) {
+              const nextOrderIndex = shuffleOrderIndex - 1;
+              set({
+                shuffleOrderIndex: nextOrderIndex,
+                currentIndex: shuffleOrder[nextOrderIndex]!,
+                currentTime: 0,
+              });
+              return;
+            }
+            if (repeatMode === "all") {
+              const nextOrderIndex = shuffleOrder.length - 1;
+              set({
+                shuffleOrderIndex: nextOrderIndex,
+                currentIndex: shuffleOrder[nextOrderIndex]!,
+                currentTime: 0,
+              });
+            }
+            return;
+          }
+          if (currentIndex > 0) {
+            set({ currentIndex: currentIndex - 1, currentTime: 0 });
+            return;
+          }
+          if (repeatMode === "all") {
+            set({ currentIndex: queue.length - 1, currentTime: 0 });
+          }
+        },
+
+        seek(seconds) {
+          const { duration } = get();
+          const clamped = Math.max(0, Math.min(seconds, duration));
+          set({ currentTime: clamped });
+          if (_audioElement) {
+            _audioElement.currentTime = clamped;
+          }
+        },
+
+        setVolume(v) {
+          const clamped = Math.max(0, Math.min(1, v));
+          set({ volume: clamped });
+          if (_audioElement) {
+            _audioElement.volume = clamped;
+          }
+        },
+
+        toggleMute() {
+          const { isMuted } = get();
+          const next = !isMuted;
+          set({ isMuted: next });
+          if (_audioElement) {
+            _audioElement.muted = next;
+          }
+        },
+
+        clear() {
+          set({
+            queue: [],
+            currentIndex: null,
+            isPlaying: false,
+            currentTime: 0,
+            duration: 0,
+            error: null,
+          });
+        },
+
+        setAudioElement(el) {
+          _audioElement = el;
+        },
+
+        _onLoadedMetadata(duration) {
+          set({ duration });
+        },
+
+        _onTimeUpdate(currentTime) {
+          set({ currentTime });
+        },
+
+        _onEnded() {
+          advance("ended");
+        },
+
+        toggleShuffle() {
+          const { shuffleMode, queue, currentIndex } = get();
+          if (shuffleMode) {
+            set({ shuffleMode: false, shuffleOrder: [], shuffleOrderIndex: -1 });
+            return;
+          }
+          if (currentIndex === null || queue.length === 0) {
+            set({ shuffleMode: true, shuffleOrder: [], shuffleOrderIndex: -1 });
+            return;
+          }
+          const order = shuffleIndices(queue.length, currentIndex);
+          set({ shuffleMode: true, shuffleOrder: order, shuffleOrderIndex: 0 });
+        },
+
+        cycleRepeat() {
+          const cycle: Record<RepeatMode, RepeatMode> = { off: "all", all: "one", one: "off" };
+          set({ repeatMode: cycle[get().repeatMode] });
+        },
+
+        _onError(message) {
+          set({ error: message, isPlaying: false });
+        },
+      };
+    },
     {
       name: "spotiarr-player",
       partialize: __partialize,


### PR DESCRIPTION
## Summary
- Adds `shuffleMode` (boolean) and `repeatMode` (`"off" | "all" | "one"`) to `usePlayerStore`, persisted alongside `volume`/`isMuted`.
- Adds Fisher-Yates `shuffleOrder` + cursor as ephemeral state; `advance(source)` closure centralizes `next()` / `_onEnded()` shuffle+repeat semantics so the two paths no longer diverge.
- Adds shuffle + repeat buttons to `GlobalPlayerBar` flanking prev/next, with state-aware aria-labels, active `text-green-500` styling, and a `<sup>1</sup>` badge for repeat-one.
- Rewrites `isAtFirst` / `isAtLast` so prev/next stay enabled whenever wrapping is active (shuffle on OR repeat-all).
- `cycleRepeat` order: `off → all → one → off`. Repeat-one only triggers on `_onEnded` (manual next still advances).

## SDD trail (engram)
- proposal #3208 · spec #3211 · design #3212 · tasks #3213 · apply #3214 · verify #3215 · archive #3216

First of three deferred player slices from #3204 (queue side-panel and mobile fullscreen now-playing follow).

## Test plan
- [x] `pnpm --filter frontend test:run` — 271/271 pass
- [x] `pnpm --filter frontend lint` — clean
- [x] typecheck — clean
- [x] `pnpm --filter frontend build` — clean
- [ ] Manual: toggle shuffle mid-queue, verify current track pins; cycle repeat off → all → one; let track end with each mode; verify prev/next stay enabled under shuffle and repeat-all; reload page, confirm shuffleMode/repeatMode persist and shuffleOrder does not