### PR TITLE
test(frontend): cover detail views and player

### DIFF
--- a/apps/frontend/tests/e2e/mocked/history.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/history.spec.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "../../fixtures/test";
+import {
+  buildHistoryItem,
+  buildPlaylist,
+  buildTrack,
+  installHistoryMocks,
+  installPlaylistMocks,
+  installTrackMocks,
+} from "../../helpers/api-mocks";
+
+const historyItem = buildHistoryItem({
+  playlistId: "history-playlist-1",
+  playlistName: "Archive Mix",
+  playlistSpotifyUrl: "https://open.spotify.com/playlist/archive-mix",
+});
+
+test.describe("Mocked history flows", () => {
+  test("opens preview detail from history when the playlist is not yet saved locally", async ({
+    page,
+  }) => {
+    await installHistoryMocks(page, { downloads: [historyItem] });
+    await installPlaylistMocks(page, {
+      playlists: [],
+      preview: {
+        coverUrl: null,
+        description: "Recovered from history.",
+        name: historyItem.playlistName,
+        owner: "Spotiarr",
+        ownerUrl: "https://open.spotify.com/user/spotiarr",
+        totalTracks: 1,
+        tracks: [
+          {
+            album: "Recovered Album",
+            artists: [{ name: "Recovered Artist" }],
+            duration: 210_000,
+            name: "Recovered Track",
+            trackUrl: "https://open.spotify.com/track/recovered-track",
+          },
+        ],
+        type: "playlist",
+      },
+    });
+
+    await page.goto("/history", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Download History" })).toBeVisible();
+    await expect(page.getByText("Archive Mix")).toBeVisible();
+
+    await page.getByText("Archive Mix").click();
+
+    await expect(page).toHaveURL(/\/preview\?url=/);
+    await expect(page.getByRole("heading", { name: "Archive Mix" })).toBeVisible();
+    await expect(page.getByText("Recovered Track")).toBeVisible();
+  });
+
+  test("opens managed playlist detail from history when the playlist already exists locally", async ({
+    page,
+  }) => {
+    const managedPlaylist = buildPlaylist({
+      id: "managed-history-playlist",
+      name: "Archive Mix",
+      spotifyUrl: historyItem.playlistSpotifyUrl,
+      tracks: [],
+    });
+
+    await installHistoryMocks(page, { downloads: [historyItem] });
+    await installPlaylistMocks(page, { playlists: [managedPlaylist] });
+    await installTrackMocks(page, {
+      tracksByPlaylistId: {
+        [managedPlaylist.id]: [
+          buildTrack({
+            album: "Offline Album",
+            id: "managed-track-1",
+            name: "Stored Track",
+            playlistId: managedPlaylist.id,
+            trackUrl: "https://open.spotify.com/track/stored-track",
+          }),
+        ],
+      },
+    });
+
+    await page.goto("/history", { waitUntil: "domcontentloaded" });
+    await page.getByText("Archive Mix").click();
+
+    await expect(page).toHaveURL(`/playlist/${managedPlaylist.id}`);
+    await expect(page.getByRole("heading", { name: "Archive Mix" })).toBeVisible();
+    await expect(
+      page.getByText("Download tracks in this playlist to start local playback."),
+    ).toBeVisible();
+  });
+
+  test("renders the empty history state when no mocked downloads exist", async ({ page }) => {
+    await installHistoryMocks(page, { downloads: [] });
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/history", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("No download history yet")).toBeVisible();
+    await expect(page.getByText("Completed downloads will appear here.")).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/library.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/library.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from "../../fixtures/test";
+import {
+  buildLibraryAlbum,
+  buildLibraryArtist,
+  buildLibraryTrack,
+  installLibraryMocks,
+} from "../../helpers/api-mocks";
+
+const albumArtist = buildLibraryArtist({
+  name: "Tycho",
+  image: undefined,
+  albums: [
+    buildLibraryAlbum({
+      artist: "Tycho",
+      image: undefined,
+      name: "Epoch",
+      path: "/library/artists/tycho/epoch",
+      tracks: [
+        buildLibraryTrack({
+          album: "Epoch",
+          artist: "Tycho",
+          filePath: "/library/artists/tycho/epoch/01 Glider.mp3",
+          name: "Glider",
+        }),
+      ],
+      year: 2016,
+    }),
+  ],
+});
+
+test.describe("Mocked library detail flows", () => {
+  test("renders the library artist album grid with mocked album cards", async ({ page }) => {
+    await installLibraryMocks(page, {
+      artistDetail: albumArtist,
+      artists: [albumArtist],
+    });
+
+    await page.goto("/library/artist/Tycho", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Tycho" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Album Epoch by Tycho, 2016, 1 tracks/i }),
+    ).toBeVisible();
+  });
+
+  test("shows the album loading state until the mocked artist detail payload resolves", async ({
+    page,
+  }) => {
+    const detailGate = Promise.withResolvers<void>();
+
+    await installLibraryMocks(page, {
+      artistDetail: albumArtist,
+      artists: [albumArtist],
+      gates: {
+        artistDetail: detailGate.promise,
+      },
+    });
+
+    await page.goto("/library/artist/Tycho/album/Epoch", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("Loading album details...")).toBeVisible();
+
+    detailGate.resolve();
+
+    await expect(page.getByRole("heading", { name: "Epoch" })).toBeVisible();
+    await expect(page.getByText("Glider")).toBeVisible();
+  });
+
+  test("renders the not-found state when the requested album is absent from the artist payload", async ({
+    page,
+  }) => {
+    await installLibraryMocks(page, {
+      artistDetail: albumArtist,
+      artists: [albumArtist],
+    });
+
+    await page.goto("/library/artist/Tycho/album/Missing%20Album", {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByText("Album not found")).toBeVisible();
+    await expect(page.getByText("Could not find this album in your library.")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Back to artist" })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "../../fixtures/test";
+import {
+  buildPlaylist,
+  buildTrack,
+  installLibraryAudioMocks,
+  installPlaylistMocks,
+  installTrackMocks,
+} from "../../helpers/api-mocks";
+
+test.describe("Mocked global player flows", () => {
+  test("updates the GlobalPlayerBar while playing a library-backed playlist queue", async ({
+    page,
+  }) => {
+    const libraryPlaylist = buildPlaylist({
+      id: "library-player-playlist",
+      name: "Local Queue",
+      spotifyUrl: "spotiarr://library-player-playlist",
+      subscribed: true,
+      tracks: [],
+    });
+
+    await installPlaylistMocks(page, { playlists: [libraryPlaylist] });
+    await installTrackMocks(page, {
+      tracksByPlaylistId: {
+        [libraryPlaylist.id]: [
+          buildTrack({
+            album: "Album One",
+            artist: "Boards of Canada",
+            audioUrl: "/api/library/audio?path=/library/boards/track-1.mp3",
+            id: "player-track-1",
+            name: "Dayvan Cowboy",
+            playlistId: libraryPlaylist.id,
+          }),
+          buildTrack({
+            album: "Album Two",
+            artist: "Tycho",
+            audioUrl: "/api/library/audio?path=/library/tycho/track-2.mp3",
+            id: "player-track-2",
+            name: "Awake",
+            playlistId: libraryPlaylist.id,
+          }),
+        ],
+      },
+    });
+    await installLibraryAudioMocks(page);
+
+    await page.goto(`/playlist/${libraryPlaylist.id}?mode=library`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Play track" }).first().click();
+
+    const playerBar = page.getByRole("region", { name: "Now playing" });
+
+    await expect(playerBar).toBeVisible();
+    await expect(playerBar.getByText("Dayvan Cowboy")).toBeVisible();
+    await expect(playerBar.getByText("Boards of Canada")).toBeVisible();
+
+    await page.getByRole("button", { name: "Next track" }).click();
+
+    await expect(playerBar.getByText("Awake")).toBeVisible();
+    await expect(playerBar.getByText("Tycho")).toBeVisible();
+
+    await playerBar.getByRole("button", { name: "Pause" }).click();
+
+    await expect(playerBar.getByRole("button", { name: "Play" })).toBeVisible();
+    await expect(playerBar.getByRole("button", { name: /Open Awake by Tycho/ })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -114,6 +114,10 @@ interface MockHistoryOptions {
   tracks?: DownloadHistoryItem[];
 }
 
+interface MockTrackOptions {
+  tracksByPlaylistId?: Record<string, Track[]>;
+}
+
 interface MockFeedOptions {
   followedArtists?: FollowedArtist[];
   releases?: ArtistRelease[];
@@ -129,6 +133,12 @@ interface MockArtistOptions {
 const DEFAULT_TIMESTAMP = new Date(0).toISOString();
 
 const DEFAULT_COMPLETED_AT = 1_700_000_000_000;
+
+const SILENT_WAV_BUFFER = Buffer.from([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
+  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x44, 0xac, 0x00, 0x00, 0x88, 0x58, 0x01, 0x00,
+  0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00,
+]);
 
 const SETTINGS_PAYLOAD = {
   data: [
@@ -239,7 +249,7 @@ const registerJsonRoute = async (
   });
 };
 
-function buildPlaylistTrack(overrides: Partial<Track> = {}): Track {
+export function buildTrack(overrides: Partial<Track> = {}): Track {
   return {
     id: "track-1",
     name: "Mock Track",
@@ -253,7 +263,7 @@ function buildPlaylistTrack(overrides: Partial<Track> = {}): Track {
   };
 }
 
-function buildLibraryTrack(overrides: Partial<LibraryTrack> = {}): LibraryTrack {
+export function buildLibraryTrack(overrides: Partial<LibraryTrack> = {}): LibraryTrack {
   return {
     fileName: "01 Mock Track.mp3",
     filePath: "/library/artists/library-artist/library-album/01 Mock Track.mp3",
@@ -270,7 +280,7 @@ function buildLibraryTrack(overrides: Partial<LibraryTrack> = {}): LibraryTrack 
   };
 }
 
-function buildLibraryAlbum(overrides: Partial<LibraryAlbum> = {}): LibraryAlbum {
+export function buildLibraryAlbum(overrides: Partial<LibraryAlbum> = {}): LibraryAlbum {
   const tracks = overrides.tracks ?? [buildLibraryTrack()];
 
   return {
@@ -312,7 +322,7 @@ export function buildPlaylist(overrides: Partial<Playlist> = {}): Playlist {
     ownerUrl: "https://open.spotify.com/user/spotiarr",
     coverUrl: "/artwork/mock-playlist.jpg",
     description: "Mock playlist used for route coverage.",
-    tracks: [buildPlaylistTrack({ playlistId: "playlist-1" })],
+    tracks: [buildTrack({ playlistId: "playlist-1" })],
     ...overrides,
   };
 }
@@ -491,6 +501,28 @@ export async function installHistoryMocks(
 ): Promise<void> {
   await registerJsonRoute(page, `${ApiRoutes.HISTORY}/downloads`, { data: downloads });
   await registerJsonRoute(page, `${ApiRoutes.HISTORY}/tracks`, { data: tracks });
+}
+
+export async function installTrackMocks(
+  page: Page,
+  { tracksByPlaylistId = {} }: MockTrackOptions = {},
+): Promise<void> {
+  await page.route(`**${buildApiUrl(`${ApiRoutes.TRACK}/playlist/**`)}`, async (route) => {
+    const url = new URL(route.request().url());
+    const playlistId = url.pathname.split("/").pop() ?? "";
+
+    await fulfillJson(route, { data: tracksByPlaylistId[playlistId] ?? [] });
+  });
+}
+
+export async function installLibraryAudioMocks(page: Page): Promise<void> {
+  await page.route(`**${buildApiUrl(`${ApiRoutes.LIBRARY}/audio**`)}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "audio/wav",
+      body: SILENT_WAV_BUFFER,
+    });
+  });
 }
 
 export async function installFeedMocks(

--- a/apps/frontend/tests/runtime/api-mocks.test.ts
+++ b/apps/frontend/tests/runtime/api-mocks.test.ts
@@ -4,16 +4,21 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
+  buildLibraryAlbum,
   buildHistoryItem,
   buildLibraryArtist,
+  buildLibraryTrack,
   buildPlaylist,
+  buildTrack,
   buildRelease,
   installArtistMocks,
   installExternalUrlMock,
   installFeedMocks,
   installHistoryMocks,
+  installLibraryAudioMocks,
   installLibraryMocks,
   installPlaylistMocks,
+  installTrackMocks,
 } from "../helpers/api-mocks";
 
 type RoutePattern = string | RegExp;
@@ -127,6 +132,32 @@ describe("api mock builders", () => {
     expect(playlist).toMatchObject({ id: "playlist-42", tracks: [] });
     expect(historyItem).toMatchObject({ playlistSpotifyUrl: null, trackCount: 0 });
     expect(release).toMatchObject({ albumType: "single", totalTracks: 2 });
+  });
+
+  test("builds reusable library album, library track, and managed track defaults", () => {
+    const libraryTrack = buildLibraryTrack();
+    const libraryAlbum = buildLibraryAlbum();
+    const track = buildTrack();
+
+    expect(libraryTrack).toMatchObject({
+      album: "Library Album",
+      artist: "Library Artist",
+      filePath: "/library/artists/library-artist/library-album/01 Mock Track.mp3",
+      format: "mp3",
+      name: "Mock Track",
+    });
+    expect(libraryAlbum).toMatchObject({
+      artist: "Library Artist",
+      name: "Library Album",
+      path: "/library/artists/library-artist/library-album",
+      trackCount: 1,
+    });
+    expect(track).toMatchObject({
+      artist: "Mock Artist",
+      id: "track-1",
+      name: "Mock Track",
+      status: "completed",
+    });
   });
 });
 
@@ -261,6 +292,39 @@ describe("api mock installers", () => {
     await expect(
       invokeJsonRoute(routes[5]!.handler, "http://127.0.0.1:4173/api/external-url?id=artist-1"),
     ).resolves.toEqual({ url: "https://open.spotify.com/artist/artist-1" });
+  });
+
+  test("installs track routes keyed by playlist id for detail views", async () => {
+    const { page, routes } = createRouteRecorder();
+    const track = buildTrack({ id: "detail-track-1", playlistId: "playlist-detail-1" });
+
+    await installTrackMocks(page, {
+      tracksByPlaylistId: {
+        "playlist-detail-1": [track],
+      },
+    });
+
+    expect(routes).toHaveLength(1);
+    expect(String(routes[0]!.pattern)).toBe("**/api/track/playlist/**");
+
+    await expect(
+      invokeJsonRoute(
+        routes[0]!.handler,
+        "http://127.0.0.1:4173/api/track/playlist/playlist-detail-1",
+      ),
+    ).resolves.toMatchObject({ data: [track] });
+    await expect(
+      invokeJsonRoute(routes[0]!.handler, "http://127.0.0.1:4173/api/track/playlist/missing"),
+    ).resolves.toMatchObject({ data: [] });
+  });
+
+  test("installs a hermetic library audio route for playback-capable specs", async () => {
+    const { page, routes } = createRouteRecorder();
+
+    await installLibraryAudioMocks(page);
+
+    expect(routes).toHaveLength(1);
+    expect(String(routes[0]!.pattern)).toBe("**/api/library/audio**");
   });
 });
 


### PR DESCRIPTION
## What

Closes #92

Adds PR3 of the E2E route coverage chain: mocked detail-view and player coverage for library album detail, history navigation, managed/preview playlist detail paths, and GlobalPlayerBar playback interactions. This stays hermetic by using mocked API/audio routes only; no Spotify, OAuth, or real external network calls.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Docs / chore

## Scope

- [x] Frontend only (`apps/frontend`)
- [ ] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Changes

| File | Change |
|------|--------|
| `apps/frontend/tests/helpers/api-mocks.ts` | Adds reusable track builders, playlist track mocks, and hermetic library audio mocks. |
| `apps/frontend/tests/runtime/api-mocks.test.ts` | Covers new mocked helper builders and installers. |
| `apps/frontend/tests/e2e/mocked/library.spec.ts` | Covers library artist album grid, album loading, and missing album state. |
| `apps/frontend/tests/e2e/mocked/history.spec.ts` | Covers history empty state plus preview/managed playlist navigation. |
| `apps/frontend/tests/e2e/mocked/player.spec.ts` | Covers GlobalPlayerBar play, next, pause, and track navigation state. |

## Verification

- [x] `pnpm run build`
- [x] `rtk vitest --config vitest.playwright.config.ts tests/runtime/api-mocks.test.ts`
- [x] `PLAYWRIGHT_TARGET=mocked rtk playwright test tests/e2e/mocked/home.spec.ts tests/e2e/mocked/playlists.spec.ts tests/e2e/mocked/library.spec.ts tests/e2e/mocked/history.spec.ts tests/e2e/mocked/player.spec.ts --project mocked`
- [x] `rtk pnpm exec oxlint ...changed PR3 files... --ignore-path .gitignore`
- [x] Fresh SDD verify: PASS, no findings (Engram `sdd/e2e-route-coverage/verify-report-pr3`)

## Checklist

- [x] Lint + build pass for affected scope (targeted validation above)
- [x] No secrets committed (`.env`, tokens, credentials)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change
