### PR TITLE
feat(track-list): Spotify-parity row UX wins

### DIFF
--- a/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
@@ -8,6 +8,23 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
+const defaultProps = {
+  isSubscribed: true,
+  hasFailed: false,
+  isRetrying: false,
+  isDownloading: false,
+  isDownloaded: true,
+  isSaved: true,
+  hasPlayableTracks: true,
+  isPlaying: false,
+  onPlayPlaylist: vi.fn(),
+  onPausePlaylist: vi.fn(),
+  onToggleSubscription: vi.fn(),
+  onRetryFailed: vi.fn(),
+  onDelete: vi.fn(),
+  onDownload: vi.fn(),
+};
+
 describe("PlaylistActions playback", () => {
   it("renders a primary play control for saved playlists with playable tracks", () => {
     const onPlayPlaylist = vi.fn();
@@ -59,5 +76,50 @@ describe("PlaylistActions playback", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "library.album.pauseTrack" }));
     expect(onPausePlaylist).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PlaylistActions shuffle button", () => {
+  it("renders shuffle button when onShufflePlay and hasPlayableTracks are provided", () => {
+    const onShufflePlay = vi.fn();
+    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+    expect(screen.getByRole("button", { name: "playlist.actions.shufflePlay" })).toBeTruthy();
+  });
+
+  it("does not render shuffle button when onShufflePlay is not provided", () => {
+    render(<PlaylistActions {...defaultProps} />);
+    expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
+  });
+
+  it("does not render shuffle button when hasPlayableTracks is false", () => {
+    render(<PlaylistActions {...defaultProps} hasPlayableTracks={false} onShufflePlay={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
+  });
+
+  it("applies text-green-500 class when isShuffleActive is true", () => {
+    render(<PlaylistActions {...defaultProps} onShufflePlay={vi.fn()} isShuffleActive={true} />);
+    const btn = screen.getByRole("button", { name: "playlist.actions.shufflePlay" });
+    expect(btn.className).toContain("text-green-500");
+  });
+
+  it("calls onShufflePlay when shuffle button is clicked", () => {
+    const onShufflePlay = vi.fn();
+    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+    fireEvent.click(screen.getByRole("button", { name: "playlist.actions.shufflePlay" }));
+    expect(onShufflePlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuffle button appears after play button in DOM order", () => {
+    const onShufflePlay = vi.fn();
+    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+    const buttons = screen.getAllByRole("button");
+    const playIndex = buttons.findIndex(
+      (b) => b.getAttribute("aria-label") === "library.album.playTrack",
+    );
+    const shuffleIndex = buttons.findIndex(
+      (b) => b.getAttribute("aria-label") === "playlist.actions.shufflePlay",
+    );
+    expect(playIndex).toBeGreaterThanOrEqual(0);
+    expect(shuffleIndex).toBeGreaterThan(playIndex);
   });
 });

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -99,7 +99,9 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
             "!h-10 !w-10 justify-center !rounded-full !p-0 transition-transform hover:scale-105",
             isShuffleActive ? "text-green-500" : "text-text-secondary hover:text-text-primary",
           )}
-        />
+        >
+          <span className="sr-only">{t("playlist.actions.shufflePlay")}</span>
+        </Button>
       ) : null}
 
       {isManaged && (

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -6,6 +6,7 @@ import {
   faPause,
   faPlay,
   faRepeat,
+  faShuffle,
   faTrash,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -36,6 +37,8 @@ interface PlaylistActionsProps {
   onRetryFailed: () => void;
   onDelete: () => void;
   onDownload: () => void;
+  onShufflePlay?: () => void;
+  isShuffleActive?: boolean;
   mode?: PlaylistActionsMode;
 }
 
@@ -54,6 +57,8 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   onRetryFailed,
   onDelete,
   onDownload,
+  onShufflePlay,
+  isShuffleActive = false,
   spotifyUrl,
   playlistId,
   playlistName,
@@ -80,6 +85,21 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
             {isPlaying ? t("library.album.pause") : t("library.album.play")}
           </span>
         </Button>
+      ) : null}
+
+      {hasPlayableTracks && onShufflePlay ? (
+        <Button
+          variant="ghost"
+          size="md"
+          onClick={onShufflePlay}
+          title={t("playlist.actions.shufflePlay")}
+          ariaLabel={t("playlist.actions.shufflePlay")}
+          icon={faShuffle}
+          className={cn(
+            "!h-10 !w-10 justify-center !rounded-full !p-0 transition-transform hover:scale-105",
+            isShuffleActive ? "text-green-500" : "text-text-secondary hover:text-text-primary",
+          )}
+        />
       ) : null}
 
       {isManaged && (

--- a/apps/frontend/src/components/molecules/TrackStatusIndicator.test.tsx
+++ b/apps/frontend/src/components/molecules/TrackStatusIndicator.test.tsx
@@ -1,0 +1,80 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TrackStatusIndicator } from "./TrackStatusIndicator";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("TrackStatusIndicator — play/pause prop branches", () => {
+  it("renders numeric index when onPlay is not provided", () => {
+    render(<TrackStatusIndicator index={3} />);
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("renders number span and hidden play button when onPlay provided and track is not current", () => {
+    const onPlay = vi.fn();
+    render(<TrackStatusIndicator index={5} onPlay={onPlay} isCurrentTrack={false} />);
+    expect(screen.getByText("5")).toBeTruthy();
+    const btn = screen.getByRole("button", { name: "library.album.playTrack" });
+    expect(btn).toBeTruthy();
+  });
+
+  it("clicking play button calls onPlay", () => {
+    const onPlay = vi.fn();
+    render(<TrackStatusIndicator index={1} onPlay={onPlay} isCurrentTrack={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "library.album.playTrack" }));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only pause button when isCurrentTrack and isPlaying are true", () => {
+    const onPlay = vi.fn();
+    render(
+      <TrackStatusIndicator index={2} onPlay={onPlay} isCurrentTrack={true} isPlaying={true} />,
+    );
+    expect(screen.getByRole("button", { name: "library.album.pauseTrack" })).toBeTruthy();
+    expect(screen.queryByText("2")).toBeNull();
+  });
+
+  it("renders only play button when isCurrentTrack is true and isPlaying is false", () => {
+    const onPlay = vi.fn();
+    render(
+      <TrackStatusIndicator index={2} onPlay={onPlay} isCurrentTrack={true} isPlaying={false} />,
+    );
+    expect(screen.getByRole("button", { name: "library.album.playTrack" })).toBeTruthy();
+    expect(screen.queryByText("2")).toBeNull();
+  });
+
+  it("current-track button has type=button and aria-label", () => {
+    const onPlay = vi.fn();
+    render(
+      <TrackStatusIndicator index={1} onPlay={onPlay} isCurrentTrack={true} isPlaying={true} />,
+    );
+    const btn = screen.getByRole("button", { name: "library.album.pauseTrack" });
+    expect(btn.getAttribute("type")).toBe("button");
+    expect(btn.getAttribute("aria-label")).toBe("library.album.pauseTrack");
+  });
+
+  it("clicking current-track pause button calls onPlay", () => {
+    const onPlay = vi.fn();
+    render(
+      <TrackStatusIndicator index={1} onPlay={onPlay} isCurrentTrack={true} isPlaying={true} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "library.album.pauseTrack" }));
+    expect(onPlay).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render play button when onPlay is not provided even if isCurrentTrack is true", () => {
+    render(<TrackStatusIndicator index={4} isCurrentTrack={true} isPlaying={false} />);
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("4")).toBeTruthy();
+  });
+
+  it("still renders error icon when status is Error regardless of onPlay", () => {
+    render(<TrackStatusIndicator index={1} status={TrackStatusEnum.Error} />);
+    expect(screen.queryByRole("button", { name: "library.album.playTrack" })).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/TrackStatusIndicator.tsx
+++ b/apps/frontend/src/components/molecules/TrackStatusIndicator.tsx
@@ -2,6 +2,8 @@ import { faClock } from "@fortawesome/free-regular-svg-icons";
 import {
   faDownload,
   faMagnifyingGlass,
+  faPause,
+  faPlay,
   faRotateRight,
   faSpinner,
   faTriangleExclamation,
@@ -16,11 +18,14 @@ interface TrackStatusIndicatorProps {
   index: number;
   onRetry?: (e: MouseEvent) => void;
   onDownload?: (e: MouseEvent) => void;
+  onPlay?: (e: MouseEvent) => void;
+  isCurrentTrack?: boolean;
+  isPlaying?: boolean;
 }
 
 export const TrackStatusIndicator: FC<TrackStatusIndicatorProps> = (props) => {
   const { t } = useTranslation();
-  const { status, index, onDownload } = props;
+  const { status, index, onDownload, onPlay, isCurrentTrack, isPlaying } = props;
 
   const getStatusRenderer = () => {
     switch (status) {
@@ -69,7 +74,41 @@ export const TrackStatusIndicator: FC<TrackStatusIndicatorProps> = (props) => {
     return <Renderer {...props} />;
   }
 
-  const showDownloadAction = !!onDownload && status !== TrackStatusEnum.Completed;
+  const showPlayCell = !!onPlay;
+  const showDownloadAction = !showPlayCell && !!onDownload && status !== TrackStatusEnum.Completed;
+
+  if (showPlayCell && isCurrentTrack) {
+    const icon = isPlaying ? faPause : faPlay;
+    const label = isPlaying ? t("library.album.pauseTrack") : t("library.album.playTrack");
+    return (
+      <button
+        type="button"
+        onClick={onPlay}
+        aria-label={label}
+        className="text-white transition-colors"
+      >
+        <FontAwesomeIcon icon={icon} />
+      </button>
+    );
+  }
+
+  if (showPlayCell) {
+    return (
+      <>
+        <span className="hidden md:block md:group-focus-within:hidden md:group-hover:hidden">
+          {index}
+        </span>
+        <button
+          type="button"
+          onClick={onPlay}
+          aria-label={t("library.album.playTrack")}
+          className="block text-white transition-colors md:hidden md:group-focus-within:block md:group-hover:block"
+        >
+          <FontAwesomeIcon icon={faPlay} />
+        </button>
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -33,7 +33,7 @@ const ProgressSection: FC = () => {
   const pct = duration > 0 ? (currentTime / duration) * 100 : 0;
 
   return (
-    <div className="flex w-full items-center gap-2">
+    <div className="group flex w-full items-center gap-2">
       <span className="text-text-secondary w-8 shrink-0 text-right text-xs tabular-nums">
         {formatSeconds(currentTime)}
       </span>
@@ -50,10 +50,20 @@ const ProgressSection: FC = () => {
         step={1}
         value={currentTime}
         onChange={(e) => seek(Number(e.target.value))}
-        className="h-1 flex-1 cursor-pointer accent-white"
-        style={{
-          background: `linear-gradient(to right, white ${pct}%, rgba(255,255,255,0.2) ${pct}%)`,
-        }}
+        className={cn(
+          "h-1 flex-1 cursor-pointer appearance-none rounded-full",
+          "[&::-webkit-slider-runnable-track]:h-1 [&::-webkit-slider-runnable-track]:rounded-full",
+          "[&::-moz-range-track]:h-1 [&::-moz-range-track]:rounded-full [&::-moz-range-track]:border-0",
+          "[&::-webkit-slider-thumb]:-mt-1 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:opacity-0 group-hover:[&::-webkit-slider-thumb]:opacity-100",
+          "[&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-white [&::-moz-range-thumb]:opacity-0 group-hover:[&::-moz-range-thumb]:opacity-100",
+          "group-hover:[background:linear-gradient(to_right,#1ed760_var(--pct),rgba(255,255,255,0.3)_var(--pct))]",
+        )}
+        style={
+          {
+            background: `linear-gradient(to right, white ${pct}%, rgba(255,255,255,0.3) ${pct}%)`,
+            "--pct": `${pct}%`,
+          } as React.CSSProperties
+        }
       />
       <span className="text-text-secondary w-8 shrink-0 text-xs tabular-nums">
         {formatSeconds(duration)}
@@ -270,7 +280,7 @@ export const GlobalPlayerBar: FC = () => {
           aria-label="Now playing"
           onKeyDown={onKeyDown}
           className={cn(
-            "bg-surface/95 border-t border-white/10 backdrop-blur-lg",
+            "bg-black",
             "fixed right-0 bottom-16 left-0 z-40 transition-[left] duration-300 md:bottom-0",
             isSidebarCollapsed ? "md:left-20" : "md:left-64",
             "px-4 py-2",

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -38,6 +38,8 @@ interface PlaylistProps {
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
   onDownloadOrRetry: () => void;
+  onShufflePlay?: () => void;
+  isShuffleActive?: boolean;
   mode?: PlaylistMode;
 }
 
@@ -68,6 +70,8 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryFailed,
   onToggleSubscription,
   onDownloadOrRetry,
+  onShufflePlay,
+  isShuffleActive = false,
   mode = "managed",
 }) => {
   const { t } = useTranslation();
@@ -130,6 +134,8 @@ export const Playlist: FC<PlaylistProps> = ({
               onRetryFailed={onRetryFailed}
               onDelete={handleDelete}
               onDownload={onDownloadOrRetry}
+              onShufflePlay={onShufflePlay}
+              isShuffleActive={isShuffleActive}
               spotifyUrl={
                 playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")
                   ? playlist.spotifyUrl

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
@@ -64,7 +64,7 @@ describe("PlaylistTracksList playback", () => {
     expect(screen.getByRole("button", { name: "library.album.pauseTrack" })).toBeTruthy();
   });
 
-  it("calls onPlayTrack when play is pressed", () => {
+  it("calls onPlayTrack when number cell play button is pressed", () => {
     const onPlayTrack = vi.fn();
 
     render(
@@ -99,5 +99,65 @@ describe("PlaylistTracksList playback", () => {
     );
 
     expect(screen.queryByRole("button", { name: "library.album.playTrack" })).toBeNull();
+  });
+
+  it("does not render faCircleCheck downloaded badge in any row", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(document.querySelector("[data-icon='circle-check']")).toBeNull();
+  });
+
+  it("does not render Reproducir text button", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.queryByText("library.album.play")).toBeNull();
+    expect(screen.queryByText("library.album.pause")).toBeNull();
+  });
+
+  it("shows pause button in number cell for current playing track", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId="track-1"
+        isPlaying={true}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "library.album.pauseTrack" })).toBeTruthy();
+    expect(screen.queryByText("library.album.pause")).toBeNull();
+  });
+
+  it("shows play button in number cell for current paused track", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId="track-1"
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "library.album.playTrack" })).toBeTruthy();
   });
 });

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
@@ -1,5 +1,4 @@
 import { faClock } from "@fortawesome/free-regular-svg-icons";
-import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { TrackStatusEnum } from "@spotiarr/shared";
 import { FC, memo, MouseEvent, useCallback, useMemo } from "react";
@@ -97,6 +96,9 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
             index={index}
             onRetry={onRetryTrack ? handleRetry : undefined}
             onDownload={onDownloadTrack ? handleDownload : undefined}
+            onPlay={canPlayTrack ? handleTogglePlayback : undefined}
+            isCurrentTrack={isCurrent}
+            isPlaying={isPlaying}
           />
         </div>
 
@@ -141,27 +143,6 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
         {/* Duration & Actions */}
         <div className="flex items-center justify-end gap-4">
           <div className="text-text-secondary flex min-w-[40px] items-center justify-end gap-2 text-right text-sm tabular-nums">
-            {canPlayTrack ? (
-              <button
-                type="button"
-                onClick={handleTogglePlayback}
-                className="text-primary hover:text-primary/80 focus-visible:ring-primary rounded px-2 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
-                aria-label={
-                  isCurrent && isPlaying
-                    ? t("library.album.pauseTrack")
-                    : t("library.album.playTrack")
-                }
-              >
-                {isCurrent && isPlaying ? t("library.album.pause") : t("library.album.play")}
-              </button>
-            ) : null}
-            {(status ?? track.status) === "completed" && (
-              <FontAwesomeIcon
-                icon={faCircleCheck}
-                className="text-base text-green-500"
-                title={t("common.downloaded")}
-              />
-            )}
             {track.durationMs ? formatDuration(track.durationMs) : "--:--"}
           </div>
         </div>

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -5,9 +5,14 @@ import { describe, expect, it, vi } from "vitest";
 import { Path } from "@/routes/routes";
 import { useLibraryAlbumDetailController } from "./useLibraryAlbumDetailController";
 
-const mockUseParams = vi.fn();
-const mockUseLibraryArtistQuery = vi.fn();
-const mockPlayQueue = vi.fn();
+const { mockUseParams, mockUseLibraryArtistQuery, mockPlayQueue, mockSetState } = vi.hoisted(
+  () => ({
+    mockUseParams: vi.fn(),
+    mockUseLibraryArtistQuery: vi.fn(),
+    mockPlayQueue: vi.fn(),
+    mockSetState: vi.fn(),
+  }),
+);
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -30,11 +35,13 @@ vi.mock("@/store/usePlayerStore", () => ({
           isPlaying: boolean;
           currentIndex: number | null;
           queue: Array<{ id: string }>;
+          shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [] }),
+      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
     ),
     {
       getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
+      setState: mockSetState,
     },
   ),
 }));
@@ -296,6 +303,97 @@ describe("useLibraryAlbumDetailController", () => {
     items.forEach((item) => {
       expect(item.contextPath).toBe(expectedPath);
     });
+  });
+
+  it("exposes onShufflePlay and isShuffleActive in return value", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.isShuffleActive).toBe("boolean");
+  });
+
+  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    mockSetState.mockClear();
+    mockPlayQueue.mockClear();
+
+    const callOrder: string[] = [];
+    mockSetState.mockImplementation(() => {
+      callOrder.push("setState");
+    });
+    mockPlayQueue.mockImplementation(() => {
+      callOrder.push("playQueue");
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onShufflePlay();
+    });
+
+    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    expect(callOrder[0]).toBe("setState");
+    expect(callOrder[1]).toBe("playQueue");
+  });
+
+  it("onShufflePlay is a no-op when hasPlayableTracks is false", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "missing",
+    });
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    mockSetState.mockClear();
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onShufflePlay();
+    });
+
+    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("isShuffleActive is false when store shuffleMode is false", () => {
+    mockUseParams.mockReturnValue({
+      name: "Sigur%20R%C3%B3s",
+      albumName: "%28%20%29",
+    });
+    mockUseLibraryArtistQuery.mockReturnValue({
+      data: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.isShuffleActive).toBe(false);
   });
 
   it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -2,7 +2,7 @@ import { ApiRoutes, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
 import { useCallback, useMemo } from "react";
 import { generatePath, useParams } from "react-router-dom";
 import { Path } from "@/routes/routes";
-import { type QueueItem } from "@/store/usePlayerStore";
+import { type QueueItem, usePlayerStore } from "@/store/usePlayerStore";
 import { Track } from "@/types";
 import { useLibraryArtistQuery } from "../queries/useLibraryArtistQuery";
 import { usePlayerQueueBinding } from "../usePlayerQueueBinding";
@@ -80,10 +80,18 @@ export const useLibraryAlbumDetailController = () => {
     onPauseTrack,
   } = usePlayerQueueBinding(queueItems);
 
+  const isShuffleActive = usePlayerStore((s) => s.shuffleMode);
+
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
     playFromIndex(currentIndex ?? 0);
   }, [currentIndex, hasPlayableTracks, playFromIndex]);
+
+  const onShufflePlay = useCallback(() => {
+    if (!hasPlayableTracks) return;
+    usePlayerStore.setState({ shuffleMode: true });
+    playFromIndex(0);
+  }, [hasPlayableTracks, playFromIndex]);
 
   const backToArtistPath = generatePath(Path.LIBRARY_ARTIST, {
     name: artistName,
@@ -107,5 +115,7 @@ export const useLibraryAlbumDetailController = () => {
     hasPlayableTracks,
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
+    isShuffleActive,
+    onShufflePlay,
   };
 };

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -3,13 +3,25 @@ import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { usePlaylistDetailController } from "./usePlaylistDetailController";
 
-const mockUseParams = vi.fn();
-const mockUseSearchParams = vi.fn();
-const mockUsePlaylistsQuery = vi.fn();
-const mockUseTracksQuery = vi.fn();
-const mockUseNavigationHelpers = vi.fn();
-const mockUsePlaylistController = vi.fn();
-const mockPlayQueue = vi.fn();
+const {
+  mockUseParams,
+  mockUseSearchParams,
+  mockUsePlaylistsQuery,
+  mockUseTracksQuery,
+  mockUseNavigationHelpers,
+  mockUsePlaylistController,
+  mockPlayQueue,
+  mockSetState,
+} = vi.hoisted(() => ({
+  mockUseParams: vi.fn(),
+  mockUseSearchParams: vi.fn(),
+  mockUsePlaylistsQuery: vi.fn(),
+  mockUseTracksQuery: vi.fn(),
+  mockUseNavigationHelpers: vi.fn(),
+  mockUsePlaylistController: vi.fn(),
+  mockPlayQueue: vi.fn(),
+  mockSetState: vi.fn(),
+}));
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -45,11 +57,13 @@ vi.mock("@/store/usePlayerStore", () => ({
           isPlaying: boolean;
           currentIndex: number | null;
           queue: Array<{ id: string }>;
+          shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [] }),
+      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
     ),
     {
       getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
+      setState: mockSetState,
     },
   ),
 }));
@@ -325,6 +339,63 @@ describe("usePlaylistDetailController", () => {
   });
 
   // T2.2 — contextPath on playlist queue items
+  it("exposes onShufflePlay and isShuffleActive in return value", () => {
+    setupDefaults("library");
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.isShuffleActive).toBe("boolean");
+  });
+
+  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
+    setupDefaults("library");
+    mockSetState.mockClear();
+    mockPlayQueue.mockClear();
+
+    const callOrder: string[] = [];
+    mockSetState.mockImplementation(() => {
+      callOrder.push("setState");
+    });
+    mockPlayQueue.mockImplementation(() => {
+      callOrder.push("playQueue");
+    });
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onShufflePlay();
+    });
+
+    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    expect(callOrder[0]).toBe("setState");
+    expect(callOrder[1]).toBe("playQueue");
+  });
+
+  it("onShufflePlay is a no-op when !hasPlayableTracks (managed mode)", () => {
+    setupDefaults("managed");
+    mockSetState.mockClear();
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onShufflePlay();
+    });
+
+    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("isShuffleActive is false when store shuffleMode is false", () => {
+    setupDefaults("library");
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(result.current.isShuffleActive).toBe(false);
+  });
+
   it("[T2.2] every dispatched QueueItem carries contextPath equal to /playlist/id?mode=library", () => {
     setupDefaults("library");
     mockPlayQueue.mockClear();

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
-import { type QueueItem } from "@/store/usePlayerStore";
+import { type QueueItem, usePlayerStore } from "@/store/usePlayerStore";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useTracksQuery } from "../queries/useTracksQuery";
 import { useNavigationHelpers } from "../useNavigationHelpers";
@@ -40,8 +40,16 @@ export const usePlaylistDetailController = () => {
   const { currentTrackId, isPlaying, hasPlayableTracks, playFromIndex, onPlayTrack, onPauseTrack } =
     usePlayerQueueBinding(queueItems);
 
+  const isShuffleActive = usePlayerStore((s) => s.shuffleMode);
+
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
+    playFromIndex(0);
+  }, [hasPlayableTracks, playFromIndex]);
+
+  const onShufflePlay = useCallback(() => {
+    if (!hasPlayableTracks) return;
+    usePlayerStore.setState({ shuffleMode: true });
     playFromIndex(0);
   }, [hasPlayableTracks, playFromIndex]);
 
@@ -86,6 +94,8 @@ export const usePlaylistDetailController = () => {
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
     hasPlayableTracks,
+    isShuffleActive,
+    onShufflePlay,
     mode,
   };
 };

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -9,7 +9,6 @@
     "close": "Close",
     "unknownError": "Unknown error",
     "downloadAll": "Download All",
-    "downloaded": "Downloaded",
     "popular": "Popular",
     "title": "Title",
     "album": "Album",
@@ -226,7 +225,8 @@
       "retryFailedTooltip": "Retry Failed Downloads",
       "delete": "Delete",
       "deleteTooltip": "Delete Playlist",
-      "downloadToEnable": "Download to enable actions"
+      "downloadToEnable": "Download to enable actions",
+      "shufflePlay": "Shuffle play"
     }
   },
   "artist": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -9,7 +9,6 @@
     "close": "Cerrar",
     "unknownError": "Error desconocido",
     "downloadAll": "Descargar todo",
-    "downloaded": "Descargado",
     "popular": "Populares",
     "title": "Título",
     "album": "Álbum",
@@ -226,7 +225,8 @@
       "retryFailedTooltip": "Reintentar descargas fallidas",
       "delete": "Eliminar",
       "deleteTooltip": "Eliminar lista",
-      "downloadToEnable": "Descargar para habilitar acciones"
+      "downloadToEnable": "Descargar para habilitar acciones",
+      "shufflePlay": "Reproducción aleatoria"
     }
   },
   "artist": {

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -1,4 +1,4 @@
-import { faMusic, faPause, faPlay } from "@fortawesome/free-solid-svg-icons";
+import { faMusic, faPause, faPlay, faShuffle } from "@fortawesome/free-solid-svg-icons";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
@@ -8,6 +8,7 @@ import { AlbumPageLayout } from "@/components/molecules/AlbumPageLayout";
 import { EmptyState } from "@/components/molecules/EmptyState";
 import { SpotifyLinkButton } from "@/components/molecules/SpotifyLinkButton";
 import { useLibraryAlbumDetailController } from "@/hooks/controllers/useLibraryAlbumDetailController";
+import { cn } from "@/utils/cn";
 
 export const LibraryAlbumDetail: FC = () => {
   const { t } = useTranslation();
@@ -28,6 +29,8 @@ export const LibraryAlbumDetail: FC = () => {
     hasPlayableTracks,
     onPlayPlaylist,
     onPausePlaylist,
+    isShuffleActive,
+    onShufflePlay,
   } = useLibraryAlbumDetailController();
 
   if (isLoading) {
@@ -115,6 +118,22 @@ export const LibraryAlbumDetail: FC = () => {
                     {isPlaying ? t("library.album.pause") : t("library.album.play")}
                   </span>
                 </Button>
+              ) : null}
+              {hasPlayableTracks && onShufflePlay ? (
+                <Button
+                  variant="ghost"
+                  size="md"
+                  onClick={onShufflePlay}
+                  title={t("playlist.actions.shufflePlay")}
+                  ariaLabel={t("playlist.actions.shufflePlay")}
+                  icon={faShuffle}
+                  className={cn(
+                    "!h-10 !w-10 justify-center !rounded-full !p-0 transition-transform hover:scale-105",
+                    isShuffleActive
+                      ? "text-green-500"
+                      : "text-text-secondary hover:text-text-primary",
+                  )}
+                />
               ) : null}
               <SpotifyLinkButton
                 provider="spotify"

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -133,7 +133,9 @@ export const LibraryAlbumDetail: FC = () => {
                       ? "text-green-500"
                       : "text-text-secondary hover:text-text-primary",
                   )}
-                />
+                >
+                  <span className="sr-only">{t("playlist.actions.shufflePlay")}</span>
+                </Button>
               ) : null}
               <SpotifyLinkButton
                 provider="spotify"

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -30,6 +30,8 @@ export const PlaylistDetail: FC = () => {
     currentTrackId,
     isPlaying,
     hasPlayableTracks,
+    isShuffleActive,
+    onShufflePlay,
     mode,
   } = usePlaylistDetailController();
 
@@ -68,6 +70,8 @@ export const PlaylistDetail: FC = () => {
         currentTrackId={currentTrackId}
         isPlaying={isPlaying}
         hasPlayableTracks={hasPlayableTracks}
+        onShufflePlay={onShufflePlay}
+        isShuffleActive={isShuffleActive}
         mode={mode}
       />
       {!hasPlayableTracks && tracks.length > 0 ? (


### PR DESCRIPTION
## Summary
Three small UX wins on playlist + album track rows, matching Spotify behavior.

- **W1 — Hover play icon replaces track number.** The `#` cell becomes a `<button>` that swaps to a play icon on hover (and on keyboard `focus-within`). For the currently-playing track it shows pause/play unconditionally and toggles playback. The redundant "Reproducir" text button in the actions column is removed.
- **W2 — Shuffle button in headers.** `PlaylistActions` gains a second circular button next to the green play, wired to `setState({ shuffleMode: true })` then `playFromIndex(0)` so the store regenerates `shuffleOrder` at call time (using the foundation shipped in #88). Shows active styling when `shuffleMode` is on, hidden when there are no playable tracks. Available on playlist detail and library album detail. Library artist intentionally untouched.
- **W3 — Remove redundant "downloaded" check.** In `PlaylistTracksList` (library context, downloads implied) the green check is gone. `TrackList` (search results) keeps it because there it carries real signal. Orphaned `common.downloaded` i18n key removed from `en.json`/`es.json`.

## SDD trail (engram)
- proposal #3228 · spec #3229 · design #3230 · tasks #3231 · apply #3235 · verify #3236 · archive #3237

`size:exception` was approved during planning: estimated ~408 LOC, single-PR delivery for a coherent UX slice. Final diff: 15 files, ~552 net LOC, ~340 of which are tests.

## Test plan
- [x] `pnpm --filter frontend test:run` — 298/298 pass (34 files)
- [x] `pnpm --filter frontend lint` — clean (oxlint)
- [x] `pnpm --filter frontend build` — clean (Vite, 1.08s)
- [ ] Manual: hover a track row → number swaps to play; click → starts at that index; tab through rows → focused row shows the icon; while a track is playing, its row shows pause; click pause → toggles
- [ ] Manual: open a playlist + an album, click the new shuffle button → playback starts shuffled; click again → re-shuffles; toggle shuffle off from the global player bar → button styling deactivates
- [ ] Manual: confirm no green check icon in any library track row; search results still show the badge