### PR TITLE
test(frontend): cover core mocked routes

### DIFF
--- a/apps/frontend/tests/e2e/mocked/activity.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/activity.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "../../fixtures/test";
+import { buildPlaylist, installPlaylistMocks } from "../../helpers/api-mocks";
+
+test.describe("Mocked activity flows", () => {
+  test("renders the activity list from mocked playlist data", async ({ page }) => {
+    await installPlaylistMocks(page, {
+      playlists: [
+        buildPlaylist({ id: "activity-1", name: "Night Drive" }),
+        buildPlaylist({ id: "activity-2", name: "Morning Queue" }),
+      ],
+    });
+
+    await page.goto("/activity", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
+    await expect(page.getByText("Night Drive")).toBeVisible();
+    await expect(page.getByText("Morning Queue")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Clear completed" })).toBeVisible();
+  });
+
+  test("renders the empty activity state when the mocked queue has no playlists", async ({
+    page,
+  }) => {
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/activity", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("No downloads in progress")).toBeVisible();
+    await expect(
+      page.getByText("Your queue looks empty. Add some tracks to see activity here."),
+    ).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/artists.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/artists.spec.ts
@@ -1,0 +1,42 @@
+import type { FollowedArtist } from "@spotiarr/shared";
+import { expect, test } from "../../fixtures/test";
+import { installFeedMocks } from "../../helpers/api-mocks";
+
+const followedArtists: FollowedArtist[] = [
+  {
+    id: "artist-1",
+    name: "Daft Punk",
+    image: null,
+    spotifyUrl: "https://open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi",
+  },
+  {
+    id: "artist-2",
+    name: "Justice",
+    image: null,
+    spotifyUrl: "https://open.spotify.com/artist/1gR0gsQYfi6joyO1dlp76N",
+  },
+];
+
+test.describe("Mocked artists flows", () => {
+  test("renders followed artists from mocked feed responses", async ({ page }) => {
+    await installFeedMocks(page, { followedArtists, releases: [] });
+
+    await page.goto("/artists", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Followed Artists" })).toBeVisible();
+    await expect(page.getByText("Daft Punk")).toBeVisible();
+    await expect(page.getByText("Justice")).toBeVisible();
+    await expect(page.getByText("Artist").first()).toBeVisible();
+  });
+
+  test("renders the artist search fallback when no mocked artist matches the filter", async ({
+    page,
+  }) => {
+    await installFeedMocks(page, { followedArtists, releases: [] });
+
+    await page.goto("/artists", { waitUntil: "domcontentloaded" });
+    await page.getByPlaceholder("Filter artists...").fill("missing artist");
+
+    await expect(page.getByText("No followed artists found.")).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/home.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/home.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "../../fixtures/test";
+import {
+  buildLibraryArtist,
+  buildPlaylist,
+  installLibraryMocks,
+  installPlaylistMocks,
+} from "../../helpers/api-mocks";
+
+test.describe("Mocked home flows", () => {
+  test("renders the home heading with mocked library artists and playlists", async ({ page }) => {
+    await installLibraryMocks(page, {
+      artists: [buildLibraryArtist({ name: "Tycho", image: null })],
+    });
+    await installPlaylistMocks(page, {
+      playlists: [buildPlaylist({ id: "playlist-home", name: "Sunrise Set" })],
+    });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Library" })).toBeVisible();
+    await expect(page.getByText("Your downloaded music collection")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Playlists" })).toBeVisible();
+    await expect(page.getByText("Sunrise Set")).toBeVisible();
+    await expect(page.getByText("Tycho")).toBeVisible();
+  });
+
+  test("renders the empty state when mocked library and playlist payloads are empty", async ({
+    page,
+  }) => {
+    await installLibraryMocks(page, {
+      artists: [],
+      stats: {
+        totalArtists: 0,
+        totalAlbums: 0,
+        totalTracks: 0,
+        totalSize: 0,
+        lastScannedAt: null,
+      },
+    });
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("Library is empty")).toBeVisible();
+    await expect(
+      page.getByText("Scan or rescan your downloads folder to populate your library and artwork."),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Scan Now" })).toBeVisible();
+  });
+
+  test("shows a loading state while mocked home data is still in flight", async ({ page }) => {
+    const libraryGate = Promise.withResolvers<void>();
+
+    await installLibraryMocks(page, {
+      artists: [buildLibraryArtist({ name: "Boards of Canada", image: null })],
+      gates: {
+        artists: libraryGate.promise,
+        stats: libraryGate.promise,
+      },
+    });
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("status", { name: "Loading" })).toBeVisible();
+
+    libraryGate.resolve();
+
+    await expect(page.getByText("Boards of Canada")).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/playlists.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/playlists.spec.ts
@@ -1,0 +1,195 @@
+import type { SpotifyPlaylist } from "@spotiarr/shared";
+import { expect, test } from "../../fixtures/test";
+import { buildPlaylist, installPlaylistMocks } from "../../helpers/api-mocks";
+
+const spotifyPlaylist: SpotifyPlaylist = {
+  id: "spotify-playlist-1",
+  name: "Road Trip",
+  image: null,
+  owner: "Alex",
+  ownerUrl: "https://open.spotify.com/user/alex",
+  tracks: 12,
+  spotifyUrl: "https://open.spotify.com/playlist/road-trip",
+};
+
+test.describe("Mocked my playlists flows", () => {
+  test("renders the My Playlists list and navigates into the preview flow", async ({ page }) => {
+    await installPlaylistMocks(page, {
+      myPlaylists: [spotifyPlaylist],
+      playlists: [],
+      preview: {
+        name: spotifyPlaylist.name,
+        type: "playlist",
+        description: "A mocked preview playlist.",
+        coverUrl: null,
+        owner: spotifyPlaylist.owner,
+        ownerUrl: spotifyPlaylist.ownerUrl,
+        totalTracks: 1,
+        tracks: [
+          {
+            name: "Midnight City",
+            artists: [{ name: "M83", url: "https://open.spotify.com/artist/m83" }],
+            album: 'Hurry Up, We"re Dreaming',
+            duration: 250_000,
+            trackUrl: "https://open.spotify.com/track/midnight-city",
+            albumUrl: "https://open.spotify.com/album/hurry-up",
+          },
+        ],
+      },
+    });
+
+    await page.goto("/my-playlists", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "My Spotify Playlists" })).toBeVisible();
+    await expect(page.getByText("Road Trip")).toBeVisible();
+
+    await page.getByText("Road Trip").click();
+
+    await expect(page).toHaveURL(/\/preview\?url=/);
+    await expect(page.getByRole("heading", { name: "Road Trip" })).toBeVisible();
+    await expect(page.getByTitle("Download Playlist")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Subscribe" })).toBeVisible();
+  });
+
+  test("fires the playlist creation trigger from the preview download CTA", async ({ page }) => {
+    let createdPayload: unknown = null;
+
+    await installPlaylistMocks(page, {
+      myPlaylists: [spotifyPlaylist],
+      playlists: [],
+      preview: {
+        name: spotifyPlaylist.name,
+        type: "playlist",
+        description: "A mocked preview playlist.",
+        coverUrl: null,
+        owner: spotifyPlaylist.owner,
+        ownerUrl: spotifyPlaylist.ownerUrl,
+        totalTracks: 1,
+        tracks: [
+          {
+            name: "Midnight City",
+            artists: [{ name: "M83", url: "https://open.spotify.com/artist/m83" }],
+            album: 'Hurry Up, We"re Dreaming',
+            duration: 250_000,
+            trackUrl: "https://open.spotify.com/track/midnight-city",
+            albumUrl: "https://open.spotify.com/album/hurry-up",
+          },
+        ],
+      },
+    });
+    await page.route("**/api/playlist", async (route) => {
+      if (route.request().method() === "POST") {
+        createdPayload = route.request().postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(
+            buildPlaylist({
+              id: "created-playlist-1",
+              spotifyUrl: spotifyPlaylist.spotifyUrl,
+              name: spotifyPlaylist.name,
+            }),
+          ),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+    });
+
+    await page.goto(`/preview?url=${encodeURIComponent(spotifyPlaylist.spotifyUrl)}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByTitle("Download Playlist").click();
+
+    await expect
+      .poll(() => createdPayload)
+      .toEqual({
+        kind: "spotifyUrl",
+        spotifyUrl: spotifyPlaylist.spotifyUrl,
+      });
+  });
+
+  test("fires the subscribe trigger by creating and updating the mocked playlist", async ({
+    page,
+  }) => {
+    let createdPayload: unknown = null;
+    let updatedPayload: unknown = null;
+
+    await installPlaylistMocks(page, {
+      myPlaylists: [spotifyPlaylist],
+      playlists: [],
+      preview: {
+        name: spotifyPlaylist.name,
+        type: "playlist",
+        description: "A mocked preview playlist.",
+        coverUrl: null,
+        owner: spotifyPlaylist.owner,
+        ownerUrl: spotifyPlaylist.ownerUrl,
+        totalTracks: 1,
+        tracks: [
+          {
+            name: "Midnight City",
+            artists: [{ name: "M83", url: "https://open.spotify.com/artist/m83" }],
+            album: 'Hurry Up, We"re Dreaming',
+            duration: 250_000,
+            trackUrl: "https://open.spotify.com/track/midnight-city",
+            albumUrl: "https://open.spotify.com/album/hurry-up",
+          },
+        ],
+      },
+    });
+    await page.route("**/api/playlist", async (route) => {
+      if (route.request().method() === "POST") {
+        createdPayload = route.request().postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(
+            buildPlaylist({
+              id: "created-playlist-2",
+              spotifyUrl: spotifyPlaylist.spotifyUrl,
+              name: spotifyPlaylist.name,
+            }),
+          ),
+        });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+    });
+    await page.route("**/api/playlist/created-playlist-2", async (route) => {
+      updatedPayload = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.goto(`/preview?url=${encodeURIComponent(spotifyPlaylist.spotifyUrl)}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.getByRole("button", { name: "Subscribe" }).click();
+
+    await expect
+      .poll(() => createdPayload)
+      .toEqual({
+        kind: "spotifyUrl",
+        spotifyUrl: spotifyPlaylist.spotifyUrl,
+      });
+    await expect
+      .poll(() => updatedPayload)
+      .toEqual({
+        subscribed: true,
+      });
+  });
+});

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -58,6 +58,12 @@ interface MockLibraryOptions {
   artists?: LibraryArtist[];
   artistDetail?: LibraryArtist;
   artworkBackfillStatus?: ArtworkBackfillStatusResponse;
+  gates?: {
+    stats?: Promise<void>;
+    artists?: Promise<void>;
+    artistDetail?: Promise<void>;
+    artworkBackfillStatus?: Promise<void>;
+  };
 }
 
 interface MockPlaylistOptions {
@@ -221,8 +227,14 @@ const fulfillJson = async (
   });
 };
 
-const registerJsonRoute = async (page: Page, pathname: string, body: unknown): Promise<void> => {
+const registerJsonRoute = async (
+  page: Page,
+  pathname: string,
+  body: unknown,
+  gate?: Promise<void>,
+): Promise<void> => {
   await page.route(`**${buildApiUrl(pathname)}`, async (route) => {
+    await gate;
     await fulfillJson(route, body);
   });
 };
@@ -411,14 +423,25 @@ export async function installLibraryMocks(
     artists = [buildLibraryArtist()],
     artistDetail = artists[0] ?? buildLibraryArtist(),
     artworkBackfillStatus = ARTWORK_BACKFILL_STATUS_PAYLOAD.data,
+    gates = {},
   }: MockLibraryOptions = {},
 ): Promise<void> {
-  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/stats`, { data: stats });
-  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/artists`, { data: artists });
-  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/artists/**`, { data: artistDetail });
-  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/artwork-backfill/status`, {
-    data: artworkBackfillStatus,
-  });
+  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/stats`, { data: stats }, gates.stats);
+  await registerJsonRoute(page, `${ApiRoutes.LIBRARY}/artists`, { data: artists }, gates.artists);
+  await registerJsonRoute(
+    page,
+    `${ApiRoutes.LIBRARY}/artists/**`,
+    { data: artistDetail },
+    gates.artistDetail,
+  );
+  await registerJsonRoute(
+    page,
+    `${ApiRoutes.LIBRARY}/artwork-backfill/status`,
+    {
+      data: artworkBackfillStatus,
+    },
+    gates.artworkBackfillStatus,
+  );
 }
 
 export async function installPlaylistMocks(

--- a/apps/frontend/tests/runtime/api-mocks.test.ts
+++ b/apps/frontend/tests/runtime/api-mocks.test.ts
@@ -156,6 +156,50 @@ describe("api mock installers", () => {
     ).resolves.toMatchObject({ data: artist });
   });
 
+  test("waits for explicit gate release before fulfilling selected library routes", async () => {
+    const { page, routes } = createRouteRecorder();
+    const releaseGate = Promise.withResolvers<void>();
+
+    await installLibraryMocks(page, {
+      gates: {
+        artists: releaseGate.promise,
+        stats: releaseGate.promise,
+      },
+    });
+
+    const statsResponse = invokeJsonRoute(
+      routes[0]!.handler,
+      "http://127.0.0.1:4173/api/library/stats",
+    );
+
+    const artistsResponse = invokeJsonRoute(
+      routes[1]!.handler,
+      "http://127.0.0.1:4173/api/library/artists",
+    );
+
+    await expect(
+      Promise.race([
+        statsResponse.then(() => "settled"),
+        new Promise((resolve) => setTimeout(() => resolve("pending"), 10)),
+      ]),
+    ).resolves.toBe("pending");
+    await expect(
+      Promise.race([
+        artistsResponse.then(() => "settled"),
+        new Promise((resolve) => setTimeout(() => resolve("pending"), 10)),
+      ]),
+    ).resolves.toBe("pending");
+
+    releaseGate.resolve();
+
+    await expect(statsResponse).resolves.toMatchObject({
+      data: { totalAlbums: 1, totalArtists: 1, totalTracks: 1 },
+    });
+    await expect(artistsResponse).resolves.toMatchObject({
+      data: [expect.objectContaining({ name: "Library Artist" })],
+    });
+  });
+
   test("installs playlist and history routes with the exact response envelopes", async () => {
     const { page, routes } = createRouteRecorder();
     const playlist = buildPlaylist();


### PR DESCRIPTION
Closes #92

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds mocked Playwright coverage for Home, Activity, Artists, and My Playlists.
- Uses PR1 shared API mock helpers and hermetic mocked fixture guardrails.
- Replaces fixed loading-state delay with deterministic route gating to avoid CI flake.

## Changes
| File | Change |
|------|--------|
| `apps/frontend/tests/e2e/mocked/home.spec.ts` | Covers Home heading, empty state, and deterministic loading state. |
| `apps/frontend/tests/e2e/mocked/activity.spec.ts` | Covers Activity feed rendering and empty state. |
| `apps/frontend/tests/e2e/mocked/artists.spec.ts` | Covers followed artists rendering and artist search fallback. |
| `apps/frontend/tests/e2e/mocked/playlists.spec.ts` | Covers My Playlists list, preview navigation, and creation trigger requests. |
| `apps/frontend/tests/helpers/api-mocks.ts` | Adds route-gating support for deterministic loading-state tests. |
| `apps/frontend/tests/runtime/api-mocks.test.ts` | Adds runtime coverage for gated library mock fulfillment. |

## Test Plan
- [x] `pnpm exec playwright test tests/e2e/mocked/home.spec.ts tests/e2e/mocked/activity.spec.ts tests/e2e/mocked/artists.spec.ts tests/e2e/mocked/playlists.spec.ts --project mocked`
- [x] `pnpm exec vitest run --config vitest.playwright.config.ts tests/runtime/api-mocks.test.ts`
- [x] Fresh SDD verify PR2: no CRITICAL/WARNING blockers

## Chained PR Context
This is PR 2 of the approved `feature-branch-chain` for `e2e-route-coverage`.
Base branch: `test/e2e-route-coverage`.
Previous merged slice: #93.
Next slice: detail views and player coverage.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers