### PR TITLE
feat(player): issue #103 follow-ups (items 1-3)

### DIFF
--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -106,6 +106,16 @@ describe("TransportControls", () => {
     expect(onRepeatCycle).toHaveBeenCalledOnce();
   });
 
+  it("repeat button aria-label uses player.transport.repeatAll when repeatMode=all", () => {
+    render(<TransportControls {...defaultProps} repeatMode="all" />);
+    expect(screen.getByRole("button", { name: "player.transport.repeatAll" })).toBeTruthy();
+  });
+
+  it("repeat button aria-label uses player.transport.repeatOne when repeatMode=one", () => {
+    render(<TransportControls {...defaultProps} repeatMode="one" />);
+    expect(screen.getByRole("button", { name: "player.transport.repeatOne" })).toBeTruthy();
+  });
+
   it("prev button is disabled when isPrevDisabled=true", () => {
     render(<TransportControls {...defaultProps} isPrevDisabled={true} />);
     expect(screen.getByRole("button", { name: "player.transport.previous" })).toHaveProperty(

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -140,8 +140,8 @@ export const TransportControls: FC<TransportControlsProps> = ({
           repeatMode === "off"
             ? t("player.transport.repeatEnable")
             : repeatMode === "all"
-              ? t("player.queue.repeatAll")
-              : t("player.queue.repeatOne")
+              ? t("player.transport.repeatAll")
+              : t("player.transport.repeatOne")
         }
         disabled={allDisabled}
         aria-disabled={allDisabled || undefined}

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -49,6 +49,8 @@ vi.mock("react-i18next", async () => {
           "player.queue.close": "Close",
           "player.queue.repeatAll": "Repeat all",
           "player.queue.repeatOne": "Repeat one",
+          "player.transport.repeatAll": "Repeat all",
+          "player.transport.repeatOne": "Repeat one",
           "player.queue.shuffleOn": "Shuffle on",
           "player.nowPlaying.open": "Open Now Playing",
           "player.nowPlaying.close": "Close",
@@ -776,6 +778,29 @@ describe("isAtFirst / isAtLast with modes", () => {
 
     const prevBtn = screen.getByRole("button", { name: "Previous track" });
     expect(prevBtn).toHaveProperty("disabled", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mobile chevron affordance (Item 3 / S3-chevron)
+// ---------------------------------------------------------------------------
+
+describe("mobile chevron affordance", () => {
+  it("ChevronUp icon is present in mobile track-meta button when a track is loaded", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    render(<GlobalPlayerBar />);
+
+    const mobileBtn = screen.getByRole("button", { name: "Open Now Playing" });
+    const chevron = mobileBtn.querySelector("[aria-hidden='true'][data-icon='chevron-up']");
+    expect(chevron).not.toBeNull();
+  });
+
+  it("ChevronUp icon is absent when no track is loaded", () => {
+    usePlayerStore.setState({ error: "Network error" });
+    render(<GlobalPlayerBar />);
+
+    const mobileBtn = screen.queryByRole("button", { name: "Open Now Playing" });
+    expect(mobileBtn).toBeNull();
   });
 });
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -1,4 +1,9 @@
-import { faListUl, faVolumeHigh, faVolumeXmark } from "@fortawesome/free-solid-svg-icons";
+import {
+  faChevronUp,
+  faListUl,
+  faVolumeHigh,
+  faVolumeXmark,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { FC, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -304,6 +309,11 @@ export const GlobalPlayerBar: FC = () => {
                     className="flex min-w-0 items-center gap-3 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 md:hidden"
                   >
                     <TrackMetaContent item={currentItem} />
+                    <FontAwesomeIcon
+                      icon={faChevronUp}
+                      aria-hidden="true"
+                      className="shrink-0 text-xs text-white/60"
+                    />
                   </button>
                   <div className="hidden min-w-0 md:flex">
                     <TrackMeta item={currentItem} onNavigate={navigate} />

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -395,7 +395,9 @@
       "pause": "Pause",
       "play": "Play",
       "seek": "Seek",
-      "repeatEnable": "Enable repeat"
+      "repeatEnable": "Enable repeat",
+      "repeatAll": "Repeat all",
+      "repeatOne": "Repeat one"
     }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -395,7 +395,9 @@
       "pause": "Pausar",
       "play": "Reproducir",
       "seek": "Avanzar",
-      "repeatEnable": "Activar repetición"
+      "repeatEnable": "Activar repetición",
+      "repeatAll": "Repetir todo",
+      "repeatOne": "Repetir una"
     }
   }
 }

--- a/apps/frontend/src/store/playerUISlice.test.ts
+++ b/apps/frontend/src/store/playerUISlice.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPlayerUISlice, type PlayerUISlice } from "./playerUISlice";
+
+describe("createPlayerUISlice", () => {
+  let set: ReturnType<typeof vi.fn>;
+  let slice: PlayerUISlice;
+
+  beforeEach(() => {
+    set = vi.fn();
+    slice = createPlayerUISlice(set as never, () => slice as never, undefined as never);
+  });
+
+  it("initializes isQueuePanelOpen to false", () => {
+    expect(slice.isQueuePanelOpen).toBe(false);
+  });
+
+  it("initializes isNowPlayingOpen to false", () => {
+    expect(slice.isNowPlayingOpen).toBe(false);
+  });
+
+  it("setQueuePanelOpen calls set with { isQueuePanelOpen: true }", () => {
+    slice.setQueuePanelOpen(true);
+    expect(set).toHaveBeenCalledWith({ isQueuePanelOpen: true });
+  });
+
+  it("setQueuePanelOpen calls set with { isQueuePanelOpen: false }", () => {
+    slice.setQueuePanelOpen(false);
+    expect(set).toHaveBeenCalledWith({ isQueuePanelOpen: false });
+  });
+
+  it("setNowPlayingOpen calls set with { isNowPlayingOpen: true }", () => {
+    slice.setNowPlayingOpen(true);
+    expect(set).toHaveBeenCalledWith({ isNowPlayingOpen: true });
+  });
+
+  it("setNowPlayingOpen calls set with { isNowPlayingOpen: false }", () => {
+    slice.setNowPlayingOpen(false);
+    expect(set).toHaveBeenCalledWith({ isNowPlayingOpen: false });
+  });
+});

--- a/apps/frontend/src/store/playerUISlice.ts
+++ b/apps/frontend/src/store/playerUISlice.ts
@@ -1,0 +1,20 @@
+import type { StateCreator } from "zustand";
+
+export interface PlayerUISlice {
+  isQueuePanelOpen: boolean;
+  isNowPlayingOpen: boolean;
+  setQueuePanelOpen: (open: boolean) => void;
+  setNowPlayingOpen: (open: boolean) => void;
+}
+
+export const createPlayerUISlice: StateCreator<
+  PlayerUISlice,
+  [["zustand/persist", unknown]],
+  [],
+  PlayerUISlice
+> = (set) => ({
+  isQueuePanelOpen: false,
+  isNowPlayingOpen: false,
+  setQueuePanelOpen: (open) => set({ isQueuePanelOpen: open }),
+  setNowPlayingOpen: (open) => set({ isNowPlayingOpen: open }),
+});

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -1,11 +1,6 @@
-/**
- * 3rd Zustand store — approved exception to the "exactly 2 stores" convention.
- * Singleton module survives client-side navigation so playback continues across
- * route changes; selector subscriptions confine ~4Hz currentTime re-renders to
- * the progress sub-component. See `sdd/global-player-bar/proposal`.
- */
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { createPlayerUISlice, type PlayerUISlice } from "./playerUISlice";
 
 export interface QueueItem {
   id: string;
@@ -26,7 +21,7 @@ export interface QueueItem {
 
 export type RepeatMode = "off" | "all" | "one";
 
-export interface PlayerState {
+export interface PlayerState extends PlayerUISlice {
   queue: QueueItem[];
   currentIndex: number | null;
   isPlaying: boolean;
@@ -40,9 +35,6 @@ export interface PlayerState {
   shuffleOrder: number[];
   shuffleOrderIndex: number;
 
-  isQueuePanelOpen: boolean;
-  isNowPlayingOpen: boolean;
-
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
   next: () => void;
@@ -53,8 +45,6 @@ export interface PlayerState {
   clear: () => void;
   toggleShuffle: () => void;
   cycleRepeat: () => void;
-  setQueuePanelOpen: (open: boolean) => void;
-  setNowPlayingOpen: (open: boolean) => void;
   playFromIndex: (index: number) => void;
 
   reorderQueue: (fromIndex: number, toIndex: number) => void;
@@ -109,8 +99,6 @@ const INITIAL_STATE = {
   repeatMode: "off" as RepeatMode,
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
-  isQueuePanelOpen: false,
-  isNowPlayingOpen: false,
 };
 
 type AdvanceSource = "user" | "ended";
@@ -159,6 +147,7 @@ export const usePlayerStore = create<PlayerState>()(
 
       return {
         ...INITIAL_STATE,
+        ...createPlayerUISlice(set, get, undefined as never),
 
         playQueue(items, startIndex) {
           if (items.length === 0 || startIndex < 0 || startIndex >= items.length) {
@@ -313,14 +302,6 @@ export const usePlayerStore = create<PlayerState>()(
 
         _onError(message) {
           set({ error: message, isPlaying: false });
-        },
-
-        setQueuePanelOpen(open) {
-          set({ isQueuePanelOpen: open });
-        },
-
-        setNowPlayingOpen(open) {
-          set({ isNowPlayingOpen: open });
         },
 
         playFromIndex(index) {


### PR DESCRIPTION
## Summary

Addresses items 1, 2, and 3 of #103 in a single bundled PR.

- **Item 1 — Ephemeral UI flags destination**: extracted `isQueuePanelOpen` / `isNowPlayingOpen` (+ setters) into a new `playerUISlice.ts` composed into `usePlayerStore` via Zustand slice composition. Preserves the 3-store rule, persist `partialize` exclusion, `clear()` reset semantics, and all consumer call sites (`GlobalPlayerBar`, `QueueSidePanel`, `NowPlayingFullscreen`). Documented fast-path to a future `useUIStore` if a 3rd ephemeral UI flag with mutual exclusion lands.
- **Item 2 — i18n namespace consistency (SUGG1)**: moved repeat aria labels `player.queue.repeatAll` / `player.queue.repeatOne` to `player.transport.repeatAll` / `player.transport.repeatOne` in `en.json`, `es.json`, and `TransportControls`. Old `player.queue.*` keys retained because `QueueSidePanel` consumes them for display text.
- **Item 3 — Mobile fullscreen trigger affordance**: added a mobile-only `ChevronUp` icon (FontAwesome `faChevronUp`, `aria-hidden="true"`) next to the track meta region in `GlobalPlayerBar` to improve discoverability.

Items 4–7 of #103 are deferred per the issue body (P3/P4 backlog and manual verification).

### Out of scope

- Items 4 (e2e drag-and-drop), 5 (`useReorderable` hook), 6 (chained-PR sizing policy), 7 (real-device manual smoke).

## Test plan

- [x] `pnpm --filter frontend test:run` — 432/432 passing.
- [x] `tsc --noEmit` — clean.
- [x] `oxlint` — clean.
- [ ] Manual mobile viewport check: chevron visible only below `md` breakpoint, opens fullscreen on tap.
- [ ] Manual desktop viewport check: chevron hidden.
- [ ] Manual repeat button: cycle off → all → one, verify aria-label translations in EN and ES.

## SDD lineage

- `sdd/player-ephemeral-ui-flags/archive-report` (#3361)
- `sdd/player-i18n-and-mobile-affordance/archive-report` (#3360)

Closes parts of #103.