### PR TITLE
chore(player): post-roadmap cleanup and hardening

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,14 @@
 pnpm exec lint-staged
+
+# Fallback guard: ban JSDoc blocks and JSX section-divider comments in molecules/organisms.
+# oxlint 1.66.0 cannot match JSX comment AST nodes via overrides[].
+SCOPE="apps/frontend/src/components"
+RG=$(which rg 2>/dev/null || echo "/opt/homebrew/bin/rg")
+if "$RG" --quiet --glob '*.tsx' --glob '!*.test.tsx' --glob '!*.spec.tsx' \
+  -e '/\*\*' -e '\{/\*\s*={3,}' -e '\{/\*\s*-{3,}' -e '\{/\*\s*SECTION:' \
+  "$SCOPE/molecules" "$SCOPE/organisms" 2>/dev/null; then
+  echo ""
+  echo "Pre-commit guard: JSDoc block or JSX section-divider comment found in molecules/organisms."
+  echo "Remove verbose comments (/** */ blocks and {/* === */} dividers) before committing."
+  exit 1
+fi

--- a/apps/frontend/src/components/molecules/SpotifyLinkButton.tsx
+++ b/apps/frontend/src/components/molecules/SpotifyLinkButton.tsx
@@ -13,7 +13,6 @@ interface SpotifyLinkButtonProps extends Omit<ButtonProps, "onClick" | "children
   id: string;
   name?: string;
   artistName?: string;
-  /** When provided, renders as a direct anchor (no lazy fetch). */
   eagerUrl?: string;
 }
 

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -45,14 +45,29 @@ describe("TransportControls", () => {
     expect(screen.getByRole("button", { name: "player.transport.shuffleOn" })).toBeTruthy();
   });
 
-  it("root carries data-size attribute when size prop provided", () => {
-    const { container } = render(<TransportControls {...defaultProps} size="lg" />);
-    expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBe("lg");
+  it("root carries data-size=large when size=large", () => {
+    const { container } = render(<TransportControls {...defaultProps} size="large" />);
+    expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBe("large");
+  });
+
+  it("root carries data-size=default when size=default", () => {
+    const { container } = render(<TransportControls {...defaultProps} size="default" />);
+    expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBe("default");
   });
 
   it("root has no data-size attribute when size is not provided", () => {
     const { container } = render(<TransportControls {...defaultProps} />);
     expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBeNull();
+  });
+
+  it("all five buttons are disabled with aria-disabled when currentTrack is null", () => {
+    render(<TransportControls {...defaultProps} currentTrack={null} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(5);
+    buttons.forEach((btn) => {
+      expect(btn).toHaveProperty("disabled", true);
+      expect(btn.getAttribute("aria-disabled")).toBe("true");
+    });
   });
 
   it("calls onPlayPause when play/pause button clicked", () => {

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TransportControls } from "./TransportControls";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const defaultProps = {
+  isPlaying: false,
+  shuffleMode: false,
+  repeatMode: "off" as const,
+  onPlayPause: vi.fn(),
+  onPrev: vi.fn(),
+  onNext: vi.fn(),
+  onShuffleToggle: vi.fn(),
+  onRepeatCycle: vi.fn(),
+};
+
+describe("TransportControls", () => {
+  it("renders all five control buttons", () => {
+    render(<TransportControls {...defaultProps} />);
+    expect(screen.getAllByRole("button")).toHaveLength(5);
+  });
+
+  it("play/pause aria-label reflects isPlaying=false", () => {
+    render(<TransportControls {...defaultProps} isPlaying={false} />);
+    expect(screen.getByRole("button", { name: "player.transport.play" })).toBeTruthy();
+  });
+
+  it("play/pause aria-label reflects isPlaying=true", () => {
+    render(<TransportControls {...defaultProps} isPlaying={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.pause" })).toBeTruthy();
+  });
+
+  it("shuffle aria-label reflects shuffleMode=false", () => {
+    render(<TransportControls {...defaultProps} shuffleMode={false} />);
+    expect(screen.getByRole("button", { name: "player.transport.shuffleOff" })).toBeTruthy();
+  });
+
+  it("shuffle aria-label reflects shuffleMode=true", () => {
+    render(<TransportControls {...defaultProps} shuffleMode={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.shuffleOn" })).toBeTruthy();
+  });
+
+  it("root carries data-size attribute when size prop provided", () => {
+    const { container } = render(<TransportControls {...defaultProps} size="lg" />);
+    expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBe("lg");
+  });
+
+  it("root has no data-size attribute when size is not provided", () => {
+    const { container } = render(<TransportControls {...defaultProps} />);
+    expect((container.firstChild as HTMLElement).getAttribute("data-size")).toBeNull();
+  });
+
+  it("calls onPlayPause when play/pause button clicked", () => {
+    const onPlayPause = vi.fn();
+    render(<TransportControls {...defaultProps} onPlayPause={onPlayPause} />);
+    fireEvent.click(screen.getByRole("button", { name: "player.transport.play" }));
+    expect(onPlayPause).toHaveBeenCalledOnce();
+  });
+
+  it("calls onPrev when previous button clicked", () => {
+    const onPrev = vi.fn();
+    render(<TransportControls {...defaultProps} onPrev={onPrev} />);
+    fireEvent.click(screen.getByRole("button", { name: "player.transport.previous" }));
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it("calls onNext when next button clicked", () => {
+    const onNext = vi.fn();
+    render(<TransportControls {...defaultProps} onNext={onNext} />);
+    fireEvent.click(screen.getByRole("button", { name: "player.transport.next" }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onShuffleToggle when shuffle button clicked", () => {
+    const onShuffleToggle = vi.fn();
+    render(<TransportControls {...defaultProps} onShuffleToggle={onShuffleToggle} />);
+    fireEvent.click(screen.getByRole("button", { name: "player.transport.shuffleOff" }));
+    expect(onShuffleToggle).toHaveBeenCalledOnce();
+  });
+
+  it("calls onRepeatCycle when repeat button clicked", () => {
+    const onRepeatCycle = vi.fn();
+    render(<TransportControls {...defaultProps} onRepeatCycle={onRepeatCycle} />);
+    const buttons = screen.getAllByRole("button");
+    fireEvent.click(buttons[buttons.length - 1]!);
+    expect(onRepeatCycle).toHaveBeenCalledOnce();
+  });
+
+  it("prev button is disabled when isPrevDisabled=true", () => {
+    render(<TransportControls {...defaultProps} isPrevDisabled={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.previous" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+
+  it("next button is disabled when isNextDisabled=true", () => {
+    render(<TransportControls {...defaultProps} isNextDisabled={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.next" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+  });
+});

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/utils/cn";
 export type RepeatMode = "off" | "all" | "one";
 
 export interface TransportControlsProps {
+  currentTrack?: { id: string } | null;
   isPlaying: boolean;
   shuffleMode: boolean;
   repeatMode: RepeatMode;
@@ -24,11 +25,12 @@ export interface TransportControlsProps {
   onRepeatCycle: () => void;
   isPrevDisabled?: boolean;
   isNextDisabled?: boolean;
-  size?: "sm" | "lg";
+  size?: "default" | "large";
   className?: string;
 }
 
 export const TransportControls: FC<TransportControlsProps> = ({
+  currentTrack,
   isPlaying,
   shuffleMode,
   repeatMode,
@@ -44,7 +46,8 @@ export const TransportControls: FC<TransportControlsProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const isLg = size === "lg";
+  const allDisabled = currentTrack === null;
+  const isLg = size === "large";
   const controlSize = isLg ? "h-12 w-12" : "h-8 w-8";
   const playSize = isLg ? "h-14 w-14" : "h-10 w-10";
   const iconSize = isLg ? "text-base" : "text-sm";
@@ -59,15 +62,19 @@ export const TransportControls: FC<TransportControlsProps> = ({
         aria-label={
           shuffleMode ? t("player.transport.shuffleOn") : t("player.transport.shuffleOff")
         }
+        disabled={allDisabled}
+        aria-disabled={allDisabled || undefined}
         onClick={onShuffleToggle}
         className={cn(
           "flex items-center justify-center rounded-full transition-colors",
           controlSize,
-          shuffleMode
-            ? "text-green-500"
-            : isLg
-              ? "text-white/70 hover:text-white"
-              : "text-text-secondary hover:text-text-primary",
+          allDisabled
+            ? "cursor-not-allowed opacity-40"
+            : shuffleMode
+              ? "text-green-500"
+              : isLg
+                ? "text-white/70 hover:text-white"
+                : "text-text-secondary hover:text-text-primary",
         )}
       >
         <FontAwesomeIcon icon={faShuffle} className={iconSize} />
@@ -76,12 +83,13 @@ export const TransportControls: FC<TransportControlsProps> = ({
       <button
         type="button"
         aria-label={t("player.transport.previous")}
-        disabled={isPrevDisabled}
+        disabled={allDisabled || isPrevDisabled}
+        aria-disabled={allDisabled || undefined}
         onClick={onPrev}
         className={cn(
           "flex items-center justify-center rounded-full transition-colors",
           controlSize,
-          isPrevDisabled
+          allDisabled || isPrevDisabled
             ? "cursor-not-allowed opacity-40"
             : isLg
               ? "text-white/70 hover:text-white"
@@ -95,10 +103,13 @@ export const TransportControls: FC<TransportControlsProps> = ({
         type="button"
         aria-label={isPlaying ? t("player.transport.pause") : t("player.transport.play")}
         aria-pressed={isPlaying}
+        disabled={allDisabled}
+        aria-disabled={allDisabled || undefined}
         onClick={onPlayPause}
         className={cn(
           "flex items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105",
           playSize,
+          allDisabled && "cursor-not-allowed opacity-40",
         )}
       >
         <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className={iconSize} />
@@ -107,12 +118,13 @@ export const TransportControls: FC<TransportControlsProps> = ({
       <button
         type="button"
         aria-label={t("player.transport.next")}
-        disabled={isNextDisabled}
+        disabled={allDisabled || isNextDisabled}
+        aria-disabled={allDisabled || undefined}
         onClick={onNext}
         className={cn(
           "flex items-center justify-center rounded-full transition-colors",
           controlSize,
-          isNextDisabled
+          allDisabled || isNextDisabled
             ? "cursor-not-allowed opacity-40"
             : isLg
               ? "text-white/70 hover:text-white"
@@ -131,15 +143,19 @@ export const TransportControls: FC<TransportControlsProps> = ({
               ? t("player.queue.repeatAll")
               : t("player.queue.repeatOne")
         }
+        disabled={allDisabled}
+        aria-disabled={allDisabled || undefined}
         onClick={onRepeatCycle}
         className={cn(
           "relative flex items-center justify-center rounded-full transition-colors",
           controlSize,
-          repeatMode !== "off"
-            ? "text-green-500"
-            : isLg
-              ? "text-white/70 hover:text-white"
-              : "text-text-secondary hover:text-text-primary",
+          allDisabled
+            ? "cursor-not-allowed opacity-40"
+            : repeatMode !== "off"
+              ? "text-green-500"
+              : isLg
+                ? "text-white/70 hover:text-white"
+                : "text-text-secondary hover:text-text-primary",
         )}
       >
         <FontAwesomeIcon icon={faRepeat} className={iconSize} />

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -1,0 +1,152 @@
+import {
+  faBackwardStep,
+  faForwardStep,
+  faPause,
+  faPlay,
+  faRepeat,
+  faShuffle,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/utils/cn";
+
+export type RepeatMode = "off" | "all" | "one";
+
+export interface TransportControlsProps {
+  isPlaying: boolean;
+  shuffleMode: boolean;
+  repeatMode: RepeatMode;
+  onPlayPause: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+  onShuffleToggle: () => void;
+  onRepeatCycle: () => void;
+  isPrevDisabled?: boolean;
+  isNextDisabled?: boolean;
+  size?: "sm" | "lg";
+  className?: string;
+}
+
+export const TransportControls: FC<TransportControlsProps> = ({
+  isPlaying,
+  shuffleMode,
+  repeatMode,
+  onPlayPause,
+  onPrev,
+  onNext,
+  onShuffleToggle,
+  onRepeatCycle,
+  isPrevDisabled = false,
+  isNextDisabled = false,
+  size,
+  className,
+}) => {
+  const { t } = useTranslation();
+
+  const isLg = size === "lg";
+  const controlSize = isLg ? "h-12 w-12" : "h-8 w-8";
+  const playSize = isLg ? "h-14 w-14" : "h-10 w-10";
+  const iconSize = isLg ? "text-base" : "text-sm";
+
+  return (
+    <div
+      data-size={size ?? undefined}
+      className={cn("flex items-center", isLg ? "gap-6" : "gap-4", className)}
+    >
+      <button
+        type="button"
+        aria-label={
+          shuffleMode ? t("player.transport.shuffleOn") : t("player.transport.shuffleOff")
+        }
+        onClick={onShuffleToggle}
+        className={cn(
+          "flex items-center justify-center rounded-full transition-colors",
+          controlSize,
+          shuffleMode
+            ? "text-green-500"
+            : isLg
+              ? "text-white/70 hover:text-white"
+              : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <FontAwesomeIcon icon={faShuffle} className={iconSize} />
+      </button>
+
+      <button
+        type="button"
+        aria-label={t("player.transport.previous")}
+        disabled={isPrevDisabled}
+        onClick={onPrev}
+        className={cn(
+          "flex items-center justify-center rounded-full transition-colors",
+          controlSize,
+          isPrevDisabled
+            ? "cursor-not-allowed opacity-40"
+            : isLg
+              ? "text-white/70 hover:text-white"
+              : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <FontAwesomeIcon icon={faBackwardStep} className={iconSize} />
+      </button>
+
+      <button
+        type="button"
+        aria-label={isPlaying ? t("player.transport.pause") : t("player.transport.play")}
+        aria-pressed={isPlaying}
+        onClick={onPlayPause}
+        className={cn(
+          "flex items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105",
+          playSize,
+        )}
+      >
+        <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className={iconSize} />
+      </button>
+
+      <button
+        type="button"
+        aria-label={t("player.transport.next")}
+        disabled={isNextDisabled}
+        onClick={onNext}
+        className={cn(
+          "flex items-center justify-center rounded-full transition-colors",
+          controlSize,
+          isNextDisabled
+            ? "cursor-not-allowed opacity-40"
+            : isLg
+              ? "text-white/70 hover:text-white"
+              : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <FontAwesomeIcon icon={faForwardStep} className={iconSize} />
+      </button>
+
+      <button
+        type="button"
+        aria-label={
+          repeatMode === "off"
+            ? t("player.transport.repeatEnable")
+            : repeatMode === "all"
+              ? t("player.queue.repeatAll")
+              : t("player.queue.repeatOne")
+        }
+        onClick={onRepeatCycle}
+        className={cn(
+          "relative flex items-center justify-center rounded-full transition-colors",
+          controlSize,
+          repeatMode !== "off"
+            ? "text-green-500"
+            : isLg
+              ? "text-white/70 hover:text-white"
+              : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        <FontAwesomeIcon icon={faRepeat} className={iconSize} />
+        {repeatMode === "one" && (
+          <sup className="absolute -top-1 -right-1 text-[0.55rem] leading-none font-bold">1</sup>
+        )}
+      </button>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/molecules/TransportControls/index.ts
+++ b/apps/frontend/src/components/molecules/TransportControls/index.ts
@@ -1,0 +1,2 @@
+export { TransportControls } from "./TransportControls";
+export type { TransportControlsProps, RepeatMode } from "./TransportControls";

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -54,6 +54,14 @@ vi.mock("react-i18next", async () => {
           "player.nowPlaying.close": "Close",
           "player.nowPlaying.title": "Now Playing",
           "player.nowPlaying.queueLabel": "Queue",
+          "player.transport.play": "Play",
+          "player.transport.pause": "Pause",
+          "player.transport.previous": "Previous track",
+          "player.transport.next": "Next track",
+          "player.transport.shuffleOn": "Disable shuffle",
+          "player.transport.shuffleOff": "Enable shuffle",
+          "player.transport.seek": "Seek",
+          "player.transport.repeatEnable": "Enable repeat",
         };
         return map[key] ?? key;
       },

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -13,6 +13,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
@@ -151,9 +152,7 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const wasOpenRef = useRef(false);
   const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
-  const wasNowPlayingOpenRef = useRef(false);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
@@ -198,6 +197,8 @@ export const GlobalPlayerBar: FC = () => {
     [next, prev, seek],
   );
   useMediaSession(currentItem, isPlaying, mediaSessionActions);
+  useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
+  useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
 
   useEffect(() => {
     const el = audioRef.current;
@@ -261,20 +262,6 @@ export const GlobalPlayerBar: FC = () => {
     }, 3000);
     return () => clearTimeout(timer);
   }, [error]);
-
-  useEffect(() => {
-    if (wasOpenRef.current && !isQueuePanelOpen) {
-      triggerRef.current?.focus();
-    }
-    wasOpenRef.current = isQueuePanelOpen;
-  }, [isQueuePanelOpen]);
-
-  useEffect(() => {
-    if (wasNowPlayingOpenRef.current && !isNowPlayingOpen) {
-      nowPlayingTriggerRef.current?.focus();
-    }
-    wasNowPlayingOpenRef.current = isNowPlayingOpen;
-  }, [isNowPlayingOpen]);
 
   const isVisible = currentIndex !== null || !!error;
   const isAtFirst =

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -1,14 +1,4 @@
-import {
-  faBackwardStep,
-  faForwardStep,
-  faListUl,
-  faPause,
-  faPlay,
-  faRepeat,
-  faShuffle,
-  faVolumeHigh,
-  faVolumeXmark,
-} from "@fortawesome/free-solid-svg-icons";
+import { faListUl, faVolumeHigh, faVolumeXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,6 +10,7 @@ import type { QueueItem } from "@/store/usePlayerStore";
 import { usePreferencesStore } from "@/store/usePreferencesStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
+import { TransportControls } from "../molecules/TransportControls";
 import { NowPlayingFullscreen } from "./NowPlayingFullscreen";
 import { QueueSidePanel } from "./QueueSidePanel";
 
@@ -31,6 +22,7 @@ function formatSeconds(seconds: number): string {
 }
 
 const ProgressSection: FC = () => {
+  const { t } = useTranslation();
   const currentTime = usePlayerStore((s) => s.currentTime);
   const duration = usePlayerStore((s) => s.duration);
   const seek = usePlayerStore((s) => s.seek);
@@ -45,7 +37,7 @@ const ProgressSection: FC = () => {
       <input
         type="range"
         role="slider"
-        aria-label="Seek"
+        aria-label={t("player.transport.seek")}
         aria-valuemin={0}
         aria-valuemax={duration}
         aria-valuenow={currentTime}
@@ -271,11 +263,6 @@ export const GlobalPlayerBar: FC = () => {
     repeatMode !== "all" &&
     (currentIndex === null || currentIndex >= queue.length - 1);
 
-  const shuffleAriaLabel = shuffleMode ? "Disable shuffle" : "Enable shuffle";
-  const repeatAriaLabel =
-    repeatMode === "off" ? "Enable repeat" : repeatMode === "all" ? "Repeat all" : "Repeat one";
-  const isRepeatActive = repeatMode !== "off";
-
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== " ") return;
     const tag = (e.target as HTMLElement).tagName;
@@ -327,72 +314,19 @@ export const GlobalPlayerBar: FC = () => {
 
             <div className="flex flex-1 flex-col items-center gap-1">
               <div className="flex items-center gap-4">
-                <button
-                  type="button"
-                  aria-label={shuffleAriaLabel}
-                  onClick={toggleShuffle}
-                  className={cn(
-                    "flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                    shuffleMode ? "text-green-500" : "text-text-secondary hover:text-text-primary",
-                  )}
-                >
-                  <FontAwesomeIcon icon={faShuffle} className="text-sm" />
-                </button>
-
-                <button
-                  type="button"
-                  aria-label="Previous track"
-                  disabled={isAtFirst}
-                  onClick={prev}
-                  className={cn(
-                    "text-text-secondary hover:text-text-primary flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                    isAtFirst && "cursor-not-allowed opacity-40",
-                  )}
-                >
-                  <FontAwesomeIcon icon={faBackwardStep} className="text-base" />
-                </button>
-
-                <button
-                  type="button"
-                  aria-label={isPlaying ? "Pause" : "Play"}
-                  aria-pressed={isPlaying}
-                  onClick={togglePlay}
-                  className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105"
-                >
-                  <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className="text-sm" />
-                </button>
-
-                <button
-                  type="button"
-                  aria-label="Next track"
-                  disabled={isAtLast}
-                  onClick={next}
-                  className={cn(
-                    "text-text-secondary hover:text-text-primary flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                    isAtLast && "cursor-not-allowed opacity-40",
-                  )}
-                >
-                  <FontAwesomeIcon icon={faForwardStep} className="text-base" />
-                </button>
-
-                <button
-                  type="button"
-                  aria-label={repeatAriaLabel}
-                  onClick={cycleRepeat}
-                  className={cn(
-                    "relative flex h-8 w-8 items-center justify-center rounded-full transition-colors",
-                    isRepeatActive
-                      ? "text-green-500"
-                      : "text-text-secondary hover:text-text-primary",
-                  )}
-                >
-                  <FontAwesomeIcon icon={faRepeat} className="text-sm" />
-                  {repeatMode === "one" && (
-                    <sup className="absolute -top-1 -right-1 text-[0.55rem] leading-none font-bold">
-                      1
-                    </sup>
-                  )}
-                </button>
+                <TransportControls
+                  size="sm"
+                  isPlaying={isPlaying}
+                  shuffleMode={shuffleMode}
+                  repeatMode={repeatMode}
+                  onPlayPause={togglePlay}
+                  onPrev={prev}
+                  onNext={next}
+                  onShuffleToggle={toggleShuffle}
+                  onRepeatCycle={cycleRepeat}
+                  isPrevDisabled={isAtFirst}
+                  isNextDisabled={isAtLast}
+                />
 
                 <button
                   ref={triggerRef}

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -315,7 +315,8 @@ export const GlobalPlayerBar: FC = () => {
             <div className="flex flex-1 flex-col items-center gap-1">
               <div className="flex items-center gap-4">
                 <TransportControls
-                  size="sm"
+                  size="default"
+                  currentTrack={currentItem ?? null}
                   isPlaying={isPlaying}
                   shuffleMode={shuffleMode}
                   repeatMode={repeatMode}

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.test.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.test.tsx
@@ -14,9 +14,24 @@ vi.mock("react-i18next", async () => {
           "player.nowPlaying.open": "Open Now Playing",
           "player.nowPlaying.close": "Close",
           "player.nowPlaying.queueLabel": "Queue",
+          "player.transport.play": "Play",
+          "player.transport.pause": "Pause",
+          "player.transport.previous": "Previous track",
+          "player.transport.next": "Next track",
+          "player.transport.shuffleOn": "Disable shuffle",
+          "player.transport.shuffleOff": "Enable shuffle",
+          "player.transport.seek": "Seek",
+          "player.queue.repeatAll": "Repeat all",
+          "player.queue.repeatOne": "Repeat one",
         };
         if (key === "player.nowPlaying.dragHandle" && opts?.name) {
           return `Drag to reorder ${opts.name as string}`;
+        }
+        if (key === "player.nowPlaying.moveUp" && opts?.name) {
+          return `Move ${opts.name as string} up`;
+        }
+        if (key === "player.nowPlaying.moveDown" && opts?.name) {
+          return `Move ${opts.name as string} down`;
         }
         return map[key] ?? key;
       },

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -126,7 +126,7 @@ export const NowPlayingFullscreen: FC = () => {
       aria-modal="true"
       aria-label={t("player.nowPlaying.title")}
       className={cn(
-        "fixed inset-0 z-[70] flex flex-col md:hidden",
+        "fixed inset-0 z-[70] flex flex-col bg-black md:hidden",
         "transition-transform duration-300 motion-reduce:transition-none",
         isNowPlayingOpen
           ? "pointer-events-auto translate-y-0"

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -217,7 +217,8 @@ export const NowPlayingFullscreen: FC = () => {
 
       <div className="flex items-center justify-center px-6 pb-4">
         <TransportControls
-          size="lg"
+          size="large"
+          currentTrack={currentItem ?? null}
           isPlaying={isPlaying}
           shuffleMode={shuffleMode}
           repeatMode={repeatMode}

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -1,19 +1,11 @@
-import {
-  faBackwardStep,
-  faChevronDown,
-  faForwardStep,
-  faGripLines,
-  faPause,
-  faPlay,
-  faRepeat,
-  faShuffle,
-} from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faGripLines } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
+import { TransportControls } from "../molecules/TransportControls";
 
 function formatSeconds(seconds: number): string {
   const s = Math.max(0, Math.floor(seconds));
@@ -128,10 +120,6 @@ export const NowPlayingFullscreen: FC = () => {
     if (dy >= 80) setNowPlayingOpen(false);
   };
 
-  const shuffleAriaLabel = shuffleMode ? "Disable shuffle" : "Enable shuffle";
-  const repeatAriaLabel =
-    repeatMode === "off" ? "Enable repeat" : repeatMode === "all" ? "Repeat all" : "Repeat one";
-
   return (
     <aside
       role="dialog"
@@ -206,7 +194,7 @@ export const NowPlayingFullscreen: FC = () => {
           <input
             type="range"
             role="slider"
-            aria-label="Seek"
+            aria-label={t("player.transport.seek")}
             aria-valuemin={0}
             aria-valuemax={duration}
             aria-valuenow={currentTime}
@@ -227,61 +215,18 @@ export const NowPlayingFullscreen: FC = () => {
         </div>
       </div>
 
-      <div className="flex items-center justify-center gap-6 px-6 pb-4">
-        <button
-          type="button"
-          aria-label={shuffleAriaLabel}
-          onClick={toggleShuffle}
-          className={cn(
-            "flex h-12 w-12 items-center justify-center rounded-full transition-colors",
-            shuffleMode ? "text-green-500" : "text-white/70 hover:text-white",
-          )}
-        >
-          <FontAwesomeIcon icon={faShuffle} />
-        </button>
-
-        <button
-          type="button"
-          aria-label="Previous track"
-          onClick={prev}
-          className="flex h-12 w-12 items-center justify-center rounded-full text-white/70 transition-colors hover:text-white"
-        >
-          <FontAwesomeIcon icon={faBackwardStep} />
-        </button>
-
-        <button
-          type="button"
-          aria-label={isPlaying ? "Pause" : "Play"}
-          aria-pressed={isPlaying}
-          onClick={togglePlay}
-          className="flex h-14 w-14 items-center justify-center rounded-full bg-white text-black shadow transition-transform hover:scale-105"
-        >
-          <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} />
-        </button>
-
-        <button
-          type="button"
-          aria-label="Next track"
-          onClick={next}
-          className="flex h-12 w-12 items-center justify-center rounded-full text-white/70 transition-colors hover:text-white"
-        >
-          <FontAwesomeIcon icon={faForwardStep} />
-        </button>
-
-        <button
-          type="button"
-          aria-label={repeatAriaLabel}
-          onClick={cycleRepeat}
-          className={cn(
-            "relative flex h-12 w-12 items-center justify-center rounded-full transition-colors",
-            repeatMode !== "off" ? "text-green-500" : "text-white/70 hover:text-white",
-          )}
-        >
-          <FontAwesomeIcon icon={faRepeat} />
-          {repeatMode === "one" && (
-            <sup className="absolute -top-1 -right-1 text-[0.55rem] leading-none font-bold">1</sup>
-          )}
-        </button>
+      <div className="flex items-center justify-center px-6 pb-4">
+        <TransportControls
+          size="lg"
+          isPlaying={isPlaying}
+          shuffleMode={shuffleMode}
+          repeatMode={repeatMode}
+          onPlayPause={togglePlay}
+          onPrev={prev}
+          onNext={next}
+          onShuffleToggle={toggleShuffle}
+          onRepeatCycle={cycleRepeat}
+        />
       </div>
 
       <section

--- a/apps/frontend/src/hooks/useFocusReturnOnClose.test.ts
+++ b/apps/frontend/src/hooks/useFocusReturnOnClose.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useFocusReturnOnClose } from "./useFocusReturnOnClose";
+
+describe("useFocusReturnOnClose", () => {
+  it("calls focus on triggerRef when isOpen transitions from true to false", () => {
+    const focusMock = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const ref = useRef<HTMLElement | null>({ focus: focusMock } as unknown as HTMLElement);
+        useFocusReturnOnClose(isOpen, ref);
+        return ref;
+      },
+      { initialProps: { isOpen: true } },
+    );
+
+    expect(focusMock).not.toHaveBeenCalled();
+
+    rerender({ isOpen: false });
+
+    expect(focusMock).toHaveBeenCalledOnce();
+    void result;
+  });
+
+  it("does not call focus on initial render when isOpen is false", () => {
+    const focusMock = vi.fn();
+    renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const ref = useRef<HTMLElement | null>({ focus: focusMock } as unknown as HTMLElement);
+        useFocusReturnOnClose(isOpen, ref);
+      },
+      { initialProps: { isOpen: false } },
+    );
+
+    expect(focusMock).not.toHaveBeenCalled();
+  });
+
+  it("does not throw and does not call focus when triggerRef.current is null at close time", () => {
+    const { rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const ref = useRef<HTMLElement | null>(null);
+        useFocusReturnOnClose(isOpen, ref);
+      },
+      { initialProps: { isOpen: true } },
+    );
+
+    expect(() => rerender({ isOpen: false })).not.toThrow();
+  });
+
+  it("calls focus exactly once per close across multiple open/close cycles", () => {
+    const focusMock = vi.fn();
+    const { rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean }) => {
+        const ref = useRef<HTMLElement | null>({ focus: focusMock } as unknown as HTMLElement);
+        useFocusReturnOnClose(isOpen, ref);
+      },
+      { initialProps: { isOpen: false } },
+    );
+
+    rerender({ isOpen: true });
+    rerender({ isOpen: false });
+    rerender({ isOpen: true });
+    rerender({ isOpen: false });
+
+    expect(focusMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/frontend/src/hooks/useFocusReturnOnClose.ts
+++ b/apps/frontend/src/hooks/useFocusReturnOnClose.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+export function useFocusReturnOnClose(
+  isOpen: boolean,
+  triggerRef: React.RefObject<HTMLElement | null>,
+): void {
+  const wasOpenRef = useRef(isOpen);
+
+  useEffect(() => {
+    if (wasOpenRef.current && !isOpen) {
+      triggerRef.current?.focus();
+    }
+    wasOpenRef.current = isOpen;
+  }, [isOpen, triggerRef]);
+}

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -384,7 +384,17 @@
       "queueLabel": "Queue",
       "dragHandle": "Drag to reorder {{name}}",
       "moveUp": "Move {{name}} up",
-      "moveDown": "Move {{name}} down"
+      "moveDown": "Move {{name}} down",
+      "seek": "Seek"
+    },
+    "transport": {
+      "shuffleOn": "Shuffle on",
+      "shuffleOff": "Shuffle off",
+      "previous": "Previous track",
+      "next": "Next track",
+      "pause": "Pause",
+      "play": "Play",
+      "seek": "Seek"
     }
   }
 }

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -394,7 +394,8 @@
       "next": "Next track",
       "pause": "Pause",
       "play": "Play",
-      "seek": "Seek"
+      "seek": "Seek",
+      "repeatEnable": "Enable repeat"
     }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -384,7 +384,17 @@
       "queueLabel": "Cola",
       "dragHandle": "Arrastrá para reordenar {{name}}",
       "moveUp": "Subir {{name}}",
-      "moveDown": "Bajar {{name}}"
+      "moveDown": "Bajar {{name}}",
+      "seek": "Avanzar"
+    },
+    "transport": {
+      "shuffleOn": "Aleatorio activado",
+      "shuffleOff": "Aleatorio desactivado",
+      "previous": "Pista anterior",
+      "next": "Pista siguiente",
+      "pause": "Pausar",
+      "play": "Reproducir",
+      "seek": "Avanzar"
     }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -394,7 +394,8 @@
       "next": "Pista siguiente",
       "pause": "Pausar",
       "play": "Reproducir",
-      "seek": "Avanzar"
+      "seek": "Avanzar",
+      "repeatEnable": "Activar repetición"
     }
   }
 }

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -447,6 +447,74 @@ describe("persist partialize", () => {
 });
 
 // ---------------------------------------------------------------------------
+// __partialize allowlist regression (REQ-5)
+// ---------------------------------------------------------------------------
+
+describe("__partialize allowlist — persisted keys are exactly volume, isMuted, shuffleMode, repeatMode", () => {
+  it("result keys are exactly the 4 approved keys", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fullState = {
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      isPlaying: true,
+      volume: 0.8,
+      isMuted: false,
+      currentTime: 30,
+      duration: 200,
+      error: null,
+      shuffleMode: true,
+      repeatMode: "all" as const,
+      shuffleOrder: [0],
+      shuffleOrderIndex: 0,
+      isQueuePanelOpen: true,
+      isNowPlayingOpen: true,
+      playQueue: vi.fn(),
+      togglePlay: vi.fn(),
+      next: vi.fn(),
+      prev: vi.fn(),
+      seek: vi.fn(),
+      setVolume: vi.fn(),
+      toggleMute: vi.fn(),
+      clear: vi.fn(),
+      toggleShuffle: vi.fn(),
+      cycleRepeat: vi.fn(),
+      setAudioElement: vi.fn(),
+      _onLoadedMetadata: vi.fn(),
+      _onTimeUpdate: vi.fn(),
+      _onEnded: vi.fn(),
+      _onError: vi.fn(),
+      setQueuePanelOpen: vi.fn(),
+      setNowPlayingOpen: vi.fn(),
+      playFromIndex: vi.fn(),
+      reorderQueue: vi.fn(),
+    };
+
+    const result = p(fullState as unknown as Parameters<typeof p>[0]);
+    expect(Object.keys(result).sort()).toEqual(["isMuted", "repeatMode", "shuffleMode", "volume"]);
+  });
+
+  it("excluded fields are absent from result", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fullState = {
+      isNowPlayingOpen: true,
+      isQueuePanelOpen: true,
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      volume: 1,
+      isMuted: false,
+      shuffleMode: false,
+      repeatMode: "off" as const,
+    } as unknown as Parameters<typeof p>[0];
+
+    const result = p(fullState);
+    expect("isNowPlayingOpen" in result).toBe(false);
+    expect("isQueuePanelOpen" in result).toBe(false);
+    expect("queue" in result).toBe(false);
+    expect("currentIndex" in result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // shuffle state (S1-1, S1-3, S1-4, S5-1, S5-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test } from "../../fixtures/test";
+
+const MOCK_AUDIO_URL = "/api/library/audio?path=%2Ftest%2Ftrack1.mp3";
+const MOCK_AUDIO_URL_2 = "/api/library/audio?path=%2Ftest%2Ftrack2.mp3";
+const MOCK_AUDIO_URL_3 = "/api/library/audio?path=%2Ftest%2Ftrack3.mp3";
+
+const MOCK_ARTIST = {
+  name: "Test Artist",
+  path: "/library/Test Artist",
+  imageUrl: null,
+  albums: [
+    {
+      name: "Test Album",
+      year: 2024,
+      coverUrl: null,
+      tracks: [
+        {
+          id: "track-1",
+          name: "Track Alpha",
+          artist: "Test Artist",
+          album: "Test Album",
+          trackUrl: MOCK_AUDIO_URL,
+          durationMs: 180_000,
+          artworkUrl: null,
+        },
+        {
+          id: "track-2",
+          name: "Track Beta",
+          artist: "Test Artist",
+          album: "Test Album",
+          trackUrl: MOCK_AUDIO_URL_2,
+          durationMs: 180_000,
+          artworkUrl: null,
+        },
+        {
+          id: "track-3",
+          name: "Track Gamma",
+          artist: "Test Artist",
+          album: "Test Album",
+          trackUrl: MOCK_AUDIO_URL_3,
+          durationMs: 180_000,
+          artworkUrl: null,
+        },
+      ],
+    },
+  ],
+};
+
+async function mockAudioRequests(page: import("@playwright/test").Page) {
+  for (const url of [MOCK_AUDIO_URL, MOCK_AUDIO_URL_2, MOCK_AUDIO_URL_3]) {
+    await page.route(`**${url}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "audio/mpeg",
+        body: Buffer.alloc(0),
+      }),
+    );
+  }
+}
+
+async function mockLibraryArtist(page: import("@playwright/test").Page) {
+  await page.route("**/api/library/artists/**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: MOCK_ARTIST }),
+    }),
+  );
+}
+
+test.describe("player — transport controls labels @smoke", () => {
+  test("transport buttons have accessible names derived from i18n keys", async ({ page }) => {
+    await mockLibraryArtist(page);
+    await mockAudioRequests(page);
+
+    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const playAlbumBtn = page.getByRole("button", { name: "Play album" });
+    const isPlayable = await playAlbumBtn.isVisible().catch(() => false);
+
+    if (!isPlayable) {
+      test.skip();
+      return;
+    }
+
+    await playAlbumBtn.click();
+
+    const playerBar = page.getByRole("region", { name: "Now playing" });
+    await expect(playerBar).toBeVisible();
+
+    const pauseBtn = playerBar.getByRole("button", { name: "Pause" });
+    await expect(pauseBtn).toBeVisible();
+
+    const prevBtn = playerBar.getByRole("button", { name: "Previous track" });
+    await expect(prevBtn).toBeVisible();
+
+    const nextBtn = playerBar.getByRole("button", { name: "Next track" });
+    await expect(nextBtn).toBeVisible();
+
+    const seekSlider = playerBar.getByRole("slider", { name: "Seek" });
+    await expect(seekSlider).toBeVisible();
+  });
+});
+
+test.describe("player — mobile now-playing fullscreen @smoke", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("mobile trigger opens and closes fullscreen overlay", async ({ page }) => {
+    await mockLibraryArtist(page);
+    await mockAudioRequests(page);
+
+    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const playBtn = page.getByRole("button", { name: "Play album" });
+    const isPlayable = await playBtn.isVisible().catch(() => false);
+
+    if (!isPlayable) {
+      test.skip();
+      return;
+    }
+
+    await playBtn.click();
+
+    const playerBar = page.getByRole("region", { name: "Now playing" });
+    await expect(playerBar).toBeVisible();
+
+    const nowPlayingTrigger = playerBar.getByRole("button", { name: "Open Now Playing" });
+    await expect(nowPlayingTrigger).toBeVisible();
+    await nowPlayingTrigger.click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    const transport = dialog.getByRole("button", { name: /(Pause|Play)/ });
+    await expect(transport).toBeVisible();
+
+    const closeBtn = dialog.getByRole("button", { name: "Close" });
+    await closeBtn.click();
+
+    await expect(dialog).not.toBeVisible();
+
+    // Focus returns to the now-playing trigger after close
+    await expect(nowPlayingTrigger).toBeFocused();
+  });
+});
+
+test.describe("player — queue reorder @smoke", () => {
+  test("moveUp button reorders second track above first", async ({ page }) => {
+    await mockLibraryArtist(page);
+    await mockAudioRequests(page);
+
+    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
+      waitUntil: "domcontentloaded",
+    });
+
+    const playBtn = page.getByRole("button", { name: "Play album" });
+    const isPlayable = await playBtn.isVisible().catch(() => false);
+
+    if (!isPlayable) {
+      test.skip();
+      return;
+    }
+
+    await playBtn.click();
+
+    const playerBar = page.getByRole("region", { name: "Now playing" });
+    const queueBtn = playerBar.getByRole("button", { name: "Open queue" });
+    await expect(queueBtn).toBeVisible();
+    await queueBtn.click();
+
+    const queuePanel = page.getByRole("complementary");
+    await expect(queuePanel).toBeVisible();
+
+    // Get all track rows in queue — move Track Beta up above Track Alpha
+    const moveUpBetaBtn = page.getByRole("button", { name: "Move Track Beta up" });
+    const isMoveVisible = await moveUpBetaBtn.isVisible().catch(() => false);
+
+    if (!isMoveVisible) {
+      test.skip();
+      return;
+    }
+
+    await moveUpBetaBtn.click();
+
+    // After moving up, Track Beta should now be before Track Alpha in queue
+    const queueItems = queuePanel.getByRole("listitem");
+    const firstItemText = await queueItems.first().textContent();
+    expect(firstItemText).toContain("Track Beta");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #98. Single PR delivery (`size:exception` accepted) covering items 1-5:

- Extract `useFocusReturnOnClose(isOpen, ref)` hook + consume in both `GlobalPlayerBar` call sites (queue panel + now-playing fullscreen).
- New `<TransportControls>` molecule with `size: "default" | "large"` variants and `currentTrack` null-state gating (all 5 buttons `disabled` + `aria-disabled` when no track). Consumed by `GlobalPlayerBar` and `NowPlayingFullscreen`; duplicated transport JSX removed.
- i18n keys `player.transport.*` (en + es). All hardcoded English aria-labels in `NowPlayingFullscreen` removed.
- `__partialize` regression test in `usePlayerStore.test.ts` — key-set assertion against allowlist `["isMuted","repeatMode","shuffleMode","volume"]`.
- Pre-commit `rg` guard banning JSDoc and JSX comments in `components/molecules/**` + `components/organisms/**` (oxlint fallback — design-approved; oxlint AST cannot match JSX comment nodes).
- Playwright e2e `tests/e2e/mocked/player.spec.ts` covering happy path.

Items 6-8 from #98 deferred per proposal: item 6 (ephemeral UI flags) → engram decision note; items 7-8 → backlog.

## Test plan

- [x] `pnpm --filter frontend test:run` — 422/422 PASS (was 400; +22 new tests)
- [x] `pnpm --filter frontend lint` — exit 0
- [x] `pnpm --filter frontend build` — exit 0
- [ ] `pnpm --filter frontend test:e2e:mocked` — requires preview server; spec compiles and skips gracefully without it
- [ ] Manual: open queue panel, drag-reorder a row, close → focus returns to trigger
- [ ] Manual mobile viewport: tap track meta → fullscreen opens → touch reorder via drag handle → swipe-down close