### PR TITLE
feat: optional token auth for secure internet exposure (engram-style)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,12 +31,6 @@ DOWNLOADS_DIR=/path/to/your/downloads/folder
 # Advanced Redis (Optional)
 # REDIS_HOST=redis
 # REDIS_PORT=6379
-# Search provider (Optional)
-# Controls which provider is used for catalog search (artist + album).
-# "spotify" (default): uses Spotify search API (legacy)
-# "deezer": uses Deezer search API (Deezer-first, no Spotify search calls)
-# SEARCH_PROVIDER is removed — catalog search is Deezer-first after PR-3.4 (CLN-1)
-
 # Instance Authentication (Optional)
 # Set a strong secret to password-protect your SpotiArr instance.
 # Leave unset (or remove entirely) for open LAN-only access — no auth check.

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,21 @@ DOWNLOADS_DIR=/path/to/your/downloads/folder
 # "spotify" (default): uses Spotify search API (legacy)
 # "deezer": uses Deezer search API (Deezer-first, no Spotify search calls)
 # SEARCH_PROVIDER is removed — catalog search is Deezer-first after PR-3.4 (CLN-1)
+
+# Instance Authentication (Optional)
+# Set a strong secret to password-protect your SpotiArr instance.
+# Leave unset (or remove entirely) for open LAN-only access — no auth check.
+# SPOTIARR_TOKEN=your-strong-secret-here
+
+# Session lifetime in hours (default: 168 = 7 days).
+# After expiry the browser prompts for the token again.
+# SPOTIARR_SESSION_TTL_HOURS=168
+
+# Max unlock attempts per minute per IP before returning 429 (default: 5).
+# SPOTIARR_UNLOCK_RATELIMIT=5
+
+# Trust proxy hop count or preset (default: unset = no proxy).
+# REQUIRED when running behind a reverse proxy (Nginx, Traefik, Caddy, etc.)
+# so that the secure cookie and rate-limiting IP detection work correctly.
+# Set to 1 for a single proxy in front of SpotiArr.
+# SPOTIARR_TRUST_PROXY=1

--- a/README.md
+++ b/README.md
@@ -210,12 +210,33 @@ pnpm --filter frontend run test:e2e
 
 **Instance Authentication (optional — recommended for internet-exposed instances):**
 
-| Variable                     | Default | Description                                                                                                 |
-| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `SPOTIARR_TOKEN`             | -       | Shared secret to password-protect the instance. Unset = open access (no auth check).                        |
-| `SPOTIARR_SESSION_TTL_HOURS` | `168`   | Session lifetime in hours (default: 7 days). Cookie expires after this period.                              |
-| `SPOTIARR_UNLOCK_RATELIMIT`  | `5`     | Max unlock attempts per minute per IP before returning 429.                                                 |
-| `SPOTIARR_TRUST_PROXY`       | -       | Set to `1` when behind a reverse proxy (Nginx, Traefik, Caddy) for correct IP and `secure` cookie handling. |
+| Variable                     | Default | Description                                                                                                                                   |
+| ---------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SPOTIARR_TOKEN`             | -       | Shared secret to gate the instance (minimum 16 characters). Unset = open LAN access, zero behavior change.                                    |
+| `SPOTIARR_SESSION_TTL_HOURS` | `168`   | Session lifetime in hours (default: 7 days). Cookie expires after this period.                                                                |
+| `SPOTIARR_UNLOCK_RATELIMIT`  | `5`     | Max unlock attempts per minute per IP before returning 429.                                                                                   |
+| `SPOTIARR_TRUST_PROXY`       | -       | Number of proxy hops (e.g. `1`), or `true`/`false`/preset. **Required** behind any reverse proxy for correct IP resolution and Secure cookie. |
+
+### Exposing SpotiArr to the internet
+
+The instance token gate is **optional**. Without `SPOTIARR_TOKEN` set, SpotiArr behaves exactly as before — fully open for trusted LAN use.
+
+To expose the instance to the internet safely:
+
+1. **Generate a strong token** and add it to your `.env`:
+
+   ```bash
+   openssl rand -base64 32
+   # → paste the output as SPOTIARR_TOKEN=<value>
+   ```
+
+   The token must be at least 16 characters. Rotating it invalidates all active sessions immediately (sessions are signed with the token itself).
+
+2. **Set `SPOTIARR_TRUST_PROXY`** if you are behind a reverse proxy (Pangolin, Traefik, Nginx, Caddy, Cloudflare Tunnel, etc.). Without this, rate limiting uses the wrong IP and the Secure cookie flag may not be set. For a single proxy hop, use `SPOTIARR_TRUST_PROXY=1`.
+
+3. **No URL config needed for the gate itself.** The only URL you must configure when going public is `SPOTIFY_REDIRECT_URI` — it must point to your public hostname (`https://your-domain.com/api/auth/spotify/callback`) and that exact URI must be whitelisted in your Spotify Developer Dashboard app settings.
+
+See the table above for all related variables and their defaults.
 
 **Note regarding HTTPS:**
 The included `docker-compose.yml` uses **Traefik** as a reverse proxy to handle HTTPS automatically on port 443. This is required for Spotify authentication on remote servers. SpotiArr itself runs on HTTP (port 3000) internally.

--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ pnpm --filter frontend run test:e2e
 | `REDIS_HOST` | `redis` | Hostname of Redis server (for external DB) |
 | `REDIS_PORT` | `6379`  | Port of Redis server                       |
 
+**Instance Authentication (optional — recommended for internet-exposed instances):**
+
+| Variable                     | Default | Description                                                                                                 |
+| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `SPOTIARR_TOKEN`             | -       | Shared secret to password-protect the instance. Unset = open access (no auth check).                        |
+| `SPOTIARR_SESSION_TTL_HOURS` | `168`   | Session lifetime in hours (default: 7 days). Cookie expires after this period.                              |
+| `SPOTIARR_UNLOCK_RATELIMIT`  | `5`     | Max unlock attempts per minute per IP before returning 429.                                                 |
+| `SPOTIARR_TRUST_PROXY`       | -       | Set to `1` when behind a reverse proxy (Nginx, Traefik, Caddy) for correct IP and `secure` cookie handling. |
+
 **Note regarding HTTPS:**
 The included `docker-compose.yml` uses **Traefik** as a reverse proxy to handle HTTPS automatically on port 443. This is required for Spotify authentication on remote servers. SpotiArr itself runs on HTTP (port 3000) internally.
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -37,7 +37,7 @@ src/
 │   └── setup/           environment.ts, prisma.ts, queues.ts
 └── presentation/
     ├── controllers/     artist, auth, events, feed, health, history, library, playlist, search, settings, track
-    ├── middleware/      async-handler.ts, error-handler.ts, validate.ts
+    ├── middleware/      async-handler.ts, cookie.ts, error-handler.ts, require-token.ts, validate.ts
     └── routes/          *.routes.ts + schemas/
 ```
 
@@ -49,6 +49,8 @@ src/
 - Never let Prisma errors escape to the presentation layer — map them in the repository.
 - SSE events emitted via `infrastructure/messaging/app-event-bus.ts`, never directly from controllers.
 - Environment access through `getEnv()` from `infrastructure/setup/environment.ts` — never `process.env` directly.
+- Instance token auth: `createRequireTokenMiddleware` is mounted at `ApiRoutes.BASE` before the API router. Public routes must be added to the allowlist in `presentation/middleware/require-token.ts` (currently POST /auth/unlock, GET /health, GET /auth/spotify/callback). GET /auth/session is intentionally NOT allowlisted.
+- `app.set("trust proxy", ...)` is driven by `SPOTIARR_TRUST_PROXY`; it MUST be set behind a reverse proxy or `req.secure` (cookie Secure flag) and `req.ip` (rate-limit bucket) break.
 
 ## Validation
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -4,11 +4,18 @@ import express, { type Express } from "express";
 import helmet from "helmet";
 import path from "path";
 import type { Container } from "./container";
+import { getEnv } from "./infrastructure/setup/environment";
 import { errorHandler } from "./presentation/middleware/error-handler";
+import { createRequireTokenMiddleware } from "./presentation/middleware/require-token";
 import { createRoutes } from "./presentation/routes";
 
 export function createApp(container: Container): Express {
   const app: Express = express();
+
+  const trustProxy = getEnv().SPOTIARR_TRUST_PROXY;
+  if (trustProxy) {
+    app.set("trust proxy", trustProxy);
+  }
 
   // Security middleware
   app.use(
@@ -32,6 +39,12 @@ export function createApp(container: Container): Express {
   // Body parsing
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
+
+  // Instance auth gate — runs before API router, after body parsing
+  app.use(
+    ApiRoutes.BASE,
+    createRequireTokenMiddleware(() => getEnv().SPOTIARR_TOKEN),
+  );
 
   // API Routes
   app.use(ApiRoutes.BASE, createRoutes(container));

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -12,10 +12,7 @@ import { createRoutes } from "./presentation/routes";
 export function createApp(container: Container): Express {
   const app: Express = express();
 
-  const trustProxy = getEnv().SPOTIARR_TRUST_PROXY;
-  if (trustProxy) {
-    app.set("trust proxy", trustProxy);
-  }
+  app.set("trust proxy", getEnv().SPOTIARR_TRUST_PROXY ?? false);
 
   // Security middleware
   app.use(
@@ -40,7 +37,6 @@ export function createApp(container: Container): Express {
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
 
-  // Instance auth gate — runs before API router, after body parsing
   app.use(
     ApiRoutes.BASE,
     createRequireTokenMiddleware(() => getEnv().SPOTIARR_TOKEN),

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -574,6 +574,8 @@ export function createContainer(env: Env) {
     settingsService,
     env.SPOTIFY_CLIENT_ID,
     env.SPOTIFY_REDIRECT_URI,
+    env.SPOTIARR_TOKEN,
+    env.SPOTIARR_SESSION_TTL_HOURS,
   );
   const healthController = new HealthController(healthService);
 
@@ -589,6 +591,7 @@ export function createContainer(env: Env) {
   });
 
   return {
+    unlockRateLimit: env.SPOTIARR_UNLOCK_RATELIMIT,
     playlistService,
     playlistController,
     trackService,

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -26,6 +26,14 @@ const CIRCUIT_BREAKER_OPEN_UNTIL_KEY = "spotify_circuit_open_until";
 validateEnvironment();
 
 const env = getEnv();
+
+if (env.SPOTIARR_TOKEN && !env.SPOTIARR_TRUST_PROXY) {
+  console.warn(
+    "⚠️  [Auth] SPOTIARR_TOKEN is set but SPOTIARR_TRUST_PROXY is not. " +
+      "The session cookie Secure flag relies on X-Forwarded-Proto — a misconfigured reverse proxy could serve cookies over plaintext.",
+  );
+}
+
 configureSpotifyRateLimiters(env);
 const PORT = 3000;
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -30,7 +30,9 @@ const env = getEnv();
 if (env.SPOTIARR_TOKEN && !env.SPOTIARR_TRUST_PROXY) {
   console.warn(
     "⚠️  [Auth] SPOTIARR_TOKEN is set but SPOTIARR_TRUST_PROXY is not. " +
-      "The session cookie Secure flag relies on X-Forwarded-Proto — a misconfigured reverse proxy could serve cookies over plaintext.",
+      "Behind a reverse proxy you MUST set SPOTIARR_TRUST_PROXY (e.g. 1), otherwise: " +
+      "(a) the session cookie will NOT get the Secure flag (req.secure stays false), and " +
+      "(b) per-client rate limiting collapses to a single shared bucket (req.ip becomes the proxy IP).",
   );
 }
 

--- a/apps/backend/src/infrastructure/setup/environment.test.ts
+++ b/apps/backend/src/infrastructure/setup/environment.test.ts
@@ -1,4 +1,105 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { envSchema } from "./environment";
+
+type AnyDef = { _def: { in: { _def: { shape: Record<string, z.ZodTypeAny> } } } };
+const innerShape = (envSchema as unknown as AnyDef)._def.in._def.shape;
+
+const tokenSchema = innerShape.SPOTIARR_TOKEN;
+const trustProxySchema = innerShape.SPOTIARR_TRUST_PROXY;
+
+describe("SPOTIARR_TOKEN schema", () => {
+  it("accepts undefined (auth disabled)", () => {
+    expect(tokenSchema.safeParse(undefined).success).toBe(true);
+    expect(tokenSchema.safeParse(undefined).data).toBeUndefined();
+  });
+
+  it("accepts a 16-character token", () => {
+    const result = tokenSchema.safeParse("abcdefghijklmnop");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("abcdefghijklmnop");
+  });
+
+  it("accepts a long token", () => {
+    expect(tokenSchema.safeParse("a-valid-token-that-is-long-enough").success).toBe(true);
+  });
+
+  it("trims surrounding whitespace and keeps the trimmed value", () => {
+    const result = tokenSchema.safeParse("  abcdefghijklmnop  ");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("abcdefghijklmnop");
+  });
+
+  it("rejects a token shorter than 16 characters", () => {
+    expect(tokenSchema.safeParse("tooshort").success).toBe(false);
+  });
+
+  it("rejects a whitespace-only string", () => {
+    expect(tokenSchema.safeParse("               ").success).toBe(false);
+  });
+
+  it("rejects an empty string", () => {
+    expect(tokenSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("SPOTIARR_TRUST_PROXY schema", () => {
+  it("accepts undefined and returns undefined", () => {
+    const result = trustProxySchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("parses '1' as the number 1", () => {
+    const result = trustProxySchema.safeParse("1");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(1);
+  });
+
+  it("parses '0' as the number 0", () => {
+    const result = trustProxySchema.safeParse("0");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(0);
+  });
+
+  it("parses 'true' as boolean true", () => {
+    const result = trustProxySchema.safeParse("true");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(true);
+  });
+
+  it("parses 'false' as boolean false", () => {
+    const result = trustProxySchema.safeParse("false");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(false);
+  });
+
+  it("parses 'loopback' as string 'loopback'", () => {
+    const result = trustProxySchema.safeParse("loopback");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe("loopback");
+  });
+
+  it("parses 'linklocal' as string 'linklocal'", () => {
+    expect(trustProxySchema.safeParse("linklocal").data).toBe("linklocal");
+  });
+
+  it("parses 'uniquelocal' as string 'uniquelocal'", () => {
+    expect(trustProxySchema.safeParse("uniquelocal").data).toBe("uniquelocal");
+  });
+
+  it("rejects an unknown string", () => {
+    expect(trustProxySchema.safeParse("garbage-value").success).toBe(false);
+  });
+
+  it("rejects 'yes' (not a valid preset or boolean)", () => {
+    expect(trustProxySchema.safeParse("yes").success).toBe(false);
+  });
+
+  it("rejects 'TRUE' (case-sensitive)", () => {
+    expect(trustProxySchema.safeParse("TRUE").success).toBe(false);
+  });
+});
 
 const REQUIRED_ENV = {
   SPOTIFY_CLIENT_ID: "client-id",

--- a/apps/backend/src/infrastructure/setup/environment.test.ts
+++ b/apps/backend/src/infrastructure/setup/environment.test.ts
@@ -7,6 +7,8 @@ const innerShape = (envSchema as unknown as AnyDef)._def.in._def.shape;
 
 const tokenSchema = innerShape.SPOTIARR_TOKEN;
 const trustProxySchema = innerShape.SPOTIARR_TRUST_PROXY;
+const sessionTtlSchema = innerShape.SPOTIARR_SESSION_TTL_HOURS;
+const unlockRatelimitSchema = innerShape.SPOTIARR_UNLOCK_RATELIMIT;
 
 describe("SPOTIARR_TOKEN schema", () => {
   it("accepts undefined (auth disabled)", () => {
@@ -98,6 +100,72 @@ describe("SPOTIARR_TRUST_PROXY schema", () => {
 
   it("rejects 'TRUE' (case-sensitive)", () => {
     expect(trustProxySchema.safeParse("TRUE").success).toBe(false);
+  });
+});
+
+describe("SPOTIARR_SESSION_TTL_HOURS schema", () => {
+  it("defaults to 168 when absent", () => {
+    const result = sessionTtlSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(168);
+  });
+
+  it("accepts 1 (min boundary)", () => {
+    expect(sessionTtlSchema.safeParse("1").success).toBe(true);
+    expect(sessionTtlSchema.safeParse("1").data).toBe(1);
+  });
+
+  it("rejects 0 (below min boundary)", () => {
+    expect(sessionTtlSchema.safeParse("0").success).toBe(false);
+  });
+
+  it("accepts 8760 (max boundary)", () => {
+    expect(sessionTtlSchema.safeParse("8760").success).toBe(true);
+    expect(sessionTtlSchema.safeParse("8760").data).toBe(8760);
+  });
+
+  it("rejects 8761 (above max boundary)", () => {
+    expect(sessionTtlSchema.safeParse("8761").success).toBe(false);
+  });
+
+  it("rejects non-integer garbage", () => {
+    expect(sessionTtlSchema.safeParse("abc").success).toBe(false);
+  });
+
+  it("coerces a string number to a number", () => {
+    const result = sessionTtlSchema.safeParse("24");
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(24);
+  });
+});
+
+describe("SPOTIARR_UNLOCK_RATELIMIT schema", () => {
+  it("defaults to 5 when absent", () => {
+    const result = unlockRatelimitSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    expect(result.data).toBe(5);
+  });
+
+  it("accepts 1 (min boundary)", () => {
+    expect(unlockRatelimitSchema.safeParse("1").success).toBe(true);
+    expect(unlockRatelimitSchema.safeParse("1").data).toBe(1);
+  });
+
+  it("rejects 0 (below min boundary)", () => {
+    expect(unlockRatelimitSchema.safeParse("0").success).toBe(false);
+  });
+
+  it("accepts 100 (max boundary)", () => {
+    expect(unlockRatelimitSchema.safeParse("100").success).toBe(true);
+    expect(unlockRatelimitSchema.safeParse("100").data).toBe(100);
+  });
+
+  it("rejects 101 (above max boundary)", () => {
+    expect(unlockRatelimitSchema.safeParse("101").success).toBe(false);
+  });
+
+  it("rejects garbage", () => {
+    expect(unlockRatelimitSchema.safeParse("garbage").success).toBe(false);
   });
 });
 

--- a/apps/backend/src/infrastructure/setup/environment.ts
+++ b/apps/backend/src/infrastructure/setup/environment.ts
@@ -134,12 +134,29 @@ const envSchema = z
     // Instance auth (optional — unset means auth is disabled)
     SPOTIARR_TOKEN: z
       .string()
-      .min(1)
       .optional()
+      .refine((t) => t === undefined || t.trim().length >= 16, {
+        message:
+          "SPOTIARR_TOKEN must be at least 16 non-whitespace characters. Generate one with: openssl rand -base64 32",
+      })
       .transform((t) => t?.trim() || undefined),
     SPOTIARR_SESSION_TTL_HOURS: z.coerce.number().int().min(1).max(8760).default(168),
     SPOTIARR_UNLOCK_RATELIMIT: z.coerce.number().int().min(1).max(100).default(5),
-    SPOTIARR_TRUST_PROXY: z.string().optional(),
+    SPOTIARR_TRUST_PROXY: z
+      .string()
+      .optional()
+      .transform((val, ctx) => {
+        if (val === undefined) return undefined;
+        if (/^\d+$/.test(val)) return Number(val);
+        if (val === "true") return true;
+        if (val === "false") return false;
+        if (["loopback", "linklocal", "uniquelocal"].includes(val)) return val as string;
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `SPOTIARR_TRUST_PROXY must be a hop count (e.g. 1), a preset (loopback/linklocal/uniquelocal), or true/false. Got: "${val}"`,
+        });
+        return z.NEVER;
+      }),
   })
   .transform((data) => {
     // Derived configurations

--- a/apps/backend/src/infrastructure/setup/environment.ts
+++ b/apps/backend/src/infrastructure/setup/environment.ts
@@ -24,7 +24,7 @@ console.log(`[Env] Loaded environment for: ${currentEnv}`);
 // Schema Validation & Auto-configuration
 // -----------------------------------------------------------------------------
 
-const envSchema = z
+export const envSchema = z
   .object({
     // Spotify
     SPOTIFY_CLIENT_ID: z.string().min(1, "SPOTIFY_CLIENT_ID is required"),

--- a/apps/backend/src/infrastructure/setup/environment.ts
+++ b/apps/backend/src/infrastructure/setup/environment.ts
@@ -130,6 +130,16 @@ const envSchema = z
 
     // System
     NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
+
+    // Instance auth (optional — unset means auth is disabled)
+    SPOTIARR_TOKEN: z
+      .string()
+      .min(1)
+      .optional()
+      .transform((t) => t?.trim() || undefined),
+    SPOTIARR_SESSION_TTL_HOURS: z.coerce.number().int().min(1).max(8760).default(168),
+    SPOTIARR_UNLOCK_RATELIMIT: z.coerce.number().int().min(1).max(100).default(5),
+    SPOTIARR_TRUST_PROXY: z.string().optional(),
   })
   .transform((data) => {
     // Derived configurations

--- a/apps/backend/src/presentation/controllers/auth.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.test.ts
@@ -155,6 +155,64 @@ describe("AuthController.unlock", () => {
     expect(res.status).toHaveBeenCalledWith(401);
     expect(res.json).toHaveBeenCalledWith({ error: "invalid_token" });
   });
+
+  it("sets secure:true on the cookie when req.secure is true", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: true,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    const [, , options] = (res.cookie as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.secure).toBe(true);
+  });
+
+  it("sets secure:false on the cookie when req.secure is false", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    const [, , options] = (res.cookie as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.secure).toBe(false);
+  });
+
+  it("sets cookie maxAge equal to SESSION_TTL_HOURS * 3600 * 1000", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    const [, , options] = (res.cookie as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.maxAge).toBe(SESSION_TTL_HOURS * 3600 * 1000);
+  });
+
+  it("cookie payload TTL equals SESSION_TTL_HOURS * 3600 seconds", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    const [, cookieValue] = (res.cookie as ReturnType<typeof vi.fn>).mock.calls[0];
+    const payload = verifyCookie(cookieValue as string, VALID_TOKEN);
+    expect(payload).not.toBeNull();
+    expect(payload!.exp - payload!.iat).toBe(SESSION_TTL_HOURS * 3600);
+  });
 });
 
 describe("AuthController.session", () => {

--- a/apps/backend/src/presentation/controllers/auth.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.test.ts
@@ -1,0 +1,186 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { COOKIE_NAME, verifyCookie } from "../middleware/cookie";
+import { AuthController } from "./auth.controller";
+
+const VALID_TOKEN = "a-valid-token-at-least-16-chars";
+const SESSION_TTL_HOURS = 1;
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    cookie: vi.fn().mockReturnThis(),
+    redirect: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function makeSettingsService(): SettingsService {
+  return {
+    getString: vi.fn(),
+    setString: vi.fn(),
+    getNumber: vi.fn(),
+    setNumber: vi.fn(),
+    getBoolean: vi.fn(),
+    setBoolean: vi.fn(),
+  } as unknown as SettingsService;
+}
+
+function makeSpotifyAuthService() {
+  return {
+    exchangeCodeForToken: vi.fn().mockResolvedValue(undefined),
+    logout: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeController(token: string = VALID_TOKEN) {
+  return new AuthController(
+    makeSpotifyAuthService(),
+    makeSettingsService(),
+    "client-id",
+    "http://localhost/callback",
+    token,
+    SESSION_TTL_HOURS,
+  );
+}
+
+function makeControllerNoToken() {
+  return new AuthController(
+    makeSpotifyAuthService(),
+    makeSettingsService(),
+    "client-id",
+    "http://localhost/callback",
+    undefined,
+    SESSION_TTL_HOURS,
+  );
+}
+
+describe("AuthController.unlock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 {ok:true} and sets the session cookie when token is correct", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+    expect(res.cookie).toHaveBeenCalledWith(
+      COOKIE_NAME,
+      expect.any(String),
+      expect.objectContaining({ httpOnly: true, sameSite: "lax" }),
+    );
+  });
+
+  it("cookie value is a valid signed payload verifiable with the same token", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: VALID_TOKEN },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    const [, cookieValue] = (res.cookie as ReturnType<typeof vi.fn>).mock.calls[0];
+    const payload = verifyCookie(cookieValue as string, VALID_TOKEN);
+    expect(payload).not.toBeNull();
+    expect(typeof payload!.iat).toBe("number");
+    expect(typeof payload!.exp).toBe("number");
+    expect(payload!.exp).toBeGreaterThan(payload!.iat);
+  });
+
+  it("returns 401 {error:'invalid_token'} when token is wrong", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: "wrong-token-value" },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "invalid_token" });
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for wrong token of a DIFFERENT length (constant-time comparison stays safe)", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: { token: "x" },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "invalid_token" });
+  });
+
+  it("returns 200 {ok:true} as no-op when spotiarrToken is undefined (auth disabled)", () => {
+    const controller = makeControllerNoToken();
+    const req = {
+      body: { token: "any-token" },
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ ok: true });
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when body token field is missing", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {
+      body: {},
+      secure: false,
+    } as unknown as Request;
+    const res = mockRes();
+
+    controller.unlock(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "invalid_token" });
+  });
+});
+
+describe("AuthController.session", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns {tokenRequired:false} when spotiarrToken is undefined", () => {
+    const controller = makeControllerNoToken();
+    const req = {} as Request;
+    const res = mockRes();
+
+    controller.session(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ tokenRequired: false });
+  });
+
+  it("returns {tokenRequired:true} when spotiarrToken is set", () => {
+    const controller = makeController(VALID_TOKEN);
+    const req = {} as Request;
+    const res = mockRes();
+
+    controller.session(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ tokenRequired: true });
+  });
+});

--- a/apps/backend/src/presentation/controllers/auth.controller.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.ts
@@ -1,8 +1,8 @@
-import { timingSafeEqual } from "crypto";
+import { createHash, timingSafeEqual } from "crypto";
 import type { Request, Response } from "express";
 import { z } from "zod";
 import type { SettingsService } from "@/application/services/settings.service";
-import { signCookie } from "../middleware/cookie";
+import { COOKIE_NAME, signCookie } from "../middleware/cookie";
 
 interface SpotifyAuthPort {
   exchangeCodeForToken(code: string): Promise<void>;
@@ -15,8 +15,6 @@ const SCOPES = [
   "playlist-read-private",
   "playlist-read-collaborative",
 ].join(" ");
-
-const COOKIE_NAME = "spotiarr_session";
 
 const unlockBodySchema = z.object({
   token: z.string().min(1),
@@ -100,11 +98,8 @@ export class AuthController {
     }
 
     const submittedToken = parsed.data.token;
-    const tokenBuf = Buffer.from(token, "utf8");
-    const submittedBuf = Buffer.from(submittedToken, "utf8");
-
-    const match =
-      tokenBuf.length === submittedBuf.length && timingSafeEqual(tokenBuf, submittedBuf);
+    const digest = (s: string) => createHash("sha256").update(s, "utf8").digest();
+    const match = timingSafeEqual(digest(token), digest(submittedToken));
 
     if (!match) {
       res.status(401).json({ error: "invalid_token" });
@@ -116,7 +111,7 @@ export class AuthController {
     const payload = { iat: nowSeconds, exp: nowSeconds + ttlSeconds };
     const cookieValue = signCookie(payload, token);
 
-    const isSecure = req.secure || req.headers["x-forwarded-proto"] === "https";
+    const isSecure = req.secure;
 
     res.cookie(COOKIE_NAME, cookieValue, {
       httpOnly: true,
@@ -137,6 +132,6 @@ export class AuthController {
       return;
     }
 
-    res.status(200).json({ tokenRequired: true, authenticated: true });
+    res.status(200).json({ tokenRequired: true });
   };
 }

--- a/apps/backend/src/presentation/controllers/auth.controller.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.ts
@@ -1,5 +1,8 @@
+import { timingSafeEqual } from "crypto";
 import type { Request, Response } from "express";
+import { z } from "zod";
 import type { SettingsService } from "@/application/services/settings.service";
+import { signCookie } from "../middleware/cookie";
 
 interface SpotifyAuthPort {
   exchangeCodeForToken(code: string): Promise<void>;
@@ -13,12 +16,20 @@ const SCOPES = [
   "playlist-read-collaborative",
 ].join(" ");
 
+const COOKIE_NAME = "spotiarr_session";
+
+const unlockBodySchema = z.object({
+  token: z.string().min(1),
+});
+
 export class AuthController {
   constructor(
     private readonly spotifyAuthService: SpotifyAuthPort,
     private readonly settingsService: SettingsService,
     private readonly spotifyClientId: string,
     private readonly spotifyRedirectUri: string,
+    private readonly spotiarrToken: string | undefined,
+    private readonly sessionTtlHours: number,
   ) {}
 
   login = async (_req: Request, res: Response) => {
@@ -72,5 +83,60 @@ export class AuthController {
       success: true,
       message: "Successfully logged out from Spotify",
     });
+  };
+
+  unlock = (req: Request, res: Response): void => {
+    const token = this.spotiarrToken;
+
+    if (!token) {
+      res.status(200).json({ ok: true });
+      return;
+    }
+
+    const parsed = unlockBodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(401).json({ error: "invalid_token" });
+      return;
+    }
+
+    const submittedToken = parsed.data.token;
+    const tokenBuf = Buffer.from(token, "utf8");
+    const submittedBuf = Buffer.from(submittedToken, "utf8");
+
+    const match =
+      tokenBuf.length === submittedBuf.length && timingSafeEqual(tokenBuf, submittedBuf);
+
+    if (!match) {
+      res.status(401).json({ error: "invalid_token" });
+      return;
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const ttlSeconds = this.sessionTtlHours * 3600;
+    const payload = { iat: nowSeconds, exp: nowSeconds + ttlSeconds };
+    const cookieValue = signCookie(payload, token);
+
+    const isSecure = req.secure || req.headers["x-forwarded-proto"] === "https";
+
+    res.cookie(COOKIE_NAME, cookieValue, {
+      httpOnly: true,
+      secure: isSecure,
+      sameSite: "lax",
+      path: "/",
+      maxAge: ttlSeconds * 1000,
+    });
+
+    res.status(200).json({ ok: true });
+  };
+
+  session = (_req: Request, res: Response): void => {
+    const token = this.spotiarrToken;
+
+    if (!token) {
+      res.status(200).json({ tokenRequired: false });
+      return;
+    }
+
+    res.status(200).json({ tokenRequired: true, authenticated: true });
   };
 }

--- a/apps/backend/src/presentation/middleware/cookie.test.ts
+++ b/apps/backend/src/presentation/middleware/cookie.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { signCookie, verifyCookie, COOKIE_NAME } from "./cookie";
+
+const SECRET = "test-secret-key-for-signing";
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+describe("COOKIE_NAME", () => {
+  it("is spotiarr_session", () => {
+    expect(COOKIE_NAME).toBe("spotiarr_session");
+  });
+});
+
+describe("signCookie / verifyCookie round-trip", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the original payload after sign → verify", () => {
+    const now = nowSeconds();
+    const payload = { iat: now, exp: now + 3600 };
+    const cookie = signCookie(payload, SECRET);
+    const result = verifyCookie(cookie, SECRET);
+
+    expect(result).not.toBeNull();
+    expect(result!.iat).toBe(payload.iat);
+    expect(result!.exp).toBe(payload.exp);
+  });
+
+  it("returns null when the signature is tampered", () => {
+    const now = nowSeconds();
+    const cookie = signCookie({ iat: now, exp: now + 3600 }, SECRET);
+    const parts = cookie.split(".");
+    const tampered = `${parts[0]}.invalidsignatureXXX`;
+
+    expect(verifyCookie(tampered, SECRET)).toBeNull();
+  });
+
+  it("returns null when the payload is tampered (signature stays original)", () => {
+    const now = nowSeconds();
+    const cookie = signCookie({ iat: now, exp: now + 3600 }, SECRET);
+    const dotIndex = cookie.lastIndexOf(".");
+    const sig = cookie.slice(dotIndex + 1);
+
+    const fakePayload = Buffer.from(JSON.stringify({ iat: now, exp: now + 9999 })).toString(
+      "base64url",
+    );
+    const tampered = `${fakePayload}.${sig}`;
+
+    expect(verifyCookie(tampered, SECRET)).toBeNull();
+  });
+
+  it("returns null when verified with a different secret", () => {
+    const now = nowSeconds();
+    const cookie = signCookie({ iat: now, exp: now + 3600 }, SECRET);
+
+    expect(verifyCookie(cookie, "wrong-secret")).toBeNull();
+  });
+});
+
+describe("verifyCookie — structure validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null for empty string", () => {
+    expect(verifyCookie("", SECRET)).toBeNull();
+  });
+
+  it("returns null for string with no dots", () => {
+    expect(verifyCookie("nodotsinhere", SECRET)).toBeNull();
+  });
+
+  it("returns null for garbage input", () => {
+    expect(verifyCookie("!!!garbage!!!", SECRET)).toBeNull();
+  });
+
+  it("returns null when exp is not a number", () => {
+    const now = nowSeconds();
+    const payload = { iat: now, exp: "not-a-number" };
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    const cookie = `${payloadB64}.${sig}`;
+
+    expect(verifyCookie(cookie, SECRET)).toBeNull();
+  });
+
+  it("returns null when iat is not a number", () => {
+    const now = nowSeconds();
+    const payload = { iat: "not-a-number", exp: now + 3600 };
+    const payloadB64 = Buffer.from(JSON.stringify(payload)).toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    const cookie = `${payloadB64}.${sig}`;
+
+    expect(verifyCookie(cookie, SECRET)).toBeNull();
+  });
+
+  it("returns null when payload is missing iat", () => {
+    const now = nowSeconds();
+    const bad = { exp: now + 3600 };
+    const payloadB64 = Buffer.from(JSON.stringify(bad)).toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    expect(verifyCookie(`${payloadB64}.${sig}`, SECRET)).toBeNull();
+  });
+
+  it("returns null when payload is missing exp", () => {
+    const now = nowSeconds();
+    const bad = { iat: now };
+    const payloadB64 = Buffer.from(JSON.stringify(bad)).toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    expect(verifyCookie(`${payloadB64}.${sig}`, SECRET)).toBeNull();
+  });
+
+  it("returns null when payload is not an object", () => {
+    const payloadB64 = Buffer.from(JSON.stringify("just-a-string")).toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    expect(verifyCookie(`${payloadB64}.${sig}`, SECRET)).toBeNull();
+  });
+
+  it("returns null when payload base64 decodes to invalid JSON", () => {
+    const badB64 = Buffer.from("not-json{{{").toString("base64url");
+    const sig = Buffer.alloc(32).toString("base64url");
+    expect(verifyCookie(`${badB64}.${sig}`, SECRET)).toBeNull();
+  });
+});
+
+describe("verifyCookie — expiry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the payload when exp is in the future (verifyCookie does not check expiry)", () => {
+    const now = nowSeconds();
+    const payload = { iat: now, exp: now + 3600 };
+    const cookie = signCookie(payload, SECRET);
+    const result = verifyCookie(cookie, SECRET);
+
+    expect(result).not.toBeNull();
+    expect(result!.exp).toBe(payload.exp);
+  });
+
+  it("still returns the payload when exp is already past — verifyCookie is a structure+sig check only", () => {
+    const now = nowSeconds();
+    const payload = { iat: now - 7200, exp: now - 3600 };
+    const cookie = signCookie(payload, SECRET);
+    const result = verifyCookie(cookie, SECRET);
+
+    expect(result).not.toBeNull();
+    expect(result!.exp).toBe(payload.exp);
+  });
+});

--- a/apps/backend/src/presentation/middleware/cookie.ts
+++ b/apps/backend/src/presentation/middleware/cookie.ts
@@ -1,5 +1,7 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
+export const COOKIE_NAME = "spotiarr_session";
+
 function toBase64url(input: string): string {
   return Buffer.from(input).toString("base64url");
 }

--- a/apps/backend/src/presentation/middleware/cookie.ts
+++ b/apps/backend/src/presentation/middleware/cookie.ts
@@ -1,0 +1,58 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+function toBase64url(input: string): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+function fromBase64url(input: string): string {
+  return Buffer.from(input, "base64url").toString("utf8");
+}
+
+function sign(payloadB64: string, secret: string): string {
+  return createHmac("sha256", secret).update(payloadB64).digest("base64url");
+}
+
+export interface SessionPayload {
+  iat: number;
+  exp: number;
+}
+
+export function signCookie(payload: SessionPayload, secret: string): string {
+  const payloadB64 = toBase64url(JSON.stringify(payload));
+  const sig = sign(payloadB64, secret);
+  return `${payloadB64}.${sig}`;
+}
+
+export function verifyCookie(value: string, secret: string): SessionPayload | null {
+  const dotIndex = value.lastIndexOf(".");
+  if (dotIndex === -1) return null;
+
+  const payloadB64 = value.slice(0, dotIndex);
+  const sig = value.slice(dotIndex + 1);
+
+  const expectedSig = sign(payloadB64, secret);
+
+  const sigBuf = Buffer.from(sig, "base64url");
+  const expectedBuf = Buffer.from(expectedSig, "base64url");
+
+  if (sigBuf.length !== expectedBuf.length) return null;
+
+  if (!timingSafeEqual(sigBuf, expectedBuf)) return null;
+
+  try {
+    const payload = JSON.parse(fromBase64url(payloadB64)) as unknown;
+    if (
+      typeof payload !== "object" ||
+      payload === null ||
+      !("iat" in payload) ||
+      !("exp" in payload) ||
+      typeof (payload as Record<string, unknown>).exp !== "number" ||
+      typeof (payload as Record<string, unknown>).iat !== "number"
+    ) {
+      return null;
+    }
+    return payload as SessionPayload;
+  } catch {
+    return null;
+  }
+}

--- a/apps/backend/src/presentation/middleware/require-token.test.ts
+++ b/apps/backend/src/presentation/middleware/require-token.test.ts
@@ -176,4 +176,94 @@ describe("createRequireTokenMiddleware — allowlist", () => {
     expect(res.json).toHaveBeenCalledWith({ error: "unauthorized" });
     expect(next).not.toHaveBeenCalled();
   });
+
+  it("GET /auth/unlock (wrong method) is NOT bypassed — returns 401 with no cookie", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({ method: "GET", path: "/auth/unlock" });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("POST /health (wrong method) is NOT bypassed — returns 401 with no cookie", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({ method: "POST", path: "/health" });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — expiry boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects a cookie where exp === nowSeconds (boundary: not-yet-expired is strictly greater)", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const value = signCookie({ iat: nowSeconds - 3600, exp: nowSeconds }, SECRET);
+    const req = makeReq({
+      method: "GET",
+      path: "/protected",
+      headers: { cookie: `${COOKIE_NAME}=${value}` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("accepts a cookie where exp === nowSeconds + 60 (clearly in the future)", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const value = signCookie({ iat: nowSeconds, exp: nowSeconds + 60 }, SECRET);
+    const req = makeReq({
+      method: "GET",
+      path: "/protected",
+      headers: { cookie: `${COOKIE_NAME}=${value}` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — multi-cookie header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts the session cookie from a multi-cookie header and calls next()", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const value = signCookie({ iat: nowSeconds, exp: nowSeconds + 3600 }, SECRET);
+    const req = makeReq({
+      method: "GET",
+      path: "/protected",
+      headers: { cookie: `foo=1; ${COOKIE_NAME}=${value}; bar=2` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
 });

--- a/apps/backend/src/presentation/middleware/require-token.test.ts
+++ b/apps/backend/src/presentation/middleware/require-token.test.ts
@@ -1,0 +1,179 @@
+import type { NextFunction, Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { signCookie, COOKIE_NAME } from "./cookie";
+import { createRequireTokenMiddleware } from "./require-token";
+
+const SECRET = "a-valid-secret-for-testing-1234";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function makeReq(override: Partial<Request> = {}): Partial<Request> {
+  return {
+    method: "GET",
+    path: "/some/protected",
+    headers: {},
+    ...override,
+  };
+}
+
+function signedCookieHeader(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const value = signCookie({ iat: now, exp: now + 3600 }, SECRET);
+  return `${COOKIE_NAME}=${value}`;
+}
+
+describe("createRequireTokenMiddleware — open mode (no token)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls next() without 401 when getToken returns undefined", () => {
+    const middleware = createRequireTokenMiddleware(() => undefined);
+    const req = makeReq();
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — token set, no cookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 {error:'unauthorized'} and does NOT call next", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({ method: "GET", path: "/protected" });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — token set, valid cookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls next() when the cookie was signed with the same secret", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({
+      method: "GET",
+      path: "/protected",
+      headers: { cookie: signedCookieHeader() },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — token set, tampered/invalid cookie", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 for a cookie signed with a different secret", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const now = Math.floor(Date.now() / 1000);
+    const badValue = signCookie({ iat: now, exp: now + 3600 }, "wrong-secret");
+    const req = makeReq({
+      headers: { cookie: `${COOKIE_NAME}=${badValue}` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for a completely garbage cookie value", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({
+      headers: { cookie: `${COOKIE_NAME}=GARBAGE!!!` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the cookie has expired", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const past = Math.floor(Date.now() / 1000) - 7200;
+    const expiredValue = signCookie({ iat: past - 3600, exp: past }, SECRET);
+    const req = makeReq({
+      headers: { cookie: `${COOKIE_NAME}=${expiredValue}` },
+    });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("createRequireTokenMiddleware — allowlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const allowlisted: Array<{ method: string; path: string }> = [
+    { method: "POST", path: "/auth/unlock" },
+    { method: "GET", path: "/health" },
+    { method: "GET", path: "/auth/spotify/callback" },
+  ];
+
+  it.each(allowlisted)(
+    "$method $path bypasses auth even with token set and no cookie",
+    ({ method, path }) => {
+      const middleware = createRequireTokenMiddleware(() => SECRET);
+      const req = makeReq({ method, path });
+      const res = mockRes();
+      const next = vi.fn() as NextFunction;
+
+      middleware(req as Request, res, next);
+
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.status).not.toHaveBeenCalled();
+    },
+  );
+
+  it("GET /auth/session is NOT allowlisted — returns 401 with token set and no cookie", () => {
+    const middleware = createRequireTokenMiddleware(() => SECRET);
+    const req = makeReq({ method: "GET", path: "/auth/session" });
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req as Request, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "unauthorized" });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/presentation/middleware/require-token.ts
+++ b/apps/backend/src/presentation/middleware/require-token.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
-import { verifyCookie } from "./cookie";
+import { COOKIE_NAME, verifyCookie } from "./cookie";
 
-const COOKIE_NAME = "spotiarr_session";
-
+// GET /auth/session is intentionally NOT here — when a token is set, its 401 is what signals
+// "locked" to the frontend; allowlisting it would let the probe succeed without a cookie.
 const ALLOWLISTED: Array<{ method: string; path: string }> = [
   { method: "POST", path: "/auth/unlock" },
   { method: "GET", path: "/health" },

--- a/apps/backend/src/presentation/middleware/require-token.ts
+++ b/apps/backend/src/presentation/middleware/require-token.ts
@@ -1,0 +1,66 @@
+import type { NextFunction, Request, Response } from "express";
+import { verifyCookie } from "./cookie";
+
+const COOKIE_NAME = "spotiarr_session";
+
+const ALLOWLISTED: Array<{ method: string; path: string }> = [
+  { method: "POST", path: "/auth/unlock" },
+  { method: "GET", path: "/health" },
+  { method: "GET", path: "/auth/spotify/callback" },
+];
+
+function parseCookies(cookieHeader: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const part of cookieHeader.split(";")) {
+    const eqIndex = part.indexOf("=");
+    if (eqIndex === -1) continue;
+    const key = part.slice(0, eqIndex).trim();
+    const val = part.slice(eqIndex + 1).trim();
+    result[key] = val;
+  }
+  return result;
+}
+
+export function createRequireTokenMiddleware(getToken: () => string | undefined) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const token = getToken();
+
+    if (!token) {
+      next();
+      return;
+    }
+
+    const isAllowlisted = ALLOWLISTED.some(
+      (entry) => entry.method === req.method && req.path === entry.path,
+    );
+
+    if (isAllowlisted) {
+      next();
+      return;
+    }
+
+    const cookieHeader = req.headers.cookie ?? "";
+    const cookies = parseCookies(cookieHeader);
+    const cookieValue = cookies[COOKIE_NAME];
+
+    if (!cookieValue) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    const payload = verifyCookie(cookieValue, token);
+
+    if (!payload) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (payload.exp <= nowSeconds) {
+      res.status(401).json({ error: "unauthorized" });
+      return;
+    }
+
+    next();
+  };
+}

--- a/apps/backend/src/presentation/routes/auth.routes.ts
+++ b/apps/backend/src/presentation/routes/auth.routes.ts
@@ -1,10 +1,51 @@
+import type { NextFunction, Request, Response } from "express";
 import { Router, type Router as ExpressRouter } from "express";
 import type { Container } from "@/container";
 import { asyncHandler } from "../middleware/async-handler";
 
+interface RateLimitEntry {
+  count: number;
+  windowStart: number;
+}
+
+const rateLimitMap = new Map<string, RateLimitEntry>();
+const WINDOW_MS = 60_000;
+
+function pruneRateLimitMap(now: number): void {
+  for (const [key, entry] of rateLimitMap) {
+    if (now - entry.windowStart >= WINDOW_MS) rateLimitMap.delete(key);
+  }
+}
+
 export function createAuthRoutes(container: Container): ExpressRouter {
   const router: ExpressRouter = Router();
-  const { authController } = container;
+  const { authController, unlockRateLimit: maxUnlockRequests } = container;
+
+  function unlockRateLimit(req: Request, res: Response, next: NextFunction): void {
+    const max = maxUnlockRequests;
+    const ip = req.ip ?? "unknown";
+    const now = Date.now();
+
+    pruneRateLimitMap(now);
+
+    const entry = rateLimitMap.get(ip);
+
+    if (!entry || now - entry.windowStart >= WINDOW_MS) {
+      rateLimitMap.set(ip, { count: 1, windowStart: now });
+      next();
+      return;
+    }
+
+    if (entry.count >= max) {
+      const retryAfterSeconds = Math.ceil((WINDOW_MS - (now - entry.windowStart)) / 1000);
+      res.set("Retry-After", String(retryAfterSeconds));
+      res.status(429).json({ error: "rate_limiter_overflow" });
+      return;
+    }
+
+    entry.count += 1;
+    next();
+  }
 
   router.get("/spotify/login", asyncHandler(authController.login));
 
@@ -13,6 +54,10 @@ export function createAuthRoutes(container: Container): ExpressRouter {
   router.get("/spotify/status", asyncHandler(authController.status));
 
   router.post("/spotify/logout", asyncHandler(authController.logout));
+
+  router.post("/unlock", unlockRateLimit, authController.unlock);
+
+  router.get("/session", authController.session);
 
   return router;
 }

--- a/apps/backend/src/presentation/routes/auth.routes.ts
+++ b/apps/backend/src/presentation/routes/auth.routes.ts
@@ -8,30 +8,30 @@ interface RateLimitEntry {
   windowStart: number;
 }
 
-const rateLimitMap = new Map<string, RateLimitEntry>();
 const WINDOW_MS = 60_000;
 
-function pruneRateLimitMap(now: number): void {
-  for (const [key, entry] of rateLimitMap) {
-    if (now - entry.windowStart >= WINDOW_MS) rateLimitMap.delete(key);
+export function createUnlockRateLimit(
+  getMax: () => number,
+): (req: Request, res: Response, next: NextFunction) => void {
+  const map = new Map<string, RateLimitEntry>();
+
+  function prune(now: number): void {
+    for (const [key, entry] of map) {
+      if (now - entry.windowStart >= WINDOW_MS) map.delete(key);
+    }
   }
-}
 
-export function createAuthRoutes(container: Container): ExpressRouter {
-  const router: ExpressRouter = Router();
-  const { authController, unlockRateLimit: maxUnlockRequests } = container;
-
-  function unlockRateLimit(req: Request, res: Response, next: NextFunction): void {
-    const max = maxUnlockRequests;
+  return function unlockRateLimit(req: Request, res: Response, next: NextFunction): void {
+    const max = getMax();
     const ip = req.ip ?? "unknown";
     const now = Date.now();
 
-    pruneRateLimitMap(now);
+    prune(now);
 
-    const entry = rateLimitMap.get(ip);
+    const entry = map.get(ip);
 
     if (!entry || now - entry.windowStart >= WINDOW_MS) {
-      rateLimitMap.set(ip, { count: 1, windowStart: now });
+      map.set(ip, { count: 1, windowStart: now });
       next();
       return;
     }
@@ -45,7 +45,14 @@ export function createAuthRoutes(container: Container): ExpressRouter {
 
     entry.count += 1;
     next();
-  }
+  };
+}
+
+export function createAuthRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { authController, unlockRateLimit: maxUnlockRequests } = container;
+
+  const unlockRateLimit = createUnlockRateLimit(() => maxUnlockRequests);
 
   router.get("/spotify/login", asyncHandler(authController.login));
 

--- a/apps/backend/src/presentation/routes/playlist.routes.ts
+++ b/apps/backend/src/presentation/routes/playlist.routes.ts
@@ -46,9 +46,9 @@ export function createPlaylistRoutes(container: Container): ExpressRouter {
   // DELETE /api/playlist/:id - Delete playlist
   router.delete("/:id", validate(playlistIdSchema), asyncHandler(playlistController.remove));
 
-  // GET /api/playlist/retry/:id - Retry failed tracks
-  router.get(
-    "/retry/:id",
+  // POST /api/playlist/:id/retry - Retry failed tracks
+  router.post(
+    "/:id/retry",
     validate(playlistIdSchema),
     asyncHandler(playlistController.retryFailedOfPlaylist),
   );

--- a/apps/backend/src/presentation/routes/track.routes.ts
+++ b/apps/backend/src/presentation/routes/track.routes.ts
@@ -10,7 +10,7 @@ export function createTrackRoutes(container: Container): ExpressRouter {
 
   router.delete("/:id", asyncHandler(trackController.remove));
 
-  router.get("/retry/:id", asyncHandler(trackController.retry));
+  router.post("/:id/retry", asyncHandler(trackController.retry));
 
   return router;
 }

--- a/apps/backend/src/presentation/routes/unlock-rate-limit.test.ts
+++ b/apps/backend/src/presentation/routes/unlock-rate-limit.test.ts
@@ -1,0 +1,94 @@
+import type { NextFunction, Request, Response } from "express";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createUnlockRateLimit } from "./auth.routes";
+
+function mockReq(ip: string = "127.0.0.1"): Request {
+  return { ip } as unknown as Request;
+}
+
+function mockRes(): Response {
+  return {
+    set: vi.fn().mockReturnThis(),
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe("createUnlockRateLimit", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("calls next() when request count is under the limit", () => {
+    const middleware = createUnlockRateLimit(() => 3);
+    const req = mockReq();
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 with Retry-After header when limit is exceeded within the window", () => {
+    const middleware = createUnlockRateLimit(() => 2);
+    const ip = "10.0.0.1";
+
+    for (let i = 0; i < 2; i++) {
+      const next = vi.fn() as NextFunction;
+      middleware(mockReq(ip), mockRes(), next);
+      expect(next).toHaveBeenCalledOnce();
+    }
+
+    const res = mockRes();
+    const next = vi.fn() as NextFunction;
+    middleware(mockReq(ip), res, next);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json).toHaveBeenCalledWith({ error: "rate_limiter_overflow" });
+    expect(res.set).toHaveBeenCalledWith("Retry-After", expect.any(String));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("resets the count after the window elapses and calls next()", () => {
+    const middleware = createUnlockRateLimit(() => 1);
+    const ip = "10.0.0.2";
+
+    middleware(mockReq(ip), mockRes(), vi.fn() as NextFunction);
+
+    const blockedRes = mockRes();
+    const blockedNext = vi.fn() as NextFunction;
+    middleware(mockReq(ip), blockedRes, blockedNext);
+    expect(blockedRes.status).toHaveBeenCalledWith(429);
+    expect(blockedNext).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(61_000);
+
+    const afterRes = mockRes();
+    const afterNext = vi.fn() as NextFunction;
+    middleware(mockReq(ip), afterRes, afterNext);
+
+    expect(afterNext).toHaveBeenCalledOnce();
+    expect(afterRes.status).not.toHaveBeenCalled();
+  });
+
+  it("gives distinct IPs independent buckets", () => {
+    const middleware = createUnlockRateLimit(() => 1);
+    const ipA = "192.168.1.1";
+    const ipB = "192.168.1.2";
+
+    middleware(mockReq(ipA), mockRes(), vi.fn() as NextFunction);
+
+    const resB = mockRes();
+    const nextB = vi.fn() as NextFunction;
+    middleware(mockReq(ipB), resB, nextB);
+
+    expect(nextB).toHaveBeenCalledOnce();
+    expect(resB.status).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -9,7 +9,7 @@ Workspace: `apps/frontend` · React 19, Vite, TanStack Query v5, Zustand, Tailwi
 - React 19 with React Compiler
 - Vite (bundler) · React Router v6 (lazy + Suspense + RouteErrorBoundary)
 - TanStack Query v5 — server state (queries + mutations)
-- Zustand — client state (2 stores, single-file with co-located selector hooks)
+- Zustand — client state (3 stores, single-file with co-located selector hooks)
 - Tailwind CSS v4 · `cn()` utility for conditional classes
 
 ## Structure
@@ -29,7 +29,7 @@ src/
 ├── locales/         en.json, es.json
 ├── routes/          routes.ts, Routing.tsx
 ├── services/        raw HTTP clients (artist/history/library/playlist/search/settings/track)
-├── store/           useDownloadStatusStore.ts, usePreferencesStore.ts
+├── store/           useDownloadStatusStore.ts, usePreferencesStore.ts, usePlayerStore.ts
 ├── views/           13 page-level route screens (Home, History, PlaylistDetail…)
 └── utils/           cache.ts, cn.ts, date.ts
 ```
@@ -42,6 +42,8 @@ src/
 - `usePreferencesStore` persists to `localStorage` (`spotiarr-preferences`). `useDownloadStatusStore` is ephemeral.
 - `useLanguageSync` controls the active language from the `UI_LANGUAGE` backend setting — never call `i18n.changeLanguage()` manually.
 - Use `cn()` from `src/utils/cn.ts` for conditional Tailwind classes.
+- Instance auth gate → `components/organisms/TokenGate.tsx` wraps the authenticated app. Gate state is EPHEMERAL React state in `useTokenGate` (hooks/controllers) — NOT a Zustand store. Do not add a 4th store for auth.
+- `httpClient` fires `setUnauthorizedHandler` on any non-auth 401; wire that handler only in `useTokenGate`, never add a second 401 handler.
 
 ## Validation
 

--- a/apps/frontend/src/app/App.tsx
+++ b/apps/frontend/src/app/App.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import { useLocation } from "react-router-dom";
 import { ToastContainer } from "@/components/organisms/ToastContainer";
+import { TokenGate } from "@/components/organisms/TokenGate";
 import { APP_VERSION } from "@/config/version";
 import { DownloadStatusProvider } from "@/contexts/DownloadStatusContext";
 import { ToastProvider } from "@/contexts/ToastContext";
@@ -9,12 +10,11 @@ import { useServerEvents } from "@/hooks/useServerEvents";
 import { Routing } from "@/routes/Routing";
 import { Path } from "@/routes/routes";
 
-export const App: FC = () => {
+const AuthenticatedApp: FC = () => {
   const { pathname } = useLocation();
   const version = APP_VERSION;
 
   useServerEvents();
-  useLanguageSync();
 
   return (
     <ToastProvider>
@@ -23,5 +23,15 @@ export const App: FC = () => {
         <Routing pathname={pathname as Path} version={version} />
       </DownloadStatusProvider>
     </ToastProvider>
+  );
+};
+
+export const App: FC = () => {
+  useLanguageSync();
+
+  return (
+    <TokenGate>
+      <AuthenticatedApp />
+    </TokenGate>
   );
 };

--- a/apps/frontend/src/components/organisms/TokenGate.test.tsx
+++ b/apps/frontend/src/components/organisms/TokenGate.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useTokenGate } from "@/hooks/controllers/useTokenGate";
+import { ApiError } from "@/services/httpClient";
+import { TokenGate } from "./TokenGate";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/hooks/controllers/useTokenGate");
+
+const mockUseTokenGate = vi.mocked(useTokenGate);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("TokenGate phase: checking", () => {
+  it("renders nothing", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "checking", unlock: vi.fn(), sessionExpired: false });
+    const { container } = render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("child")).toBeNull();
+  });
+});
+
+describe("TokenGate phase: unlocked", () => {
+  it("renders children", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "unlocked", unlock: vi.fn(), sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    expect(screen.getByText("child")).toBeTruthy();
+  });
+});
+
+describe("TokenGate phase: error", () => {
+  it("shows connection-error card with title and reload button", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "error", unlock: vi.fn(), sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    expect(screen.getByText("instanceAuth.connectionErrorTitle")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "instanceAuth.reloadButton" })).toBeTruthy();
+    expect(screen.queryByText("child")).toBeNull();
+  });
+});
+
+describe("TokenGate phase: locked", () => {
+  it("shows unlock form and no children", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock: vi.fn(), sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    expect(screen.getByText("instanceAuth.title")).toBeTruthy();
+    expect(screen.getByLabelText("instanceAuth.tokenLabel")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "instanceAuth.submitButton" })).toBeTruthy();
+    expect(screen.queryByText("child")).toBeNull();
+  });
+
+  it("submit button is disabled when input is empty", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock: vi.fn(), sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    const btn = screen.getByRole("button", { name: "instanceAuth.submitButton" });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("calls unlock with the typed token on submit", async () => {
+    const unlock = vi.fn().mockResolvedValue(undefined);
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock, sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+
+    const input = screen.getByLabelText("instanceAuth.tokenLabel");
+    fireEvent.change(input, { target: { value: "my-token" } });
+    fireEvent.click(screen.getByRole("button", { name: "instanceAuth.submitButton" }));
+
+    await waitFor(() => expect(unlock).toHaveBeenCalledWith("my-token"));
+  });
+
+  it("shows instanceAuth.rateLimited when unlock rejects with ApiError 429", async () => {
+    const unlock = vi.fn().mockRejectedValue(new ApiError("rate limited", undefined, 429));
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock, sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+
+    fireEvent.change(screen.getByLabelText("instanceAuth.tokenLabel"), {
+      target: { value: "tok" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "instanceAuth.submitButton" }));
+
+    await waitFor(() => expect(screen.getByText("instanceAuth.rateLimited")).toBeTruthy());
+  });
+
+  it("shows instanceAuth.invalidToken when unlock rejects with non-429 error", async () => {
+    const unlock = vi.fn().mockRejectedValue(new ApiError("bad token", undefined, 401));
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock, sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+
+    fireEvent.change(screen.getByLabelText("instanceAuth.tokenLabel"), {
+      target: { value: "tok" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "instanceAuth.submitButton" }));
+
+    await waitFor(() => expect(screen.getByText("instanceAuth.invalidToken")).toBeTruthy());
+  });
+
+  it("shows instanceAuth.sessionExpired when sessionExpired is true", () => {
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock: vi.fn(), sessionExpired: true });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+    expect(screen.getByText("instanceAuth.sessionExpired")).toBeTruthy();
+  });
+
+  it("disables input and button while unlock is pending", async () => {
+    let resolve!: () => void;
+    const deferred = new Promise<void>((res) => {
+      resolve = res;
+    });
+    const unlock = vi.fn().mockReturnValue(deferred);
+    mockUseTokenGate.mockReturnValue({ phase: "locked", unlock, sessionExpired: false });
+    render(
+      <TokenGate>
+        <span>child</span>
+      </TokenGate>,
+    );
+
+    const input = screen.getByLabelText("instanceAuth.tokenLabel");
+    fireEvent.change(input, { target: { value: "tok" } });
+    fireEvent.click(screen.getByRole("button", { name: "instanceAuth.submitButton" }));
+
+    await waitFor(() => expect((input as HTMLInputElement).disabled).toBe(true));
+    expect(
+      (screen.getByRole("button", { name: "instanceAuth.loadingButton" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+
+    resolve();
+  });
+});

--- a/apps/frontend/src/components/organisms/TokenGate.tsx
+++ b/apps/frontend/src/components/organisms/TokenGate.tsx
@@ -1,0 +1,87 @@
+import { type FC, type ReactNode, type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useTokenGate } from "@/hooks/controllers/useTokenGate";
+import { ApiError } from "@/services/httpClient";
+
+interface TokenGateProps {
+  children: ReactNode;
+}
+
+export const TokenGate: FC<TokenGateProps> = ({ children }) => {
+  const { t } = useTranslation();
+  const { phase, unlock, sessionExpired } = useTokenGate();
+  const [token, setToken] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const sessionExpiredMsg = sessionExpired ? t("instanceAuth.sessionExpired") : null;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (phase === "checking") {
+    return null;
+  }
+
+  if (phase === "unlocked") {
+    return <>{children}</>;
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      await unlock(token);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 429) {
+          setError(t("instanceAuth.rateLimited"));
+        } else {
+          setError(t("instanceAuth.invalidToken"));
+        }
+      } else {
+        setError(t("instanceAuth.invalidToken"));
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <div className="bg-background-elevated w-full max-w-sm space-y-6 rounded-lg border border-white/10 p-8">
+        <div className="space-y-2 text-center">
+          <h1 className="text-text-primary text-xl font-bold">{t("instanceAuth.title")}</h1>
+          <p className="text-text-secondary text-sm">{t("instanceAuth.description")}</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor="instance-token" className="text-text-secondary text-sm">
+              {t("instanceAuth.tokenLabel")}
+            </label>
+            <input
+              id="instance-token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder={t("instanceAuth.tokenPlaceholder")}
+              autoComplete="current-password"
+              className="bg-background text-text-primary placeholder-text-secondary focus:ring-primary w-full rounded-md border border-white/20 px-3 py-2 text-sm outline-none focus:ring-2"
+              disabled={isSubmitting}
+            />
+          </div>
+
+          {(error ?? sessionExpiredMsg) && (
+            <p className="text-sm text-red-400">{error ?? sessionExpiredMsg}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting || !token}
+            className="bg-primary hover:bg-primary/90 w-full rounded-md px-4 py-2 text-sm font-medium text-white transition-colors disabled:opacity-50"
+          >
+            {isSubmitting ? t("instanceAuth.loadingButton") : t("instanceAuth.submitButton")}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/apps/frontend/src/components/organisms/TokenGate.tsx
+++ b/apps/frontend/src/components/organisms/TokenGate.tsx
@@ -1,4 +1,4 @@
-import { type FC, type ReactNode, type FormEvent, useState } from "react";
+import { type FC, type FormEvent, type ReactNode, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useTokenGate } from "@/hooks/controllers/useTokenGate";
 import { ApiError } from "@/services/httpClient";
@@ -12,37 +12,29 @@ export const TokenGate: FC<TokenGateProps> = ({ children }) => {
   const { phase, unlock, sessionExpired } = useTokenGate();
   const [token, setToken] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const sessionExpiredMsg = sessionExpired ? t("instanceAuth.sessionExpired") : null;
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  if (phase === "checking") {
-    return null;
-  }
-
-  if (phase === "unlocked") {
-    return <>{children}</>;
-  }
-
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setIsSubmitting(true);
-    try {
-      await unlock(token);
-    } catch (err) {
-      if (err instanceof ApiError) {
-        if (err.status === 429) {
-          setError(t("instanceAuth.rateLimited"));
-        } else {
-          setError(t("instanceAuth.invalidToken"));
-        }
-      } else {
-        setError(t("instanceAuth.invalidToken"));
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      setError(null);
+      setIsSubmitting(true);
+      try {
+        await unlock(token);
+      } catch (err) {
+        const rateLimited = err instanceof ApiError && err.status === 429;
+        setError(t(rateLimited ? "instanceAuth.rateLimited" : "instanceAuth.invalidToken"));
+      } finally {
+        setIsSubmitting(false);
       }
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+    },
+    [unlock, token, t],
+  );
+
+  if (phase === "checking") return null;
+  if (phase === "unlocked") return <>{children}</>;
+
+  const message = error ?? (sessionExpired ? t("instanceAuth.sessionExpired") : null);
 
   return (
     <div className="bg-background flex min-h-screen items-center justify-center p-4">
@@ -69,9 +61,7 @@ export const TokenGate: FC<TokenGateProps> = ({ children }) => {
             />
           </div>
 
-          {(error ?? sessionExpiredMsg) && (
-            <p className="text-sm text-red-400">{error ?? sessionExpiredMsg}</p>
-          )}
+          {message && <p className="text-sm text-red-400">{message}</p>}
 
           <button
             type="submit"

--- a/apps/frontend/src/components/organisms/TokenGate.tsx
+++ b/apps/frontend/src/components/organisms/TokenGate.tsx
@@ -34,6 +34,30 @@ export const TokenGate: FC<TokenGateProps> = ({ children }) => {
   if (phase === "checking") return null;
   if (phase === "unlocked") return <>{children}</>;
 
+  if (phase === "error") {
+    return (
+      <div className="bg-background flex min-h-screen items-center justify-center p-4">
+        <div className="bg-background-elevated w-full max-w-sm space-y-6 rounded-lg border border-white/10 p-8 text-center">
+          <div className="space-y-2">
+            <h1 className="text-text-primary text-xl font-bold">
+              {t("instanceAuth.connectionErrorTitle")}
+            </h1>
+            <p className="text-text-secondary text-sm">
+              {t("instanceAuth.connectionErrorMessage")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="bg-primary hover:bg-primary/90 w-full rounded-md px-4 py-2 text-sm font-medium text-white transition-colors"
+          >
+            {t("instanceAuth.reloadButton")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   const message = error ?? (sessionExpired ? t("instanceAuth.sessionExpired") : null);
 
   return (

--- a/apps/frontend/src/hooks/controllers/useTokenGate.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.test.tsx
@@ -1,0 +1,152 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTokenGate } from "./useTokenGate";
+
+const mockMutateAsync = vi.fn();
+let mockSessionState: {
+  isPending: boolean;
+  isFetching: boolean;
+  isSuccess: boolean;
+  error: unknown;
+} = {
+  isPending: true,
+  isFetching: false,
+  isSuccess: false,
+  error: null,
+};
+
+vi.mock("../queries/useAuthSessionQuery", () => ({
+  useAuthSessionQuery: () => mockSessionState,
+}));
+
+vi.mock("../mutations/useUnlockMutation", () => ({
+  useUnlockMutation: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+const mockSetUnauthorizedHandler = vi.fn();
+const mockClearUnauthorizedHandler = vi.fn();
+
+vi.mock("@/services/httpClient", () => ({
+  setUnauthorizedHandler: (fn: () => void) => mockSetUnauthorizedHandler(fn),
+  clearUnauthorizedHandler: () => mockClearUnauthorizedHandler(),
+}));
+
+describe("useTokenGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionState = { isPending: true, isFetching: false, isSuccess: false, error: null };
+  });
+
+  it("TG-1: phase is 'checking' when session is pending", () => {
+    mockSessionState = { isPending: true, isFetching: false, isSuccess: false, error: null };
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("checking");
+  });
+
+  it("TG-2: phase is 'checking' when session is fetching (not pending)", () => {
+    mockSessionState = { isPending: false, isFetching: true, isSuccess: false, error: null };
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("checking");
+  });
+
+  it("TG-3: phase is 'unlocked' when session succeeds", () => {
+    mockSessionState = { isPending: false, isFetching: false, isSuccess: true, error: null };
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("unlocked");
+    expect(result.current.sessionExpired).toBe(false);
+  });
+
+  it("TG-4: phase is 'locked' when session errors with 401", () => {
+    mockSessionState = {
+      isPending: false,
+      isFetching: false,
+      isSuccess: false,
+      error: { status: 401 },
+    };
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("locked");
+  });
+
+  it("TG-5: phase is 'error' when session errors with non-401 (retries exhausted)", () => {
+    mockSessionState = {
+      isPending: false,
+      isFetching: false,
+      isSuccess: false,
+      error: { status: 503 },
+    };
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("error");
+  });
+
+  it("TG-6: registers setUnauthorizedHandler on mount and clears on unmount", () => {
+    const { unmount } = renderHook(() => useTokenGate());
+    expect(mockSetUnauthorizedHandler).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mockClearUnauthorizedHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it("TG-7: sessionExpired re-lock — unauthorized handler sets phase to locked and sessionExpired when previously unlocked", () => {
+    mockSessionState = { isPending: false, isFetching: false, isSuccess: true, error: null };
+
+    const { result } = renderHook(() => useTokenGate());
+    expect(result.current.phase).toBe("unlocked");
+
+    const handler = mockSetUnauthorizedHandler.mock.calls[0][0] as () => void;
+    act(() => {
+      handler();
+    });
+
+    expect(result.current.phase).toBe("locked");
+    expect(result.current.sessionExpired).toBe(true);
+  });
+
+  it("TG-8: unauthorized handler sets phase locked but NOT sessionExpired when never unlocked", () => {
+    mockSessionState = { isPending: true, isFetching: false, isSuccess: false, error: null };
+
+    const { result } = renderHook(() => useTokenGate());
+
+    const handler = mockSetUnauthorizedHandler.mock.calls[0][0] as () => void;
+    act(() => {
+      handler();
+    });
+
+    expect(result.current.phase).toBe("locked");
+    expect(result.current.sessionExpired).toBe(false);
+  });
+
+  it("TG-9: unlock() calls mutateAsync with the token and clears sessionExpired", async () => {
+    mockSessionState = { isPending: false, isFetching: false, isSuccess: true, error: null };
+    mockMutateAsync.mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useTokenGate());
+
+    const handler = mockSetUnauthorizedHandler.mock.calls[0][0] as () => void;
+    act(() => {
+      handler();
+    });
+    expect(result.current.sessionExpired).toBe(true);
+
+    await act(async () => {
+      await result.current.unlock("secret-token");
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith("secret-token");
+    expect(result.current.sessionExpired).toBe(false);
+  });
+
+  it("TG-10: unlock() propagates mutateAsync rejection", async () => {
+    mockSessionState = { isPending: false, isFetching: false, isSuccess: false, error: null };
+    mockMutateAsync.mockRejectedValueOnce({ status: 401, message: "Bad token" });
+
+    const { result } = renderHook(() => useTokenGate());
+
+    await expect(
+      act(async () => {
+        await result.current.unlock("wrong-token");
+      }),
+    ).rejects.toBeDefined();
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -1,67 +1,51 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { authService } from "@/services/auth.service";
 import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/httpClient";
+import { useUnlockMutation } from "../mutations/useUnlockMutation";
+import { useAuthSessionQuery } from "../queries/useAuthSessionQuery";
 
 type GatePhase = "checking" | "locked" | "unlocked" | "error";
 
-const MAX_PROBE_ATTEMPTS = 5;
-const PROBE_RETRY_DELAY_MS = 1000;
-
 export const useTokenGate = () => {
-  const [phase, setPhase] = useState<GatePhase>("checking");
-  const [sessionExpired, setSessionExpired] = useState(false);
+  const session = useAuthSessionQuery();
+  const unlockMutation = useUnlockMutation();
+
   const wasUnlocked = useRef(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const [forcedPhase, setForcedPhase] = useState<"locked" | null>(null);
+
+  const derivedPhase: GatePhase = (() => {
+    if (session.isPending || session.isFetching) return "checking";
+    if (session.isSuccess) return "unlocked";
+    const status = (session.error as { status?: number } | null)?.status;
+    if (status === 401) return "locked";
+    return "error";
+  })();
+
+  const phase: GatePhase = forcedPhase ?? derivedPhase;
+
+  if (derivedPhase === "unlocked") {
+    wasUnlocked.current = true;
+  }
 
   useEffect(() => {
     setUnauthorizedHandler(() => {
-      if (wasUnlocked.current) setSessionExpired(true);
-      wasUnlocked.current = false;
-      setPhase("locked");
+      if (wasUnlocked.current) {
+        setSessionExpired(true);
+        wasUnlocked.current = false;
+      }
+      setForcedPhase("locked");
     });
     return () => clearUnauthorizedHandler();
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
-
-    const probe = (attempt: number) => {
-      authService
-        .getSession()
-        .then(() => {
-          if (cancelled) return;
-          wasUnlocked.current = true;
-          setPhase("unlocked");
-        })
-        .catch((err: unknown) => {
-          if (cancelled) return;
-          const status = (err as { status?: number }).status;
-          if (status === 401) {
-            setPhase("locked");
-            return;
-          }
-          if (attempt < MAX_PROBE_ATTEMPTS) {
-            retryTimeout = setTimeout(() => probe(attempt + 1), PROBE_RETRY_DELAY_MS);
-            return;
-          }
-          setPhase("error");
-        });
-    };
-
-    probe(1);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(retryTimeout);
-    };
-  }, []);
-
-  const unlock = useCallback(async (token: string): Promise<void> => {
-    await authService.unlock(token);
-    setSessionExpired(false);
-    wasUnlocked.current = true;
-    setPhase("unlocked");
-  }, []);
+  const unlock = useCallback(
+    async (token: string): Promise<void> => {
+      await unlockMutation.mutateAsync(token);
+      setSessionExpired(false);
+      setForcedPhase(null);
+    },
+    [unlockMutation],
+  );
 
   return { phase, unlock, sessionExpired };
 };

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { authService } from "@/services/auth.service";
 import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/httpClient";
 
-type GatePhase = "checking" | "locked" | "unlocked";
+type GatePhase = "checking" | "locked" | "unlocked" | "error";
 
 const MAX_PROBE_ATTEMPTS = 5;
 const PROBE_RETRY_DELAY_MS = 1000;
@@ -42,8 +42,9 @@ export const useTokenGate = () => {
           }
           if (attempt < MAX_PROBE_ATTEMPTS) {
             retryTimeout = setTimeout(() => probe(attempt + 1), PROBE_RETRY_DELAY_MS);
+            return;
           }
-          // all retries exhausted: stay in "checking" — never auto-unlock
+          setPhase("error");
         });
     };
 

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { authService } from "@/services/auth.service";
 import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/httpClient";
 
@@ -7,10 +7,12 @@ type GatePhase = "checking" | "locked" | "unlocked";
 export const useTokenGate = () => {
   const [phase, setPhase] = useState<GatePhase>("checking");
   const [sessionExpired, setSessionExpired] = useState(false);
+  const wasUnlocked = useRef(false);
 
   useEffect(() => {
     setUnauthorizedHandler(() => {
-      setSessionExpired(true);
+      if (wasUnlocked.current) setSessionExpired(true);
+      wasUnlocked.current = false;
       setPhase("locked");
     });
     return () => clearUnauthorizedHandler();
@@ -22,7 +24,9 @@ export const useTokenGate = () => {
     authService
       .getSession()
       .then(() => {
-        if (!cancelled) setPhase("unlocked");
+        if (cancelled) return;
+        wasUnlocked.current = true;
+        setPhase("unlocked");
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -38,6 +42,7 @@ export const useTokenGate = () => {
   const unlock = useCallback(async (token: string): Promise<void> => {
     await authService.unlock(token);
     setSessionExpired(false);
+    wasUnlocked.current = true;
     setPhase("unlocked");
   }, []);
 

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -1,0 +1,53 @@
+import { ApiRoutes, type AuthSessionResponseDto } from "@spotiarr/shared";
+import { useCallback, useEffect, useState } from "react";
+import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/httpClient";
+import { httpClient } from "@/services/httpClient";
+
+type GatePhase = "checking" | "locked" | "unlocked";
+
+export const useTokenGate = () => {
+  const [phase, setPhase] = useState<GatePhase>("checking");
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  useEffect(() => {
+    setUnauthorizedHandler(() => {
+      setSessionExpired(true);
+      setPhase("locked");
+    });
+    return () => clearUnauthorizedHandler();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    httpClient
+      .get<AuthSessionResponseDto>(ApiRoutes.AUTH_SESSION)
+      .then((data) => {
+        if (cancelled) return;
+        setPhase("unlocked");
+        void data;
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const status = (err as { status?: number }).status;
+        if (status === 401) {
+          setPhase("locked");
+        } else {
+          setPhase("unlocked");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const unlock = useCallback(async (token: string): Promise<void> => {
+    const response = await httpClient.post<{ ok: boolean }>(ApiRoutes.AUTH_UNLOCK, { token });
+    void response;
+    setSessionExpired(false);
+    setPhase("unlocked");
+  }, []);
+
+  return { phase, unlock, sessionExpired };
+};

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -1,7 +1,6 @@
-import { ApiRoutes, type AuthSessionResponseDto } from "@spotiarr/shared";
 import { useCallback, useEffect, useState } from "react";
+import { authService } from "@/services/auth.service";
 import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/httpClient";
-import { httpClient } from "@/services/httpClient";
 
 type GatePhase = "checking" | "locked" | "unlocked";
 
@@ -20,21 +19,15 @@ export const useTokenGate = () => {
   useEffect(() => {
     let cancelled = false;
 
-    httpClient
-      .get<AuthSessionResponseDto>(ApiRoutes.AUTH_SESSION)
-      .then((data) => {
-        if (cancelled) return;
-        setPhase("unlocked");
-        void data;
+    authService
+      .getSession()
+      .then(() => {
+        if (!cancelled) setPhase("unlocked");
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         const status = (err as { status?: number }).status;
-        if (status === 401) {
-          setPhase("locked");
-        } else {
-          setPhase("unlocked");
-        }
+        setPhase(status === 401 ? "locked" : "unlocked");
       });
 
     return () => {
@@ -43,8 +36,7 @@ export const useTokenGate = () => {
   }, []);
 
   const unlock = useCallback(async (token: string): Promise<void> => {
-    const response = await httpClient.post<{ ok: boolean }>(ApiRoutes.AUTH_UNLOCK, { token });
-    void response;
+    await authService.unlock(token);
     setSessionExpired(false);
     setPhase("unlocked");
   }, []);

--- a/apps/frontend/src/hooks/controllers/useTokenGate.ts
+++ b/apps/frontend/src/hooks/controllers/useTokenGate.ts
@@ -4,6 +4,9 @@ import { clearUnauthorizedHandler, setUnauthorizedHandler } from "@/services/htt
 
 type GatePhase = "checking" | "locked" | "unlocked";
 
+const MAX_PROBE_ATTEMPTS = 5;
+const PROBE_RETRY_DELAY_MS = 1000;
+
 export const useTokenGate = () => {
   const [phase, setPhase] = useState<GatePhase>("checking");
   const [sessionExpired, setSessionExpired] = useState(false);
@@ -20,22 +23,35 @@ export const useTokenGate = () => {
 
   useEffect(() => {
     let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | undefined;
 
-    authService
-      .getSession()
-      .then(() => {
-        if (cancelled) return;
-        wasUnlocked.current = true;
-        setPhase("unlocked");
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const status = (err as { status?: number }).status;
-        setPhase(status === 401 ? "locked" : "unlocked");
-      });
+    const probe = (attempt: number) => {
+      authService
+        .getSession()
+        .then(() => {
+          if (cancelled) return;
+          wasUnlocked.current = true;
+          setPhase("unlocked");
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          const status = (err as { status?: number }).status;
+          if (status === 401) {
+            setPhase("locked");
+            return;
+          }
+          if (attempt < MAX_PROBE_ATTEMPTS) {
+            retryTimeout = setTimeout(() => probe(attempt + 1), PROBE_RETRY_DELAY_MS);
+          }
+          // all retries exhausted: stay in "checking" — never auto-unlock
+        });
+    };
+
+    probe(1);
 
     return () => {
       cancelled = true;
+      clearTimeout(retryTimeout);
     };
   }, []);
 

--- a/apps/frontend/src/hooks/mutations/useUnlockMutation.test.tsx
+++ b/apps/frontend/src/hooks/mutations/useUnlockMutation.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authService } from "@/services/auth.service";
+import { queryKeys } from "../queryKeys";
+import { useUnlockMutation } from "./useUnlockMutation";
+
+vi.mock("@/services/auth.service", () => ({
+  authService: {
+    unlock: vi.fn(),
+  },
+}));
+
+let queryClient: QueryClient;
+
+const createWrapper = () => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useUnlockMutation", () => {
+  it("mutateAsync calls authService.unlock with the provided token", async () => {
+    vi.mocked(authService.unlock).mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useUnlockMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("my-token");
+    });
+
+    expect(authService.unlock).toHaveBeenCalledWith("my-token");
+  });
+
+  it("on success, invalidates the authSession query", async () => {
+    vi.mocked(authService.unlock).mockResolvedValueOnce({ ok: true });
+
+    const { result } = renderHook(() => useUnlockMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await act(async () => {
+      await result.current.mutateAsync("my-token");
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: queryKeys.authSession });
+  });
+
+  it("on failure, mutation is in error state and does not invalidate queries", async () => {
+    const error = { status: 401, message: "Bad token" };
+    vi.mocked(authService.unlock).mockRejectedValueOnce(error);
+
+    const { result } = renderHook(() => useUnlockMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    await act(async () => {
+      await result.current.mutateAsync("wrong-token").catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/mutations/useUnlockMutation.ts
+++ b/apps/frontend/src/hooks/mutations/useUnlockMutation.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { authService } from "@/services/auth.service";
+import { queryKeys } from "../queryKeys";
+
+export const useUnlockMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (token: string) => authService.unlock(token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.authSession });
+    },
+  });
+};

--- a/apps/frontend/src/hooks/queries/useAuthSessionQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useAuthSessionQuery.test.tsx
@@ -52,17 +52,21 @@ describe("useAuthSessionQuery", () => {
     expect(authService.getSession).toHaveBeenCalledTimes(1);
   });
 
-  it("non-401: retries at least once (getSession called more than once after advancing timers)", async () => {
+  it("non-401: exhausts retries — called 6 times total and ends in error state with no data", async () => {
     vi.useFakeTimers();
     vi.mocked(authService.getSession).mockRejectedValue({ status: 500 });
 
-    renderHook(() => useAuthSessionQuery(), {
+    const { result } = renderHook(() => useAuthSessionQuery(), {
       wrapper: createWrapper(),
     });
 
-    await vi.advanceTimersByTimeAsync(1100);
-    await vi.advanceTimersByTimeAsync(1100);
+    for (let i = 0; i < 5; i++) {
+      await vi.advanceTimersByTimeAsync(1_100);
+    }
+    await vi.runAllTimersAsync();
 
-    expect(vi.mocked(authService.getSession).mock.calls.length).toBeGreaterThanOrEqual(2);
-  });
+    expect(result.current.isError).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(authService.getSession).toHaveBeenCalledTimes(6);
+  }, 20_000);
 });

--- a/apps/frontend/src/hooks/queries/useAuthSessionQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useAuthSessionQuery.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { authService } from "@/services/auth.service";
+import { useAuthSessionQuery } from "./useAuthSessionQuery";
+
+vi.mock("@/services/auth.service", () => ({
+  authService: {
+    getSession: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useAuthSessionQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = { authenticated: true };
+    vi.mocked(authService.getSession).mockResolvedValueOnce(data as never);
+
+    const { result } = renderHook(() => useAuthSessionQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("401: does not retry — getSession called exactly once and hook is in error state", async () => {
+    vi.mocked(authService.getSession).mockRejectedValue({ status: 401 });
+
+    const { result } = renderHook(() => useAuthSessionQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(authService.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("non-401: retries at least once (getSession called more than once after advancing timers)", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authService.getSession).mockRejectedValue({ status: 500 });
+
+    renderHook(() => useAuthSessionQuery(), {
+      wrapper: createWrapper(),
+    });
+
+    await vi.advanceTimersByTimeAsync(1100);
+    await vi.advanceTimersByTimeAsync(1100);
+
+    expect(vi.mocked(authService.getSession).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useAuthSessionQuery.ts
+++ b/apps/frontend/src/hooks/queries/useAuthSessionQuery.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { authService } from "@/services/auth.service";
+import { queryKeys } from "../queryKeys";
+
+export const useAuthSessionQuery = () => {
+  return useQuery({
+    queryKey: queryKeys.authSession,
+    queryFn: () => authService.getSession(),
+    staleTime: Infinity,
+    retry: (failureCount, error) =>
+      (error as { status?: number })?.status !== 401 && failureCount < 5,
+    retryDelay: 1000,
+  });
+};

--- a/apps/frontend/src/hooks/queryKeys.ts
+++ b/apps/frontend/src/hooks/queryKeys.ts
@@ -25,4 +25,5 @@ export const queryKeys = {
   libraryArtistDetail: (name: string) => ["library", "artist", name] as const,
   search: (query: string, types: string[], limit: number) =>
     ["search", query, types, limit] as const,
+  authSession: ["auth", "session"] as const,
 } as const;

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -360,6 +360,17 @@
       "title": "Album"
     }
   },
+  "instanceAuth": {
+    "title": "Instance Protected",
+    "description": "This SpotiArr instance is password-protected. Enter the access token to continue.",
+    "tokenLabel": "Access Token",
+    "tokenPlaceholder": "Enter access token...",
+    "submitButton": "Unlock",
+    "loadingButton": "Unlocking...",
+    "invalidToken": "Invalid token. Please try again.",
+    "rateLimited": "Too many attempts. Please wait a moment before trying again.",
+    "sessionExpired": "Your session has expired. Please enter the token again."
+  },
   "player": {
     "queue": {
       "title": "Queue",

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -369,7 +369,10 @@
     "loadingButton": "Unlocking...",
     "invalidToken": "Invalid token. Please try again.",
     "rateLimited": "Too many attempts. Please wait a moment before trying again.",
-    "sessionExpired": "Your session has expired. Please enter the token again."
+    "sessionExpired": "Your session has expired. Please enter the token again.",
+    "connectionErrorTitle": "Cannot connect",
+    "connectionErrorMessage": "Could not reach the SpotiArr server. Check that it is running and try again.",
+    "reloadButton": "Retry"
   },
   "player": {
     "queue": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -360,6 +360,17 @@
       "title": "Álbum"
     }
   },
+  "instanceAuth": {
+    "title": "Instancia protegida",
+    "description": "Esta instancia de SpotiArr está protegida con contraseña. Introduce el token de acceso para continuar.",
+    "tokenLabel": "Token de acceso",
+    "tokenPlaceholder": "Introduce el token de acceso...",
+    "submitButton": "Desbloquear",
+    "loadingButton": "Desbloqueando...",
+    "invalidToken": "Token incorrecto. Por favor, inténtalo de nuevo.",
+    "rateLimited": "Demasiados intentos. Espera un momento antes de volver a intentarlo.",
+    "sessionExpired": "Tu sesión ha expirado. Por favor, introduce el token de nuevo."
+  },
   "player": {
     "queue": {
       "title": "Cola",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -369,7 +369,10 @@
     "loadingButton": "Desbloqueando...",
     "invalidToken": "Token incorrecto. Por favor, inténtalo de nuevo.",
     "rateLimited": "Demasiados intentos. Espera un momento antes de volver a intentarlo.",
-    "sessionExpired": "Tu sesión ha expirado. Por favor, introduce el token de nuevo."
+    "sessionExpired": "Tu sesión ha expirado. Por favor, introduce el token de nuevo.",
+    "connectionErrorTitle": "No se puede conectar",
+    "connectionErrorMessage": "No se ha podido contactar con el servidor de SpotiArr. Comprueba que está en marcha e inténtalo de nuevo.",
+    "reloadButton": "Reintentar"
   },
   "player": {
     "queue": {

--- a/apps/frontend/src/services/auth.service.test.ts
+++ b/apps/frontend/src/services/auth.service.test.ts
@@ -1,0 +1,33 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { authService } from "./auth.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("authService", () => {
+  it("getSession calls httpClient.get with AUTH_SESSION and returns the result", async () => {
+    const payload = { authenticated: true };
+    vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+    const result = await authService.getSession();
+
+    expect(httpClient.get).toHaveBeenCalledWith(ApiRoutes.AUTH_SESSION);
+    expect(result).toBe(payload);
+  });
+
+  it("unlock calls httpClient.post with AUTH_UNLOCK and token, and returns the result", async () => {
+    const payload = { ok: true };
+    vi.mocked(httpClient.post).mockResolvedValueOnce(payload);
+
+    const result = await authService.unlock("secret");
+
+    expect(httpClient.post).toHaveBeenCalledWith(ApiRoutes.AUTH_UNLOCK, { token: "secret" });
+    expect(result).toBe(payload);
+  });
+});

--- a/apps/frontend/src/services/auth.service.ts
+++ b/apps/frontend/src/services/auth.service.ts
@@ -1,0 +1,12 @@
+import { ApiRoutes, type AuthSessionResponseDto } from "@spotiarr/shared";
+import { httpClient } from "./httpClient";
+
+export const authService = {
+  getSession: async (): Promise<AuthSessionResponseDto> => {
+    return httpClient.get<AuthSessionResponseDto>(ApiRoutes.AUTH_SESSION);
+  },
+
+  unlock: async (token: string): Promise<{ ok: boolean }> => {
+    return httpClient.post<{ ok: boolean }>(ApiRoutes.AUTH_UNLOCK, { token });
+  },
+};

--- a/apps/frontend/src/services/httpClient.test.ts
+++ b/apps/frontend/src/services/httpClient.test.ts
@@ -76,6 +76,15 @@ describe("401 handling", () => {
     await expect(httpClient.post("/auth/unlock", { token: "x" })).rejects.toBeInstanceOf(ApiError);
     expect(handler).not.toHaveBeenCalled();
   });
+
+  it("fires onUnauthorized for /auth/sessionXYZ (not a real auth endpoint)", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/auth/sessionXYZ")).rejects.toBeInstanceOf(ApiError);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("successful response", () => {
@@ -93,13 +102,11 @@ describe("successful response", () => {
   it("returns undefined for 204 No Content", async () => {
     vi.stubGlobal(
       "fetch",
-      vi
-        .fn()
-        .mockResolvedValue({
-          status: 204,
-          ok: true,
-          text: () => Promise.resolve(""),
-        } as unknown as Response),
+      vi.fn().mockResolvedValue({
+        status: 204,
+        ok: true,
+        text: () => Promise.resolve(""),
+      } as unknown as Response),
     );
 
     const result = await httpClient.delete("/playlists/1");
@@ -129,6 +136,21 @@ describe("non-ok response", () => {
     const err = await httpClient.get("/playlists").catch((e: unknown) => e);
     expect(err).toBeInstanceOf(ApiError);
     expect((err as ApiError).status).toBe(500);
+  });
+});
+
+describe("network failure", () => {
+  it("propagates raw TypeError when fetch itself rejects — does NOT wrap in ApiError and does NOT fire onUnauthorized", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    const networkError = new TypeError("Failed to fetch");
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkError));
+
+    const err = await httpClient.get("/playlists").catch((e: unknown) => e);
+
+    expect(err).toBe(networkError);
+    expect(err).not.toBeInstanceOf(ApiError);
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/src/services/httpClient.test.ts
+++ b/apps/frontend/src/services/httpClient.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ApiError,
+  clearUnauthorizedHandler,
+  httpClient,
+  setUnauthorizedHandler,
+} from "./httpClient";
+
+const makeResponse = (status: number, body?: unknown): Response => {
+  const text = body !== undefined ? JSON.stringify(body) : "";
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    text: () => Promise.resolve(text),
+    statusText: String(status),
+  } as unknown as Response;
+};
+
+afterEach(() => {
+  clearUnauthorizedHandler();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("setUnauthorizedHandler / clearUnauthorizedHandler", () => {
+  it("registers a handler that is called on 401 non-auth endpoint", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/playlists")).rejects.toBeInstanceOf(ApiError);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearUnauthorizedHandler removes the handler", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    clearUnauthorizedHandler();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/playlists")).rejects.toBeInstanceOf(ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("401 handling", () => {
+  beforeEach(() => {
+    setUnauthorizedHandler(vi.fn());
+  });
+
+  it("fires the handler and throws ApiError(401) for non-auth endpoint", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/playlists")).rejects.toMatchObject({
+      status: 401,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire handler on 401 for /auth/session", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/auth/session")).rejects.toBeInstanceOf(ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire handler on 401 for /auth/unlock", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.post("/auth/unlock", { token: "x" })).rejects.toBeInstanceOf(ApiError);
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+describe("successful response", () => {
+  it("returns parsed JSON and does not fire the handler", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    const payload = { id: 1, name: "foo" };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(200, payload)));
+
+    const result = await httpClient.get("/playlists");
+    expect(result).toEqual(payload);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns undefined for 204 No Content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({
+          status: 204,
+          ok: true,
+          text: () => Promise.resolve(""),
+        } as unknown as Response),
+    );
+
+    const result = await httpClient.delete("/playlists/1");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("non-ok response", () => {
+  it("throws ApiError with code and status from the response body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(makeResponse(422, { error: "VALIDATION_ERROR", message: "bad input" })),
+    );
+
+    await expect(httpClient.post("/playlists", {})).rejects.toMatchObject({
+      status: 422,
+      code: "VALIDATION_ERROR",
+      message: "bad input",
+    });
+  });
+
+  it("throws ApiError with statusText when body has no error shape", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(500, { detail: "crash" })));
+
+    const err = await httpClient.get("/playlists").catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(500);
+  });
+});
+
+describe("request options", () => {
+  it("sends credentials: same-origin on every request", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await httpClient.get("/playlists");
+    expect(fetchMock.mock.calls[0]![1]).toMatchObject({ credentials: "same-origin" });
+  });
+
+  it("sends Content-Type: application/json header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(makeResponse(200, {}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await httpClient.get("/playlists");
+    expect(fetchMock.mock.calls[0]![1]?.headers).toMatchObject({
+      "Content-Type": "application/json",
+    });
+  });
+});

--- a/apps/frontend/src/services/httpClient.ts
+++ b/apps/frontend/src/services/httpClient.ts
@@ -29,7 +29,10 @@ class HttpClient {
       return undefined as unknown as T;
     }
 
-    if (response.status === 401 && !AUTH_ENDPOINTS.some((e) => endpoint.startsWith(e))) {
+    if (
+      response.status === 401 &&
+      !AUTH_ENDPOINTS.some((e) => endpoint === e || endpoint.startsWith(e + "/"))
+    ) {
       _onUnauthorized?.();
     }
 

--- a/apps/frontend/src/services/httpClient.ts
+++ b/apps/frontend/src/services/httpClient.ts
@@ -11,10 +11,26 @@ export class ApiError extends Error {
   }
 }
 
+let _onUnauthorized: (() => void) | undefined;
+
+export function setUnauthorizedHandler(fn: () => void): void {
+  _onUnauthorized = fn;
+}
+
+export function clearUnauthorizedHandler(): void {
+  _onUnauthorized = undefined;
+}
+
+const AUTH_ENDPOINTS = [ApiRoutes.AUTH_UNLOCK, ApiRoutes.AUTH_SESSION];
+
 class HttpClient {
-  private async handleResponse<T>(response: Response): Promise<T> {
+  private async handleResponse<T>(response: Response, endpoint: string): Promise<T> {
     if (response.status === 204) {
       return undefined as unknown as T;
+    }
+
+    if (response.status === 401 && !AUTH_ENDPOINTS.some((e) => endpoint.startsWith(e))) {
+      _onUnauthorized?.();
     }
 
     const text = await response.text();
@@ -42,6 +58,7 @@ class HttpClient {
 
   async request<T>(endpoint: string, options?: RequestInit): Promise<T> {
     const response = await fetch(`${ApiRoutes.BASE}${endpoint}`, {
+      credentials: "same-origin",
       headers: {
         "Content-Type": "application/json",
         ...options?.headers,
@@ -49,7 +66,7 @@ class HttpClient {
       ...options,
     });
 
-    return this.handleResponse<T>(response);
+    return this.handleResponse<T>(response, endpoint);
   }
 
   async get<T>(endpoint: string, options?: RequestInit): Promise<T> {

--- a/apps/frontend/src/services/playlist.service.ts
+++ b/apps/frontend/src/services/playlist.service.ts
@@ -67,7 +67,7 @@ export const playlistService = {
   },
 
   retryFailedTracks: async (playlistId: string): Promise<void> => {
-    return httpClient.get<void>(`${ApiRoutes.PLAYLIST}/retry/${playlistId}`);
+    return httpClient.post<void>(`${ApiRoutes.PLAYLIST}/${playlistId}/retry`);
   },
 
   deletePlaylist: async (id: string): Promise<void> => {

--- a/apps/frontend/src/services/track.service.ts
+++ b/apps/frontend/src/services/track.service.ts
@@ -11,7 +11,7 @@ export const trackService = {
   },
 
   retryTrack: async (id: string): Promise<void> => {
-    return httpClient.get<void>(`${ApiRoutes.TRACK}/retry/${id}`);
+    return httpClient.post<void>(`${ApiRoutes.TRACK}/${id}/retry`);
   },
 
   deleteTrack: async (id: string): Promise<void> => {

--- a/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "../../fixtures/test";
+import {
+  buildLibraryArtist,
+  mockAuthSession,
+  mockAuthSessionUnauthorized,
+  mockAuthSessionError,
+  mockAuthUnlock,
+  mockLockedThenUnlock,
+  installLibraryMocks,
+  installPlaylistMocks,
+} from "../../helpers/api-mocks";
+
+test.use({
+  ignoredConsoleErrors: [
+    "Failed to load resource: the server responded with a status of 401",
+    "Failed to load resource: the server responded with a status of 500",
+  ],
+});
+
+test.describe("Instance auth — TokenGate", () => {
+  test("OPEN mode: renders app shell when session returns tokenRequired:false", async ({
+    page,
+  }) => {
+    await mockAuthSession(page, { tokenRequired: false });
+    await installLibraryMocks(page, {
+      artists: [buildLibraryArtist({ name: "Library Artist", image: null })],
+    });
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible();
+  });
+
+  test("LOCKED: shows unlock form and hides app content when session returns 401", async ({
+    page,
+  }) => {
+    await mockAuthSessionUnauthorized(page);
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Library", exact: true })).not.toBeVisible();
+  });
+
+  test("UNLOCK flow: submitting a valid token unlocks and shows the app", async ({ page }) => {
+    await mockLockedThenUnlock(page);
+    await installLibraryMocks(page, {
+      artists: [buildLibraryArtist({ name: "Library Artist", image: null })],
+    });
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).toBeVisible();
+
+    await page.getByLabel("Access Token").fill("correct-token");
+    await page.getByRole("button", { name: "Unlock" }).click();
+
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible();
+  });
+
+  test("WRONG token: shows error message and keeps gate visible when unlock returns 401", async ({
+    page,
+  }) => {
+    await mockAuthSessionUnauthorized(page);
+    await mockAuthUnlock(page, { status: 401 });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).toBeVisible();
+
+    await page.getByLabel("Access Token").fill("wrong-token");
+    await page.getByRole("button", { name: "Unlock" }).click();
+
+    await expect(page.getByText("Invalid token. Please try again.")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).toBeVisible();
+  });
+
+  test("CONNECTION error: shows cannot-connect card with Retry button after session errors", async ({
+    page,
+  }) => {
+    test.slow();
+
+    await mockAuthSessionError(page, 500);
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { name: "Cannot connect" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+  });
+});

--- a/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
@@ -17,6 +17,107 @@ test.use({
   ],
 });
 
+test.describe("SESSION EXPIRED re-lock", () => {
+  /**
+   * Approach: two-phase route handlers.
+   * Phase 1 (initial load): session 200 + artists 200 → app shows Library heading.
+   * Phase 2 (reload): session 200 gates artists until session response is sent,
+   * then artists returns 401 → httpClient fires onUnauthorized → TokenGate
+   * re-locks with sessionExpired banner.
+   *
+   * Limitation: requires a page.reload() to trigger a second round of queries,
+   * because useAuthSessionQuery uses staleTime:Infinity and won't refetch
+   * without a hard navigation.
+   */
+  test("shows session-expired banner when a mid-session API call returns 401", async ({ page }) => {
+    let loadPhase: "initial" | "reload" = "initial";
+    let resolveSessionSent!: () => void;
+    const sessionSentGate = new Promise<void>((resolve) => {
+      resolveSessionSent = resolve;
+    });
+
+    await page.route("**/api/auth/session", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ tokenRequired: false }),
+      });
+      if (loadPhase === "reload") {
+        resolveSessionSent();
+      }
+    });
+
+    await page.route("**/api/library/artists", async (route) => {
+      if (loadPhase === "initial") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            data: [buildLibraryArtist({ name: "Library Artist", image: null })],
+          }),
+        });
+      } else {
+        await sessionSentGate;
+        await route.fulfill({ status: 401, contentType: "application/json", body: "{}" });
+      }
+    });
+
+    await page.route("**/api/library/stats", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            totalArtists: 1,
+            totalAlbums: 1,
+            totalTracks: 1,
+            totalSize: 4096,
+            lastScannedAt: null,
+          },
+        }),
+      });
+    });
+
+    await page.route("**/api/library/artwork-backfill/status", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            runId: null,
+            status: "idle",
+            phase: null,
+            totals: 0,
+            processed: 0,
+            skippedExisting: 0,
+            written: 0,
+            failed: 0,
+            externalCalls: 0,
+            lastCheckpoint: null,
+            rateLimitUntil: null,
+            updatedAt: null,
+          },
+        }),
+      });
+    });
+
+    await installPlaylistMocks(page, { playlists: [] });
+
+    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    loadPhase = "reload";
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await expect(
+      page.getByText("Your session has expired. Please enter the token again."),
+    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole("heading", { name: "Instance Protected" })).toBeVisible();
+  });
+});
+
 test.describe("Instance auth — TokenGate", () => {
   test("OPEN mode: renders app shell when session returns tokenRequired:false", async ({
     page,

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -542,6 +542,63 @@ export async function installArtistMocks(
   await registerJsonRoute(page, `${ApiRoutes.ARTIST}/${artistId}/albums/**/tracks`, tracks);
 }
 
+export async function mockAuthSession(
+  page: Page,
+  { tokenRequired }: { tokenRequired: boolean },
+): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_SESSION)}`, async (route) => {
+    await fulfillJson(route, { tokenRequired });
+  });
+}
+
+export async function mockAuthSessionUnauthorized(page: Page): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_SESSION)}`, async (route) => {
+    await route.fulfill({ status: 401, contentType: "application/json", body: "{}" });
+  });
+}
+
+export async function mockAuthSessionError(page: Page, status = 500): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_SESSION)}`, async (route) => {
+    await route.fulfill({ status, contentType: "application/json", body: "{}" });
+  });
+}
+
+export async function mockAuthUnlock(
+  page: Page,
+  { status = 200 }: { status?: number } = {},
+): Promise<void> {
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_UNLOCK)}`, async (route) => {
+    if (status === 200) {
+      await fulfillJson(route, { ok: true });
+    } else {
+      await route.fulfill({ status, contentType: "application/json", body: "{}" });
+    }
+  });
+}
+
+export async function mockLockedThenUnlock(page: Page): Promise<{ resolve: () => void }> {
+  let unlocked = false;
+
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_SESSION)}`, async (route) => {
+    if (unlocked) {
+      await fulfillJson(route, { tokenRequired: false });
+    } else {
+      await route.fulfill({ status: 401, contentType: "application/json", body: "{}" });
+    }
+  });
+
+  await page.route(`**${buildApiUrl(ApiRoutes.AUTH_UNLOCK)}`, async (route) => {
+    unlocked = true;
+    await fulfillJson(route, { ok: true });
+  });
+
+  return {
+    resolve: () => {
+      unlocked = true;
+    },
+  };
+}
+
 export async function installExternalUrlMock(
   page: Page,
   resolved: { url: string } = { url: "https://open.spotify.com" },

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -636,6 +636,7 @@ export async function installAppShellMocks(
 
   await mockSettingsPageData(page, { settings, settingsMetadata, supportedFormats });
   await mockSpotifyAuthStatus(page, spotifyAuthStatus);
+  await mockAuthSession(page, { tokenRequired: false });
 
   await page.route("**/api/events", async (route) => {
     await route.fulfill({

--- a/docs/ARCHITECTURE.en.md
+++ b/docs/ARCHITECTURE.en.md
@@ -234,6 +234,22 @@ We implement a **fail-fast** strategy and strict data validation.
 - **Centralized Error Handling:** Global Middleware (`error-handler.ts`) capturing any exception, standardizing it to a safe JSON response (no stack traces in production) and preventing server crashes.
 - **Personal Rate Limiting:** The download worker (`track-download.worker.ts`) implements its own pause mechanism based on user configuration (`YT_DOWNLOADS_PER_MINUTE`) to be "good citizens" with YouTube servers.
 
+### 8.1. Instance Authentication (`require-token` middleware)
+
+**Threat model:** SpotiArr is designed for trusted LAN use. When exposed to the internet, a single shared-secret gate protects the entire instance without adding user accounts or external identity providers.
+
+**Design:**
+
+- **Optional, env-gated.** When `SPOTIARR_TOKEN` is not set, the middleware is never mounted — zero overhead, zero behavior change for LAN deployments.
+- **Layer placement.** The `require-token` middleware sits in the `presentation/` layer, registered on the Express router before all `/api/*` routes. The token value is injected from `container.ts` (composition root), keeping the middleware ignorant of `process.env` and respecting the R4 layer boundary.
+- **Stateless HMAC-SHA256 cookie.** On a successful unlock (`POST /api/auth/unlock`), the server issues an httpOnly, Secure, `SameSite=Strict` cookie signed with the token itself. All subsequent API calls are validated against this cookie. Because the cookie is signed with the token, rotating `SPOTIARR_TOKEN` immediately invalidates all active sessions — no session store required.
+- **Constant-time comparison.** Token verification uses `crypto.timingSafeEqual` to prevent timing side-channels.
+- **Rate limiting.** The unlock endpoint is rate-limited per IP (`SPOTIARR_UNLOCK_RATELIMIT`, default 5/min) to resist brute-force attempts. `SPOTIARR_TRUST_PROXY` must be set when behind a reverse proxy so the real client IP is resolved correctly.
+- **SSE transport.** Server-Sent Events (`/api/events`) are covered by the same cookie check — no separate auth token needed for the event stream.
+- **Allowlist.** Three paths bypass the gate: `POST /api/auth/unlock` (the unlock flow itself), `GET /api/health` (infrastructure probes), and `GET /api/auth/spotify/callback` (OAuth redirect — Spotify contacts this URL server-side and cannot present the cookie).
+
+**Frontend counterpart:** When the backend returns `401`, the React app renders `<TokenGate>` — a full-screen unlock form — instead of the normal UI. Once the cookie is set, the app resumes normally without a page reload.
+
 ## 9. Download Lifecycle
 
 The most critical process of the application works like this:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -234,6 +234,22 @@ Implementamos una estrategia de **fail-fast** y validación estricta de datos.
 - **Error Handling Centralizado:** Middleware global (`error-handler.ts`) que captura cualquier excepción, la estandariza a una respuesta JSON segura (sin stack traces en producción) y previene caídas del servidor.
 - **Rate Limiting Personal:** El worker de descargas (`track-download.worker.ts`) implementa su propio mecanismo de pausa basado en la configuración del usuario (`YT_DOWNLOADS_PER_MINUTE`) para ser "buenos ciudadanos" con los servidores de YouTube.
 
+### 8.1. Autenticación de instancia (middleware `require-token`)
+
+**Modelo de amenaza:** SpotiArr está diseñado para uso en red local de confianza. Cuando se expone a internet, una clave compartida protege la instancia completa sin necesidad de cuentas de usuario ni proveedores de identidad externos.
+
+**Diseño:**
+
+- **Opcional, activado por variable de entorno.** Cuando `SPOTIARR_TOKEN` no está configurado, el middleware no se monta — cero sobrecarga, cero cambio de comportamiento para despliegues en LAN.
+- **Ubicación en capas.** El middleware `require-token` vive en la capa `presentation/`, registrado en el router de Express antes de todas las rutas `/api/*`. El valor del token se inyecta desde `container.ts` (raíz de composición), manteniendo el middleware ajeno a `process.env` y respetando el límite de capa R4.
+- **Cookie HMAC-SHA256 sin estado.** Tras un desbloqueo exitoso (`POST /api/auth/unlock`), el servidor emite una cookie httpOnly, Secure, `SameSite=Strict` firmada con el propio token. Todas las llamadas API posteriores se validan contra esta cookie. Al estar firmada con el token, rotar `SPOTIARR_TOKEN` invalida de inmediato todas las sesiones activas — sin necesidad de almacén de sesiones.
+- **Comparación en tiempo constante.** La verificación del token usa `crypto.timingSafeEqual` para prevenir ataques de temporización.
+- **Rate limiting.** El endpoint de desbloqueo tiene límite de intentos por IP (`SPOTIARR_UNLOCK_RATELIMIT`, por defecto 5/min) para resistir ataques de fuerza bruta. `SPOTIARR_TRUST_PROXY` debe configurarse cuando se opera detrás de un proxy inverso para que la IP real del cliente se resuelva correctamente.
+- **Transporte SSE.** Los Server-Sent Events (`/api/events`) están cubiertos por la misma verificación de cookie — no se necesita un token de autenticación separado para el flujo de eventos.
+- **Lista de exclusión.** Tres rutas omiten el control: `POST /api/auth/unlock` (el flujo de desbloqueo en sí), `GET /api/health` (sondas de infraestructura) y `GET /api/auth/spotify/callback` (redirección OAuth — Spotify contacta esta URL del lado del servidor y no puede presentar la cookie).
+
+**Contraparte en el frontend:** Cuando el backend devuelve `401`, la aplicación React muestra `<TokenGate>` — un formulario de desbloqueo a pantalla completa — en lugar de la UI normal. Una vez que la cookie está establecida, la aplicación se reanuda sin recargar la página.
+
 ## 9. Ciclo de Vida de una Descarga
 
 El proceso más crítico de la aplicación funciona así:

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -390,5 +390,4 @@ export interface UnlockRequestDto {
 
 export interface AuthSessionResponseDto {
   tokenRequired: boolean;
-  authenticated?: boolean;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -164,7 +164,9 @@ export type ApiErrorCode =
   | "playlist_not_accessible"
   | "rate_limiter_overflow"
   | "circuit_open"
-  | "interactive_timeout";
+  | "interactive_timeout"
+  | "unauthorized"
+  | "invalid_token";
 
 export interface ApiErrorShape {
   error: ApiErrorCode;
@@ -380,4 +382,13 @@ export interface ArtworkBackfillStatusResponse {
 export interface ArtworkBackfillStartResponse {
   runId: string;
   status: "running";
+}
+
+export interface UnlockRequestDto {
+  token: string;
+}
+
+export interface AuthSessionResponseDto {
+  tokenRequired: boolean;
+  authenticated?: boolean;
 }

--- a/packages/shared/src/routes.ts
+++ b/packages/shared/src/routes.ts
@@ -8,6 +8,8 @@ export const ApiRoutes = {
   ARTIST: "/artist",
   FEED: "/feed",
   AUTH: "/auth",
+  AUTH_UNLOCK: "/auth/unlock",
+  AUTH_SESSION: "/auth/session",
   HEALTH: "/health",
   LIBRARY: "/library",
   SEARCH: "/search",

--- a/skills/spotiarr-architecture/SKILL.md
+++ b/skills/spotiarr-architecture/SKILL.md
@@ -29,6 +29,7 @@ Backend — where does it go?
   Use-case orchestration?            → application/
   DB, queues, APIs, filesystem?      → infrastructure/
   HTTP routes, controllers, SSE?     → presentation/
+  Cross-cutting request guards?      → presentation/middleware/
 
 Frontend — where does it go?
   UI rendering / composition?        → components/
@@ -36,6 +37,7 @@ Frontend — where does it go?
   View logic / orchestration?        → hooks/
   Remote fetch / mutate?             → services/ + hooks/queries|mutations
   App-wide client state?             → store/
+  Ephemeral gate/overlay state?      → local useState in the controller hook (NOT a Zustand store; see useTokenGate)
 
 Cross-cutting types / utils?         → packages/shared/
 ```
@@ -44,3 +46,5 @@ Cross-cutting types / utils?         → packages/shared/
 
 - DI container: `apps/backend/src/container.ts`
 - Store pattern: `apps/frontend/src/store/`
+- Request guards: `apps/backend/src/presentation/middleware/`
+- Auth gate hook: `apps/frontend/src/hooks/controllers/useTokenGate.ts`

--- a/skills/spotiarr-docker/SKILL.md
+++ b/skills/spotiarr-docker/SKILL.md
@@ -53,6 +53,17 @@ REDIS_HOST=redis   # default: "redis" (service name)
 REDIS_PORT=6379    # default: 6379
 ```
 
+## Instance Auth (Optional)
+
+```bash
+SPOTIARR_TOKEN=                   # >=16 chars; omit to disable the gate
+SPOTIARR_SESSION_TTL_HOURS=168    # default: 168 (7 days)
+SPOTIARR_UNLOCK_RATELIMIT=5       # default: 5 per IP per minute
+SPOTIARR_TRUST_PROXY=1            # hop count (e.g. 1) or Express preset; REQUIRED behind Traefik/any
+                                  # reverse proxy — otherwise req.ip is the proxy IP and rate-limiting
+                                  # locks out everyone together
+```
+
 ## Update Flow
 
 ```bash

--- a/skills/spotiarr-i18n/SKILL.md
+++ b/skills/spotiarr-i18n/SKILL.md
@@ -22,6 +22,7 @@ Load when adding/modifying translations, working with i18n keys, or adding a new
 - Nested dot-notation: `common.loading`, `common.errors.pageNotFound`, `common.trackStatus.error`
 - Interpolation keys: `common.dates.todayAt` → `t("common.dates.todayAt", { time: "14:30" })`
 - camelCase key names: `downloadAll`, `clearAll`, `openInSpotify`
+- Top-level groups beyond `common` exist (e.g. `instanceAuth`, `player`, `settings`) — check `src/locales/en.json` for the current group list before adding a new top-level key.
 
 ## Decision Gates
 

--- a/skills/spotiarr-sse/SKILL.md
+++ b/skills/spotiarr-sse/SKILL.md
@@ -17,6 +17,7 @@ Load when adding real-time updates, emitting new SSE events, or extending `useSe
 - `useServerEvents` reacts to events by **invalidating TanStack Query caches** — NOT by writing to Zustand stores.
 - No reconnection logic exists — if needed, add it inside `useServerEvents`, nowhere else.
 - Backend: emit SSE events via `infrastructure/messaging/app-event-bus.ts` only. Never emit from controllers directly.
+- `useServerEvents` must stay mounted inside the authenticated subtree under `<TokenGate>` (currently `AuthenticatedApp` in App.tsx). The `/api/events` SSE endpoint is gated by `require-token`; mounting SSE before unlock produces 401s. Never hoist `useServerEvents` above `<TokenGate>`.
 
 ## Event Contracts
 

--- a/skills/spotiarr-workflow/SKILL.md
+++ b/skills/spotiarr-workflow/SKILL.md
@@ -15,6 +15,8 @@ Load when running commands, validating changes, creating PRs, managing branches,
 
 - CI runs lint, tests, and build as separate jobs. Automated tests cover backend and frontend utilities.
 - Never commit `.env`, tokens, or credentials. Use `.env.example` as source of truth.
+- `SPOTIARR_TOKEN` (instance auth token) is a secret — treat like a password, never hardcode or log it. Generate with `openssl rand -base64 32`.
+- Cover new code with tests — services, query/mutation hooks, components, middleware, and utils all get unit tests. The absence of a sibling test is NOT a reason to skip; being the first test of its kind is fine.
 - Never bypass pre-commit hooks (`--no-verify` is forbidden).
 - External services required locally: **Redis**, **FFmpeg**, **yt-dlp**, **Python 3.11/3.12**.
 

--- a/skills/spotiarr-zustand/SKILL.md
+++ b/skills/spotiarr-zustand/SKILL.md
@@ -54,7 +54,17 @@ Use bulk hooks in list components to avoid per-item store subscriptions.
 - The single `<audio>` element is owned by `GlobalPlayerBar` and bound via `setAudioElement`; internal handlers (`_onTimeUpdate`, `_onEnded`, etc.) are wired by the bar and not called from controllers.
 - **Dispatch pattern**: page controllers build a `QueueItem[]` snapshot from their domain data (normalizing source DTO fields like `trackUrl` or `audioUrl` to `QueueItem.audioUrl`) and call `playQueue(items, startIndex)`.
 - **Shared binding hook**: use `usePlayerQueueBinding(queueItems)` (`apps/frontend/src/hooks/usePlayerQueueBinding.ts`) to read `{ currentTrackId, isPlaying, hasPlayableTracks, playFromIndex, onPlayTrack, onPauseTrack }`. Do not subscribe to the same selectors manually in new controllers.
-- **Approved exception** to the 2-store convention; rationale recorded in the store file header and the `sdd/global-player-bar/proposal` SDD artifact.
+- **Approved exception** to the prior store-count convention; rationale recorded in the store file header and the `sdd/global-player-bar/proposal` SDD artifact.
+
+### Auth gate — ephemeral React state (not a store)
+
+`useTokenGate` (`apps/frontend/src/hooks/controllers/useTokenGate.ts`) deliberately uses local `useState`, not a 4th Zustand store:
+
+- One-time startup concern; no component outside `TokenGate` needs to subscribe to it.
+- Ephemeral by design — "unlocked" must not survive a page reload (a store with `persist` would break this).
+- Preserves the 3-store ceiling without a documented proposal.
+
+Promoting it to a store requires a written SDD proposal.
 
 ## Adding State
 


### PR DESCRIPTION
Closes #113

## What

Adds **optional, proxy-agnostic instance authentication** so spotiarr can be safely exposed to the internet (Pangolin, Cloudflare Tunnel, Tailscale, raw reverse proxy). Modeled on engram's `ENGRAM_HTTP_TOKEN`. No email/password.

- `SPOTIARR_TOKEN` env, **optional**. Unset → fully open LAN access (zero breaking change). Set → the whole instance is gated.
- `POST /api/auth/unlock` validates the token (`crypto.timingSafeEqual`, constant-time) and issues an **httpOnly, SameSite=Lax** cookie, HMAC-SHA256 signed **with the token itself** (rotating the token instantly invalidates all sessions). `secure` is derived per-request.
- A single `require-token` middleware gates **all** `/api/*` except `POST /api/auth/unlock`, `GET /api/health`, and `GET /api/auth/spotify/callback` (OAuth return). The static frontend is never gated.
- SSE rides the same cookie (`EventSource` can't set headers); `useServerEvents` does not mount until unlocked.
- Frontend `<TokenGate>` probes `GET /api/auth/session`, shows an unlock form when locked, re-locks on 401. The raw token is never stored in `localStorage`.
- In-memory fixed-window rate limit on `/unlock` (`SPOTIARR_UNLOCK_RATELIMIT`, default 5/min).
- `SPOTIARR_TRUST_PROXY` for `Secure` cookies behind an HTTPS proxy; startup warning when the token is set without it.

## Why

Today the only auth is Spotify OAuth (connects your account) — it does not protect the instance. Anyone reaching the URL gets the full app and can download music into your homelab. This closes that gap proxy-agnostically. See #113 for the full design and threat model.

## Security review

Adversarial fresh-context review (empirically tested Express 5 path matching with raw sockets — traversal, encoded, trailing slash, query): **no auth bypass, no exploitable CSRF**. Two mutating `GET` retry routes were found and migrated to `POST` (CSRF hardening under `SameSite=Lax`).

## Verification

- `pnpm --filter backend run test` → 392/392 · `pnpm --filter frontend run test` → 433/433
- Backend + frontend + shared builds green. Lint clean (only pre-existing `any` warnings in unrelated test files).
- Manual: token unset → app open; token set → unlock gate, wrong token 401, correct token → cookie → app + SSE work; 6th unlock attempt/min → 429.

## Size

~510 lines across 22 files — single PR by request (`size:exception`). Logically grouped into 6 conventional commits (shared → backend gate → CSRF backend → frontend → CSRF frontend → docs).

## Notes

- Session TTL default 7 days (tunable via `SPOTIARR_SESSION_TTL_HOURS`).
- Behind a reverse proxy you **must** set `SPOTIARR_TRUST_PROXY` for `Secure` cookies and correct rate-limit IPs.