### PR TITLE
feat(player): mobile fullscreen now-playing with touch reorder

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -31,6 +31,10 @@ vi.mock("./QueueSidePanel", () => ({
   QueueSidePanel: () => null,
 }));
 
+vi.mock("./NowPlayingFullscreen", () => ({
+  NowPlayingFullscreen: () => null,
+}));
+
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
   return {
@@ -46,6 +50,10 @@ vi.mock("react-i18next", async () => {
           "player.queue.repeatAll": "Repeat all",
           "player.queue.repeatOne": "Repeat one",
           "player.queue.shuffleOn": "Shuffle on",
+          "player.nowPlaying.open": "Open Now Playing",
+          "player.nowPlaying.close": "Close",
+          "player.nowPlaying.title": "Now Playing",
+          "player.nowPlaying.queueLabel": "Queue",
         };
         return map[key] ?? key;
       },
@@ -148,8 +156,8 @@ describe("track metadata", () => {
 
     render(<GlobalPlayerBar />);
 
-    expect(screen.getByText("Track a")).not.toBeNull();
-    expect(screen.getByText("Artist a")).not.toBeNull();
+    expect(screen.getAllByText("Track a").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Artist a").length).toBeGreaterThan(0);
   });
 
   it("shows artwork when artworkUrl is provided", () => {
@@ -157,8 +165,8 @@ describe("track metadata", () => {
 
     render(<GlobalPlayerBar />);
 
-    const img = screen.queryByRole("img", { name: /Track a/i });
-    expect(img).not.toBeNull();
+    const imgs = screen.queryAllByRole("img", { name: /Track a/i });
+    expect(imgs.length).toBeGreaterThan(0);
   });
 
   it("shows placeholder when artworkUrl is missing", () => {
@@ -454,16 +462,16 @@ describe("TrackMeta navigation", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/playlist/abc?mode=library");
   });
 
-  it("[T2.7] renders as non-interactive div when contextPath is absent", () => {
+  it("[T2.7] desktop TrackMeta renders as non-interactive div when contextPath is absent", () => {
     const item = makeItem("y"); // no contextPath
     usePlayerStore.getState().playQueue([item], 0);
 
     render(<GlobalPlayerBar />);
 
-    // No button with navigate aria-label
-    expect(screen.queryByRole("button", { name: /Open Track y/ })).toBeNull();
-    // Track name still visible
-    expect(screen.getByText("Track y")).not.toBeNull();
+    // No navigate button (contextPath-based) — only the mobile now-playing trigger
+    expect(screen.queryByRole("button", { name: /Open Track y by Artist y/ })).toBeNull();
+    // Track name still visible (rendered in mobile button)
+    expect(screen.getAllByText("Track y").length).toBeGreaterThan(0);
   });
 });
 
@@ -760,5 +768,66 @@ describe("isAtFirst / isAtLast with modes", () => {
 
     const prevBtn = screen.getByRole("button", { name: "Previous track" });
     expect(prevBtn).toHaveProperty("disabled", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mobile now-playing trigger (Tasks 2 / S2 / S6)
+// ---------------------------------------------------------------------------
+
+describe("mobile now-playing trigger", () => {
+  it("renders mobile trigger button with aria-label 'Open Now Playing'", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    expect(screen.getByRole("button", { name: "Open Now Playing" })).not.toBeNull();
+  });
+
+  it("mobile trigger button has md:hidden class", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open Now Playing" });
+    expect(btn.className).toContain("md:hidden");
+  });
+
+  it("clicking mobile trigger calls setNowPlayingOpen(true)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Now Playing" }));
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(true);
+  });
+
+  it("aria-pressed on mobile trigger reflects isNowPlayingOpen", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open Now Playing" });
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("desktop TrackMeta wrapper has hidden md:flex classes", () => {
+    const item = makeItemWithContext("x", "/playlist/abc?mode=library");
+    usePlayerStore.getState().playQueue([item], 0);
+    render(<GlobalPlayerBar />);
+
+    const navBtn = screen.getByRole("button", { name: /Open Track x by Artist x/ });
+    const wrapper = navBtn.closest("div");
+    expect(wrapper?.className).toContain("hidden");
+    expect(wrapper?.className).toContain("md:flex");
+  });
+
+  it("focus returns to mobile trigger when isNowPlayingOpen transitions true → false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { rerender } = render(<GlobalPlayerBar />);
+
+    usePlayerStore.setState({ isNowPlayingOpen: false });
+    rerender(<GlobalPlayerBar />);
+
+    const btn = screen.getByRole("button", { name: "Open Now Playing" });
+    expect(document.activeElement).toBe(btn);
   });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -19,6 +19,7 @@ import type { QueueItem } from "@/store/usePlayerStore";
 import { usePreferencesStore } from "@/store/usePreferencesStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
+import { NowPlayingFullscreen } from "./NowPlayingFullscreen";
 import { QueueSidePanel } from "./QueueSidePanel";
 
 function formatSeconds(seconds: number): string {
@@ -151,6 +152,8 @@ export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const wasOpenRef = useRef(false);
+  const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
+  const wasNowPlayingOpenRef = useRef(false);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
@@ -159,6 +162,8 @@ export const GlobalPlayerBar: FC = () => {
   const currentIndex = usePlayerStore((s) => s.currentIndex);
   const isQueuePanelOpen = usePlayerStore((s) => s.isQueuePanelOpen);
   const setQueuePanelOpen = usePlayerStore((s) => s.setQueuePanelOpen);
+  const isNowPlayingOpen = usePlayerStore((s) => s.isNowPlayingOpen);
+  const setNowPlayingOpen = usePlayerStore((s) => s.setNowPlayingOpen);
   const isPlaying = usePlayerStore((s) => s.isPlaying);
   const error = usePlayerStore((s) => s.error);
   const shuffleMode = usePlayerStore((s) => s.shuffleMode);
@@ -264,6 +269,13 @@ export const GlobalPlayerBar: FC = () => {
     wasOpenRef.current = isQueuePanelOpen;
   }, [isQueuePanelOpen]);
 
+  useEffect(() => {
+    if (wasNowPlayingOpenRef.current && !isNowPlayingOpen) {
+      nowPlayingTriggerRef.current?.focus();
+    }
+    wasNowPlayingOpenRef.current = isNowPlayingOpen;
+  }, [isNowPlayingOpen]);
+
   const isVisible = currentIndex !== null || !!error;
   const isAtFirst =
     !shuffleMode && repeatMode !== "all" && (currentIndex === null || currentIndex <= 0);
@@ -289,6 +301,7 @@ export const GlobalPlayerBar: FC = () => {
     <>
       <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
       <QueueSidePanel />
+      <NowPlayingFullscreen />
 
       {isVisible && (
         <section
@@ -307,7 +320,21 @@ export const GlobalPlayerBar: FC = () => {
               {error ? (
                 <span className="text-sm text-red-400">{error}</span>
               ) : currentItem ? (
-                <TrackMeta item={currentItem} onNavigate={navigate} />
+                <>
+                  <button
+                    type="button"
+                    ref={nowPlayingTriggerRef}
+                    aria-label={t("player.nowPlaying.open")}
+                    aria-pressed={isNowPlayingOpen}
+                    onClick={() => setNowPlayingOpen(true)}
+                    className="flex min-w-0 items-center gap-3 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 md:hidden"
+                  >
+                    <TrackMetaContent item={currentItem} />
+                  </button>
+                  <div className="hidden min-w-0 md:flex">
+                    <TrackMeta item={currentItem} onNavigate={navigate} />
+                  </div>
+                </>
               ) : null}
             </div>
 

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.test.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.test.tsx
@@ -1,0 +1,407 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { NowPlayingFullscreen } from "./NowPlayingFullscreen";
+
+vi.mock("react-i18next", async () => {
+  const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) => {
+        const map: Record<string, string> = {
+          "player.nowPlaying.title": "Now Playing",
+          "player.nowPlaying.open": "Open Now Playing",
+          "player.nowPlaying.close": "Close",
+          "player.nowPlaying.queueLabel": "Queue",
+        };
+        if (key === "player.nowPlaying.dragHandle" && opts?.name) {
+          return `Drag to reorder ${opts.name as string}`;
+        }
+        return map[key] ?? key;
+      },
+    }),
+  };
+});
+
+HTMLElement.prototype.setPointerCapture = vi.fn();
+HTMLElement.prototype.releasePointerCapture = vi.fn();
+
+// jsdom does not implement elementFromPoint — define it so spies work
+if (!document.elementFromPoint) {
+  document.elementFromPoint = () => null;
+}
+
+const makeItem = (id: string, audioUrl = `/api/library/audio?id=${id}`) => ({
+  id,
+  name: `Track ${id}`,
+  artist: `Artist ${id}`,
+  artworkUrl: `https://example.com/art/${id}.jpg`,
+  audioUrl,
+  durationMs: 180_000,
+});
+
+function resetStore() {
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: null,
+    isPlaying: false,
+    volume: 1,
+    isMuted: false,
+    currentTime: 0,
+    duration: 180,
+    error: null,
+    shuffleMode: false,
+    repeatMode: "off",
+    shuffleOrder: [],
+    shuffleOrderIndex: -1,
+    isNowPlayingOpen: false,
+    isQueuePanelOpen: false,
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  resetStore();
+});
+
+// ---------------------------------------------------------------------------
+// Tests 11–25: NowPlayingFullscreen shell
+// ---------------------------------------------------------------------------
+
+describe("NowPlayingFullscreen shell", () => {
+  it("11. renders role=dialog with non-empty aria-label", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<NowPlayingFullscreen />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).not.toBeNull();
+    expect(dialog.getAttribute("aria-label")).toBeTruthy();
+  });
+
+  it("12. renders blurred backdrop img with aria-hidden when artworkUrl exists", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const backdrop = container.querySelector("img[aria-hidden='true']");
+    expect(backdrop).not.toBeNull();
+  });
+
+  it("13. renders track name and artist from currentItem", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<NowPlayingFullscreen />);
+
+    expect(screen.getAllByText("Track a").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Artist a").length).toBeGreaterThan(0);
+  });
+
+  it("14. renders transport buttons; clicking play/pause calls togglePlay", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true, isPlaying: false });
+    render(<NowPlayingFullscreen />);
+
+    const playBtn = screen.getByRole("button", { name: "Play" });
+    expect(playBtn).not.toBeNull();
+    fireEvent.click(playBtn);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("15. renders seek scrubber wired to currentTime/duration; change calls seek", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true, currentTime: 30, duration: 180 });
+    render(<NowPlayingFullscreen />);
+
+    const slider = screen.getByRole("slider", { name: "Seek" });
+    expect(slider).not.toBeNull();
+    fireEvent.change(slider, { target: { value: "90" } });
+    expect(usePlayerStore.getState().currentTime).toBe(90);
+  });
+
+  it("16. renders queue rows; row count matches queue.length", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const rows = container.querySelectorAll("li");
+    expect(rows.length).toBe(3);
+  });
+
+  it("17. active row at currentIndex carries aria-current=true", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const rows = container.querySelectorAll("li");
+    expect(rows[1]?.getAttribute("aria-current")).toBe("true");
+    expect(rows[0]?.getAttribute("aria-current")).toBeFalsy();
+  });
+
+  it("18. clicking row N calls playFromIndex(N)", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<NowPlayingFullscreen />);
+
+    // click the play button inside row 2 (Track c) - exact match avoids dragHandle label collision
+    const rowBtn = screen.getByRole("button", { name: "Track c" });
+    fireEvent.click(rowBtn);
+    expect(usePlayerStore.getState().currentIndex).toBe(2);
+  });
+
+  it("19. chevron button click calls setNowPlayingOpen(false)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<NowPlayingFullscreen />);
+
+    const closeBtn = screen.getByRole("button", { name: "Close" });
+    fireEvent.click(closeBtn);
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("20. ESC keydown calls setNowPlayingOpen(false) when open", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    render(<NowPlayingFullscreen />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("21. ESC keydown does nothing when isNowPlayingOpen is false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: false });
+    render(<NowPlayingFullscreen />);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("22. root has translate-y-0 when open, translate-y-full when closed", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { rerender } = render(<NowPlayingFullscreen />);
+
+    let dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("translate-y-0");
+
+    usePlayerStore.setState({ isNowPlayingOpen: false });
+    rerender(<NowPlayingFullscreen />);
+    dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("translate-y-full");
+  });
+
+  it("23. root has motion-reduce:transition-none class", () => {
+    render(<NowPlayingFullscreen />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("motion-reduce:transition-none");
+  });
+
+  it("24. focus moves to close button when isNowPlayingOpen transitions to true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: false });
+    const { rerender } = render(<NowPlayingFullscreen />);
+
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    rerender(<NowPlayingFullscreen />);
+
+    const closeBtn = screen.getByRole("button", { name: "Close" });
+    expect(document.activeElement).toBe(closeBtn);
+  });
+
+  it("25. root carries md:hidden class", () => {
+    render(<NowPlayingFullscreen />);
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.className).toContain("md:hidden");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests 26–31: Touch reorder via Pointer Events
+// ---------------------------------------------------------------------------
+
+describe("touch reorder", () => {
+  beforeEach(() => {
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(null);
+  });
+
+  it("26. pointerdown on drag handle sets opacity-50 on dragging row", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const handles = container.querySelectorAll("[data-drag-handle]");
+    act(() => {
+      fireEvent.pointerDown(handles[0]!, { clientX: 0, clientY: 0, pointerId: 1 });
+    });
+
+    const rows = container.querySelectorAll("li");
+    expect(rows[0]?.className).toContain("opacity-50");
+  });
+
+  it("27. pointermove over another row shows border-t-2 on hovered row", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const rows = container.querySelectorAll("li");
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(rows[1] as Element);
+
+    const handles = container.querySelectorAll("[data-drag-handle]");
+    act(() => {
+      fireEvent.pointerDown(handles[0]!, { clientX: 0, clientY: 0, pointerId: 1 });
+      fireEvent.pointerMove(handles[0]!, { clientX: 0, clientY: 60, pointerId: 1 });
+    });
+
+    expect(rows[1]?.className).toContain("border-t-2");
+  });
+
+  it("28. pointerup after move calls reorderQueue(fromIndex, dragOverIndex)", () => {
+    const reorderSpy = vi.fn();
+    usePlayerStore.setState({ reorderQueue: reorderSpy } as unknown as Parameters<
+      typeof usePlayerStore.setState
+    >[0]);
+
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const rows = container.querySelectorAll("li");
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(rows[2] as Element);
+
+    const handles = container.querySelectorAll("[data-drag-handle]");
+    act(() => {
+      fireEvent.pointerDown(handles[0]!, { clientX: 0, clientY: 0, pointerId: 1 });
+      fireEvent.pointerMove(handles[0]!, { clientX: 0, clientY: 60, pointerId: 1 });
+      fireEvent.pointerUp(handles[0]!, { clientX: 0, clientY: 60, pointerId: 1 });
+    });
+
+    expect(reorderSpy).toHaveBeenCalledWith(0, 2);
+  });
+
+  it("29. pointercancel clears state without calling reorderQueue", () => {
+    const reorderSpy = vi.fn();
+    usePlayerStore.setState({ reorderQueue: reorderSpy } as unknown as Parameters<
+      typeof usePlayerStore.setState
+    >[0]);
+
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const handles = container.querySelectorAll("[data-drag-handle]");
+    act(() => {
+      fireEvent.pointerDown(handles[0]!, { clientX: 0, clientY: 0, pointerId: 1 });
+      fireEvent.pointerCancel(handles[0]!, { pointerId: 1 });
+    });
+
+    expect(reorderSpy).not.toHaveBeenCalled();
+    const rows = container.querySelectorAll("li");
+    expect(rows[0]?.className).not.toContain("opacity-50");
+  });
+
+  it("30. pointerup with from === to does NOT call reorderQueue", () => {
+    const reorderSpy = vi.fn();
+    usePlayerStore.setState({ reorderQueue: reorderSpy } as unknown as Parameters<
+      typeof usePlayerStore.setState
+    >[0]);
+
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const rows = container.querySelectorAll("li");
+    vi.spyOn(document, "elementFromPoint").mockReturnValue(rows[0] as Element);
+
+    const handles = container.querySelectorAll("[data-drag-handle]");
+    act(() => {
+      fireEvent.pointerDown(handles[0]!, { clientX: 0, clientY: 0, pointerId: 1 });
+      fireEvent.pointerMove(handles[0]!, { clientX: 0, clientY: 5, pointerId: 1 });
+      fireEvent.pointerUp(handles[0]!, { clientX: 0, clientY: 5, pointerId: 1 });
+    });
+
+    expect(reorderSpy).not.toHaveBeenCalled();
+  });
+
+  it("31. drag handle has touch-action: none style and non-empty aria-label", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const handle = container.querySelector("[data-drag-handle]") as HTMLElement;
+    expect(handle).not.toBeNull();
+    expect(handle.getAttribute("aria-label")).toBeTruthy();
+    expect(handle.style.touchAction).toBe("none");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests 32–34: Swipe-down close gesture
+// ---------------------------------------------------------------------------
+
+describe("swipe-down close", () => {
+  it("32. pointerdown + pointermove 100px down + pointerup closes panel", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const heroZone = container.querySelector("[data-swipe-zone]") as HTMLElement;
+    act(() => {
+      fireEvent.pointerDown(heroZone, { clientX: 100, clientY: 100, pointerId: 1 });
+      fireEvent.pointerMove(heroZone, { clientX: 100, clientY: 200, pointerId: 1 });
+      fireEvent.pointerUp(heroZone, { clientX: 100, clientY: 200, pointerId: 1 });
+    });
+
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("33. pointermove 50px down + pointerup does NOT close (below 80px threshold)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const heroZone = container.querySelector("[data-swipe-zone]") as HTMLElement;
+    act(() => {
+      fireEvent.pointerDown(heroZone, { clientX: 100, clientY: 100, pointerId: 1 });
+      fireEvent.pointerMove(heroZone, { clientX: 100, clientY: 150, pointerId: 1 });
+      fireEvent.pointerUp(heroZone, { clientX: 100, clientY: 150, pointerId: 1 });
+    });
+
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(true);
+  });
+
+  it("34. pointerdown on data-no-swipe ancestor does NOT engage swipe", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isNowPlayingOpen: true });
+    const { container } = render(<NowPlayingFullscreen />);
+
+    const noSwipeEl = container.querySelector("[data-no-swipe]") as HTMLElement;
+    act(() => {
+      fireEvent.pointerDown(noSwipeEl, { clientX: 100, clientY: 100, pointerId: 1 });
+      fireEvent.pointerMove(noSwipeEl, { clientX: 100, clientY: 200, pointerId: 1 });
+      fireEvent.pointerUp(noSwipeEl, { clientX: 100, clientY: 200, pointerId: 1 });
+    });
+
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(true);
+  });
+});

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -1,0 +1,362 @@
+import {
+  faBackwardStep,
+  faChevronDown,
+  faForwardStep,
+  faGripLines,
+  faPause,
+  faPlay,
+  faRepeat,
+  faShuffle,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { cn } from "@/utils/cn";
+import { Image } from "../atoms/Image";
+
+function formatSeconds(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return `${m}:${rem.toString().padStart(2, "0")}`;
+}
+
+export const NowPlayingFullscreen: FC = () => {
+  const { t } = useTranslation();
+
+  const queue = usePlayerStore((s) => s.queue);
+  const currentIndex = usePlayerStore((s) => s.currentIndex);
+  const isPlaying = usePlayerStore((s) => s.isPlaying);
+  const isNowPlayingOpen = usePlayerStore((s) => s.isNowPlayingOpen);
+  const setNowPlayingOpen = usePlayerStore((s) => s.setNowPlayingOpen);
+  const shuffleMode = usePlayerStore((s) => s.shuffleMode);
+  const repeatMode = usePlayerStore((s) => s.repeatMode);
+  const togglePlay = usePlayerStore((s) => s.togglePlay);
+  const next = usePlayerStore((s) => s.next);
+  const prev = usePlayerStore((s) => s.prev);
+  const seek = usePlayerStore((s) => s.seek);
+  const toggleShuffle = usePlayerStore((s) => s.toggleShuffle);
+  const cycleRepeat = usePlayerStore((s) => s.cycleRepeat);
+  const playFromIndex = usePlayerStore((s) => s.playFromIndex);
+  const reorderQueue = usePlayerStore((s) => s.reorderQueue);
+  const currentTime = usePlayerStore((s) => s.currentTime);
+  const duration = usePlayerStore((s) => s.duration);
+
+  const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
+
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // drag state for touch reorder
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const draggingIndexRef = useRef<number | null>(null);
+  const dragOverIndexRef = useRef<number | null>(null);
+
+  // swipe-down state
+  const swipeStartYRef = useRef<number | null>(null);
+  const [dragOffsetY, setDragOffsetY] = useState(0);
+
+  useEffect(() => {
+    if (!isNowPlayingOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setNowPlayingOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isNowPlayingOpen, setNowPlayingOpen]);
+
+  useEffect(() => {
+    if (isNowPlayingOpen) closeButtonRef.current?.focus();
+  }, [isNowPlayingOpen]);
+
+  const pct = duration > 0 ? (currentTime / duration) * 100 : 0;
+
+  const onHandlePointerDown = (e: React.PointerEvent, index: number) => {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    draggingIndexRef.current = index;
+    dragOverIndexRef.current = null;
+    setDraggingIndex(index);
+  };
+
+  const onHandlePointerMove = (e: React.PointerEvent) => {
+    if (draggingIndexRef.current === null) return;
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    const row = el?.closest("[data-row-index]") as HTMLElement | null;
+    const overIndex = row ? Number(row.dataset.rowIndex) : null;
+    if (overIndex !== null && overIndex !== dragOverIndexRef.current) {
+      dragOverIndexRef.current = overIndex;
+      setDragOverIndex(overIndex);
+    }
+  };
+
+  const onHandlePointerUp = (e: React.PointerEvent) => {
+    if (draggingIndexRef.current === null) return;
+    const from = draggingIndexRef.current;
+    const el = document.elementFromPoint(e.clientX, e.clientY);
+    const row = el?.closest("[data-row-index]") as HTMLElement | null;
+    const to = row ? Number(row.dataset.rowIndex) : (dragOverIndexRef.current ?? from);
+    draggingIndexRef.current = null;
+    dragOverIndexRef.current = null;
+    setDraggingIndex(null);
+    setDragOverIndex(null);
+    if (from !== to) reorderQueue(from, to);
+  };
+
+  const onHandlePointerCancel = () => {
+    draggingIndexRef.current = null;
+    dragOverIndexRef.current = null;
+    setDraggingIndex(null);
+    setDragOverIndex(null);
+  };
+
+  const onSwipePointerDown = (e: React.PointerEvent) => {
+    if ((e.target as HTMLElement).closest("[data-no-swipe]")) return;
+    swipeStartYRef.current = e.clientY;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onSwipePointerMove = (e: React.PointerEvent) => {
+    if (swipeStartYRef.current === null) return;
+    const dy = Math.max(0, e.clientY - swipeStartYRef.current);
+    setDragOffsetY(dy);
+  };
+
+  const onSwipePointerUp = (e: React.PointerEvent) => {
+    if (swipeStartYRef.current === null) return;
+    const dy = e.clientY - swipeStartYRef.current;
+    swipeStartYRef.current = null;
+    setDragOffsetY(0);
+    if (dy >= 80) setNowPlayingOpen(false);
+  };
+
+  const shuffleAriaLabel = shuffleMode ? "Disable shuffle" : "Enable shuffle";
+  const repeatAriaLabel =
+    repeatMode === "off" ? "Enable repeat" : repeatMode === "all" ? "Repeat all" : "Repeat one";
+
+  return (
+    <aside
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("player.nowPlaying.title")}
+      className={cn(
+        "fixed inset-0 z-[70] flex flex-col md:hidden",
+        "transition-transform duration-300 motion-reduce:transition-none",
+        isNowPlayingOpen
+          ? "pointer-events-auto translate-y-0"
+          : "pointer-events-none translate-y-full",
+      )}
+      style={
+        dragOffsetY > 0
+          ? { transform: `translateY(${dragOffsetY}px)`, transitionProperty: "none" }
+          : undefined
+      }
+    >
+      {/* blurred backdrop */}
+      <div className="absolute inset-0 -z-10 overflow-hidden">
+        {currentItem?.artworkUrl && (
+          <img
+            src={currentItem.artworkUrl}
+            alt=""
+            aria-hidden="true"
+            className="h-full w-full scale-125 object-cover opacity-70 blur-3xl"
+          />
+        )}
+        <div className="absolute inset-0 bg-black/60" />
+      </div>
+
+      {/* top bar + hero zone (swipe area) */}
+      <div
+        data-swipe-zone
+        onPointerDown={onSwipePointerDown}
+        onPointerMove={onSwipePointerMove}
+        onPointerUp={onSwipePointerUp}
+        onPointerCancel={() => {
+          swipeStartYRef.current = null;
+          setDragOffsetY(0);
+        }}
+        className="flex flex-col"
+      >
+        <header className="flex items-center justify-between px-4 pt-4">
+          <button
+            type="button"
+            ref={closeButtonRef}
+            aria-label={t("player.nowPlaying.close")}
+            onClick={() => setNowPlayingOpen(false)}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-white/80 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"
+          >
+            <FontAwesomeIcon icon={faChevronDown} />
+          </button>
+          <span className="sr-only">{t("player.nowPlaying.title")}</span>
+        </header>
+
+        {/* hero artwork */}
+        <div className="flex flex-1 items-center justify-center px-6 py-4">
+          <div className="aspect-square w-[70vw] max-w-[280px] overflow-hidden rounded-lg shadow-2xl">
+            <Image src={currentItem?.artworkUrl} alt={currentItem?.name ?? ""} />
+          </div>
+        </div>
+
+        {/* track meta */}
+        <div className="px-6 text-center">
+          <div className="truncate text-lg font-semibold text-white">{currentItem?.name}</div>
+          <div className="text-text-secondary truncate text-sm">{currentItem?.artist}</div>
+        </div>
+      </div>
+
+      {/* seek scrubber */}
+      <div className="px-6 py-3">
+        <div className="group flex w-full items-center gap-2">
+          <span className="text-text-secondary w-8 shrink-0 text-right text-xs tabular-nums">
+            {formatSeconds(currentTime)}
+          </span>
+          <input
+            type="range"
+            role="slider"
+            aria-label="Seek"
+            aria-valuemin={0}
+            aria-valuemax={duration}
+            aria-valuenow={currentTime}
+            aria-valuetext={`${formatSeconds(currentTime)} of ${formatSeconds(duration)}`}
+            min={0}
+            max={duration || 1}
+            step={1}
+            value={currentTime}
+            onChange={(e) => seek(Number(e.target.value))}
+            className="h-1 flex-1 cursor-pointer appearance-none rounded-full"
+            style={{
+              background: `linear-gradient(to right, white ${pct}%, rgba(255,255,255,0.3) ${pct}%)`,
+            }}
+          />
+          <span className="text-text-secondary w-8 shrink-0 text-xs tabular-nums">
+            {formatSeconds(duration)}
+          </span>
+        </div>
+      </div>
+
+      {/* transport row */}
+      <div className="flex items-center justify-center gap-6 px-6 pb-4">
+        <button
+          type="button"
+          aria-label={shuffleAriaLabel}
+          onClick={toggleShuffle}
+          className={cn(
+            "flex h-12 w-12 items-center justify-center rounded-full transition-colors",
+            shuffleMode ? "text-green-500" : "text-white/70 hover:text-white",
+          )}
+        >
+          <FontAwesomeIcon icon={faShuffle} />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Previous track"
+          onClick={prev}
+          className="flex h-12 w-12 items-center justify-center rounded-full text-white/70 transition-colors hover:text-white"
+        >
+          <FontAwesomeIcon icon={faBackwardStep} />
+        </button>
+
+        <button
+          type="button"
+          aria-label={isPlaying ? "Pause" : "Play"}
+          aria-pressed={isPlaying}
+          onClick={togglePlay}
+          className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105"
+        >
+          <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} />
+        </button>
+
+        <button
+          type="button"
+          aria-label="Next track"
+          onClick={next}
+          className="flex h-12 w-12 items-center justify-center rounded-full text-white/70 transition-colors hover:text-white"
+        >
+          <FontAwesomeIcon icon={faForwardStep} />
+        </button>
+
+        <button
+          type="button"
+          aria-label={repeatAriaLabel}
+          onClick={cycleRepeat}
+          className={cn(
+            "relative flex h-12 w-12 items-center justify-center rounded-full transition-colors",
+            repeatMode !== "off" ? "text-green-500" : "text-white/70 hover:text-white",
+          )}
+        >
+          <FontAwesomeIcon icon={faRepeat} />
+          {repeatMode === "one" && (
+            <sup className="absolute -top-1 -right-1 text-[0.55rem] leading-none font-bold">1</sup>
+          )}
+        </button>
+      </div>
+
+      {/* inline queue */}
+      <section
+        className="pb-safe flex-1 overflow-y-auto px-4"
+        aria-label={t("player.nowPlaying.queueLabel")}
+        data-no-swipe
+      >
+        <ul>
+          {queue.map((item, index) => (
+            <li
+              key={item.id}
+              data-row-index={index}
+              aria-current={index === currentIndex ? "true" : undefined}
+              className={cn(
+                "flex items-center gap-2 rounded px-2 py-2",
+                index === currentIndex && "bg-white/5 text-green-400",
+                draggingIndex === index && "opacity-50",
+                dragOverIndex === index && draggingIndex !== index && "border-t-2 border-green-500",
+              )}
+            >
+              <button
+                type="button"
+                aria-label={item.name}
+                onClick={() => playFromIndex(index)}
+                className="flex min-w-0 flex-1 items-center gap-2 text-left"
+              >
+                <span className="truncate text-sm text-white">{item.name}</span>
+                <span className="text-text-secondary truncate text-xs">{item.artist}</span>
+              </button>
+
+              <button
+                type="button"
+                aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
+                disabled={index === 0}
+                onClick={() => index > 0 && reorderQueue(index, index - 1)}
+                className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
+                disabled={index === queue.length - 1}
+                onClick={() => index < queue.length - 1 && reorderQueue(index, index + 1)}
+                className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"
+              >
+                ↓
+              </button>
+
+              <span
+                role="button"
+                data-drag-handle
+                aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
+                onPointerDown={(e) => onHandlePointerDown(e, index)}
+                onPointerMove={onHandlePointerMove}
+                onPointerUp={onHandlePointerUp}
+                onPointerCancel={onHandlePointerCancel}
+                className="cursor-grab touch-none p-2 text-white/60 active:cursor-grabbing"
+                style={{ touchAction: "none" }}
+              >
+                <FontAwesomeIcon icon={faGripLines} />
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </aside>
+  );
+};

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -47,13 +47,11 @@ export const NowPlayingFullscreen: FC = () => {
 
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  // drag state for touch reorder
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const draggingIndexRef = useRef<number | null>(null);
   const dragOverIndexRef = useRef<number | null>(null);
 
-  // swipe-down state
   const swipeStartYRef = useRef<number | null>(null);
   const [dragOffsetY, setDragOffsetY] = useState(0);
 
@@ -323,7 +321,7 @@ export const NowPlayingFullscreen: FC = () => {
 
               <button
                 type="button"
-                aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
+                aria-label={t("player.nowPlaying.moveUp", { name: item.name })}
                 disabled={index === 0}
                 onClick={() => index > 0 && reorderQueue(index, index - 1)}
                 className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"
@@ -332,7 +330,7 @@ export const NowPlayingFullscreen: FC = () => {
               </button>
               <button
                 type="button"
-                aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
+                aria-label={t("player.nowPlaying.moveDown", { name: item.name })}
                 disabled={index === queue.length - 1}
                 onClick={() => index < queue.length - 1 && reorderQueue(index, index + 1)}
                 className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -150,7 +150,6 @@ export const NowPlayingFullscreen: FC = () => {
           : undefined
       }
     >
-      {/* blurred backdrop */}
       <div className="absolute inset-0 -z-10 overflow-hidden">
         {currentItem?.artworkUrl && (
           <img
@@ -163,7 +162,6 @@ export const NowPlayingFullscreen: FC = () => {
         <div className="absolute inset-0 bg-black/60" />
       </div>
 
-      {/* top bar + hero zone (swipe area) */}
       <div
         data-swipe-zone
         onPointerDown={onSwipePointerDown}
@@ -188,21 +186,18 @@ export const NowPlayingFullscreen: FC = () => {
           <span className="sr-only">{t("player.nowPlaying.title")}</span>
         </header>
 
-        {/* hero artwork */}
         <div className="flex flex-1 items-center justify-center px-6 py-4">
           <div className="aspect-square w-[70vw] max-w-[280px] overflow-hidden rounded-lg shadow-2xl">
             <Image src={currentItem?.artworkUrl} alt={currentItem?.name ?? ""} />
           </div>
         </div>
 
-        {/* track meta */}
         <div className="px-6 text-center">
           <div className="truncate text-lg font-semibold text-white">{currentItem?.name}</div>
           <div className="text-text-secondary truncate text-sm">{currentItem?.artist}</div>
         </div>
       </div>
 
-      {/* seek scrubber */}
       <div className="px-6 py-3">
         <div className="group flex w-full items-center gap-2">
           <span className="text-text-secondary w-8 shrink-0 text-right text-xs tabular-nums">
@@ -232,7 +227,6 @@ export const NowPlayingFullscreen: FC = () => {
         </div>
       </div>
 
-      {/* transport row */}
       <div className="flex items-center justify-center gap-6 px-6 pb-4">
         <button
           type="button"
@@ -290,7 +284,6 @@ export const NowPlayingFullscreen: FC = () => {
         </button>
       </div>
 
-      {/* inline queue */}
       <section
         className="pb-safe flex-1 overflow-y-auto px-4"
         aria-label={t("player.nowPlaying.queueLabel")}

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -376,6 +376,13 @@
       "repeatAll": "Repeat all",
       "repeatOne": "Repeat one",
       "shuffleOn": "Shuffle on"
+    },
+    "nowPlaying": {
+      "title": "Now Playing",
+      "open": "Open Now Playing",
+      "close": "Close",
+      "queueLabel": "Queue",
+      "dragHandle": "Drag to reorder {{name}}"
     }
   }
 }

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -382,7 +382,9 @@
       "open": "Open Now Playing",
       "close": "Close",
       "queueLabel": "Queue",
-      "dragHandle": "Drag to reorder {{name}}"
+      "dragHandle": "Drag to reorder {{name}}",
+      "moveUp": "Move {{name}} up",
+      "moveDown": "Move {{name}} down"
     }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -382,7 +382,9 @@
       "open": "Abrir reproduciendo ahora",
       "close": "Cerrar",
       "queueLabel": "Cola",
-      "dragHandle": "Arrastrá para reordenar {{name}}"
+      "dragHandle": "Arrastrá para reordenar {{name}}",
+      "moveUp": "Subir {{name}}",
+      "moveDown": "Bajar {{name}}"
     }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -376,6 +376,13 @@
       "repeatAll": "Repetir todo",
       "repeatOne": "Repetir una",
       "shuffleOn": "Aleatorio activado"
+    },
+    "nowPlaying": {
+      "title": "Reproduciendo ahora",
+      "open": "Abrir reproduciendo ahora",
+      "close": "Cerrar",
+      "queueLabel": "Cola",
+      "dragHandle": "Arrastrá para reordenar {{name}}"
     }
   }
 }

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1036,6 +1036,46 @@ describe("reorderQueue", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isNowPlayingOpen + setNowPlayingOpen
+// ---------------------------------------------------------------------------
+
+describe("isNowPlayingOpen", () => {
+  it("initial value is false", () => {
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("setNowPlayingOpen(true) sets flag to true", () => {
+    usePlayerStore.getState().setNowPlayingOpen(true);
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(true);
+  });
+
+  it("setNowPlayingOpen(false) sets flag to false", () => {
+    usePlayerStore.getState().setNowPlayingOpen(true);
+    usePlayerStore.getState().setNowPlayingOpen(false);
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("clear() resets isNowPlayingOpen to false", () => {
+    usePlayerStore.getState().setNowPlayingOpen(true);
+    usePlayerStore.getState().clear();
+    expect(usePlayerStore.getState().isNowPlayingOpen).toBe(false);
+  });
+
+  it("__partialize does NOT include isNowPlayingOpen in returned keys", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      isNowPlayingOpen: true,
+      volume: 1,
+      isMuted: false,
+      shuffleMode: false,
+      repeatMode: "off" as const,
+    } as unknown as Parameters<typeof p>[0];
+    const persisted = p(fakeState);
+    expect("isNowPlayingOpen" in persisted).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -41,6 +41,7 @@ export interface PlayerState {
   shuffleOrderIndex: number;
 
   isQueuePanelOpen: boolean;
+  isNowPlayingOpen: boolean;
 
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
@@ -53,6 +54,7 @@ export interface PlayerState {
   toggleShuffle: () => void;
   cycleRepeat: () => void;
   setQueuePanelOpen: (open: boolean) => void;
+  setNowPlayingOpen: (open: boolean) => void;
   playFromIndex: (index: number) => void;
 
   reorderQueue: (fromIndex: number, toIndex: number) => void;
@@ -108,6 +110,7 @@ const INITIAL_STATE = {
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
   isQueuePanelOpen: false,
+  isNowPlayingOpen: false,
 };
 
 type AdvanceSource = "user" | "ended";
@@ -269,6 +272,7 @@ export const usePlayerStore = create<PlayerState>()(
             duration: 0,
             error: null,
             isQueuePanelOpen: false,
+            isNowPlayingOpen: false,
           });
         },
 
@@ -313,6 +317,10 @@ export const usePlayerStore = create<PlayerState>()(
 
         setQueuePanelOpen(open) {
           set({ isQueuePanelOpen: open });
+        },
+
+        setNowPlayingOpen(open) {
+          set({ isNowPlayingOpen: open });
         },
 
         playFromIndex(index) {


### PR DESCRIPTION
## Summary

- New `NowPlayingFullscreen` organism. Mobile-only (`<md`). Tap track meta in `GlobalPlayerBar` → fullscreen sheet slides up.
- Layout: blurred album-art backdrop, hero artwork, track meta, seek scrubber, transport row, inline queue.
- Close: chevron-down button + ESC + swipe-down gesture (≥80px, scroll-safe via `data-no-swipe`).
- Touch reorder for queue rows via Pointer Events API (closes the deferral from Slice B). WCAG 2.5.7 alt: explicit up/down buttons per row.
- `isNowPlayingOpen` flag on `usePlayerStore`. Excluded from persistence, reset on `clear()`.
- No MediaSession duplicate registration (handled by `GlobalPlayerBar`).
- `pb-safe` for iOS safe-area-inset-bottom.

Touch reorder uses persistent drag handles + pointer events because HTML5 native DnD does not support touch (root cause from PR #95).

## Size: exception

~430 LOC across implementation + tests + i18n. Single PR approved by maintainer (`size:exception`) to keep the player roadmap shippable as one unit.

## SDD trail (engram)

- proposal #3288, spec #3289, design #3290, tasks #3291, apply #3292, verify #3294, archive #3295.

## Test plan

- [x] `pnpm --filter frontend test:run` — 400/400 passing
- [x] `pnpm --filter frontend lint` — clean
- [x] `pnpm --filter frontend build` — clean
- [ ] Manual mobile (or DevTools mobile emulation):
  - Tap track meta → fullscreen opens with slide-up
  - Chevron / ESC / swipe-down all close + focus returns to trigger
  - Transport, seek, shuffle, repeat still work from fullscreen
  - Inline queue: tap row jumps; ↑/↓ buttons reorder; long-press drag handle reorders via pointer events
  - Desktop (≥md): no fullscreen, regular bar behavior unchanged

## Player roadmap (now complete)

- #88 shuffle/repeat
- #90 track-list quick wins + Spotify look
- #91 queue side-panel Slice A
- #95 queue side-panel reorder Slice B (touch deferred)
- THIS PR mobile fullscreen + touch reorder