### PR TITLE
fix(backend): initialize env before auth wiring

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -3,48 +3,53 @@ import cors from "cors";
 import express, { type Express } from "express";
 import helmet from "helmet";
 import path from "path";
+import type { Container } from "./container";
 import { errorHandler } from "./presentation/middleware/error-handler";
-import routes from "./presentation/routes";
+import { createRoutes } from "./presentation/routes";
 
-export const app: Express = express();
+export function createApp(container: Container): Express {
+  const app: Express = express();
 
-// Security middleware
-app.use(
-  helmet({
-    contentSecurityPolicy: {
-      directives: {
-        ...helmet.contentSecurityPolicy.getDefaultDirectives(),
-        "img-src": ["'self'", "data:", "https:"],
-        "script-src": ["'self'", "'unsafe-inline'"],
-        "style-src": ["'self'", "https:", "'unsafe-inline'"],
-        "upgrade-insecure-requests": null,
+  // Security middleware
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+          "img-src": ["'self'", "data:", "https:"],
+          "script-src": ["'self'", "'unsafe-inline'"],
+          "style-src": ["'self'", "https:", "'unsafe-inline'"],
+          "upgrade-insecure-requests": null,
+        },
       },
-    },
-    hsts: false,
-    crossOriginOpenerPolicy: false,
-    originAgentCluster: false,
-  }),
-);
-app.use(cors());
+      hsts: false,
+      crossOriginOpenerPolicy: false,
+      originAgentCluster: false,
+    }),
+  );
+  app.use(cors());
 
-// Body parsing
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
+  // Body parsing
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: true }));
 
-// API Routes
-app.use(ApiRoutes.BASE, routes);
+  // API Routes
+  app.use(ApiRoutes.BASE, createRoutes(container));
 
-// Serve static files (frontend)
-const frontendPath = path.resolve(__dirname, "../../frontend/dist");
-app.use(express.static(frontendPath));
+  // Serve static files (frontend)
+  const frontendPath = path.resolve(__dirname, "../../frontend/dist");
+  app.use(express.static(frontendPath));
 
-// Catch-all for SPA routing (must come before error handler)
-app.use((req, res, next) => {
-  if (req.path.startsWith("/api")) {
-    return next();
-  }
-  res.sendFile(path.join(frontendPath, "index.html"));
-});
+  // Catch-all for SPA routing (must come before error handler)
+  app.use((req, res, next) => {
+    if (req.path.startsWith("/api")) {
+      return next();
+    }
+    res.sendFile(path.join(frontendPath, "index.html"));
+  });
 
-// Global error handler (must be last)
-app.use(errorHandler);
+  // Global error handler (must be last)
+  app.use(errorHandler);
+
+  return app;
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -88,7 +88,7 @@ import { FileSystemTrackPathService } from "./infrastructure/services/file-syste
 import { FileSystemLibraryAudioService } from "./infrastructure/services/library-audio.service";
 import { FileSystemLibraryImageService } from "./infrastructure/services/library-image.service";
 import { MetadataService } from "./infrastructure/services/metadata.service";
-import { getEnv } from "./infrastructure/setup/environment";
+import type { Env } from "./infrastructure/setup/environment";
 import { prisma } from "./infrastructure/setup/prisma";
 import { ArtistController } from "./presentation/controllers/artist.controller";
 import { ArtworkBackfillController } from "./presentation/controllers/artwork-backfill.controller";
@@ -104,570 +104,545 @@ import { SearchController } from "./presentation/controllers/search.controller";
 import { SettingsController } from "./presentation/controllers/settings.controller";
 import { TrackController } from "./presentation/controllers/track.controller";
 
-function resolveDownloadsRoot(): string {
-  try {
-    return getEnv().DOWNLOADS;
-  } catch {
-    // Test suites can import the container before environment validation bootstraps.
-    // TODO(secure-library-image-serving): Remove this fallback after `getEnv()` becomes lazily initialized.
-    return process.env.DOWNLOADS ?? ".";
-  }
-}
-
-function resolveSpotifyAuthConfig(): { clientId: string; redirectUri: string } {
-  try {
-    const env = getEnv();
-    return { clientId: env.SPOTIFY_CLIENT_ID, redirectUri: env.SPOTIFY_REDIRECT_URI };
-  } catch {
-    return { clientId: "", redirectUri: "" };
-  }
-}
-
 type ComposedSpotifyUserLibrary = SpotifyUserLibraryPort & {
   getMyPlaylists: SpotifyPlaylistLibraryService["getMyPlaylists"];
   getArtistCatalogData: SpotifyArtistCatalogService["getArtistCatalogData"];
 };
 
-// Repositories
-const playlistRepository = new PrismaPlaylistRepository();
-const trackRepository = new PrismaTrackRepository();
-const historyRepository = new PrismaHistoryRepository();
-const settingsRepository = new PrismaSettingsRepository();
-const followedArtistRepository = new FollowedArtistRepository(prisma);
-const artistAlbumCacheRepository = new ArtistAlbumCacheRepository(prisma);
-const artistReleaseCacheRepository = new ArtistReleaseCacheRepository(prisma);
-const feedSyncStateRepository = new FeedSyncStateRepository(prisma);
-const artworkBackfillRepository = new PrismaArtworkBackfillRepository(prisma);
-const feedCacheEvictionRepository = new FeedCacheEvictionRepository(prisma);
-const feedCacheEvictionService = new FeedCacheEvictionService(feedCacheEvictionRepository);
-const feedRepository: FeedRepositoryPort = {
-  getArtistBySpotifyId: (spotifyId) => followedArtistRepository.getArtistBySpotifyId(spotifyId),
-  getArtistByAnyId: (id) => followedArtistRepository.getArtistByAnyId(id),
-  getArtistCatalogIdentities: (spotifyIds) =>
-    followedArtistRepository.getArtistCatalogIdentities(spotifyIds),
-  updateArtistCatalogIdentities: (identities) =>
-    followedArtistRepository.updateArtistCatalogIdentities(identities),
-  getReleases: (lookbackDays) => artistReleaseCacheRepository.getReleases(lookbackDays),
-  getArtists: () => followedArtistRepository.getArtists(),
-  upsertArtists: (artists) => followedArtistRepository.upsertArtists(artists),
-  upsertReleases: (releases) => artistReleaseCacheRepository.upsertReleases(releases),
-  getArtistAlbumWithArtist: (spotifyArtistId, albumId) =>
-    artistAlbumCacheRepository.getArtistAlbumWithArtist(spotifyArtistId, albumId),
-  getArtistReleaseWithArtist: (artistId, albumId) =>
-    artistReleaseCacheRepository.getArtistReleaseWithArtist(artistId, albumId),
-  updateArtistAlbumIdentities: (id, identities) =>
-    artistAlbumCacheRepository.updateArtistAlbumIdentities(id, identities),
-  upsertArtistAlbumSpotifyUrl: (input) =>
-    artistAlbumCacheRepository.upsertArtistAlbumSpotifyUrl(input),
-  updateArtistReleaseSpotifyUrl: (artistId, albumId, spotifyUrl) =>
-    artistReleaseCacheRepository.updateArtistReleaseSpotifyUrl(artistId, albumId, spotifyUrl),
-  getArtistAlbumCount: (spotifyArtistId) =>
-    artistAlbumCacheRepository.getArtistAlbumCount(spotifyArtistId),
-  getArtistAlbumsFreshness: (spotifyArtistId) =>
-    artistAlbumCacheRepository.getArtistAlbumsFreshness(spotifyArtistId),
-  getArtistIdsWithNoAlbums: () => followedArtistRepository.getArtistIdsWithNoAlbums(),
-  getArtistIdsWithFreshAlbums: (cutoffDate) =>
-    artistAlbumCacheRepository.getArtistIdsWithFreshAlbums(cutoffDate),
-  getArtistIdsWithFreshReleases: (cutoffDate) =>
-    artistReleaseCacheRepository.getArtistIdsWithFreshReleases(cutoffDate),
-  getArtistAlbums: (spotifyArtistId, limit, offset) =>
-    artistAlbumCacheRepository.getArtistAlbums(spotifyArtistId, limit, offset),
-  upsertArtistAlbums: (albums) => artistAlbumCacheRepository.upsertArtistAlbums(albums),
-  evictStaleFeedCache: (artistIds, cutoffDays) =>
-    feedCacheEvictionService.evictStaleFeedCache(artistIds, cutoffDays),
-  getArtistIdsNeedingCatalogSync: (cutoffDate, limit) =>
-    followedArtistRepository.getArtistIdsNeedingCatalogSync(cutoffDate, limit),
-  getActiveArtistIdsForReleasesSync: (releaseCutoff, activityWindowDate, limit) =>
-    followedArtistRepository.getActiveArtistIdsForReleasesSync(
-      releaseCutoff,
-      activityWindowDate,
-      limit,
-    ),
-  updateArtistCatalogSyncedAt: (artistIds) =>
-    followedArtistRepository.updateArtistCatalogSyncedAt(artistIds),
-  updateArtistReleasesSyncedAt: (artistIds) =>
-    followedArtistRepository.updateArtistReleasesSyncedAt(artistIds),
-  getSyncState: () => feedSyncStateRepository.getSyncState(),
-  setSyncState: (status, error) => feedSyncStateRepository.setSyncState(status, error),
-  getCatalogSyncState: () => feedSyncStateRepository.getCatalogSyncState(),
-  setCatalogSyncState: (status, error) =>
-    feedSyncStateRepository.setCatalogSyncState(status, error),
-};
-const connectivityAdapter = new PrismaConnectivityAdapter();
+export function createContainer(env: Env) {
+  const playlistRepository = new PrismaPlaylistRepository();
+  const trackRepository = new PrismaTrackRepository();
+  const historyRepository = new PrismaHistoryRepository();
+  const settingsRepository = new PrismaSettingsRepository();
+  const followedArtistRepository = new FollowedArtistRepository(prisma);
+  const artistAlbumCacheRepository = new ArtistAlbumCacheRepository(prisma);
+  const artistReleaseCacheRepository = new ArtistReleaseCacheRepository(prisma);
+  const feedSyncStateRepository = new FeedSyncStateRepository(prisma);
+  const artworkBackfillRepository = new PrismaArtworkBackfillRepository(prisma);
+  const feedCacheEvictionRepository = new FeedCacheEvictionRepository(prisma);
+  const feedCacheEvictionService = new FeedCacheEvictionService(feedCacheEvictionRepository);
+  const feedRepository: FeedRepositoryPort = {
+    getArtistBySpotifyId: (spotifyId) => followedArtistRepository.getArtistBySpotifyId(spotifyId),
+    getArtistByAnyId: (id) => followedArtistRepository.getArtistByAnyId(id),
+    getArtistCatalogIdentities: (spotifyIds) =>
+      followedArtistRepository.getArtistCatalogIdentities(spotifyIds),
+    updateArtistCatalogIdentities: (identities) =>
+      followedArtistRepository.updateArtistCatalogIdentities(identities),
+    getReleases: (lookbackDays) => artistReleaseCacheRepository.getReleases(lookbackDays),
+    getArtists: () => followedArtistRepository.getArtists(),
+    upsertArtists: (artists) => followedArtistRepository.upsertArtists(artists),
+    upsertReleases: (releases) => artistReleaseCacheRepository.upsertReleases(releases),
+    getArtistAlbumWithArtist: (spotifyArtistId, albumId) =>
+      artistAlbumCacheRepository.getArtistAlbumWithArtist(spotifyArtistId, albumId),
+    getArtistReleaseWithArtist: (artistId, albumId) =>
+      artistReleaseCacheRepository.getArtistReleaseWithArtist(artistId, albumId),
+    updateArtistAlbumIdentities: (id, identities) =>
+      artistAlbumCacheRepository.updateArtistAlbumIdentities(id, identities),
+    upsertArtistAlbumSpotifyUrl: (input) =>
+      artistAlbumCacheRepository.upsertArtistAlbumSpotifyUrl(input),
+    updateArtistReleaseSpotifyUrl: (artistId, albumId, spotifyUrl) =>
+      artistReleaseCacheRepository.updateArtistReleaseSpotifyUrl(artistId, albumId, spotifyUrl),
+    getArtistAlbumCount: (spotifyArtistId) =>
+      artistAlbumCacheRepository.getArtistAlbumCount(spotifyArtistId),
+    getArtistAlbumsFreshness: (spotifyArtistId) =>
+      artistAlbumCacheRepository.getArtistAlbumsFreshness(spotifyArtistId),
+    getArtistIdsWithNoAlbums: () => followedArtistRepository.getArtistIdsWithNoAlbums(),
+    getArtistIdsWithFreshAlbums: (cutoffDate) =>
+      artistAlbumCacheRepository.getArtistIdsWithFreshAlbums(cutoffDate),
+    getArtistIdsWithFreshReleases: (cutoffDate) =>
+      artistReleaseCacheRepository.getArtistIdsWithFreshReleases(cutoffDate),
+    getArtistAlbums: (spotifyArtistId, limit, offset) =>
+      artistAlbumCacheRepository.getArtistAlbums(spotifyArtistId, limit, offset),
+    upsertArtistAlbums: (albums) => artistAlbumCacheRepository.upsertArtistAlbums(albums),
+    evictStaleFeedCache: (artistIds, cutoffDays) =>
+      feedCacheEvictionService.evictStaleFeedCache(artistIds, cutoffDays),
+    getArtistIdsNeedingCatalogSync: (cutoffDate, limit) =>
+      followedArtistRepository.getArtistIdsNeedingCatalogSync(cutoffDate, limit),
+    getActiveArtistIdsForReleasesSync: (releaseCutoff, activityWindowDate, limit) =>
+      followedArtistRepository.getActiveArtistIdsForReleasesSync(
+        releaseCutoff,
+        activityWindowDate,
+        limit,
+      ),
+    updateArtistCatalogSyncedAt: (artistIds) =>
+      followedArtistRepository.updateArtistCatalogSyncedAt(artistIds),
+    updateArtistReleasesSyncedAt: (artistIds) =>
+      followedArtistRepository.updateArtistReleasesSyncedAt(artistIds),
+    getSyncState: () => feedSyncStateRepository.getSyncState(),
+    setSyncState: (status, error) => feedSyncStateRepository.setSyncState(status, error),
+    getCatalogSyncState: () => feedSyncStateRepository.getCatalogSyncState(),
+    setCatalogSyncState: (status, error) =>
+      feedSyncStateRepository.setCatalogSyncState(status, error),
+  };
+  const connectivityAdapter = new PrismaConnectivityAdapter();
 
-const internalizedNumericSettingMap: Record<string, () => number> = {
-  FEED_SYNC_INTERVAL_MINUTES: () => getEnv().FEED_SYNC_INTERVAL_MINUTES,
-  RELEASES_SYNC_INTERVAL_MINUTES: () => getEnv().RELEASES_SYNC_INTERVAL_MINUTES,
-  CATALOG_SYNC_INTERVAL_HOURS: () => getEnv().CATALOG_SYNC_INTERVAL_HOURS,
-  CATALOG_LOOKBACK_DAYS: () => getEnv().CATALOG_LOOKBACK_DAYS,
-  MAX_ACTIVE_ARTISTS_PER_CYCLE: () => getEnv().MAX_ACTIVE_ARTISTS_PER_CYCLE,
-  MAX_CATALOG_ARTISTS_PER_CYCLE: () => getEnv().MAX_CATALOG_ARTISTS_PER_CYCLE,
-  FOLLOWED_ARTISTS_MAX: () => getEnv().FOLLOWED_ARTISTS_MAX,
-  RELEASES_LOOKBACK_DAYS: () => getEnv().RELEASES_LOOKBACK_DAYS,
-  RELEASES_CACHE_MINUTES: () => getEnv().RELEASES_CACHE_MINUTES,
-  YT_SEARCH_CONCURRENCY: () => getEnv().YT_SEARCH_CONCURRENCY,
-  YT_SEARCH_DELAY_MS: () => getEnv().YT_SEARCH_DELAY_MS,
-  YT_DOWNLOADS_PER_MINUTE: () => getEnv().YT_DOWNLOADS_PER_MINUTE,
-  STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES: () => getEnv().STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES,
-  STUCK_TRACKS_TIMEOUT_MINUTES: () => getEnv().STUCK_TRACKS_TIMEOUT_MINUTES,
-};
+  const internalizedNumericSettingMap: Record<string, () => number> = {
+    FEED_SYNC_INTERVAL_MINUTES: () => env.FEED_SYNC_INTERVAL_MINUTES,
+    RELEASES_SYNC_INTERVAL_MINUTES: () => env.RELEASES_SYNC_INTERVAL_MINUTES,
+    CATALOG_SYNC_INTERVAL_HOURS: () => env.CATALOG_SYNC_INTERVAL_HOURS,
+    CATALOG_LOOKBACK_DAYS: () => env.CATALOG_LOOKBACK_DAYS,
+    MAX_ACTIVE_ARTISTS_PER_CYCLE: () => env.MAX_ACTIVE_ARTISTS_PER_CYCLE,
+    MAX_CATALOG_ARTISTS_PER_CYCLE: () => env.MAX_CATALOG_ARTISTS_PER_CYCLE,
+    FOLLOWED_ARTISTS_MAX: () => env.FOLLOWED_ARTISTS_MAX,
+    RELEASES_LOOKBACK_DAYS: () => env.RELEASES_LOOKBACK_DAYS,
+    RELEASES_CACHE_MINUTES: () => env.RELEASES_CACHE_MINUTES,
+    YT_SEARCH_CONCURRENCY: () => env.YT_SEARCH_CONCURRENCY,
+    YT_SEARCH_DELAY_MS: () => env.YT_SEARCH_DELAY_MS,
+    YT_DOWNLOADS_PER_MINUTE: () => env.YT_DOWNLOADS_PER_MINUTE,
+    STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES: () => env.STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES,
+    STUCK_TRACKS_TIMEOUT_MINUTES: () => env.STUCK_TRACKS_TIMEOUT_MINUTES,
+  };
 
-// Services (Base)
-const settingsService = new SettingsService(settingsRepository, (key) =>
-  internalizedNumericSettingMap[key]?.(),
-);
+  const settingsService = new SettingsService(settingsRepository, (key) =>
+    internalizedNumericSettingMap[key]?.(),
+  );
 
-const trackFileHelper = new FileSystemTrackPathService(settingsService);
-const m3uService = new FileSystemM3uService(settingsService, trackFileHelper);
-const youtubeSearchService = new YoutubeSearchService(settingsService);
-const youtubeDownloadService = new YoutubeDownloadService(settingsService, youtubeSearchService);
-const metadataService = new MetadataService();
-const artworkAssetsService = new ArtworkAssetsService();
+  const trackFileHelper = new FileSystemTrackPathService(settingsService);
+  const m3uService = new FileSystemM3uService(settingsService, trackFileHelper);
+  const youtubeSearchService = new YoutubeSearchService(settingsService);
+  const youtubeDownloadService = new YoutubeDownloadService(settingsService, youtubeSearchService);
+  const metadataService = new MetadataService();
+  const artworkAssetsService = new ArtworkAssetsService();
 
-const queueService = new BullMqTrackQueueService();
-const artworkBackfillQueueService = new BullMqArtworkBackfillQueueService();
-const eventBus = new AppEventBus();
+  const queueService = new BullMqTrackQueueService();
+  const artworkBackfillQueueService = new BullMqArtworkBackfillQueueService();
+  const eventsController = new EventsController();
+  const eventBus = new AppEventBus(eventsController.emit);
 
-let spotifyUserLibraryService: ComposedSpotifyUserLibrary | null = null;
-let spotifyUserLibrarySyncService: ComposedSpotifyUserLibrary | null = null;
-let spotifyPlaylistLibraryService: SpotifyPlaylistLibraryService | null = null;
-let spotifyPlaylistLibrarySyncService: SpotifyPlaylistLibraryService | null = null;
-let spotifyArtistCatalogService: SpotifyArtistCatalogService | null = null;
-let spotifyArtistCatalogSyncService: SpotifyArtistCatalogService | null = null;
-let spotifyFollowedArtistsService: SpotifyFollowedArtistsService | null = null;
-let spotifyFollowedArtistsSyncService: SpotifyFollowedArtistsService | null = null;
+  let spotifyUserLibraryService: ComposedSpotifyUserLibrary | null = null;
+  let spotifyUserLibrarySyncService: ComposedSpotifyUserLibrary | null = null;
+  let spotifyPlaylistLibraryService: SpotifyPlaylistLibraryService | null = null;
+  let spotifyPlaylistLibrarySyncService: SpotifyPlaylistLibraryService | null = null;
+  let spotifyArtistCatalogService: SpotifyArtistCatalogService | null = null;
+  let spotifyArtistCatalogSyncService: SpotifyArtistCatalogService | null = null;
+  let spotifyFollowedArtistsService: SpotifyFollowedArtistsService | null = null;
+  let spotifyFollowedArtistsSyncService: SpotifyFollowedArtistsService | null = null;
 
-// Spotify
-const spotifyAuthService = SpotifyAuthService.getInstance(settingsService, () => {
-  spotifyUserLibraryService?.clearCache();
-  spotifyUserLibrarySyncService?.clearCache();
-});
-const spotifyRequestCache = new PromiseCache({ ttlMs: 30_000 });
-const spotifyArtistClient = new SpotifyArtistClient(
-  spotifyAuthService,
-  settingsService,
-  spotifyRequestCache,
-  "interactive",
-);
-const spotifyTrackClient = new SpotifyTrackClient(
-  spotifyAuthService,
-  settingsService,
-  "interactive",
-  spotifyRequestCache,
-);
-const spotifyAlbumClient = new SpotifyAlbumClient(
-  spotifyAuthService,
-  settingsService,
-  spotifyRequestCache,
-  "interactive",
-);
-const spotifyPlaylistClient = new SpotifyPlaylistClient(
-  spotifyAuthService,
-  settingsService,
-  spotifyTrackClient,
-  spotifyAlbumClient,
-  spotifyRequestCache,
-  "interactive",
-);
+  const spotifyAuthService = SpotifyAuthService.getInstance(settingsService, () => {
+    spotifyUserLibraryService?.clearCache();
+    spotifyUserLibrarySyncService?.clearCache();
+  });
+  const spotifyRequestCache = new PromiseCache({ ttlMs: 30_000 });
+  const spotifyArtistClient = new SpotifyArtistClient(
+    spotifyAuthService,
+    settingsService,
+    spotifyRequestCache,
+    "interactive",
+  );
+  const spotifyTrackClient = new SpotifyTrackClient(
+    spotifyAuthService,
+    settingsService,
+    "interactive",
+    spotifyRequestCache,
+  );
+  const spotifyAlbumClient = new SpotifyAlbumClient(
+    spotifyAuthService,
+    settingsService,
+    spotifyRequestCache,
+    "interactive",
+  );
+  const spotifyPlaylistClient = new SpotifyPlaylistClient(
+    spotifyAuthService,
+    settingsService,
+    spotifyTrackClient,
+    spotifyAlbumClient,
+    spotifyRequestCache,
+    "interactive",
+  );
+  const spotifyPlaylistClientSync = new SpotifyPlaylistClient(
+    spotifyAuthService,
+    settingsService,
+    spotifyTrackClient,
+    spotifyAlbumClient,
+    spotifyRequestCache,
+    "sync",
+  );
+  const spotifySearchClient = new SpotifySearchClient(
+    spotifyAuthService,
+    settingsService,
+    spotifyRequestCache,
+    "interactive",
+  );
 
-// Playlist client for background workers (downloads, sync) — uses sync limiter
-// to avoid competing with user-facing interactive requests
-const spotifyPlaylistClientSync = new SpotifyPlaylistClient(
-  spotifyAuthService,
-  settingsService,
-  spotifyTrackClient,
-  spotifyAlbumClient,
-  spotifyRequestCache,
-  "sync",
-);
-const spotifySearchClient = new SpotifySearchClient(
-  spotifyAuthService,
-  settingsService,
-  spotifyRequestCache,
-  "interactive",
-);
+  spotifyFollowedArtistsService = new SpotifyFollowedArtistsService(
+    settingsService,
+    spotifyAuthService,
+    "user",
+  );
+  spotifyPlaylistLibraryService = new SpotifyPlaylistLibraryService(
+    settingsService,
+    spotifyAuthService,
+    "user",
+  );
+  spotifyArtistCatalogService = new SpotifyArtistCatalogService(
+    settingsService,
+    spotifyAuthService,
+    "user",
+  );
 
-spotifyFollowedArtistsService = new SpotifyFollowedArtistsService(
-  settingsService,
-  spotifyAuthService,
-  "user",
-);
-spotifyPlaylistLibraryService = new SpotifyPlaylistLibraryService(
-  settingsService,
-  spotifyAuthService,
-  "user",
-);
-spotifyArtistCatalogService = new SpotifyArtistCatalogService(
-  settingsService,
-  spotifyAuthService,
-  "user",
-);
+  spotifyFollowedArtistsSyncService = new SpotifyFollowedArtistsService(
+    settingsService,
+    spotifyAuthService,
+    "sync",
+  );
+  spotifyPlaylistLibrarySyncService = new SpotifyPlaylistLibraryService(
+    settingsService,
+    spotifyAuthService,
+    "sync",
+  );
+  spotifyArtistCatalogSyncService = new SpotifyArtistCatalogService(
+    settingsService,
+    spotifyAuthService,
+    "sync",
+  );
 
-spotifyFollowedArtistsSyncService = new SpotifyFollowedArtistsService(
-  settingsService,
-  spotifyAuthService,
-  "sync",
-);
-spotifyPlaylistLibrarySyncService = new SpotifyPlaylistLibraryService(
-  settingsService,
-  spotifyAuthService,
-  "sync",
-);
-spotifyArtistCatalogSyncService = new SpotifyArtistCatalogService(
-  settingsService,
-  spotifyAuthService,
-  "sync",
-);
+  spotifyUserLibraryService = {
+    getFollowedArtists: () => spotifyFollowedArtistsService.getFollowedArtists(),
+    getMyPlaylists: () => spotifyPlaylistLibraryService.getMyPlaylists(),
+    getArtistCatalogData: (artists, earlyStopBeforeDate) =>
+      spotifyArtistCatalogService.getArtistCatalogData(artists, earlyStopBeforeDate),
+    clearCache: () => {
+      spotifyFollowedArtistsService?.clearCache();
+      spotifyPlaylistLibraryService?.clearCache();
+      spotifyArtistCatalogService?.clearCache();
+    },
+  };
 
-spotifyUserLibraryService = {
-  getFollowedArtists: () => spotifyFollowedArtistsService.getFollowedArtists(),
-  getMyPlaylists: () => spotifyPlaylistLibraryService.getMyPlaylists(),
-  getArtistCatalogData: (artists, earlyStopBeforeDate) =>
-    spotifyArtistCatalogService.getArtistCatalogData(artists, earlyStopBeforeDate),
-  clearCache: () => {
-    spotifyFollowedArtistsService?.clearCache();
-    spotifyPlaylistLibraryService?.clearCache();
-    spotifyArtistCatalogService?.clearCache();
-  },
-};
+  spotifyUserLibrarySyncService = {
+    getFollowedArtists: () => spotifyFollowedArtistsSyncService.getFollowedArtists(),
+    getMyPlaylists: () => spotifyPlaylistLibrarySyncService.getMyPlaylists(),
+    getArtistCatalogData: (artists, earlyStopBeforeDate) =>
+      spotifyArtistCatalogSyncService.getArtistCatalogData(artists, earlyStopBeforeDate),
+    clearCache: () => {
+      spotifyFollowedArtistsSyncService?.clearCache();
+      spotifyPlaylistLibrarySyncService?.clearCache();
+      spotifyArtistCatalogSyncService?.clearCache();
+    },
+  };
 
-spotifyUserLibrarySyncService = {
-  getFollowedArtists: () => spotifyFollowedArtistsSyncService.getFollowedArtists(),
-  getMyPlaylists: () => spotifyPlaylistLibrarySyncService.getMyPlaylists(),
-  getArtistCatalogData: (artists, earlyStopBeforeDate) =>
-    spotifyArtistCatalogSyncService.getArtistCatalogData(artists, earlyStopBeforeDate),
-  clearCache: () => {
-    spotifyFollowedArtistsSyncService?.clearCache();
-    spotifyPlaylistLibrarySyncService?.clearCache();
-    spotifyArtistCatalogSyncService?.clearCache();
-  },
-};
+  const deezerClient = new DeezerClient();
+  const deezerArtistLookupAdapter = new DeezerArtistLookupAdapter(deezerClient);
+  const catalogSearchPort = new DeezerCatalogSearchAdapter(deezerClient, feedRepository);
+  const musicBrainzClient = new MusicBrainzClient();
+  const releaseFeedService = new ReleaseFeedService(
+    feedRepository,
+    deezerClient,
+    musicBrainzClient,
+  );
 
-// External catalog providers (Deezer primary, MusicBrainz fallback; Spotify URLs materialize on demand)
-const deezerClient = new DeezerClient();
-const deezerArtistLookupAdapter = new DeezerArtistLookupAdapter(deezerClient);
+  const externalUrlCacheRepository = new ExternalUrlCacheRepository(prisma);
+  const spotifyUrlLookupClient = new SpotifyUrlLookupClient(spotifyAuthService, settingsService);
+  const resolveExternalUrlUseCase = new ResolveExternalUrlUseCase(
+    externalUrlCacheRepository,
+    spotifyUrlLookupClient,
+  );
+  const externalUrlController = new ExternalUrlController(resolveExternalUrlUseCase);
 
-// Catalog search is Deezer-first after PR-3.4 cleanup.
-// SpotifyCatalogSearchAdapter and SEARCH_PROVIDER=spotify branch removed (CLN-1).
-const catalogSearchPort = new DeezerCatalogSearchAdapter(deezerClient, feedRepository);
-const musicBrainzClient = new MusicBrainzClient();
-const releaseFeedService = new ReleaseFeedService(feedRepository, deezerClient, musicBrainzClient);
+  const spotifyService = new SpotifyService({
+    artistClient: spotifyArtistClient,
+    trackClient: spotifyTrackClient,
+    albumClient: spotifyAlbumClient,
+    playlistClient: spotifyPlaylistClient,
+    searchClient: spotifySearchClient,
+    userLibraryService: spotifyUserLibraryService,
+  });
+  const spotifyServiceSync = new SpotifyService({
+    artistClient: spotifyArtistClient,
+    trackClient: spotifyTrackClient,
+    albumClient: spotifyAlbumClient,
+    playlistClient: spotifyPlaylistClientSync,
+    searchClient: spotifySearchClient,
+    userLibraryService: spotifyUserLibrarySyncService,
+  });
 
-// External URL lazy resolution (Design D2)
-const externalUrlCacheRepository = new ExternalUrlCacheRepository(prisma);
-const spotifyUrlLookupClient = new SpotifyUrlLookupClient(spotifyAuthService, settingsService);
-const resolveExternalUrlUseCase = new ResolveExternalUrlUseCase(
-  externalUrlCacheRepository,
-  spotifyUrlLookupClient,
-);
-const externalUrlController = new ExternalUrlController(resolveExternalUrlUseCase);
+  const artworkService = new ArtworkService(
+    playlistRepository,
+    spotifyServiceSync,
+    trackFileHelper,
+    artworkAssetsService,
+  );
+  const trackPostProcessingService = new TrackPostProcessingService(
+    artworkService,
+    metadataService,
+    playlistRepository,
+    trackRepository,
+    trackFileHelper,
+    m3uService,
+  );
 
-// Interactive SpotifyService — for user-facing controllers (preview, search, artist detail)
-const spotifyService = new SpotifyService({
-  artistClient: spotifyArtistClient,
-  trackClient: spotifyTrackClient,
-  albumClient: spotifyAlbumClient,
-  playlistClient: spotifyPlaylistClient,
-  searchClient: spotifySearchClient,
-  userLibraryService: spotifyUserLibraryService,
-});
+  const createTrackUseCase = new CreateTrackUseCase(trackRepository, queueService);
+  const deleteTrackUseCase = new DeleteTrackUseCase(trackRepository);
+  const getTracksUseCase = new GetTracksUseCase(
+    trackRepository,
+    playlistRepository,
+    trackFileHelper,
+  );
+  const updateTrackUseCase = new UpdateTrackUseCase(trackRepository);
+  const searchTrackOnYoutubeUseCase = new SearchTrackOnYoutubeUseCase(
+    trackRepository,
+    youtubeSearchService,
+    settingsService,
+    queueService,
+    eventBus,
+  );
+  const retryTrackDownloadUseCase = new RetryTrackDownloadUseCase(trackRepository, queueService);
+  const rescueStuckTracksUseCase = new RescueStuckTracksUseCase(
+    trackRepository,
+    retryTrackDownloadUseCase,
+  );
+  const downloadTrackUseCase = new DownloadTrackUseCase(
+    trackRepository,
+    youtubeDownloadService,
+    trackFileHelper,
+    playlistRepository,
+    historyRepository,
+    eventBus,
+    trackPostProcessingService,
+  );
 
-// Sync SpotifyService — for background workers (create playlist, sync, post-processing)
-// Uses sync rate limiter for playlist fetches to avoid starving interactive requests
-const spotifyServiceSync = new SpotifyService({
-  artistClient: spotifyArtistClient,
-  trackClient: spotifyTrackClient,
-  albumClient: spotifyAlbumClient,
-  playlistClient: spotifyPlaylistClientSync,
-  searchClient: spotifySearchClient,
-  userLibraryService: spotifyUserLibrarySyncService,
-});
+  const trackService = new TrackService({
+    searchTrackOnYoutubeUseCase,
+    downloadTrackUseCase,
+    createTrackUseCase,
+    deleteTrackUseCase,
+    getTracksUseCase,
+    retryTrackDownloadUseCase,
+    updateTrackUseCase,
+  });
+  const trackController = new TrackController(
+    deleteTrackUseCase,
+    getTracksUseCase,
+    retryTrackDownloadUseCase,
+  );
 
-// Services (Post-Processing) — uses sync service to avoid starving interactive requests
-const artworkService = new ArtworkService(
-  playlistRepository,
-  spotifyServiceSync,
-  trackFileHelper,
-  artworkAssetsService,
-);
-const trackPostProcessingService = new TrackPostProcessingService(
-  artworkService,
-  metadataService,
-  playlistRepository,
-  trackRepository,
-  trackFileHelper,
-  m3uService,
-);
+  const getSettingsUseCase = new GetSettingsUseCase(settingsRepository);
+  const updateSettingUseCase = new UpdateSettingUseCase(
+    settingsRepository,
+    spotifyUserLibraryService,
+    eventBus,
+  );
 
-// Use Cases - Tracks
-const createTrackUseCase = new CreateTrackUseCase(trackRepository, queueService);
-const deleteTrackUseCase = new DeleteTrackUseCase(trackRepository);
-const getTracksUseCase = new GetTracksUseCase(trackRepository, playlistRepository, trackFileHelper);
-const updateTrackUseCase = new UpdateTrackUseCase(trackRepository);
-const searchTrackOnYoutubeUseCase = new SearchTrackOnYoutubeUseCase(
-  trackRepository,
-  youtubeSearchService,
-  settingsService,
-  queueService,
-  eventBus,
-);
-const retryTrackDownloadUseCase = new RetryTrackDownloadUseCase(trackRepository, queueService);
-const rescueStuckTracksUseCase = new RescueStuckTracksUseCase(
-  trackRepository,
-  retryTrackDownloadUseCase,
-);
-const downloadTrackUseCase = new DownloadTrackUseCase(
-  trackRepository,
-  youtubeDownloadService,
-  trackFileHelper,
-  playlistRepository,
-  historyRepository,
-  eventBus,
-  trackPostProcessingService,
-);
+  const getSystemStatusUseCase = new GetSystemStatusUseCase(playlistRepository);
+  const getPlaylistPreviewUseCase = new GetPlaylistPreviewUseCase(spotifyService);
+  const getPlaylistPreviewTracksPageUseCase = new GetPlaylistPreviewTracksPageUseCase(
+    spotifyService,
+  );
+  const getPlaylistsUseCase = new GetPlaylistsUseCase(playlistRepository);
+  const deletePlaylistUseCase = new DeletePlaylistUseCase(playlistRepository, eventBus);
+  const updatePlaylistUseCase = new UpdatePlaylistUseCase(playlistRepository, eventBus);
 
-// Domain Services (Track)
-const trackService = new TrackService({
-  searchTrackOnYoutubeUseCase,
-  downloadTrackUseCase,
-  createTrackUseCase,
-  deleteTrackUseCase,
-  getTracksUseCase,
-  retryTrackDownloadUseCase,
-  updateTrackUseCase,
-});
+  const spotifyCircuitBreakerAdapter = new SpotifyCircuitBreakerAdapter();
+  const syncSubscribedPlaylistsUseCase = new SyncSubscribedPlaylistsUseCase(
+    playlistRepository,
+    spotifyServiceSync,
+    trackService,
+    eventBus,
+    spotifyCircuitBreakerAdapter,
+  );
+  const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(
+    playlistRepository,
+    trackService,
+  );
+  const getMyPlaylistsUseCase = new GetMyPlaylistsUseCase(spotifyService);
 
-const trackController = new TrackController(
-  deleteTrackUseCase,
-  getTracksUseCase,
-  retryTrackDownloadUseCase,
-);
+  const fileSystemScannerService = new FileSystemScannerService();
+  const cacheArtworkSourceService = new CacheArtworkSourceService(prisma, trackFileHelper);
+  const fileSystemArtworkSourceService = new FileSystemArtworkSourceService(
+    trackFileHelper,
+    artworkAssetsService,
+  );
+  const embeddedArtworkSourceService = new EmbeddedArtworkSourceService();
+  const spotifyArtworkSourceService = new SpotifyArtworkSourceService(
+    spotifyArtistClient,
+    spotifyAlbumClient,
+    spotifySearchClient,
+  );
+  const deezerArtworkSourceService = new DeezerArtworkSourceService(deezerClient);
+  const externalArtworkSources = [deezerArtworkSourceService, spotifyArtworkSourceService];
+  const processArtworkBackfillBatchUseCase = new ProcessArtworkBackfillBatchUseCase(
+    cacheArtworkSourceService,
+    fileSystemArtworkSourceService,
+    cacheArtworkSourceService,
+    embeddedArtworkSourceService,
+    externalArtworkSources,
+    artworkBackfillRepository,
+  );
+  const startArtworkBackfillUseCase = new StartArtworkBackfillUseCase(
+    artworkBackfillRepository,
+    artworkBackfillQueueService,
+  );
+  const pauseArtworkBackfillUseCase = new PauseArtworkBackfillUseCase(artworkBackfillRepository);
+  const resumeArtworkBackfillUseCase = new ResumeArtworkBackfillUseCase(
+    artworkBackfillRepository,
+    artworkBackfillQueueService,
+  );
+  const getArtworkBackfillStatusUseCase = new GetArtworkBackfillStatusUseCase(
+    artworkBackfillRepository,
+  );
+  const scanLibraryUseCase = new ScanLibraryUseCase(
+    fileSystemScannerService,
+    trackFileHelper,
+    trackRepository,
+  );
+  const libraryService = new LibraryService(scanLibraryUseCase);
+  const libraryAudioService = new FileSystemLibraryAudioService(() => env.DOWNLOADS);
+  const libraryImageService = new FileSystemLibraryImageService(() => env.DOWNLOADS);
 
-// Use Cases - Settings
-const getSettingsUseCase = new GetSettingsUseCase(settingsRepository);
-const updateSettingUseCase = new UpdateSettingUseCase(
-  settingsRepository,
-  spotifyUserLibraryService,
-  eventBus,
-);
+  const libraryController = new LibraryController(
+    libraryService,
+    libraryAudioService,
+    libraryImageService,
+  );
+  const artworkBackfillController = new ArtworkBackfillController(
+    startArtworkBackfillUseCase,
+    pauseArtworkBackfillUseCase,
+    resumeArtworkBackfillUseCase,
+    getArtworkBackfillStatusUseCase,
+  );
+  const healthService = new HealthService(connectivityAdapter);
 
-// Use Cases - Playlists
-const getSystemStatusUseCase = new GetSystemStatusUseCase(playlistRepository);
-const getPlaylistPreviewUseCase = new GetPlaylistPreviewUseCase(spotifyService);
-const getPlaylistPreviewTracksPageUseCase = new GetPlaylistPreviewTracksPageUseCase(spotifyService);
-const getPlaylistsUseCase = new GetPlaylistsUseCase(playlistRepository);
-const deletePlaylistUseCase = new DeletePlaylistUseCase(playlistRepository, eventBus);
-const updatePlaylistUseCase = new UpdatePlaylistUseCase(playlistRepository, eventBus);
+  const getArtistDetailUseCase = new GetArtistDetailUseCase(
+    feedRepository,
+    releaseFeedService,
+    deezerArtistLookupAdapter,
+  );
+  const getArtistAlbumsUseCase = new GetArtistAlbumsUseCase(feedRepository, releaseFeedService);
+  const noopAlbumTracksCache = new NoopAlbumTracksCache();
+  const getAlbumTracksUseCase = new GetAlbumTracksUseCase(
+    feedRepository,
+    deezerClient,
+    musicBrainzClient,
+    noopAlbumTracksCache,
+  );
+  const createPlaylistUseCase = new CreatePlaylistUseCase(
+    playlistRepository,
+    spotifyServiceSync,
+    trackService,
+    settingsService,
+    eventBus,
+    getAlbumTracksUseCase,
+    feedRepository,
+    deezerClient,
+  );
 
-const spotifyCircuitBreakerAdapter = new SpotifyCircuitBreakerAdapter();
+  const playlistService = new PlaylistService({
+    createPlaylistUseCase,
+    getSystemStatusUseCase,
+    getPlaylistPreviewUseCase,
+    syncSubscribedPlaylistsUseCase,
+    getPlaylistsUseCase,
+    deletePlaylistUseCase,
+    updatePlaylistUseCase,
+    retryPlaylistDownloadsUseCase,
+    getMyPlaylistsUseCase,
+  });
+  const playlistController = new PlaylistController(
+    createPlaylistUseCase,
+    deletePlaylistUseCase,
+    getMyPlaylistsUseCase,
+    getPlaylistPreviewUseCase,
+    getPlaylistPreviewTracksPageUseCase,
+    getPlaylistsUseCase,
+    getSystemStatusUseCase,
+    retryPlaylistDownloadsUseCase,
+    updatePlaylistUseCase,
+  );
 
-const syncSubscribedPlaylistsUseCase = new SyncSubscribedPlaylistsUseCase(
-  playlistRepository,
-  spotifyServiceSync,
-  trackService,
-  eventBus,
-  spotifyCircuitBreakerAdapter,
-);
+  const artistController = new ArtistController(
+    getArtistDetailUseCase,
+    getArtistAlbumsUseCase,
+    getAlbumTracksUseCase,
+  );
+  const searchController = new SearchController(catalogSearchPort);
+  const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 
-const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(
-  playlistRepository,
-  trackService,
-);
+  const historyUseCases = new HistoryUseCases({ repository: historyRepository });
+  const historyController = new HistoryController(historyUseCases);
+  const getRecentReleasesUseCase = new GetRecentReleasesUseCase(
+    feedRepository,
+    spotifyUserLibraryService,
+    releaseFeedService,
+    settingsService,
+  );
+  const feedController = new FeedController(
+    spotifyUserLibraryService,
+    feedRepository,
+    getRecentReleasesUseCase,
+  );
+  const authController = new AuthController(
+    spotifyAuthService,
+    settingsService,
+    env.SPOTIFY_CLIENT_ID,
+    env.SPOTIFY_REDIRECT_URI,
+  );
+  const healthController = new HealthController(healthService);
 
-const getMyPlaylistsUseCase = new GetMyPlaylistsUseCase(spotifyService);
+  eventBus.on("settings:updated", ({ key }: { key: string }) => {
+    if (key === "SPOTIFY_MARKET") {
+      spotifyArtistClient.clearMarketCache();
+      spotifyAlbumClient.clearMarketCache();
+      spotifyTrackClient.clearMarketCache();
+      spotifyPlaylistClient.clearMarketCache();
+      spotifySearchClient.clearMarketCache();
+      spotifyPlaylistClientSync.clearMarketCache();
+    }
+  });
 
-// Library Services
-const fileSystemScannerService = new FileSystemScannerService();
-const cacheArtworkSourceService = new CacheArtworkSourceService(prisma, trackFileHelper);
-const fileSystemArtworkSourceService = new FileSystemArtworkSourceService(
-  trackFileHelper,
-  artworkAssetsService,
-);
-const embeddedArtworkSourceService = new EmbeddedArtworkSourceService();
-const spotifyArtworkSourceService = new SpotifyArtworkSourceService(
-  spotifyArtistClient,
-  spotifyAlbumClient,
-  spotifySearchClient,
-);
-const deezerArtworkSourceService = new DeezerArtworkSourceService(deezerClient);
-const externalArtworkSources = [deezerArtworkSourceService, spotifyArtworkSourceService];
-const processArtworkBackfillBatchUseCase = new ProcessArtworkBackfillBatchUseCase(
-  cacheArtworkSourceService,
-  fileSystemArtworkSourceService,
-  cacheArtworkSourceService,
-  embeddedArtworkSourceService,
-  externalArtworkSources,
-  artworkBackfillRepository,
-);
-const startArtworkBackfillUseCase = new StartArtworkBackfillUseCase(
-  artworkBackfillRepository,
-  artworkBackfillQueueService,
-);
-const pauseArtworkBackfillUseCase = new PauseArtworkBackfillUseCase(artworkBackfillRepository);
-const resumeArtworkBackfillUseCase = new ResumeArtworkBackfillUseCase(
-  artworkBackfillRepository,
-  artworkBackfillQueueService,
-);
-const getArtworkBackfillStatusUseCase = new GetArtworkBackfillStatusUseCase(
-  artworkBackfillRepository,
-);
-const scanLibraryUseCase = new ScanLibraryUseCase(
-  fileSystemScannerService,
-  trackFileHelper,
-  trackRepository,
-);
-const libraryService = new LibraryService(scanLibraryUseCase);
-const libraryAudioService = new FileSystemLibraryAudioService(() => resolveDownloadsRoot());
-const libraryImageService = new FileSystemLibraryImageService(() => resolveDownloadsRoot());
+  return {
+    playlistService,
+    playlistController,
+    trackService,
+    trackController,
+    artistController,
+    searchController,
+    externalUrlController,
+    libraryController,
+    artworkBackfillController,
+    settingsController,
+    historyController,
+    feedController,
+    authController,
+    healthController,
+    eventsController,
+    spotifyService,
+    spotifyArtistClient,
+    spotifyTrackClient,
+    spotifyAlbumClient,
+    spotifyPlaylistClient,
+    spotifySearchClient,
+    spotifyUserLibraryService,
+    spotifyUserLibrarySyncService,
+    spotifyAuthService,
+    deezerClient,
+    musicBrainzClient,
+    releaseFeedService,
+    settingsService,
+    getSettingsUseCase,
+    updateSettingUseCase,
+    queueService,
+    eventBus,
+    trackPostProcessingService,
+    rescueStuckTracksUseCase,
+    libraryService,
+    feedRepository,
+    artworkBackfillRepository,
+    processArtworkBackfillBatchUseCase,
+  };
+}
 
-const libraryController = new LibraryController(
-  libraryService,
-  libraryAudioService,
-  libraryImageService,
-);
-const artworkBackfillController = new ArtworkBackfillController(
-  startArtworkBackfillUseCase,
-  pauseArtworkBackfillUseCase,
-  resumeArtworkBackfillUseCase,
-  getArtworkBackfillStatusUseCase,
-);
-const healthService = new HealthService(connectivityAdapter);
+export type Container = ReturnType<typeof createContainer>;
 
-const getArtistDetailUseCase = new GetArtistDetailUseCase(
-  feedRepository,
-  releaseFeedService,
-  deezerArtistLookupAdapter,
-);
-const getArtistAlbumsUseCase = new GetArtistAlbumsUseCase(feedRepository, releaseFeedService);
-const noopAlbumTracksCache = new NoopAlbumTracksCache();
-const getAlbumTracksUseCase = new GetAlbumTracksUseCase(
-  feedRepository,
-  deezerClient,
-  musicBrainzClient,
-  noopAlbumTracksCache,
-);
-// Background use cases — use sync service to avoid starving interactive requests
-// getAlbumTracksUseCase must be declared before this
-const createPlaylistUseCase = new CreatePlaylistUseCase(
-  playlistRepository,
-  spotifyServiceSync,
-  trackService,
-  settingsService,
-  eventBus,
-  getAlbumTracksUseCase,
-  feedRepository,
-  deezerClient,
-);
+let currentContainer: Container | null = null;
 
-// Domain Services (Playlist)
-const playlistService = new PlaylistService({
-  createPlaylistUseCase,
-  getSystemStatusUseCase,
-  getPlaylistPreviewUseCase,
-  syncSubscribedPlaylistsUseCase,
-  getPlaylistsUseCase,
-  deletePlaylistUseCase,
-  updatePlaylistUseCase,
-  retryPlaylistDownloadsUseCase,
-  getMyPlaylistsUseCase,
-});
+export function initializeContainer(env: Env): Container {
+  currentContainer = createContainer(env);
+  return currentContainer;
+}
 
-const playlistController = new PlaylistController(
-  createPlaylistUseCase,
-  deletePlaylistUseCase,
-  getMyPlaylistsUseCase,
-  getPlaylistPreviewUseCase,
-  getPlaylistPreviewTracksPageUseCase,
-  getPlaylistsUseCase,
-  getSystemStatusUseCase,
-  retryPlaylistDownloadsUseCase,
-  updatePlaylistUseCase,
-);
-
-const artistController = new ArtistController(
-  getArtistDetailUseCase,
-  getArtistAlbumsUseCase,
-  getAlbumTracksUseCase,
-);
-const searchController = new SearchController(catalogSearchPort);
-
-const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
-
-const historyUseCases = new HistoryUseCases({ repository: historyRepository });
-const historyController = new HistoryController(historyUseCases);
-
-const getRecentReleasesUseCase = new GetRecentReleasesUseCase(
-  feedRepository,
-  spotifyUserLibraryService,
-  releaseFeedService,
-  settingsService,
-);
-const feedController = new FeedController(
-  spotifyUserLibraryService,
-  feedRepository,
-  getRecentReleasesUseCase,
-);
-const authController = new AuthController(
-  spotifyAuthService,
-  settingsService,
-  resolveSpotifyAuthConfig().clientId,
-  resolveSpotifyAuthConfig().redirectUri,
-);
-const healthController = new HealthController(healthService);
-const eventsController = new EventsController();
-
-// When SPOTIFY_MARKET changes, invalidate the in-memory market cache on all clients
-// so the next request picks up the new value from DB
-eventBus.on("settings:updated", ({ key }: { key: string }) => {
-  if (key === "SPOTIFY_MARKET") {
-    spotifyArtistClient.clearMarketCache();
-    spotifyAlbumClient.clearMarketCache();
-    spotifyTrackClient.clearMarketCache();
-    spotifyPlaylistClient.clearMarketCache();
-    spotifySearchClient.clearMarketCache();
-    spotifyPlaylistClientSync.clearMarketCache();
+export function getContainer(): Container {
+  if (!currentContainer) {
+    throw new Error("Container not initialized. Call initializeContainer() first.");
   }
-});
 
-// Export container
-export const container = {
-  playlistService,
-  playlistController,
-  trackService,
-  trackController,
-  artistController,
-  searchController,
-  externalUrlController,
-  libraryController,
-  artworkBackfillController,
-  settingsController,
-  historyController,
-  feedController,
-  authController,
-  healthController,
-  eventsController,
-  spotifyService,
-  spotifyArtistClient,
-  spotifyTrackClient,
-  spotifyAlbumClient,
-  spotifyPlaylistClient,
-  spotifySearchClient,
-  spotifyUserLibraryService,
-  spotifyUserLibrarySyncService,
-  spotifyAuthService,
-  deezerClient,
-  musicBrainzClient,
-  releaseFeedService,
-
-  settingsService,
-  getSettingsUseCase,
-  updateSettingUseCase,
-  queueService,
-  eventBus,
-  trackPostProcessingService,
-  rescueStuckTracksUseCase,
-  libraryService,
-  feedRepository,
-  artworkBackfillRepository,
-  processArtworkBackfillBatchUseCase,
-};
+  return currentContainer;
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from "events";
 import * as fs from "fs";
 import * as http from "http";
-import { app } from "./app";
-import { container } from "./container";
+import { createApp } from "./app";
+import { initializeContainer } from "./container";
 import { PrismaSettingsRepository } from "./infrastructure/database/prisma-settings.repository";
-import { configureAppTokenCircuitBreaker } from "./infrastructure/external/spotify-http.client";
+import {
+  configureAppTokenCircuitBreaker,
+  configureSpotifyRateLimiters,
+} from "./infrastructure/external/spotify-http.client";
 import { startScheduledJobs } from "./infrastructure/jobs";
 import { getEnv, validateEnvironment } from "./infrastructure/setup/environment";
 import { prisma } from "./infrastructure/setup/prisma";
@@ -23,6 +26,7 @@ const CIRCUIT_BREAKER_OPEN_UNTIL_KEY = "spotify_circuit_open_until";
 validateEnvironment();
 
 const env = getEnv();
+configureSpotifyRateLimiters(env);
 const PORT = 3000;
 
 // Worker references for shutdown
@@ -34,6 +38,8 @@ let artworkBackfillWorker: import("bullmq").Worker;
 
 async function bootstrap() {
   console.log("🚀 Starting SpotiArr Backend...\n");
+
+  const container = initializeContainer(env);
 
   // Create downloads directory if it doesn't exist
   const downloadsPath = env.DOWNLOADS;
@@ -95,6 +101,7 @@ async function bootstrap() {
   await container.rescueStuckTracksUseCase.execute();
 
   // Create HTTP server
+  const app = createApp(container);
   const server = http.createServer(app);
 
   // Start scheduled jobs

--- a/apps/backend/src/infrastructure/external/spotify-http.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-http.client.ts
@@ -1,4 +1,4 @@
-import { getEnv } from "@/infrastructure/setup/environment";
+import type { Env } from "@/infrastructure/setup/environment";
 import { CircuitBreaker } from "./circuit-breaker";
 import { RateLimiter } from "./rate-limiter";
 import { SpotifyAuthService } from "./spotify-auth.service";
@@ -23,72 +23,81 @@ export const SPOTIFY_LIMITER_MODE = {
 
 export type SpotifyLimiterMode = (typeof SPOTIFY_LIMITER_MODE)[keyof typeof SPOTIFY_LIMITER_MODE];
 
-function resolveLimiterConfig(): {
-  user: { maxConcurrency: number; queueTimeoutMs: number; minIntervalMs: number };
-  sync: { maxConcurrency: number; queueTimeoutMs: number; minIntervalMs: number };
-  interactive: { maxConcurrency: number; queueTimeoutMs: number; minIntervalMs: number };
-} {
-  try {
-    const env = getEnv();
-    return {
-      user: {
-        maxConcurrency: env.SPOTIFY_HTTP_MAX_CONCURRENCY,
-        queueTimeoutMs: env.SPOTIFY_HTTP_QUEUE_TIMEOUT_MS,
-        minIntervalMs: env.SPOTIFY_HTTP_MIN_INTERVAL_MS,
-      },
-      sync: {
-        maxConcurrency: env.SPOTIFY_SYNC_MAX_CONCURRENCY,
-        queueTimeoutMs: env.SPOTIFY_SYNC_QUEUE_TIMEOUT_MS,
-        minIntervalMs: env.SPOTIFY_SYNC_MIN_INTERVAL_MS,
-      },
-      interactive: {
-        maxConcurrency: env.SPOTIFY_INTERACTIVE_MAX_CONCURRENCY,
-        queueTimeoutMs: env.SPOTIFY_INTERACTIVE_QUEUE_TIMEOUT_MS,
-        minIntervalMs: env.SPOTIFY_INTERACTIVE_MIN_INTERVAL_MS,
-      },
-    };
-  } catch {
-    return {
-      user: {
-        maxConcurrency: DEFAULT_SPOTIFY_HTTP_MAX_CONCURRENCY,
-        queueTimeoutMs: DEFAULT_SPOTIFY_HTTP_QUEUE_TIMEOUT_MS,
-        minIntervalMs: DEFAULT_SPOTIFY_HTTP_MIN_INTERVAL_MS,
-      },
-      sync: {
-        maxConcurrency: DEFAULT_SPOTIFY_SYNC_MAX_CONCURRENCY,
-        queueTimeoutMs: DEFAULT_SPOTIFY_SYNC_QUEUE_TIMEOUT_MS,
-        minIntervalMs: DEFAULT_SPOTIFY_SYNC_MIN_INTERVAL_MS,
-      },
-      interactive: {
-        maxConcurrency: DEFAULT_SPOTIFY_INTERACTIVE_MAX_CONCURRENCY,
-        queueTimeoutMs: DEFAULT_SPOTIFY_INTERACTIVE_QUEUE_TIMEOUT_MS,
-        minIntervalMs: DEFAULT_SPOTIFY_INTERACTIVE_MIN_INTERVAL_MS,
-      },
-    };
-  }
+interface SpotifyLimiterBucketConfig {
+  maxConcurrency: number;
+  queueTimeoutMs: number;
+  minIntervalMs: number;
 }
 
-const limiterConfig = resolveLimiterConfig();
+interface SpotifyLimiterConfig {
+  user: SpotifyLimiterBucketConfig;
+  sync: SpotifyLimiterBucketConfig;
+  interactive: SpotifyLimiterBucketConfig;
+}
 
-// User-facing limiter: faster, shorter timeout
-const userRateLimiter = new RateLimiter({
-  maxConcurrency: limiterConfig.user.maxConcurrency,
-  queueTimeoutMs: limiterConfig.user.queueTimeoutMs,
-  minIntervalMs: limiterConfig.user.minIntervalMs,
-});
+function createRateLimiter(config: SpotifyLimiterBucketConfig): RateLimiter {
+  return new RateLimiter({
+    maxConcurrency: config.maxConcurrency,
+    queueTimeoutMs: config.queueTimeoutMs,
+    minIntervalMs: config.minIntervalMs,
+  });
+}
 
-// Background sync limiter: slower, longer timeout, doesn't block user requests
-const syncRateLimiter = new RateLimiter({
-  maxConcurrency: limiterConfig.sync.maxConcurrency,
-  queueTimeoutMs: limiterConfig.sync.queueTimeoutMs,
-  minIntervalMs: limiterConfig.sync.minIntervalMs,
-});
+function createDefaultLimiterConfig(): SpotifyLimiterConfig {
+  return {
+    user: {
+      maxConcurrency: DEFAULT_SPOTIFY_HTTP_MAX_CONCURRENCY,
+      queueTimeoutMs: DEFAULT_SPOTIFY_HTTP_QUEUE_TIMEOUT_MS,
+      minIntervalMs: DEFAULT_SPOTIFY_HTTP_MIN_INTERVAL_MS,
+    },
+    sync: {
+      maxConcurrency: DEFAULT_SPOTIFY_SYNC_MAX_CONCURRENCY,
+      queueTimeoutMs: DEFAULT_SPOTIFY_SYNC_QUEUE_TIMEOUT_MS,
+      minIntervalMs: DEFAULT_SPOTIFY_SYNC_MIN_INTERVAL_MS,
+    },
+    interactive: {
+      maxConcurrency: DEFAULT_SPOTIFY_INTERACTIVE_MAX_CONCURRENCY,
+      queueTimeoutMs: DEFAULT_SPOTIFY_INTERACTIVE_QUEUE_TIMEOUT_MS,
+      minIntervalMs: DEFAULT_SPOTIFY_INTERACTIVE_MIN_INTERVAL_MS,
+    },
+  };
+}
 
-const interactiveRateLimiter = new RateLimiter({
-  maxConcurrency: limiterConfig.interactive.maxConcurrency,
-  queueTimeoutMs: limiterConfig.interactive.queueTimeoutMs,
-  minIntervalMs: limiterConfig.interactive.minIntervalMs,
-});
+function resolveLimiterConfig(env: Env): SpotifyLimiterConfig {
+  return {
+    user: {
+      maxConcurrency: env.SPOTIFY_HTTP_MAX_CONCURRENCY,
+      queueTimeoutMs: env.SPOTIFY_HTTP_QUEUE_TIMEOUT_MS,
+      minIntervalMs: env.SPOTIFY_HTTP_MIN_INTERVAL_MS,
+    },
+    sync: {
+      maxConcurrency: env.SPOTIFY_SYNC_MAX_CONCURRENCY,
+      queueTimeoutMs: env.SPOTIFY_SYNC_QUEUE_TIMEOUT_MS,
+      minIntervalMs: env.SPOTIFY_SYNC_MIN_INTERVAL_MS,
+    },
+    interactive: {
+      maxConcurrency: env.SPOTIFY_INTERACTIVE_MAX_CONCURRENCY,
+      queueTimeoutMs: env.SPOTIFY_INTERACTIVE_QUEUE_TIMEOUT_MS,
+      minIntervalMs: env.SPOTIFY_INTERACTIVE_MIN_INTERVAL_MS,
+    },
+  };
+}
+
+const defaultLimiterConfig = createDefaultLimiterConfig();
+
+// Keep import-time defaults for tests and isolated imports. Production bootstrap
+// must replace these after environment validation.
+let userRateLimiter = createRateLimiter(defaultLimiterConfig.user);
+let syncRateLimiter = createRateLimiter(defaultLimiterConfig.sync);
+let interactiveRateLimiter = createRateLimiter(defaultLimiterConfig.interactive);
+
+export function configureSpotifyRateLimiters(env: Env): void {
+  const limiterConfig = resolveLimiterConfig(env);
+
+  userRateLimiter = createRateLimiter(limiterConfig.user);
+  syncRateLimiter = createRateLimiter(limiterConfig.sync);
+  interactiveRateLimiter = createRateLimiter(limiterConfig.interactive);
+}
 
 // Shared app-token limiter + circuit breaker to prevent 429 storms across workers
 const appTokenRateLimiter = new RateLimiter({

--- a/apps/backend/src/infrastructure/jobs/catalog-sync.job.ts
+++ b/apps/backend/src/infrastructure/jobs/catalog-sync.job.ts
@@ -1,14 +1,13 @@
 import cron from "node-cron";
 import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
-import { container } from "@/container";
+import { getContainer } from "@/container";
 import { getCatalogSyncQueue } from "../setup/queues";
-
-const { settingsService, feedRepository } = container;
 
 let lastCatalogSyncCheckTimestamp = 0;
 
 export const catalogSyncJob = cron.createTask("* * * * *", async () => {
   try {
+    const { settingsService, feedRepository } = getContainer();
     const intervalHours = await settingsService.getNumber("CATALOG_SYNC_INTERVAL_HOURS", 6);
     const safeIntervalHours = intervalHours > 0 ? intervalHours : 6;
     const now = Date.now();

--- a/apps/backend/src/infrastructure/jobs/feed-sync.job.ts
+++ b/apps/backend/src/infrastructure/jobs/feed-sync.job.ts
@@ -1,14 +1,13 @@
 import cron from "node-cron";
 import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
-import { container } from "@/container";
+import { getContainer } from "@/container";
 import { getFeedSyncQueue } from "../setup/queues";
-
-const { settingsService, feedRepository } = container;
 
 let lastFeedSyncCheckTimestamp = 0;
 
 export const feedSyncJob = cron.createTask("* * * * *", async () => {
   try {
+    const { settingsService, feedRepository } = getContainer();
     const intervalMinutes = await settingsService.getNumber("RELEASES_SYNC_INTERVAL_MINUTES", 60);
     const safeIntervalMinutes = intervalMinutes > 0 ? intervalMinutes : 60;
     const now = Date.now();

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -1,16 +1,15 @@
 import { TrackStatusEnum } from "@spotiarr/shared";
 import cron from "node-cron";
-import { container } from "../../container";
+import { getContainer } from "../../container";
 import { startCatalogSyncJob } from "./catalog-sync.job";
 import { startFeedSyncJob } from "./feed-sync.job";
-
-const { playlistService, settingsService, trackService, eventBus } = container;
 
 let lastPlaylistCheckTimestamp = 0;
 let lastStuckTracksCleanupTimestamp = 0;
 
 export const checkPlaylistsJob = cron.createTask("* * * * *", async () => {
   try {
+    const { playlistService, settingsService } = getContainer();
     const intervalMinutes = await settingsService.getNumber("PLAYLIST_CHECK_INTERVAL_MINUTES");
     const safeIntervalMinutes = intervalMinutes > 0 ? intervalMinutes : 60;
     const now = Date.now();
@@ -30,6 +29,7 @@ export const checkPlaylistsJob = cron.createTask("* * * * *", async () => {
 
 export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
   try {
+    const { trackService, settingsService, eventBus } = getContainer();
     const cleanupIntervalMinutes = await settingsService.getNumber(
       "STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES",
     );

--- a/apps/backend/src/infrastructure/messaging/app-event-bus.ts
+++ b/apps/backend/src/infrastructure/messaging/app-event-bus.ts
@@ -1,8 +1,13 @@
 import { EventEmitter } from "events";
-import { container } from "@/container";
 import type { EventBus } from "@/domain/events/event-bus";
 
+type SseEmitter = (event: string, data?: unknown) => void;
+
 export class AppEventBus extends EventEmitter implements EventBus {
+  constructor(private readonly emitToClients: SseEmitter = () => {}) {
+    super();
+  }
+
   // Override emit to send to both internal listeners and SSE
   emit(event: string, data?: unknown): boolean {
     // 1. Emit to internal Node.js listeners
@@ -10,7 +15,7 @@ export class AppEventBus extends EventEmitter implements EventBus {
 
     // 2. Emit to Frontend via SSE
     // (We only send data if it's serializable, which it usually is in this app)
-    container.eventsController.emit(event, data);
+    this.emitToClients(event, data);
 
     return result;
   }

--- a/apps/backend/src/infrastructure/workers/artwork-backfill.worker.ts
+++ b/apps/backend/src/infrastructure/workers/artwork-backfill.worker.ts
@@ -1,7 +1,7 @@
 import { Worker, type Job } from "bullmq";
 import { z } from "zod";
 import { ProcessArtworkBackfillBatchUseCase } from "@/application/use-cases/artwork-backfill/process-artwork-backfill-batch.use-case";
-import { container } from "@/container";
+import { getContainer, type Container } from "@/container";
 import { ARTWORK_BACKFILL_STATUS } from "@/domain/artwork-backfill.types";
 import { AppError } from "@/domain/errors/app-error";
 import { getEnv } from "../setup/environment";
@@ -18,10 +18,10 @@ const ArtworkBackfillJobDataSchema = z.object({
 type JobData = z.infer<typeof ArtworkBackfillJobDataSchema>;
 
 export interface ArtworkBackfillWorkerDependencies {
-  backfillRepository: typeof container.artworkBackfillRepository;
+  backfillRepository: Container["artworkBackfillRepository"];
   processBatchUseCase: ProcessArtworkBackfillBatchUseCase;
-  eventBus: typeof container.eventBus;
-  libraryService: Pick<typeof container.libraryService, "clearCache">;
+  eventBus: Container["eventBus"];
+  libraryService: Pick<Container["libraryService"], "clearCache">;
 }
 
 export async function runArtworkBackfillJob(
@@ -118,7 +118,7 @@ export function createArtworkBackfillWorker(): Worker {
     processArtworkBackfillBatchUseCase,
     eventBus,
     libraryService,
-  } = container;
+  } = getContainer();
 
   const worker = new Worker(
     ARTWORK_BACKFILL_QUEUE,

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
@@ -2,7 +2,7 @@ import { Worker } from "bullmq";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
 import type { SettingsService } from "@/application/services/settings.service";
-import { container } from "@/container";
+import { getContainer } from "@/container";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { CATALOG_SYNC_QUEUE } from "../setup/queues";
@@ -102,7 +102,7 @@ export async function runCatalogSyncJob(deps: CatalogSyncJobDependencies): Promi
 }
 
 export function createCatalogSyncWorker(): Worker {
-  const { feedRepository, releaseFeedService, eventBus, settingsService } = container;
+  const { feedRepository, releaseFeedService, eventBus, settingsService } = getContainer();
 
   // If the process crashed mid-sync, the state is stuck in "running".
   // Reset it on startup so the cron can enqueue a new job.

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
@@ -17,7 +17,7 @@ vi.mock("bullmq", () => ({
 }));
 
 vi.mock("@/container", () => ({
-  container: {
+  getContainer: () => ({
     spotifyUserLibrarySyncService: {},
     releaseFeedService: {},
     feedRepository: {
@@ -30,7 +30,13 @@ vi.mock("@/container", () => ({
     settingsService: {
       getNumber: vi.fn(),
     },
-  },
+  }),
+  initializeContainer: vi.fn(),
+  getContainerOrThrow: vi.fn(),
+  getContainerUnsafe: vi.fn(),
+  // Keep the mock shape explicit so tests fail loudly if code tries to rely on removed exports.
+  getContainerState: vi.fn(),
+  __esModule: true,
 }));
 
 vi.mock("../setup/environment", () => ({

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -2,19 +2,11 @@ import { Worker } from "bullmq";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import type { SettingsService } from "@/application/services/settings.service";
-import { container } from "@/container";
+import { getContainer } from "@/container";
 import type { ReleaseFeedService } from "../external/release-feed.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { FEED_SYNC_QUEUE } from "../setup/queues";
-
-const {
-  spotifyUserLibrarySyncService,
-  releaseFeedService,
-  feedRepository,
-  eventBus,
-  settingsService,
-} = container;
 
 const RELEASES_SYNC_TTL_HOURS = 24;
 const RELEASES_ACTIVITY_WINDOW_DAYS = 90;
@@ -116,6 +108,14 @@ export async function runFeedSyncJob(deps: FeedSyncJobDependencies): Promise<voi
 }
 
 export function createFeedSyncWorker(): Worker {
+  const {
+    spotifyUserLibrarySyncService,
+    releaseFeedService,
+    feedRepository,
+    eventBus,
+    settingsService,
+  } = getContainer();
+
   // If the process crashed mid-sync, the state is stuck in "running".
   // Reset it on startup so the cron can enqueue a new job.
   feedRepository

--- a/apps/backend/src/infrastructure/workers/track-download.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-download.worker.ts
@@ -1,11 +1,10 @@
 import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { Worker } from "bullmq";
-import { container } from "../../container";
+import { getContainer } from "../../container";
 import { getEnv } from "../setup/environment";
 
-const { trackService, settingsService } = container;
-
 export async function createTrackDownloadWorker() {
+  const { trackService, settingsService, libraryService, eventsController } = getContainer();
   const maxPerMinute = await settingsService.getNumber("YT_DOWNLOADS_PER_MINUTE");
 
   const worker = new Worker(
@@ -34,8 +33,8 @@ export async function createTrackDownloadWorker() {
   worker.on("drained", async () => {
     console.log(`[TrackDownloadWorker] Queue drained, triggering library scan...`);
     try {
-      await container.libraryService.scan();
-      container.eventsController.emit("library-updated");
+      await libraryService.scan();
+      eventsController.emit("library-updated");
       console.log(`[TrackDownloadWorker] Library scan completed successfully.`);
     } catch (err) {
       console.error(`[TrackDownloadWorker] Failed to scan library after queue drain:`, err);
@@ -60,7 +59,7 @@ export async function createTrackDownloadWorker() {
           status: TrackStatusEnum.Error,
           error: err instanceof Error ? err.message : String(err),
         });
-        container.eventsController.emit("playlists-updated");
+        eventsController.emit("playlists-updated");
       } catch (updateError) {
         console.error(`Failed to update track ${trackId} status after job failure:`, updateError);
       }

--- a/apps/backend/src/infrastructure/workers/track-search.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.ts
@@ -1,11 +1,10 @@
 import { type ITrack } from "@spotiarr/shared";
 import { Worker } from "bullmq";
-import { container } from "../../container";
+import { getContainer } from "../../container";
 import { getEnv } from "../setup/environment";
 
-const { trackService, settingsService } = container;
-
 export async function createTrackSearchWorker() {
+  const { trackService, settingsService } = getContainer();
   const concurrency = await settingsService.getNumber("YT_SEARCH_CONCURRENCY");
 
   const worker = new Worker(

--- a/apps/backend/src/presentation/routes/artist.routes.ts
+++ b/apps/backend/src/presentation/routes/artist.routes.ts
@@ -1,14 +1,16 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { artistController } = container;
+export function createArtistRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { artistController } = container;
 
-router.get("/:id", asyncHandler(artistController.getArtistDetail));
+  router.get("/:id", asyncHandler(artistController.getArtistDetail));
 
-router.get("/:id/albums", asyncHandler(artistController.getArtistAlbums));
+  router.get("/:id/albums", asyncHandler(artistController.getArtistAlbums));
 
-router.get("/:id/albums/:albumId/tracks", asyncHandler(artistController.getAlbumTracks));
+  router.get("/:id/albums/:albumId/tracks", asyncHandler(artistController.getAlbumTracks));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/auth.routes.ts
+++ b/apps/backend/src/presentation/routes/auth.routes.ts
@@ -1,16 +1,18 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "@/container";
+import type { Container } from "@/container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { authController } = container;
+export function createAuthRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { authController } = container;
 
-router.get("/spotify/login", asyncHandler(authController.login));
+  router.get("/spotify/login", asyncHandler(authController.login));
 
-router.get("/spotify/callback", asyncHandler(authController.callback));
+  router.get("/spotify/callback", asyncHandler(authController.callback));
 
-router.get("/spotify/status", asyncHandler(authController.status));
+  router.get("/spotify/status", asyncHandler(authController.status));
 
-router.post("/spotify/logout", asyncHandler(authController.logout));
+  router.post("/spotify/logout", asyncHandler(authController.logout));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/events.routes.test.ts
+++ b/apps/backend/src/presentation/routes/events.routes.test.ts
@@ -1,0 +1,60 @@
+import express from "express";
+import type { Request, Response } from "express";
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Container } from "@/container";
+import { createEventsRoutes } from "./events.routes";
+
+const servers: http.Server[] = [];
+
+function createTestContainer(): Pick<Container, "eventsController"> {
+  return {
+    eventsController: {
+      connect: vi.fn((_req: Request, res: Response) => {
+        res.status(200).json({ ok: true });
+      }),
+    },
+  } as unknown as Pick<Container, "eventsController">;
+}
+
+async function startServer(container: Pick<Container, "eventsController">): Promise<string> {
+  const app = express();
+  app.use("/events", createEventsRoutes(container as Container));
+
+  const server = await new Promise<http.Server>((resolve) => {
+    const instance = app.listen(0, () => resolve(instance));
+  });
+
+  servers.push(server);
+  const address = server.address();
+
+  if (address && typeof address === "object") {
+    return `http://127.0.0.1:${address.port}`;
+  }
+
+  throw new Error("Unable to resolve server address");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("createEventsRoutes", () => {
+  it("registers the initialized controller handler without proxy failures", async () => {
+    const container = createTestContainer();
+    const baseUrl = await startServer(container);
+
+    const response = await fetch(`${baseUrl}/events`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(container.eventsController.connect).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/presentation/routes/events.routes.ts
+++ b/apps/backend/src/presentation/routes/events.routes.ts
@@ -1,14 +1,12 @@
 import type { Router as ExpressRouter } from "express";
 import { Router } from "express";
-import { container } from "@/container";
+import type { Container } from "@/container";
 
-const router: ExpressRouter = Router();
+export function createEventsRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
 
-// Delegate SSE client registration to the container's EventsController,
-// which is the single source of truth for all server-sent events.
-// Previously this file maintained its own client list, disconnected from
-// the EventsController that all backend services emit to — meaning no
-// events ever reached the frontend.
-router.get("/", container.eventsController.connect);
+  // Delegate SSE client registration to the initialized EventsController instance.
+  router.get("/", container.eventsController.connect);
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/external-url.routes.ts
+++ b/apps/backend/src/presentation/routes/external-url.routes.ts
@@ -1,10 +1,12 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { externalUrlController } = container;
+export function createExternalUrlRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { externalUrlController } = container;
 
-router.get("/", asyncHandler(externalUrlController.resolve));
+  router.get("/", asyncHandler(externalUrlController.resolve));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/feed.routes.ts
+++ b/apps/backend/src/presentation/routes/feed.routes.ts
@@ -1,12 +1,14 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { feedController } = container;
+export function createFeedRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { feedController } = container;
 
-router.get("/releases", asyncHandler(feedController.getRecentReleases));
+  router.get("/releases", asyncHandler(feedController.getRecentReleases));
 
-router.get("/artists", asyncHandler(feedController.getArtists));
+  router.get("/artists", asyncHandler(feedController.getArtists));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/health.routes.ts
+++ b/apps/backend/src/presentation/routes/health.routes.ts
@@ -1,10 +1,12 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 
-const router: ExpressRouter = Router();
-const { healthController } = container;
+export function createHealthRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { healthController } = container;
 
-// GET /api/health - Health check endpoint
-router.get("/", healthController.check);
+  // GET /api/health - Health check endpoint
+  router.get("/", healthController.check);
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/history.routes.ts
+++ b/apps/backend/src/presentation/routes/history.routes.ts
@@ -1,14 +1,16 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { historyController } = container;
+export function createHistoryRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { historyController } = container;
 
-// GET /api/history/downloads - Get recent completed downloads
-router.get("/downloads", asyncHandler(historyController.getRecentDownloads));
+  // GET /api/history/downloads - Get recent completed downloads
+  router.get("/downloads", asyncHandler(historyController.getRecentDownloads));
 
-// GET /api/history/tracks - Get recent completed download tracks
-router.get("/tracks", asyncHandler(historyController.getRecentTracks));
+  // GET /api/history/tracks - Get recent completed download tracks
+  router.get("/tracks", asyncHandler(historyController.getRecentTracks));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/index.ts
+++ b/apps/backend/src/presentation/routes/index.ts
@@ -1,31 +1,34 @@
 import { ApiRoutes } from "@spotiarr/shared";
 import { Router, type Router as ExpressRouter } from "express";
-import artistRoutes from "./artist.routes";
-import authRoutes from "./auth.routes";
-import eventsRoutes from "./events.routes";
-import externalUrlRoutes from "./external-url.routes";
-import feedRoutes from "./feed.routes";
-import healthRoutes from "./health.routes";
-import historyRoutes from "./history.routes";
-import libraryRoutes from "./library.routes";
-import playlistRoutes from "./playlist.routes";
-import searchRoutes from "./search.routes";
-import settingsRoutes from "./settings.routes";
-import trackRoutes from "./track.routes";
+import type { Container } from "../../container";
+import { createArtistRoutes } from "./artist.routes";
+import { createAuthRoutes } from "./auth.routes";
+import { createEventsRoutes } from "./events.routes";
+import { createExternalUrlRoutes } from "./external-url.routes";
+import { createFeedRoutes } from "./feed.routes";
+import { createHealthRoutes } from "./health.routes";
+import { createHistoryRoutes } from "./history.routes";
+import { createLibraryRoutes } from "./library.routes";
+import { createPlaylistRoutes } from "./playlist.routes";
+import { createSearchRoutes } from "./search.routes";
+import { createSettingsRoutes } from "./settings.routes";
+import { createTrackRoutes } from "./track.routes";
 
-const router: ExpressRouter = Router();
+export function createRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
 
-router.use(ApiRoutes.HEALTH, healthRoutes);
-router.use(ApiRoutes.PLAYLIST, playlistRoutes);
-router.use(ApiRoutes.TRACK, trackRoutes);
-router.use(ApiRoutes.HISTORY, historyRoutes);
-router.use(ApiRoutes.SETTINGS, settingsRoutes);
-router.use(ApiRoutes.EVENTS, eventsRoutes);
-router.use(ApiRoutes.FEED, feedRoutes);
-router.use(ApiRoutes.ARTIST, artistRoutes);
-router.use(ApiRoutes.AUTH, authRoutes);
-router.use(ApiRoutes.LIBRARY, libraryRoutes);
-router.use(ApiRoutes.SEARCH, searchRoutes);
-router.use(ApiRoutes.EXTERNAL_URL, externalUrlRoutes);
+  router.use(ApiRoutes.HEALTH, createHealthRoutes(container));
+  router.use(ApiRoutes.PLAYLIST, createPlaylistRoutes(container));
+  router.use(ApiRoutes.TRACK, createTrackRoutes(container));
+  router.use(ApiRoutes.HISTORY, createHistoryRoutes(container));
+  router.use(ApiRoutes.SETTINGS, createSettingsRoutes(container));
+  router.use(ApiRoutes.EVENTS, createEventsRoutes(container));
+  router.use(ApiRoutes.FEED, createFeedRoutes(container));
+  router.use(ApiRoutes.ARTIST, createArtistRoutes(container));
+  router.use(ApiRoutes.AUTH, createAuthRoutes(container));
+  router.use(ApiRoutes.LIBRARY, createLibraryRoutes(container));
+  router.use(ApiRoutes.SEARCH, createSearchRoutes(container));
+  router.use(ApiRoutes.EXTERNAL_URL, createExternalUrlRoutes(container));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/library.routes.ts
+++ b/apps/backend/src/presentation/routes/library.routes.ts
@@ -1,35 +1,37 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 import { validate } from "../middleware/validate";
 import { libraryAudioRequestSchema } from "./schemas/library.schema";
 
-const router: ExpressRouter = Router();
-const { libraryController, artworkBackfillController } = container;
+export function createLibraryRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { libraryController, artworkBackfillController } = container;
 
-// GET /api/library/stats - Get library statistics
-router.get("/stats", asyncHandler(libraryController.getStats));
+  // GET /api/library/stats - Get library statistics
+  router.get("/stats", asyncHandler(libraryController.getStats));
 
-// GET /api/library/artists - Get all artists (summary)
-router.get("/artists", asyncHandler(libraryController.getArtists));
+  // GET /api/library/artists - Get all artists (summary)
+  router.get("/artists", asyncHandler(libraryController.getArtists));
 
-// GET /api/library/artists/:name - Get specific artist with albums and tracks
-router.get("/artists/:name", asyncHandler(libraryController.getArtist));
+  // GET /api/library/artists/:name - Get specific artist with albums and tracks
+  router.get("/artists/:name", asyncHandler(libraryController.getArtist));
 
-// GET /api/library/image?path=...
-router.get("/image", asyncHandler(libraryController.getImage));
-router.get(
-  "/audio",
-  validate(libraryAudioRequestSchema),
-  asyncHandler(libraryController.streamAudio),
-);
+  // GET /api/library/image?path=...
+  router.get("/image", asyncHandler(libraryController.getImage));
+  router.get(
+    "/audio",
+    validate(libraryAudioRequestSchema),
+    asyncHandler(libraryController.streamAudio),
+  );
 
-// POST /api/library/scan - Trigger a manual library scan
-router.post("/scan", asyncHandler(libraryController.scan));
+  // POST /api/library/scan - Trigger a manual library scan
+  router.post("/scan", asyncHandler(libraryController.scan));
 
-router.post("/artwork-backfill/start", asyncHandler(artworkBackfillController.start));
-router.post("/artwork-backfill/pause", asyncHandler(artworkBackfillController.pause));
-router.post("/artwork-backfill/resume", asyncHandler(artworkBackfillController.resume));
-router.get("/artwork-backfill/status", asyncHandler(artworkBackfillController.status));
+  router.post("/artwork-backfill/start", asyncHandler(artworkBackfillController.start));
+  router.post("/artwork-backfill/pause", asyncHandler(artworkBackfillController.pause));
+  router.post("/artwork-backfill/resume", asyncHandler(artworkBackfillController.resume));
+  router.get("/artwork-backfill/status", asyncHandler(artworkBackfillController.status));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/playlist.routes.ts
+++ b/apps/backend/src/presentation/routes/playlist.routes.ts
@@ -1,5 +1,5 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 import { validate } from "../middleware/validate";
 import {
@@ -10,49 +10,51 @@ import {
   updatePlaylistSchema,
 } from "./schemas/playlist.schema";
 
-const router: ExpressRouter = Router();
-const { playlistController } = container;
+export function createPlaylistRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { playlistController } = container;
 
-// GET /api/playlist/preview - Get playlist preview from Spotify URL
-router.get(
-  "/preview",
-  validate(playlistPreviewSchema),
-  asyncHandler(playlistController.getPreview),
-);
+  // GET /api/playlist/preview - Get playlist preview from Spotify URL
+  router.get(
+    "/preview",
+    validate(playlistPreviewSchema),
+    asyncHandler(playlistController.getPreview),
+  );
 
-// GET /api/playlist/preview/tracks - Get paginated preview tracks from Spotify URL
-router.get(
-  "/preview/tracks",
-  validate(playlistPreviewTracksSchema),
-  asyncHandler(playlistController.getPreviewTracks),
-);
+  // GET /api/playlist/preview/tracks - Get paginated preview tracks from Spotify URL
+  router.get(
+    "/preview/tracks",
+    validate(playlistPreviewTracksSchema),
+    asyncHandler(playlistController.getPreviewTracks),
+  );
 
-// GET /api/playlist/me - Get user's playlists from Spotify
-router.get("/me", asyncHandler(playlistController.getMyPlaylists));
+  // GET /api/playlist/me - Get user's playlists from Spotify
+  router.get("/me", asyncHandler(playlistController.getMyPlaylists));
 
-// GET /api/playlist/status - Get download status summary
-router.get("/status", asyncHandler(playlistController.getDownloadStatus));
+  // GET /api/playlist/status - Get download status summary
+  router.get("/status", asyncHandler(playlistController.getDownloadStatus));
 
-// GET /api/playlist - Get all playlists
-router.get("/", asyncHandler(playlistController.findAll));
+  // GET /api/playlist - Get all playlists
+  router.get("/", asyncHandler(playlistController.findAll));
 
-// POST /api/playlist - Create new playlist
-router.post("/", validate(createPlaylistSchema), asyncHandler(playlistController.create));
+  // POST /api/playlist - Create new playlist
+  router.post("/", validate(createPlaylistSchema), asyncHandler(playlistController.create));
 
-// PUT /api/playlist/:id - Update playlist
-router.put("/:id", validate(updatePlaylistSchema), asyncHandler(playlistController.update));
+  // PUT /api/playlist/:id - Update playlist
+  router.put("/:id", validate(updatePlaylistSchema), asyncHandler(playlistController.update));
 
-// DELETE /api/playlist/completed - Delete all completed playlists
-router.delete("/completed", asyncHandler(playlistController.removeCompleted));
+  // DELETE /api/playlist/completed - Delete all completed playlists
+  router.delete("/completed", asyncHandler(playlistController.removeCompleted));
 
-// DELETE /api/playlist/:id - Delete playlist
-router.delete("/:id", validate(playlistIdSchema), asyncHandler(playlistController.remove));
+  // DELETE /api/playlist/:id - Delete playlist
+  router.delete("/:id", validate(playlistIdSchema), asyncHandler(playlistController.remove));
 
-// GET /api/playlist/retry/:id - Retry failed tracks
-router.get(
-  "/retry/:id",
-  validate(playlistIdSchema),
-  asyncHandler(playlistController.retryFailedOfPlaylist),
-);
+  // GET /api/playlist/retry/:id - Retry failed tracks
+  router.get(
+    "/retry/:id",
+    validate(playlistIdSchema),
+    asyncHandler(playlistController.retryFailedOfPlaylist),
+  );
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/search.routes.ts
+++ b/apps/backend/src/presentation/routes/search.routes.ts
@@ -1,10 +1,12 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { searchController } = container;
+export function createSearchRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { searchController } = container;
 
-router.get("/", asyncHandler(searchController.searchCatalog));
+  router.get("/", asyncHandler(searchController.searchCatalog));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/settings.routes.ts
+++ b/apps/backend/src/presentation/routes/settings.routes.ts
@@ -1,20 +1,22 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { settingsController } = container;
+export function createSettingsRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { settingsController } = container;
 
-// GET /api/settings - Get all settings
-router.get("/", asyncHandler(settingsController.getSettings));
+  // GET /api/settings - Get all settings
+  router.get("/", asyncHandler(settingsController.getSettings));
 
-// GET /api/settings/metadata - Get settings metadata
-router.get("/metadata", asyncHandler(settingsController.getMetadata));
+  // GET /api/settings/metadata - Get settings metadata
+  router.get("/metadata", asyncHandler(settingsController.getMetadata));
 
-// GET /api/settings/formats - Get supported audio formats
-router.get("/formats", asyncHandler(settingsController.getFormats));
+  // GET /api/settings/formats - Get supported audio formats
+  router.get("/formats", asyncHandler(settingsController.getFormats));
 
-// PUT /api/settings - Update multiple settings at once
-router.put("/", asyncHandler(settingsController.updateSettings));
+  // PUT /api/settings - Update multiple settings at once
+  router.put("/", asyncHandler(settingsController.updateSettings));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/presentation/routes/track.routes.ts
+++ b/apps/backend/src/presentation/routes/track.routes.ts
@@ -1,14 +1,16 @@
 import { Router, type Router as ExpressRouter } from "express";
-import { container } from "../../container";
+import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 
-const router: ExpressRouter = Router();
-const { trackController } = container;
+export function createTrackRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { trackController } = container;
 
-router.get("/playlist/:id", asyncHandler(trackController.getAllByPlaylist));
+  router.get("/playlist/:id", asyncHandler(trackController.getAllByPlaylist));
 
-router.delete("/:id", asyncHandler(trackController.remove));
+  router.delete("/:id", asyncHandler(trackController.remove));
 
-router.get("/retry/:id", asyncHandler(trackController.retry));
+  router.get("/retry/:id", asyncHandler(trackController.retry));
 
-export default router;
+  return router;
+}

--- a/apps/backend/src/testing/playwright-real-stack-server.ts
+++ b/apps/backend/src/testing/playwright-real-stack-server.ts
@@ -1,0 +1,114 @@
+import * as http from "node:http";
+import { createApp } from "../app";
+import { initializeContainer } from "../container";
+import { configureSpotifyRateLimiters } from "../infrastructure/external/spotify-http.client";
+import { getEnv, validateEnvironment } from "../infrastructure/setup/environment";
+import { prisma } from "../infrastructure/setup/prisma";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 3000;
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+interface PlaywrightRealStackServerOptions {
+  host?: string;
+  port?: number;
+}
+
+function getHost(options: PlaywrightRealStackServerOptions): string {
+  return options.host ?? DEFAULT_HOST;
+}
+
+function getPort(options: PlaywrightRealStackServerOptions): number {
+  const port = options.port ?? DEFAULT_PORT;
+
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`Invalid Playwright real-stack port: ${String(port)}`);
+  }
+
+  return port;
+}
+
+export async function startPlaywrightRealStackServer(
+  options: PlaywrightRealStackServerOptions = {},
+): Promise<{
+  server: http.Server;
+  shutdown: () => Promise<void>;
+}> {
+  validateEnvironment();
+  const env = getEnv();
+  configureSpotifyRateLimiters(env);
+
+  const container = initializeContainer(env);
+  const app = createApp(container);
+  const server = http.createServer(app);
+  const host = getHost(options);
+  const port = getPort(options);
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  console.log(`[playwright-real-stack] ready at http://${host}:${port}`);
+
+  return {
+    server,
+    shutdown: () => closeServer(server),
+  };
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  const closeServer = new Promise<void>((resolve, reject) => {
+    server.close((error?: Error) => (error ? reject(error) : resolve()));
+  });
+
+  const forceClose = new Promise<void>((resolve) => {
+    setTimeout(() => {
+      server.closeAllConnections();
+      resolve();
+    }, SHUTDOWN_TIMEOUT_MS).unref();
+  });
+
+  await Promise.race([closeServer, forceClose]);
+
+  await prisma.$disconnect();
+}
+
+async function shutdown(server: http.Server, exitCode: number): Promise<void> {
+  await closeServer(server);
+  process.exit(exitCode);
+}
+
+async function main(): Promise<void> {
+  const host = process.argv[2] ?? DEFAULT_HOST;
+  const port = Number.parseInt(process.argv[3] ?? String(DEFAULT_PORT), 10);
+  const { server } = await startPlaywrightRealStackServer({ host, port });
+
+  let shuttingDown = false;
+
+  const handleSignal = (signal: string) => {
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    void shutdown(server, 0).catch((error: unknown) => {
+      console.error(`[playwright-real-stack] failed to shutdown after ${signal}`, error);
+      process.exit(1);
+    });
+  };
+
+  process.on("SIGINT", () => handleSignal("SIGINT"));
+  process.on("SIGTERM", () => handleSignal("SIGTERM"));
+}
+
+if (require.main === module) {
+  void main().catch(async (error: unknown) => {
+    console.error("[playwright-real-stack] failed to start", error);
+    await prisma.$disconnect().catch(() => undefined);
+    process.exit(1);
+  });
+}

--- a/apps/frontend/tests/helpers/real-stack.ts
+++ b/apps/frontend/tests/helpers/real-stack.ts
@@ -1,15 +1,16 @@
 import { PrismaClient } from "@prisma/client";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import http from "node:http";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 const HOST = "127.0.0.1";
 const PORT = Number.parseInt(process.env.PLAYWRIGHT_REAL_PORT ?? "3000", 10);
 const ROOT_DIR = fileURLToPath(new URL("../../../../", import.meta.url));
 const BACKEND_DIR = path.join(ROOT_DIR, "apps/backend");
+const requireBackendHarness = createRequire(import.meta.url);
 
 const SEEDED_SETTINGS = [
   { key: "UI_LANGUAGE", value: "en" },
@@ -95,6 +96,17 @@ interface RealStackContext {
   downloadsDir: string;
   databasePath: string;
   databaseUrl: string;
+}
+
+interface PlaywrightRealStackServerHandle {
+  shutdown: () => Promise<void>;
+}
+
+interface PlaywrightRealStackServerModule {
+  startPlaywrightRealStackServer: (options: {
+    host: string;
+    port: number;
+  }) => Promise<PlaywrightRealStackServerHandle>;
 }
 
 interface SeedPlaylistInput {
@@ -312,31 +324,11 @@ async function seedDatabase(databaseUrl: string): Promise<void> {
   }
 }
 
-async function startServer(): Promise<{
-  server: http.Server;
-  disconnectPrisma: () => Promise<void>;
-}> {
-  const { validateEnvironment } = await import(
-    pathToFileURL(path.join(BACKEND_DIR, "dist/infrastructure/setup/environment.js")).href
-  );
+async function startServer(): Promise<PlaywrightRealStackServerHandle> {
+  const harnessPath = path.join(BACKEND_DIR, "dist/testing/playwright-real-stack-server.js");
+  const harness = requireBackendHarness(harnessPath) as PlaywrightRealStackServerModule;
 
-  validateEnvironment();
-
-  const { app } = await import(pathToFileURL(path.join(BACKEND_DIR, "dist/app.js")).href);
-  const { prisma } = await import(
-    pathToFileURL(path.join(BACKEND_DIR, "dist/infrastructure/setup/prisma.js")).href
-  );
-
-  const server = http.createServer(app);
-
-  await new Promise<void>((resolve) => {
-    server.listen(PORT, HOST, () => resolve());
-  });
-
-  return {
-    server,
-    disconnectPrisma: () => prisma.$disconnect(),
-  };
+  return harness.startPlaywrightRealStackServer({ host: HOST, port: PORT });
 }
 
 async function main(): Promise<void> {
@@ -346,11 +338,16 @@ async function main(): Promise<void> {
   runBackendMigrations();
   await seedDatabase(context.databaseUrl);
 
-  const { server, disconnectPrisma } = await startServer();
+  const { shutdown: shutdownServer } = await startServer();
+  let shuttingDown = false;
 
   const shutdown = async (exitCode = 0): Promise<void> => {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
-    await disconnectPrisma();
+    if (shuttingDown) {
+      return;
+    }
+
+    shuttingDown = true;
+    await shutdownServer();
     rmSync(context.tempDir, { recursive: true, force: true });
     process.exit(exitCode);
   };
@@ -362,12 +359,10 @@ async function main(): Promise<void> {
   process.on("SIGTERM", () => {
     void shutdown(0);
   });
-
-  console.log(`[playwright-real-stack] ready at http://${HOST}:${PORT}`);
 }
 
 const executedAsScript = process.argv[1]
-  ? pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
   : false;
 
 if (executedAsScript) {


### PR DESCRIPTION
Closes #55

## What

Fixes Docker Spotify OAuth redirects that were generated with empty `client_id` and `redirect_uri` by making backend startup explicit: environment validation now happens before Spotify auth config, rate limiters, container wiring, routes, jobs, and workers are initialized.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Docs / chore

## Scope

- [ ] Frontend only (`apps/frontend`)
- [x] Backend only (`apps/backend`)
- [ ] Shared (`packages/shared`)
- [ ] Cross-workspace

## Summary

- Replace import-time container wiring with `initializeContainer(env)` after validated environment load.
- Build Express routes from explicit `create*Routes(container)` factories instead of singleton container imports.
- Configure Spotify HTTP rate limiters from validated env and add regression coverage for route handler wiring.

## Changes

| File | Change |
|------|--------|
| `apps/backend/src/index.ts` | Validates env, configures Spotify limiters, initializes DI, then creates app. |
| `apps/backend/src/container.ts` | Converts backend DI to validated-env factory; removes import-time Spotify auth config. |
| `apps/backend/src/app.ts`, `presentation/routes/*` | Passes `Container` explicitly through app/route factories. |
| `apps/backend/src/infrastructure/jobs/*`, `workers/*` | Resolves container during startup/runtime instead of import-time destructuring. |
| `apps/backend/src/infrastructure/external/spotify-http.client.ts` | Adds explicit `configureSpotifyRateLimiters(env)` startup configuration. |
| `apps/backend/src/infrastructure/messaging/app-event-bus.ts` | Injects SSE emitter explicitly. |
| `apps/backend/src/presentation/routes/events.routes.test.ts` | Adds smoke regression for route handler registration. |

## Test Plan

- [x] `pnpm --filter backend run lint`
- [x] `pnpm --filter backend run build`
- [x] `pnpm --filter backend exec vitest run src/presentation/routes/events.routes.test.ts src/infrastructure/workers/feed-sync.worker.create.test.ts`
- [x] Fresh-context reviews completed; final verdict: GO, no blockers.

## Review size

- [x] `size:exception` accepted: diff is >400 lines because route factory changes are mechanical and must land with DI bootstrap to avoid reintroducing singleton/proxy hazards.

## Checklist

- [x] Lint + build pass for affected scope (`pnpm --filter <workspace> run lint && build`)
- [x] No secrets committed (`.env`, tokens, credentials`)
- [x] Pre-commit hooks passed (no `--no-verify`)
- [ ] Screenshots / GIF attached for UI changes
- [ ] `CHANGELOG.md` updated if this is a user-facing change
