### PR TITLE
feat(player): queue side panel drag-to-reorder (Slice B)

### DIFF
--- a/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
@@ -10,6 +10,7 @@ const mockStore = vi.hoisted(() => ({
   isQueuePanelOpen: false,
   setQueuePanelOpen: vi.fn(),
   playFromIndex: vi.fn(),
+  reorderQueue: vi.fn(),
 }));
 
 vi.mock("@/store/usePlayerStore", () => ({
@@ -53,6 +54,16 @@ function resetMock() {
   mockStore.isQueuePanelOpen = false;
   mockStore.setQueuePanelOpen = vi.fn();
   mockStore.playFromIndex = vi.fn();
+  mockStore.reorderQueue = vi.fn();
+}
+
+function makeDragTransfer(data = "") {
+  return {
+    setData: vi.fn(),
+    getData: vi.fn().mockReturnValue(data),
+    effectAllowed: "",
+    dropEffect: "",
+  };
 }
 
 beforeEach(resetMock);
@@ -246,5 +257,123 @@ describe("backdrop propagation (S7-4)", () => {
     const backdrop = screen.getByTestId("queue-backdrop");
     fireEvent.click(backdrop);
     expect(outerClick).not.toHaveBeenCalled();
+  });
+});
+
+describe("drag and drop", () => {
+  beforeEach(() => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b"), makeItem("c")];
+    mockStore.currentIndex = 0;
+  });
+
+  it('dragstart on row N sets dataTransfer text/plain to "N"', () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[2]!, { dataTransfer: dt });
+    expect(dt.setData).toHaveBeenCalledWith("text/plain", "2");
+  });
+
+  it('dragstart sets effectAllowed to "move"', () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[1]!, { dataTransfer: dt });
+    expect(dt.effectAllowed).toBe("move");
+  });
+
+  it("dragover calls preventDefault", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const event = new Event("dragover", { bubbles: true, cancelable: true });
+    const preventDefaultSpy = vi.spyOn(event, "preventDefault");
+    rows[0]!.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it("drop on row M after dragstart on row N calls reorderQueue(N, M)", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dtStart = makeDragTransfer();
+    fireEvent.dragStart(rows[1]!, { dataTransfer: dtStart });
+
+    const dtDrop = makeDragTransfer("1");
+    fireEvent.drop(rows[2]!, { dataTransfer: dtDrop });
+    expect(mockStore.reorderQueue).toHaveBeenCalledWith(1, 2);
+  });
+
+  it("dragged row gets opacity-50 class after dragstart", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[0]!, { dataTransfer: dt });
+    expect(rows[0]!.className).toContain("opacity-50");
+  });
+
+  it("dragged row loses opacity-50 class after dragend", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[0]!, { dataTransfer: dt });
+    fireEvent.dragEnd(rows[0]!);
+    expect(rows[0]!.className).not.toContain("opacity-50");
+  });
+
+  it("drop target row gets border-t-2 class during dragover", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dtStart = makeDragTransfer();
+    fireEvent.dragStart(rows[0]!, { dataTransfer: dtStart });
+
+    const dtOver = makeDragTransfer();
+    fireEvent.dragOver(rows[2]!, { dataTransfer: dtOver });
+    expect(rows[2]!.className).toContain("border-t-2");
+  });
+
+  it("drop target row loses border-t-2 class after dragend", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dtStart = makeDragTransfer();
+    fireEvent.dragStart(rows[0]!, { dataTransfer: dtStart });
+    fireEvent.dragOver(rows[2]!, { dataTransfer: dtStart });
+    fireEvent.dragEnd(rows[0]!);
+    expect(rows[2]!.className).not.toContain("border-t-2");
+  });
+
+  it("drop with non-numeric dataTransfer is no-op (NaN guard)", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dtDrop = makeDragTransfer("not-a-number");
+    fireEvent.drop(rows[0]!, { dataTransfer: dtDrop });
+    expect(mockStore.reorderQueue).not.toHaveBeenCalled();
+  });
+
+  it("dragend without drop clears all drag visual state", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[1]!, { dataTransfer: dt });
+    fireEvent.dragOver(rows[2]!, { dataTransfer: dt });
+    fireEvent.dragEnd(rows[1]!);
+    expect(rows[1]!.className).not.toContain("opacity-50");
+    expect(rows[2]!.className).not.toContain("border-t-2");
+  });
+
+  it("ESC closes panel after drag interaction", () => {
+    render(<QueueSidePanel />);
+    const rows = screen.getAllByRole("listitem");
+    const dt = makeDragTransfer();
+    fireEvent.dragStart(rows[0]!, { dataTransfer: dt });
+    fireEvent.dragEnd(rows[0]!);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(mockStore.setQueuePanelOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("click on row still triggers playFromIndex after DnD is wired", () => {
+    render(<QueueSidePanel />);
+    const buttons = screen.getAllByRole("button").filter((b) => /Track/i.test(b.textContent ?? ""));
+    fireEvent.click(buttons[1]!);
+    expect(mockStore.playFromIndex).toHaveBeenCalledWith(1);
   });
 });

--- a/apps/frontend/src/components/organisms/QueueSidePanel.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.tsx
@@ -112,7 +112,7 @@ export const QueueSidePanel: FC = () => {
                     }}
                     onDragOver={(e) => {
                       e.preventDefault();
-                      e.dataTransfer.dropEffect = "move";
+                      if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
                       if (dragOverIndex !== index) setDragOverIndex(index);
                     }}
                     onDragLeave={(e) => {

--- a/apps/frontend/src/components/organisms/QueueSidePanel.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.tsx
@@ -1,6 +1,6 @@
 import { faShuffle, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useEffect, useRef } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
@@ -8,6 +8,8 @@ import { cn } from "@/utils/cn";
 export const QueueSidePanel: FC = () => {
   const { t } = useTranslation();
   const activeRowRef = useRef<HTMLLIElement>(null);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
@@ -16,6 +18,7 @@ export const QueueSidePanel: FC = () => {
   const isQueuePanelOpen = usePlayerStore((s) => s.isQueuePanelOpen);
   const setQueuePanelOpen = usePlayerStore((s) => s.setQueuePanelOpen);
   const playFromIndex = usePlayerStore((s) => s.playFromIndex);
+  const reorderQueue = usePlayerStore((s) => s.reorderQueue);
 
   useEffect(() => {
     if (!isQueuePanelOpen) return;
@@ -89,11 +92,45 @@ export const QueueSidePanel: FC = () => {
             <ul className="py-2">
               {queue.map((item, index) => {
                 const isCurrent = index === currentIndex;
+                const isDragging = draggingIndex === index;
+                const isDropTarget = dragOverIndex === index && draggingIndex !== index;
                 return (
                   <li
                     key={item.id}
                     ref={isCurrent ? activeRowRef : undefined}
                     aria-current={isCurrent ? "true" : undefined}
+                    draggable
+                    className={cn(
+                      isDragging && "cursor-grabbing opacity-50",
+                      isDropTarget && "border-t-2 border-green-500",
+                      !isDragging && "cursor-grab",
+                    )}
+                    onDragStart={(e) => {
+                      e.dataTransfer.setData("text/plain", String(index));
+                      e.dataTransfer.effectAllowed = "move";
+                      setDraggingIndex(index);
+                    }}
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      e.dataTransfer.dropEffect = "move";
+                      if (dragOverIndex !== index) setDragOverIndex(index);
+                    }}
+                    onDragLeave={(e) => {
+                      if (e.currentTarget === e.target) setDragOverIndex(null);
+                    }}
+                    onDrop={(e) => {
+                      e.preventDefault();
+                      const raw = e.dataTransfer.getData("text/plain");
+                      const fromIndex = Number(raw);
+                      setDraggingIndex(null);
+                      setDragOverIndex(null);
+                      if (Number.isNaN(fromIndex)) return;
+                      reorderQueue(fromIndex, index);
+                    }}
+                    onDragEnd={() => {
+                      setDraggingIndex(null);
+                      setDragOverIndex(null);
+                    }}
                   >
                     <button
                       type="button"

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -875,6 +875,167 @@ describe("playFromIndex", () => {
 });
 
 // ---------------------------------------------------------------------------
+// reorderQueue
+// ---------------------------------------------------------------------------
+
+describe("reorderQueue", () => {
+  const makeQueue = () => [
+    makeItem("a"),
+    makeItem("b"),
+    makeItem("c"),
+    makeItem("d"),
+    makeItem("e"),
+  ];
+
+  it("moves current track forward → currentIndex equals toIndex", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().reorderQueue(1, 3);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(3);
+    expect(state.queue[3]!.id).toBe("b");
+  });
+
+  it("moves current track backward → currentIndex equals toIndex", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 3);
+    usePlayerStore.getState().reorderQueue(3, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.queue[1]!.id).toBe("d");
+  });
+
+  it("moves track from before current to after current → currentIndex decreases by 1", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().reorderQueue(0, 3);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.queue[1]!.id).toBe("c");
+  });
+
+  it("moves track from before current to exactly currentIndex → currentIndex decreases by 1", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.getState().reorderQueue(0, 2);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.queue[1]!.id).toBe("c");
+  });
+
+  it("moves track from after current to before current → currentIndex increases by 1", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().reorderQueue(3, 0);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(2);
+    expect(state.queue[2]!.id).toBe("b");
+  });
+
+  it("moves track from after current to exactly currentIndex → currentIndex increases by 1", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().reorderQueue(3, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(2);
+    expect(state.queue[2]!.id).toBe("b");
+  });
+
+  it("moves track within before-current segment only → currentIndex unchanged", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 3);
+    usePlayerStore.getState().reorderQueue(0, 1);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(3);
+    expect(state.queue[3]!.id).toBe("d");
+  });
+
+  it("moves track within after-current segment only → currentIndex unchanged", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.getState().reorderQueue(3, 4);
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.queue[1]!.id).toBe("b");
+  });
+
+  it("no-op when fromIndex equals toIndex → queue reference unchanged", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    const queueBefore = usePlayerStore.getState().queue;
+    usePlayerStore.getState().reorderQueue(2, 2);
+
+    expect(usePlayerStore.getState().queue).toBe(queueBefore);
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("no-op when fromIndex out of range → queue reference unchanged", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    const queueBefore = usePlayerStore.getState().queue;
+    usePlayerStore.getState().reorderQueue(-1, 0);
+
+    expect(usePlayerStore.getState().queue).toBe(queueBefore);
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("no-op when toIndex out of range → queue reference unchanged", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    const queueBefore = usePlayerStore.getState().queue;
+    usePlayerStore.getState().reorderQueue(0, 10);
+
+    expect(usePlayerStore.getState().queue).toBe(queueBefore);
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+  });
+
+  it("shuffleMode true: shuffleOrder pinned at new currentIndex, shuffleOrderIndex reset to 0", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ shuffleMode: true });
+    usePlayerStore.getState().reorderQueue(3, 0);
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrder).toHaveLength(5);
+    expect(state.shuffleOrder[0]).toBe(state.currentIndex);
+    expect(state.shuffleOrderIndex).toBe(0);
+  });
+
+  it("shuffleMode false: shuffleOrder untouched after reorder", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ shuffleOrder: [1, 3, 0, 4, 2], shuffleOrderIndex: 1 });
+    const orderBefore = usePlayerStore.getState().shuffleOrder.slice();
+    usePlayerStore.getState().reorderQueue(0, 3);
+
+    const state = usePlayerStore.getState();
+    expect(state.shuffleOrder).toEqual(orderBefore);
+    expect(state.shuffleOrderIndex).toBe(1);
+  });
+
+  it("isPlaying, currentTime, duration unchanged after valid reorder", () => {
+    const items = makeQueue();
+    usePlayerStore.getState().playQueue(items, 2);
+    usePlayerStore.setState({ currentTime: 42, duration: 200 });
+
+    usePlayerStore.getState().reorderQueue(0, 4);
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(true);
+    expect(state.currentTime).toBe(42);
+    expect(state.duration).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -55,6 +55,8 @@ export interface PlayerState {
   setQueuePanelOpen: (open: boolean) => void;
   playFromIndex: (index: number) => void;
 
+  reorderQueue: (fromIndex: number, toIndex: number) => void;
+
   setAudioElement: (el: HTMLAudioElement | null) => void;
   _onLoadedMetadata: (duration: number) => void;
   _onTimeUpdate: (currentTime: number) => void;
@@ -320,6 +322,39 @@ export const usePlayerStore = create<PlayerState>()(
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {
             const order = shuffleIndices(queue.length, index);
+            set({ shuffleOrder: order, shuffleOrderIndex: 0 });
+          }
+        },
+
+        reorderQueue(fromIndex, toIndex) {
+          const { queue, currentIndex, shuffleMode } = get();
+          const len = queue.length;
+
+          if (fromIndex === toIndex) return;
+          if (fromIndex < 0 || fromIndex >= len) return;
+          if (toIndex < 0 || toIndex >= len) return;
+
+          const nextQueue = queue.slice();
+          const [moved] = nextQueue.splice(fromIndex, 1);
+          nextQueue.splice(toIndex, 0, moved!);
+
+          // ADR-1: 4-scenario currentIndex arithmetic
+          let nextCurrentIndex = currentIndex;
+          if (currentIndex !== null) {
+            if (fromIndex === currentIndex) {
+              nextCurrentIndex = toIndex; // (1) moved the current track
+            } else if (fromIndex < currentIndex && toIndex >= currentIndex) {
+              nextCurrentIndex = currentIndex - 1; // (2) before → at/after current
+            } else if (fromIndex > currentIndex && toIndex <= currentIndex) {
+              nextCurrentIndex = currentIndex + 1; // (3) after → at/before current
+            }
+            // (4) both on same side → unchanged
+          }
+
+          set({ queue: nextQueue, currentIndex: nextCurrentIndex });
+
+          if (shuffleMode && nextCurrentIndex !== null) {
+            const order = shuffleIndices(nextQueue.length, nextCurrentIndex);
             set({ shuffleOrder: order, shuffleOrderIndex: 0 });
           }
         },


### PR DESCRIPTION
## Summary

- Adds `reorderQueue(fromIndex, toIndex)` action to `usePlayerStore` with correct `currentIndex` arithmetic across 4 scenarios (drag current, drag before current, drag after current, drag unrelated) plus shuffle recomputation pinned at new currentIndex.
- Wires HTML5 native drag-and-drop on `QueueSidePanel` rows (`dragstart` / `dragover` / `drop`) with visual feedback (opacity on dragged row, top-border drop indicator on target).
- Touch reorder explicitly deferred to a future mobile-fullscreen slice (Option A from SDD proposal).

## SDD trail (engram)

- proposal #3278, spec #3279, design #3280, tasks #3281, apply-progress #3282, verify #3283, archive #3284.

## Test plan

- [x] `pnpm --filter frontend test:run` — 365/365 passing (14 new store tests + 12 new panel DnD tests)
- [x] `pnpm --filter frontend lint` — clean
- [x] `pnpm --filter frontend build` — clean
- [ ] Manual: drag a track in the queue panel — verify reorder, currentIndex stays correct, shuffle still works after reorder

## Known limitations

- HTML5 native DnD does not support touch. Mobile reorder will land with the upcoming mobile fullscreen now-playing slice.