### PR TITLE
test(frontend): add hermetic Playwright E2E coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ pnpm dev
 # Backend:  http://localhost:3000 (API)
 ```
 
+### Frontend E2E Commands
+
+Build the shared package before running Playwright in a fresh checkout:
+
+```bash
+pnpm --filter @spotiarr/shared run build
+pnpm --filter frontend run test:e2e:mocked
+pnpm --filter frontend run test:e2e:real
+pnpm --filter frontend run test:e2e
+```
+
 ## ⚙️ Configuration
 
 ### Environment Variables

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,6 +13,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:e2e": "playwright test",
+    "test:e2e:mocked": "PLAYWRIGHT_TARGET=mocked playwright test --project=mocked",
+    "test:e2e:real": "PLAYWRIGHT_TARGET=real playwright test --project=real",
     "test:e2e:runtime": "vitest run --config vitest.playwright.config.ts",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -1,36 +1,68 @@
 import { defineConfig, devices } from "@playwright/test";
 import { fileURLToPath } from "node:url";
 
-const PORT = 4173;
-const HOST = "127.0.0.1";
-const BASE_URL = `http://${HOST}:${PORT}`;
+const PREVIEW_PORT = 4173;
+const PREVIEW_HOST = "127.0.0.1";
+const PREVIEW_BASE_URL = `http://${PREVIEW_HOST}:${PREVIEW_PORT}`;
+const REAL_BASE_URL = process.env.PLAYWRIGHT_REAL_BASE_URL ?? "http://127.0.0.1:3000";
 const ROOT_DIR = fileURLToPath(new URL(".", import.meta.url));
+const PLAYWRIGHT_TARGET = process.env.PLAYWRIGHT_TARGET;
+
+const webServers = [];
+
+if (PLAYWRIGHT_TARGET !== "real") {
+  webServers.push({
+    command: `pnpm run build && vite preview --host ${PREVIEW_HOST} --port ${PREVIEW_PORT} --strictPort`,
+    cwd: ROOT_DIR,
+    url: PREVIEW_BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe" as const,
+    stderr: "pipe" as const,
+    timeout: 120_000,
+  });
+}
+
+if (PLAYWRIGHT_TARGET !== "mocked") {
+  webServers.push({
+    command:
+      "pnpm --filter @spotiarr/shared run build && pnpm --filter frontend run build && pnpm --filter backend run build && tsx tests/helpers/real-stack.ts",
+    cwd: ROOT_DIR,
+    url: REAL_BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    stdout: "pipe" as const,
+    stderr: "pipe" as const,
+    timeout: 120_000,
+  });
+}
 
 export default defineConfig({
-  testDir: "./tests",
+  testDir: "./tests/e2e",
   testMatch: "**/*.spec.ts",
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
-    baseURL: BASE_URL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
   projects: [
     {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      name: "mocked",
+      testMatch: "**/mocked/**/*.spec.ts",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: PREVIEW_BASE_URL,
+      },
+    },
+    {
+      name: "real",
+      testMatch: "**/real/**/*.spec.ts",
+      use: {
+        ...devices["Desktop Chrome"],
+        baseURL: REAL_BASE_URL,
+      },
     },
   ],
-  webServer: {
-    command: `pnpm run build && vite preview --host ${HOST} --port ${PORT} --strictPort`,
-    cwd: ROOT_DIR,
-    url: BASE_URL,
-    reuseExistingServer: !process.env.CI,
-    stdout: "pipe",
-    stderr: "pipe",
-    timeout: 120_000,
-  },
+  webServer: webServers,
 });

--- a/apps/frontend/src/components/atoms/Loading.tsx
+++ b/apps/frontend/src/components/atoms/Loading.tsx
@@ -10,9 +10,14 @@ interface LoadingProps {
 
 export const Loading: FC<LoadingProps> = ({ message, className = "" }) => {
   return (
-    <div className={cn("flex min-h-[50vh] flex-1 items-center justify-center", className)}>
+    <div
+      className={cn("flex min-h-[50vh] flex-1 items-center justify-center", className)}
+      role="status"
+      aria-label={message ?? "Loading"}
+    >
       <div className="space-y-3 text-center">
         <FontAwesomeIcon icon={faCircleNotch} spin className="text-primary text-4xl" />
+        {!message && <span className="sr-only">Loading</span>}
         {message && <p className="text-text-secondary animate-pulse">{message}</p>}
       </div>
     </div>

--- a/apps/frontend/tests/e2e/mocked/search.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/search.spec.ts
@@ -1,0 +1,93 @@
+import type { SpotifySearchResults } from "@spotiarr/shared";
+import { expect, test } from "../../fixtures/test";
+import { mockSearchResults } from "../../helpers/api-mocks";
+
+const populatedResults: SpotifySearchResults = {
+  tracks: [
+    {
+      id: "track-1",
+      name: "Digital Love",
+      artist: "Daft Punk",
+      artists: [
+        { name: "Daft Punk", url: "https://open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi" },
+      ],
+      album: "Discovery",
+      albumId: "album-1",
+      albumCoverUrl: "/logo.svg",
+      albumUrl: "https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc",
+      durationMs: 301000,
+      primaryArtist: "artist-1",
+      spotifyUrl: "https://open.spotify.com/track/2VEZx7NWsZ1D0eJ4uv5Fym",
+      trackUrl: "https://open.spotify.com/track/2VEZx7NWsZ1D0eJ4uv5Fym",
+    },
+  ],
+  albums: [
+    {
+      artistId: "artist-1",
+      artistName: "Daft Punk",
+      artistImageUrl: null,
+      albumId: "album-1",
+      albumName: "Discovery",
+      coverUrl: null,
+      spotifyUrl: "https://open.spotify.com/album/2noRn2Aes5aoNVsU6iWThc",
+      totalTracks: 14,
+    },
+  ],
+  artists: [
+    {
+      id: "artist-1",
+      name: "Daft Punk",
+      image: null,
+      spotifyUrl: "https://open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi",
+    },
+  ],
+};
+
+test.describe("Mocked search flows", () => {
+  test("shows a loading state before rendering populated results", async ({ page }) => {
+    await mockSearchResults(page, {
+      query: "daft",
+      results: populatedResults,
+      delayMs: 1_000,
+    });
+
+    await page.goto("/search?q=daft", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("status", { name: "Loading" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Top result" })).toBeVisible();
+    await expect(page.getByText("Digital Love")).toBeVisible();
+  });
+
+  test("shows the no-results state when the mocked search payload is empty", async ({ page }) => {
+    await mockSearchResults(page, {
+      query: "missing",
+      results: {
+        tracks: [],
+        albums: [],
+        artists: [],
+      },
+    });
+
+    await page.goto("/search?q=missing", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("No results found")).toBeVisible();
+  });
+
+  test("renders populated track, artist, and album content from mocked search results", async ({
+    page,
+  }) => {
+    await mockSearchResults(page, {
+      query: "daft",
+      results: populatedResults,
+    });
+
+    await page.goto("/search?q=daft", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Top result" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Tracks" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Albums" })).toBeVisible();
+    await expect(page.getByText("Digital Love")).toBeVisible();
+    await expect(page.getByText("Discovery")).toBeVisible();
+    await expect(page.getByText("Daft Punk").first()).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/settings.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/settings.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "../../fixtures/test";
+import { mockSettingsPageData, mockSpotifyAuthStatus } from "../../helpers/api-mocks";
+
+test.describe("Mocked settings flows", () => {
+  test("renders the disconnected Spotify auth state from mocked responses", async ({ page }) => {
+    await mockSettingsPageData(page);
+    await mockSpotifyAuthStatus(page, { authenticated: false, hasRefreshToken: false });
+
+    await page.goto("/settings", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByText("Spotify Authentication")).toBeVisible();
+    await expect(page.getByText("Not Connected")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Connect with Spotify" })).toBeVisible();
+    await expect(page.getByText("Why connect?")).toBeVisible();
+  });
+
+  test("renders mocked settings metadata and current values", async ({ page }) => {
+    await mockSettingsPageData(page, {
+      settings: [
+        { key: "UI_LANGUAGE", value: "en", updatedAt: new Date(0).toISOString() },
+        { key: "FORMAT", value: "m4a", updatedAt: new Date(0).toISOString() },
+      ],
+    });
+    await mockSpotifyAuthStatus(page, { authenticated: false, hasRefreshToken: false });
+
+    await page.goto("/settings", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("General")).toBeVisible();
+    await expect(page.getByLabel("Interface Language")).toHaveValue("en");
+    await expect(page.getByLabel("Audio format")).toHaveValue("m4a");
+    await expect(page.getByRole("button", { name: "Reset to Defaults" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Save Settings" })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/real/health.spec.ts
+++ b/apps/frontend/tests/e2e/real/health.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Real-stack health and routing", () => {
+  test("serves the backend health endpoint from the seeded database", async ({ request }) => {
+    const response = await request.get("/api/health");
+
+    expect(response.ok()).toBeTruthy();
+    await expect(response.json()).resolves.toMatchObject({ status: "ok" });
+  });
+
+  test("serves the SPA fallback for a direct client-route request", async ({ page }) => {
+    const response = await page.goto("/this-route-does-not-exist", {
+      waitUntil: "domcontentloaded",
+    });
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: "Page Not Found" })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/real/settings.spec.ts
+++ b/apps/frontend/tests/e2e/real/settings.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Real-stack settings page", () => {
+  test("renders a connected Spotify auth state from seeded tokens", async ({ page }) => {
+    const response = await page.goto("/settings", { waitUntil: "domcontentloaded" });
+
+    expect(response?.status()).toBe(200);
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByText("Connected", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Disconnect Spotify" })).toBeVisible();
+  });
+
+  test("renders seeded settings values from the real database", async ({ page }) => {
+    await page.goto("/settings", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByLabel("Interface Language")).toHaveValue("en");
+    await expect(page.getByLabel("Audio format")).toHaveValue("m4a");
+    await expect(page.getByRole("button", { name: "Save Settings" })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/fixtures/test.ts
+++ b/apps/frontend/tests/fixtures/test.ts
@@ -1,0 +1,57 @@
+import { expect, test as base, type Page } from "@playwright/test";
+import { installAppShellMocks, type AppShellMockGuard } from "../helpers/api-mocks";
+
+interface MockedFixtures {
+  appShell: AppShellMockGuard;
+}
+
+const ALLOWED_HOSTS = new Set(["127.0.0.1", "localhost"]);
+
+function shouldIgnoreConsoleError(message: string): boolean {
+  return message === "EventSource failed: Event";
+}
+
+async function blockExternalNetwork(page: Page): Promise<void> {
+  await page.route(/^https?:\/\//, async (route) => {
+    const url = new URL(route.request().url());
+
+    if (ALLOWED_HOSTS.has(url.hostname)) {
+      await route.continue();
+      return;
+    }
+
+    await route.abort("blockedbyclient");
+  });
+}
+
+export const test = base.extend<MockedFixtures>({
+  appShell: [
+    async ({ page }, applyFixture) => {
+      const consoleErrors: string[] = [];
+      const pageErrors: string[] = [];
+
+      page.on("console", (message) => {
+        if (message.type() === "error" && !shouldIgnoreConsoleError(message.text())) {
+          consoleErrors.push(message.text());
+        }
+      });
+
+      page.on("pageerror", (error) => {
+        pageErrors.push(error.message);
+      });
+
+      await blockExternalNetwork(page);
+
+      const appShell = await installAppShellMocks(page);
+
+      await applyFixture(appShell);
+
+      await appShell.assertNoUnhandledRequests(500);
+      expect(consoleErrors, "Unexpected browser console errors").toEqual([]);
+      expect(pageErrors, "Unexpected uncaught page errors").toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -1,16 +1,80 @@
 import { type Page } from "@playwright/test";
+import {
+  ApiRoutes,
+  type SettingItem,
+  type SettingMetadata,
+  type SpotifySearchResults,
+  UI_SUPPORTED_AUDIO_FORMATS,
+  type SupportedAudioFormat,
+} from "@spotiarr/shared";
 
 interface AppShellMockOptions {
   mockPlaylistStatus?: boolean;
+  settings?: SettingItem[];
+  settingsMetadata?: Record<string, SettingMetadata>;
+  supportedFormats?: SupportedAudioFormat[];
+  spotifyAuthStatus?: SpotifyAuthStatus;
 }
 
-interface AppShellMockGuard {
+export interface AppShellMockGuard {
   assertNoUnhandledRequests(timeoutMs?: number): Promise<void>;
   waitForUnhandledRequest(timeoutMs?: number): Promise<string>;
 }
 
+interface SpotifyAuthStatus {
+  authenticated: boolean;
+  hasRefreshToken: boolean;
+}
+
+interface MockSettingsPageDataOptions {
+  settings?: SettingItem[];
+  settingsMetadata?: Record<string, SettingMetadata>;
+  supportedFormats?: SupportedAudioFormat[];
+}
+
+interface MockSearchResultsOptions {
+  query: string;
+  results: SpotifySearchResults;
+  delayMs?: number;
+  types?: string[];
+}
+
+const DEFAULT_TIMESTAMP = new Date(0).toISOString();
+
 const SETTINGS_PAYLOAD = {
-  data: [{ key: "UI_LANGUAGE", value: "en", updatedAt: new Date(0).toISOString() }],
+  data: [
+    { key: "UI_LANGUAGE", value: "en", updatedAt: DEFAULT_TIMESTAMP },
+    { key: "FORMAT", value: "mp3", updatedAt: DEFAULT_TIMESTAMP },
+  ],
+};
+
+const SETTINGS_METADATA_PAYLOAD: { data: Record<string, SettingMetadata> } = {
+  data: {
+    UI_LANGUAGE: {
+      key: "UI_LANGUAGE",
+      defaultValue: "en",
+      type: "string",
+      component: "select",
+      section: "General",
+      label: "Interface Language",
+      description: "Select your preferred language for the interface.",
+      options: ["en", "es"],
+    },
+    FORMAT: {
+      key: "FORMAT",
+      defaultValue: "mp3",
+      type: "string",
+      component: "select",
+      section: "General",
+      label: "Audio format",
+      description: "The audio format for downloaded tracks.",
+      options: [...UI_SUPPORTED_AUDIO_FORMATS],
+    },
+  },
+};
+
+const SUPPORTED_FORMATS_PAYLOAD = {
+  data: [...UI_SUPPORTED_AUDIO_FORMATS],
 };
 
 const DOWNLOAD_STATUS_PAYLOAD = {
@@ -21,9 +85,95 @@ const DOWNLOAD_STATUS_PAYLOAD = {
 
 const SSE_PAYLOAD = ": connected\n\n";
 
+const SPOTIFY_AUTH_STATUS_PAYLOAD: SpotifyAuthStatus = {
+  authenticated: false,
+  hasRefreshToken: false,
+};
+
+const buildApiUrl = (pathname: string): string => `${ApiRoutes.BASE}${pathname}`;
+
+const waitForDelay = async (delayMs = 0): Promise<void> => {
+  if (delayMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+};
+
+const fulfillJson = async (
+  route: Parameters<Page["route"]>[1] extends (route: infer T) => unknown ? T : never,
+  body: unknown,
+) => {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+};
+
+export async function mockSettingsPageData(
+  page: Page,
+  {
+    settings = SETTINGS_PAYLOAD.data,
+    settingsMetadata = SETTINGS_METADATA_PAYLOAD.data,
+    supportedFormats = SUPPORTED_FORMATS_PAYLOAD.data,
+  }: MockSettingsPageDataOptions = {},
+): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.SETTINGS)}`, async (route) => {
+    await fulfillJson(route, { data: settings });
+  });
+
+  await page.route(`**${buildApiUrl(`${ApiRoutes.SETTINGS}/metadata`)}`, async (route) => {
+    await fulfillJson(route, { data: settingsMetadata });
+  });
+
+  await page.route(`**${buildApiUrl(`${ApiRoutes.SETTINGS}/formats`)}`, async (route) => {
+    await fulfillJson(route, { data: supportedFormats });
+  });
+}
+
+export async function mockSpotifyAuthStatus(
+  page: Page,
+  status: SpotifyAuthStatus = SPOTIFY_AUTH_STATUS_PAYLOAD,
+): Promise<void> {
+  await page.route(`**${buildApiUrl(`${ApiRoutes.AUTH}/spotify/status`)}`, async (route) => {
+    await fulfillJson(route, status);
+  });
+}
+
+export async function mockSearchResults(
+  page: Page,
+  { query, results, delayMs = 0, types }: MockSearchResultsOptions,
+): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.SEARCH)}**`, async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.searchParams.get("q") !== query) {
+      throw new Error(`Unexpected mocked search query: ${url.searchParams.get("q")}`);
+    }
+
+    if (types) {
+      const requestedTypes = url.searchParams.get("types")?.split(",") ?? [];
+
+      if (requestedTypes.join(",") !== types.join(",")) {
+        throw new Error(`Unexpected mocked search types: ${requestedTypes.join(",")}`);
+      }
+    }
+
+    await waitForDelay(delayMs);
+    await fulfillJson(route, { data: results });
+  });
+}
+
 export async function installAppShellMocks(
   page: Page,
-  { mockPlaylistStatus = true }: AppShellMockOptions = {},
+  {
+    mockPlaylistStatus = true,
+    settings = SETTINGS_PAYLOAD.data,
+    settingsMetadata = SETTINGS_METADATA_PAYLOAD.data,
+    supportedFormats = SUPPORTED_FORMATS_PAYLOAD.data,
+    spotifyAuthStatus = SPOTIFY_AUTH_STATUS_PAYLOAD,
+  }: AppShellMockOptions = {},
 ): Promise<AppShellMockGuard> {
   let unhandledRequestMessage: string | null = null;
   let resolveUnhandledRequest: ((message: string) => void) | null = null;
@@ -43,13 +193,8 @@ export async function installAppShellMocks(
     await route.abort("failed");
   });
 
-  await page.route("**/api/settings", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(SETTINGS_PAYLOAD),
-    });
-  });
+  await mockSettingsPageData(page, { settings, settingsMetadata, supportedFormats });
+  await mockSpotifyAuthStatus(page, spotifyAuthStatus);
 
   await page.route("**/api/events", async (route) => {
     await route.fulfill({
@@ -65,11 +210,7 @@ export async function installAppShellMocks(
 
   if (mockPlaylistStatus) {
     await page.route("**/api/playlist/status", async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(DOWNLOAD_STATUS_PAYLOAD),
-      });
+      await fulfillJson(route, DOWNLOAD_STATUS_PAYLOAD);
     });
   }
 

--- a/apps/frontend/tests/helpers/real-stack.ts
+++ b/apps/frontend/tests/helpers/real-stack.ts
@@ -1,0 +1,137 @@
+import { PrismaClient } from "@prisma/client";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import http from "node:http";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HOST = "127.0.0.1";
+const PORT = 3000;
+const ROOT_DIR = fileURLToPath(new URL("../../../../", import.meta.url));
+const BACKEND_DIR = path.join(ROOT_DIR, "apps/backend");
+
+const SEEDED_SETTINGS = [
+  { key: "UI_LANGUAGE", value: "en" },
+  { key: "FORMAT", value: "m4a" },
+  { key: "spotify_user_access_token", value: "e2e-access-token" },
+  { key: "spotify_user_refresh_token", value: "e2e-refresh-token" },
+] as const;
+
+interface RealStackContext {
+  tempDir: string;
+  downloadsDir: string;
+  databasePath: string;
+  databaseUrl: string;
+}
+
+function createContext(): RealStackContext {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "spotiarr-e2e-real-"));
+  const downloadsDir = path.join(tempDir, "downloads");
+  const databasePath = path.join(tempDir, "real-stack.db");
+
+  mkdirSync(downloadsDir, { recursive: true });
+
+  return {
+    tempDir,
+    downloadsDir,
+    databasePath,
+    databaseUrl: `file:${databasePath}`,
+  };
+}
+
+function applyEnvironment(context: RealStackContext): void {
+  process.env.NODE_ENV = "test";
+  process.env.DATABASE_URL = context.databaseUrl;
+  process.env.DOWNLOADS = context.downloadsDir;
+  process.env.REDIS_HOST = HOST;
+  process.env.REDIS_PORT = "6379";
+  process.env.SPOTIFY_CLIENT_ID = "e2e-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = "e2e-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI = `http://${HOST}:${PORT}/api/auth/spotify/callback`;
+  process.env.PLAYWRIGHT_REAL_BASE_URL = `http://${HOST}:${PORT}`;
+}
+
+function runBackendMigrations(): void {
+  execFileSync("pnpm", ["--filter", "backend", "run", "prisma:migrate:deploy"], {
+    cwd: ROOT_DIR,
+    env: process.env,
+    stdio: "inherit",
+  });
+}
+
+async function seedDatabase(databaseUrl: string): Promise<void> {
+  const prisma = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+
+  try {
+    await prisma.setting.deleteMany();
+
+    await prisma.setting.createMany({
+      data: SEEDED_SETTINGS.map((setting) => ({
+        key: setting.key,
+        value: setting.value,
+        updatedAt: BigInt(0),
+      })),
+    });
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+async function startServer(): Promise<{
+  server: http.Server;
+  disconnectPrisma: () => Promise<void>;
+}> {
+  const { validateEnvironment } = await import(
+    pathToFileURL(path.join(BACKEND_DIR, "dist/infrastructure/setup/environment.js")).href
+  );
+
+  validateEnvironment();
+
+  const { app } = await import(pathToFileURL(path.join(BACKEND_DIR, "dist/app.js")).href);
+  const { prisma } = await import(
+    pathToFileURL(path.join(BACKEND_DIR, "dist/infrastructure/setup/prisma.js")).href
+  );
+
+  const server = http.createServer(app);
+
+  await new Promise<void>((resolve) => {
+    server.listen(PORT, HOST, () => resolve());
+  });
+
+  return {
+    server,
+    disconnectPrisma: () => prisma.$disconnect(),
+  };
+}
+
+async function main(): Promise<void> {
+  const context = createContext();
+  applyEnvironment(context);
+  runBackendMigrations();
+  await seedDatabase(context.databaseUrl);
+
+  const { server, disconnectPrisma } = await startServer();
+
+  const shutdown = async (exitCode = 0): Promise<void> => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    await disconnectPrisma();
+    rmSync(context.tempDir, { recursive: true, force: true });
+    process.exit(exitCode);
+  };
+
+  process.on("SIGINT", () => {
+    void shutdown(0);
+  });
+
+  process.on("SIGTERM", () => {
+    void shutdown(0);
+  });
+
+  console.log(`[playwright-real-stack] ready at http://${HOST}:${PORT}`);
+}
+
+void main().catch((error: unknown) => {
+  console.error("[playwright-real-stack] failed to start", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds a broader Playwright E2E suite for frontend flows, with hermetic mocked coverage and minimal real-stack coverage for backend/frontend seams. This improves regression confidence without relying on Spotify/OAuth/external network calls.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / chore

## Scope

- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Summary

- Adds mocked and real-stack Playwright projects plus frontend E2E scripts.
- Adds hermetic mocked fixtures with API mocking, external network blocking, and unhandled request checks.
- Adds real-stack health/settings coverage using deterministic temporary SQLite state.
- Documents E2E commands in the README.

## Verification

- [x] `pnpm test` — backend 391 + frontend 215 passed
- [x] `pnpm --filter @spotiarr/shared run build`
- [x] `pnpm --filter frontend run lint`
- [x] `pnpm --filter frontend run test:run`
- [x] `pnpm --filter frontend run build`
- [x] `pnpm --filter frontend run test:e2e:mocked` — 5 passed
- [x] `pnpm --filter frontend run test:e2e:real` — 4 passed
- [x] `pnpm --filter frontend run test:e2e` — 9 passed
- [x] Fresh PR review: no secrets, no unrelated changes, no focused tests

## Notes

- Mocked Playwright runs may still print Vite proxy `ECONNREFUSED` noise when backend is absent; tests remain hermetic via browser-level routing.
- Interrupted local runs can leave stale `4173`/`3000` listeners; final audit found no lingering listeners.

## Checklist

- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials`)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change