### PR TITLE
feat(player): queue side-panel — list + click-to-jump

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -27,6 +27,28 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => {
+        const map: Record<string, string> = {
+          "player.queue.toggleOpen": "Open queue",
+          "player.queue.toggleClose": "Close queue",
+          "player.queue.title": "Queue",
+          "player.queue.empty": "No tracks in queue",
+          "player.queue.close": "Close",
+          "player.queue.repeatAll": "Repeat all",
+          "player.queue.repeatOne": "Repeat one",
+          "player.queue.shuffleOn": "Shuffle on",
+        };
+        return map[key] ?? key;
+      },
+    }),
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -586,6 +608,114 @@ describe("repeat button", () => {
     const { container } = render(<GlobalPlayerBar />);
 
     expect(container.querySelector("sup")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queue button (S3-1 through S3-7 + focus return)
+// ---------------------------------------------------------------------------
+
+const { usePlayerStore: mockUsePlayerStore } = vi.hoisted(() => {
+  const storeMock = {
+    queue: [] as ReturnType<typeof makeItem>[],
+    isQueuePanelOpen: false,
+    setQueuePanelOpen: vi.fn(),
+  };
+  return {
+    usePlayerStore: Object.assign(
+      (selector: (s: typeof storeMock) => unknown) => selector(storeMock),
+      {
+        getState: () => storeMock,
+        setState: (partial: Partial<typeof storeMock>) => Object.assign(storeMock, partial),
+      },
+    ),
+  };
+});
+
+describe("queue button", () => {
+  beforeEach(() => {
+    mockUsePlayerStore.setState({
+      queue: [makeItem("a"), makeItem("b")],
+      isQueuePanelOpen: false,
+      setQueuePanelOpen: vi.fn(),
+    });
+  });
+
+  it("S3-1: queue button renders after repeat button", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    const buttons = screen.getAllByRole("button");
+    const repeatIdx = buttons.findIndex((b) => /repeat/i.test(b.getAttribute("aria-label") ?? ""));
+    const queueIdx = buttons.findIndex((b) => /queue/i.test(b.getAttribute("aria-label") ?? ""));
+    expect(queueIdx).toBeGreaterThan(repeatIdx);
+  });
+
+  it("S3-2: aria-label=Open queue and aria-pressed=false when closed", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ isQueuePanelOpen: false });
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open queue" });
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("S3-3: aria-label=Close queue and aria-pressed=true when open", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ isQueuePanelOpen: true });
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Close queue" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("S3-4: click calls setQueuePanelOpen(true) when closed", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ isQueuePanelOpen: false });
+    render(<GlobalPlayerBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open queue" }));
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(true);
+  });
+
+  it("S3-5: click calls setQueuePanelOpen(false) when open", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ isQueuePanelOpen: true });
+    render(<GlobalPlayerBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Close queue" }));
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(false);
+  });
+
+  it("S3-6: button is disabled when queue is empty", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState().clear();
+    usePlayerStore.setState({ error: "err", currentIndex: 0 });
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open queue" });
+    expect(btn).toHaveProperty("disabled", true);
+    expect(btn).not.toBeNull();
+  });
+
+  it("S3-7: button is NOT disabled when queue has tracks", () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open queue" });
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("focus returns to queue button when panel transitions true→false", async () => {
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+    usePlayerStore.setState({ isQueuePanelOpen: true });
+    const { rerender } = render(<GlobalPlayerBar />);
+
+    usePlayerStore.setState({ isQueuePanelOpen: false });
+    rerender(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open queue" });
+    expect(document.activeElement).toBe(btn);
   });
 });
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -27,6 +27,10 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+vi.mock("./QueueSidePanel", () => ({
+  QueueSidePanel: () => null,
+}));
+
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
   return {

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -1,6 +1,7 @@
 import {
   faBackwardStep,
   faForwardStep,
+  faListUl,
   faPause,
   faPlay,
   faRepeat,
@@ -10,6 +11,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
@@ -146,11 +148,16 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
 
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
+  const isQueuePanelOpen = usePlayerStore((s) => s.isQueuePanelOpen);
+  const setQueuePanelOpen = usePlayerStore((s) => s.setQueuePanelOpen);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const error = usePlayerStore((s) => s.error);
   const shuffleMode = usePlayerStore((s) => s.shuffleMode);
@@ -248,6 +255,13 @@ export const GlobalPlayerBar: FC = () => {
     }, 3000);
     return () => clearTimeout(timer);
   }, [error]);
+
+  useEffect(() => {
+    if (wasOpenRef.current && !isQueuePanelOpen) {
+      triggerRef.current?.focus();
+    }
+    wasOpenRef.current = isQueuePanelOpen;
+  }, [isQueuePanelOpen]);
 
   const isVisible = currentIndex !== null || !!error;
   const isAtFirst =
@@ -362,6 +376,26 @@ export const GlobalPlayerBar: FC = () => {
                       1
                     </sup>
                   )}
+                </button>
+
+                <button
+                  ref={triggerRef}
+                  type="button"
+                  aria-label={
+                    isQueuePanelOpen ? t("player.queue.toggleClose") : t("player.queue.toggleOpen")
+                  }
+                  aria-pressed={isQueuePanelOpen}
+                  disabled={queue.length === 0}
+                  onClick={() => setQueuePanelOpen(!isQueuePanelOpen)}
+                  className={cn(
+                    "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
+                    isQueuePanelOpen
+                      ? "text-green-500"
+                      : "text-text-secondary hover:text-text-primary",
+                    queue.length === 0 && "cursor-not-allowed opacity-40",
+                  )}
+                >
+                  <FontAwesomeIcon icon={faListUl} className="text-sm" />
                 </button>
               </div>
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -19,6 +19,7 @@ import type { QueueItem } from "@/store/usePlayerStore";
 import { usePreferencesStore } from "@/store/usePreferencesStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
+import { QueueSidePanel } from "./QueueSidePanel";
 
 function formatSeconds(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
@@ -287,6 +288,7 @@ export const GlobalPlayerBar: FC = () => {
   return (
     <>
       <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
+      <QueueSidePanel />
 
       {isVisible && (
         <section

--- a/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
@@ -1,0 +1,250 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { QueueSidePanel } from "./QueueSidePanel";
+
+const mockStore = vi.hoisted(() => ({
+  queue: [] as Array<{ id: string; name: string; artist: string; audioUrl: string }>,
+  currentIndex: 0 as number | null,
+  shuffleMode: false,
+  repeatMode: "off" as "off" | "all" | "one",
+  isQueuePanelOpen: false,
+  setQueuePanelOpen: vi.fn(),
+  playFromIndex: vi.fn(),
+}));
+
+vi.mock("@/store/usePlayerStore", () => ({
+  usePlayerStore: (selector: (s: typeof mockStore) => unknown) => selector(mockStore),
+}));
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => {
+        const map: Record<string, string> = {
+          "player.queue.title": "Queue",
+          "player.queue.empty": "No tracks in queue",
+          "player.queue.toggleOpen": "Open queue",
+          "player.queue.toggleClose": "Close queue",
+          "player.queue.close": "Close",
+          "player.queue.repeatAll": "Repeat all",
+          "player.queue.repeatOne": "Repeat one",
+          "player.queue.shuffleOn": "Shuffle on",
+        };
+        return map[key] ?? key;
+      },
+    }),
+  };
+});
+
+const makeItem = (id: string) => ({
+  id,
+  name: `Track ${id}`,
+  artist: `Artist ${id}`,
+  audioUrl: `/api/audio/${id}`,
+});
+
+function resetMock() {
+  mockStore.queue = [];
+  mockStore.currentIndex = 0;
+  mockStore.shuffleMode = false;
+  mockStore.repeatMode = "off";
+  mockStore.isQueuePanelOpen = false;
+  mockStore.setQueuePanelOpen = vi.fn();
+  mockStore.playFromIndex = vi.fn();
+}
+
+beforeEach(resetMock);
+afterEach(() => {
+  vi.clearAllMocks();
+  resetMock();
+});
+
+describe("panel visibility (S4-1, S4-2)", () => {
+  it("S4-1: panel has translate-x-full when closed", () => {
+    mockStore.isQueuePanelOpen = false;
+    const { container } = render(<QueueSidePanel />);
+    const aside = container.querySelector("aside");
+    expect(aside?.className).toContain("translate-x-full");
+    expect(aside?.className).not.toContain("translate-x-0");
+  });
+
+  it("S4-1: backdrop is not rendered when closed", () => {
+    mockStore.isQueuePanelOpen = false;
+    render(<QueueSidePanel />);
+    expect(screen.queryByTestId("queue-backdrop")).toBeNull();
+  });
+
+  it("S4-2: panel has translate-x-0 when open", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    const { container } = render(<QueueSidePanel />);
+    const aside = container.querySelector("aside");
+    expect(aside?.className).toContain("translate-x-0");
+  });
+
+  it("S4-2: backdrop is rendered when open", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.getByTestId("queue-backdrop")).not.toBeNull();
+  });
+});
+
+describe("panel close actions (S4-3, S4-4, S4-5, S4-6)", () => {
+  it("S4-3: backdrop click calls setQueuePanelOpen(false)", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByTestId("queue-backdrop"));
+    expect(mockStore.setQueuePanelOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("S4-4: X button click calls setQueuePanelOpen(false)", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(mockStore.setQueuePanelOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("S4-5: ESC keydown calls setQueuePanelOpen(false) when open", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(mockStore.setQueuePanelOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("S4-6: ESC keydown does nothing when closed", () => {
+    mockStore.isQueuePanelOpen = false;
+    render(<QueueSidePanel />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(mockStore.setQueuePanelOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe("queue list (S5-1, S5-2, S5-3, S5-4, S5-7)", () => {
+  it("S5-1: renders 3 li rows for queue of 3 tracks when open", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b"), makeItem("c")];
+    mockStore.currentIndex = 0;
+    render(<QueueSidePanel />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+  });
+
+  it("S5-2: row at currentIndex has aria-current=true; others do not", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b"), makeItem("c")];
+    mockStore.currentIndex = 1;
+    render(<QueueSidePanel />);
+    const items = screen.getAllByRole("listitem");
+    expect(items[0]?.getAttribute("aria-current")).not.toBe("true");
+    expect(items[1]?.getAttribute("aria-current")).toBe("true");
+    expect(items[2]?.getAttribute("aria-current")).not.toBe("true");
+  });
+
+  it("S5-3: click row index 2 calls playFromIndex(2)", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b"), makeItem("c")];
+    mockStore.currentIndex = 0;
+    render(<QueueSidePanel />);
+    const buttons = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-label") === null || /Track/i.test(b.textContent ?? ""));
+    fireEvent.click(buttons[2]!);
+    expect(mockStore.playFromIndex).toHaveBeenCalledWith(2);
+  });
+
+  it("S5-4: empty queue renders empty-state message", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [];
+    render(<QueueSidePanel />);
+    expect(screen.getByText("No tracks in queue")).not.toBeNull();
+    expect(screen.queryByRole("listitem")).toBeNull();
+  });
+
+  it("S5-7: Enter key on row button calls playFromIndex", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b")];
+    mockStore.currentIndex = 0;
+    render(<QueueSidePanel />);
+    const rowButtons = screen
+      .getAllByRole("button")
+      .filter((b) => /Track/i.test(b.textContent ?? ""));
+    fireEvent.keyDown(rowButtons[1]!, { key: "Enter" });
+    expect(mockStore.playFromIndex).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("header indicators (S6-1 through S6-6)", () => {
+  it("S6-1: shuffle indicator rendered when shuffleMode=true", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.shuffleMode = true;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.getByText("Shuffle on")).not.toBeNull();
+  });
+
+  it("S6-2: no shuffle indicator when shuffleMode=false", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.shuffleMode = false;
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.queryByText("Shuffle on")).toBeNull();
+  });
+
+  it("S6-3: repeat badge shows Repeat all when repeatMode=all", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.repeatMode = "all";
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.getByText("Repeat all")).not.toBeNull();
+  });
+
+  it("S6-4: repeat badge shows Repeat one when repeatMode=one", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.repeatMode = "one";
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.getByText("Repeat one")).not.toBeNull();
+  });
+
+  it("S6-5: no repeat badge when repeatMode=off", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.repeatMode = "off";
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    expect(screen.queryByText("Repeat all")).toBeNull();
+    expect(screen.queryByText("Repeat one")).toBeNull();
+  });
+
+  it("S6-6: shuffle indicator and repeat badge have no click handlers (no store calls on click)", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.shuffleMode = true;
+    mockStore.repeatMode = "all";
+    mockStore.queue = [makeItem("a")];
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByText("Shuffle on"));
+    fireEvent.click(screen.getByText("Repeat all"));
+    expect(mockStore.setQueuePanelOpen).not.toHaveBeenCalled();
+    expect(mockStore.playFromIndex).not.toHaveBeenCalled();
+  });
+});
+
+describe("backdrop propagation (S7-4)", () => {
+  it("S7-4: backdrop click does not propagate to elements behind", () => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a")];
+    const outerClick = vi.fn();
+    render(
+      <div onClick={outerClick}>
+        <QueueSidePanel />
+      </div>,
+    );
+    const backdrop = screen.getByTestId("queue-backdrop");
+    fireEvent.click(backdrop);
+    expect(outerClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/organisms/QueueSidePanel.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.tsx
@@ -1,0 +1,122 @@
+import { faShuffle, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { cn } from "@/utils/cn";
+
+export const QueueSidePanel: FC = () => {
+  const { t } = useTranslation();
+  const activeRowRef = useRef<HTMLLIElement>(null);
+
+  const queue = usePlayerStore((s) => s.queue);
+  const currentIndex = usePlayerStore((s) => s.currentIndex);
+  const shuffleMode = usePlayerStore((s) => s.shuffleMode);
+  const repeatMode = usePlayerStore((s) => s.repeatMode);
+  const isQueuePanelOpen = usePlayerStore((s) => s.isQueuePanelOpen);
+  const setQueuePanelOpen = usePlayerStore((s) => s.setQueuePanelOpen);
+  const playFromIndex = usePlayerStore((s) => s.playFromIndex);
+
+  useEffect(() => {
+    if (!isQueuePanelOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setQueuePanelOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [isQueuePanelOpen, setQueuePanelOpen]);
+
+  useEffect(() => {
+    if (isQueuePanelOpen && activeRowRef.current?.scrollIntoView) {
+      activeRowRef.current.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  }, [isQueuePanelOpen, currentIndex]);
+
+  return (
+    <>
+      {isQueuePanelOpen && (
+        <div
+          role="presentation"
+          aria-hidden="true"
+          data-testid="queue-backdrop"
+          className="fixed inset-0 z-[55] bg-black/40"
+          onClick={(e) => {
+            e.stopPropagation();
+            setQueuePanelOpen(false);
+          }}
+        />
+      )}
+
+      <aside
+        role="complementary"
+        aria-label={t("player.queue.title")}
+        className={cn(
+          "fixed top-0 right-0 bottom-16 z-60 w-full md:bottom-0 md:w-80",
+          "flex flex-col bg-zinc-900 transition-transform duration-300",
+          isQueuePanelOpen ? "translate-x-0" : "translate-x-full",
+        )}
+      >
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-white">{t("player.queue.title")}</span>
+            {shuffleMode && (
+              <span className="flex items-center gap-1 text-xs text-green-500">
+                <FontAwesomeIcon icon={faShuffle} />
+                <span>{t("player.queue.shuffleOn")}</span>
+              </span>
+            )}
+            {repeatMode !== "off" && (
+              <span className="text-xs font-medium tracking-wide text-white/60 uppercase">
+                {repeatMode === "all" ? t("player.queue.repeatAll") : t("player.queue.repeatOne")}
+              </span>
+            )}
+          </div>
+
+          <button
+            type="button"
+            aria-label={t("player.queue.close")}
+            onClick={() => setQueuePanelOpen(false)}
+            className="flex h-8 w-8 items-center justify-center rounded-full text-white/60 transition-colors hover:text-white"
+          >
+            <FontAwesomeIcon icon={faTimes} className="text-sm" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto">
+          {queue.length === 0 ? (
+            <p className="mt-8 px-4 text-center text-sm text-white/40">{t("player.queue.empty")}</p>
+          ) : (
+            <ul className="py-2">
+              {queue.map((item, index) => {
+                const isCurrent = index === currentIndex;
+                return (
+                  <li
+                    key={item.id}
+                    ref={isCurrent ? activeRowRef : undefined}
+                    aria-current={isCurrent ? "true" : undefined}
+                    className={cn("px-4 py-0", isCurrent && "bg-white/5")}
+                  >
+                    <button
+                      type="button"
+                      className={cn(
+                        "flex w-full flex-col items-start rounded py-2 text-left transition-colors hover:bg-white/5",
+                        isCurrent ? "text-green-400" : "text-white",
+                      )}
+                      onClick={() => playFromIndex(index)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") playFromIndex(index);
+                      }}
+                    >
+                      <span className="w-full truncate text-sm font-medium">{item.name}</span>
+                      <span className="w-full truncate text-xs text-white/50">{item.artist}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+};

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -365,5 +365,17 @@
     "detail": {
       "title": "Album"
     }
+  },
+  "player": {
+    "queue": {
+      "title": "Queue",
+      "empty": "No tracks in queue",
+      "toggleOpen": "Open queue",
+      "toggleClose": "Close queue",
+      "close": "Close",
+      "repeatAll": "Repeat all",
+      "repeatOne": "Repeat one",
+      "shuffleOn": "Shuffle on"
+    }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -365,5 +365,17 @@
     "detail": {
       "title": "Álbum"
     }
+  },
+  "player": {
+    "queue": {
+      "title": "Cola",
+      "empty": "No hay pistas en la cola",
+      "toggleOpen": "Abrir cola",
+      "toggleClose": "Cerrar cola",
+      "close": "Cerrar",
+      "repeatAll": "Repetir todo",
+      "repeatOne": "Repetir una",
+      "shuffleOn": "Aleatorio activado"
+    }
   }
 }

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -755,6 +755,126 @@ describe("_onEnded() with modes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isQueuePanelOpen + setQueuePanelOpen (S1-1 through S1-6)
+// ---------------------------------------------------------------------------
+
+describe("isQueuePanelOpen", () => {
+  it("S1-1: initial value is false", () => {
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(false);
+  });
+
+  it("S1-2: setQueuePanelOpen(true) sets flag to true", () => {
+    usePlayerStore.getState().setQueuePanelOpen(true);
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(true);
+  });
+
+  it("S1-3: setQueuePanelOpen(false) sets flag to false", () => {
+    usePlayerStore.getState().setQueuePanelOpen(true);
+    usePlayerStore.getState().setQueuePanelOpen(false);
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(false);
+  });
+
+  it("S1-4: setQueuePanelOpen(true) when already true remains true (idempotent)", () => {
+    usePlayerStore.getState().setQueuePanelOpen(true);
+    usePlayerStore.getState().setQueuePanelOpen(true);
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(true);
+  });
+
+  it("S1-5: clear() resets isQueuePanelOpen to false", () => {
+    usePlayerStore.getState().setQueuePanelOpen(true);
+    usePlayerStore.getState().clear();
+    expect(usePlayerStore.getState().isQueuePanelOpen).toBe(false);
+  });
+
+  it("S1-6: __partialize does NOT include isQueuePanelOpen in returned keys", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      isQueuePanelOpen: true,
+      volume: 1,
+      isMuted: false,
+      shuffleMode: false,
+      repeatMode: "off" as const,
+    } as unknown as Parameters<typeof p>[0];
+    const persisted = p(fakeState);
+    expect("isQueuePanelOpen" in persisted).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// playFromIndex (S2-1 through S2-7)
+// ---------------------------------------------------------------------------
+
+describe("playFromIndex", () => {
+  it("S2-1: happy path shuffle OFF — sets currentIndex, isPlaying=true, currentTime=0, shuffleOrder unchanged", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 0);
+    const orderBefore = usePlayerStore.getState().shuffleOrder.slice();
+    usePlayerStore.getState().playFromIndex(3);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(3);
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(0);
+    expect(state.shuffleOrder).toEqual(orderBefore);
+  });
+
+  it("S2-2: out-of-bounds negative is a no-op", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    const stateBefore = usePlayerStore.getState().currentIndex;
+    usePlayerStore.getState().playFromIndex(-1);
+    expect(usePlayerStore.getState().currentIndex).toBe(stateBefore);
+  });
+
+  it("S2-3: out-of-bounds equal to length is a no-op", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().playFromIndex(5);
+    expect(usePlayerStore.getState().currentIndex).toBe(2);
+  });
+
+  it("S2-4: empty queue is a no-op", () => {
+    usePlayerStore.getState().playFromIndex(0);
+    expect(usePlayerStore.getState().currentIndex).toBeNull();
+  });
+
+  it("S2-5: happy path shuffle ON — currentIndex set, shuffleOrder recomputed, shuffleOrderIndex=0", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c"), makeItem("d"), makeItem("e")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ shuffleMode: true });
+    usePlayerStore.getState().playFromIndex(2);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(2);
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(0);
+    expect(state.shuffleOrder).toHaveLength(5);
+    expect(state.shuffleOrder[0]).toBe(2);
+    expect(state.shuffleOrderIndex).toBe(0);
+  });
+
+  it("S2-6: restart currently-playing — currentTime=0, isPlaying=true", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ currentTime: 45 });
+    usePlayerStore.getState().playFromIndex(1);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(0);
+  });
+
+  it("S2-7: queue array reference unchanged after playFromIndex", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    const queueRef = usePlayerStore.getState().queue;
+    usePlayerStore.getState().playFromIndex(0);
+    expect(usePlayerStore.getState().queue).toBe(queueRef);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -40,6 +40,8 @@ export interface PlayerState {
   shuffleOrder: number[];
   shuffleOrderIndex: number;
 
+  isQueuePanelOpen: boolean;
+
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
   next: () => void;
@@ -50,6 +52,8 @@ export interface PlayerState {
   clear: () => void;
   toggleShuffle: () => void;
   cycleRepeat: () => void;
+  setQueuePanelOpen: (open: boolean) => void;
+  playFromIndex: (index: number) => void;
 
   setAudioElement: (el: HTMLAudioElement | null) => void;
   _onLoadedMetadata: (duration: number) => void;
@@ -101,6 +105,7 @@ const INITIAL_STATE = {
   repeatMode: "off" as RepeatMode,
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
+  isQueuePanelOpen: false,
 };
 
 type AdvanceSource = "user" | "ended";
@@ -261,6 +266,7 @@ export const usePlayerStore = create<PlayerState>()(
             currentTime: 0,
             duration: 0,
             error: null,
+            isQueuePanelOpen: false,
           });
         },
 
@@ -301,6 +307,21 @@ export const usePlayerStore = create<PlayerState>()(
 
         _onError(message) {
           set({ error: message, isPlaying: false });
+        },
+
+        setQueuePanelOpen(open) {
+          set({ isQueuePanelOpen: open });
+        },
+
+        playFromIndex(index) {
+          const { queue, shuffleMode } = get();
+          if (index < 0 || index >= queue.length) return;
+          set({ currentIndex: index, isPlaying: true, currentTime: 0 });
+          if (_audioElement) _audioElement.currentTime = 0;
+          if (shuffleMode) {
+            const order = shuffleIndices(queue.length, index);
+            set({ shuffleOrder: order, shuffleOrderIndex: 0 });
+          }
         },
       };
     },


### PR DESCRIPTION
## Summary

- Slide-in queue side-panel triggered from `GlobalPlayerBar` (faListUl button after repeat)
- Lists `queue` from `usePlayerStore` with current track highlighted; click row jumps via new `playFromIndex` action
- Read-only shuffle/repeat indicators in panel header
- Ephemeral `isQueuePanelOpen` state on `usePlayerStore` (not persisted, excluded by `__partialize` allowlist, reset by `clear()`)
- Close via X button, backdrop click, or ESC; focus returns to queue button on close
- Drag-to-reorder deferred to follow-up slice `queue-side-panel-reorder` (Slice B)

## Implementation

- Store: `isQueuePanelOpen`, `setQueuePanelOpen(open)`, `playFromIndex(index)` (recomputes `shuffleOrder` when shuffle ON, restart-on-current)
- New organism `QueueSidePanel.tsx` (122 LOC); `fixed right-0` overlay + backdrop, `z-60`
- i18n keys under `player.queue.*` (en + es)
- Strict TDD: every change preceded by RED tests (41 new tests across 4 files)

## Test plan

- [x] `pnpm --filter frontend test:run` — 339/339 passing
- [x] `pnpm --filter frontend lint` — clean
- [x] `pnpm --filter frontend build` — clean (1.06s)
- [x] Manual: open panel, click row, jump works; shuffle ON shows indicator; ESC closes; focus returns
- [ ] e2e (deferred): z-index stacking vs sidebar; scrollIntoView on open; responsive offset on wide screens