### PR TITLE
feat(frontend): installable PWA support + iOS input zoom fix

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -6,6 +6,10 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#1DB954" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="SpotiArr" />
     <meta
       name="description"
       content="Self-hosted Spotify downloader with Jellyfin/Plex integration"
@@ -46,7 +50,6 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -51,6 +51,7 @@
     "jsdom": "^29.1.1",
     "tailwindcss": "^4.1.17",
     "vite": "^7.2.7",
+    "vite-plugin-pwa": "^1.3.0",
     "vitest": "^3.2.4"
   }
 }

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -13,7 +13,7 @@ const webServers = [];
 
 if (PLAYWRIGHT_TARGET !== "real") {
   webServers.push({
-    command: `pnpm run build && vite preview --host ${PREVIEW_HOST} --port ${PREVIEW_PORT} --strictPort`,
+    command: `PWA_DISABLE=true pnpm run build && vite preview --host ${PREVIEW_HOST} --port ${PREVIEW_PORT} --strictPort`,
     cwd: ROOT_DIR,
     url: PREVIEW_BASE_URL,
     reuseExistingServer: !process.env.CI,
@@ -26,7 +26,7 @@ if (PLAYWRIGHT_TARGET !== "real") {
 if (PLAYWRIGHT_TARGET !== "mocked") {
   webServers.push({
     command:
-      "pnpm --filter @spotiarr/shared run build && pnpm --filter frontend run build && pnpm --filter backend run build && tsx tests/helpers/real-stack.ts",
+      "pnpm --filter @spotiarr/shared run build && PWA_DISABLE=true pnpm --filter frontend run build && pnpm --filter backend run build && tsx tests/helpers/real-stack.ts",
     cwd: ROOT_DIR,
     url: REAL_BASE_URL,
     reuseExistingServer: false,

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -22,6 +22,18 @@
   --color-border-light: rgba(255, 255, 255, 0.05);
 }
 
+/* Mobile browsers (iOS Safari and Chromium/Android such as Chrome and Brave)
+   auto-zoom form fields with font-size < 16px on focus. Force 16px on touch
+   devices only; unlayered + !important to beat Tailwind text-sm/text-xs
+   utilities. Desktop styling and pinch-zoom are untouched. */
+@media (pointer: coarse) {
+  input:not([type="checkbox"]):not([type="radio"]),
+  textarea,
+  select {
+    font-size: 16px !important;
+  }
+}
+
 @layer base {
   body {
     padding: 0;

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 import { readFileSync } from "fs";
 import { resolve } from "path";
 import { defineConfig, loadEnv } from "vite";
+import { VitePWA } from "vite-plugin-pwa";
 
 const packageJson = JSON.parse(readFileSync(resolve(__dirname, "../../package.json"), "utf-8"));
 
@@ -12,7 +13,39 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, envDir, "");
 
   return {
-    plugins: [react(), tailwindcss()],
+    plugins: [
+      react(),
+      tailwindcss(),
+      VitePWA({
+        registerType: "autoUpdate",
+        injectRegister: "auto",
+        devOptions: { enabled: false },
+        manifest: {
+          name: "SpotiArr",
+          short_name: "SpotiArr",
+          description: "Self-hosted Spotify downloader with Jellyfin/Plex integration",
+          theme_color: "#1DB954",
+          background_color: "#000000",
+          display: "standalone",
+          icons: [
+            { src: "/android-chrome-192x192.png", sizes: "192x192", type: "image/png" },
+            { src: "/android-chrome-512x512.png", sizes: "512x512", type: "image/png" },
+          ],
+        },
+        workbox: {
+          globPatterns: ["**/*.{js,css,html,svg,png,woff2}"],
+          maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+          // API and SSE must never be cached or intercepted by the SW
+          navigateFallbackDenylist: [/^\/api/],
+          runtimeCaching: [
+            {
+              urlPattern: ({ url }) => url.pathname.startsWith("/api"),
+              handler: "NetworkOnly",
+            },
+          ],
+        },
+      }),
+    ],
     define: {
       __APP_VERSION__: JSON.stringify(packageJson.version),
     },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig(({ mode }) => {
       react(),
       tailwindcss(),
       VitePWA({
+        disable: process.env.PWA_DISABLE === "true",
         registerType: "autoUpdate",
         injectRegister: "auto",
         devOptions: { enabled: false },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       vite:
         specifier: ^7.2.7
         version: 7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite-plugin-pwa:
+        specifier: ^1.3.0
+        version: 1.3.0(vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(jsdom@29.1.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
@@ -206,6 +209,15 @@ importers:
         version: 5.9.3
 
 packages:
+  "@apideck/better-ajv-errors@0.3.7":
+    resolution:
+      {
+        integrity: sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      ajv: ">=8"
+
   "@asamuzakjp/css-color@5.1.11":
     resolution:
       {
@@ -240,10 +252,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/code-frame@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/compat-data@7.28.5":
     resolution:
       {
         integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/compat-data@7.29.7":
+    resolution:
+      {
+        integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -261,12 +287,59 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-annotate-as-pure@7.29.7":
+    resolution:
+      {
+        integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-compilation-targets@7.27.2":
     resolution:
       {
         integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==,
       }
     engines: { node: ">=6.9.0" }
+
+  "@babel/helper-compilation-targets@7.29.7":
+    resolution:
+      {
+        integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-create-class-features-plugin@7.29.7":
+    resolution:
+      {
+        integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-create-regexp-features-plugin@7.29.7":
+    resolution:
+      {
+        integrity: sha512-907Uymvqgg1dwUA+7IGwFAOSYzQOuzPXKNJ1yxzwPffzkYFg2q2eHi1fIOs6sXkG9NbIUMunnUlkYsfRFNvomg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-define-polyfill-provider@0.6.8":
+    resolution:
+      {
+        integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
 
   "@babel/helper-globals@7.28.0":
     resolution:
@@ -275,10 +348,31 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-globals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-member-expression-to-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-module-imports@7.27.1":
     resolution:
       {
         integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-module-imports@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -291,10 +385,58 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0
 
+  "@babel/helper-module-transforms@7.29.7":
+    resolution:
+      {
+        integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-optimise-call-expression@7.29.7":
+    resolution:
+      {
+        integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-plugin-utils@7.27.1":
     resolution:
       {
         integrity: sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-plugin-utils@7.29.7":
+    resolution:
+      {
+        integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-remap-async-to-generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-replace-supers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -305,6 +447,13 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-string-parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-validator-identifier@7.28.5":
     resolution:
       {
@@ -312,10 +461,31 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/helper-validator-identifier@7.29.7":
+    resolution:
+      {
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/helper-validator-option@7.27.1":
     resolution:
       {
         integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-validator-option@7.29.7":
+    resolution:
+      {
+        integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/helper-wrap-function@7.29.7":
+    resolution:
+      {
+        integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -333,6 +503,455 @@ packages:
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
+
+  "@babel/parser@7.29.7":
+    resolution:
+      {
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j8SrR0zLZrRsC09DlszEx8FpMiwukKffYXMK0d5LmOglO7vGG6sz/BR/20yHqWH+Lnn31JTt2PE3hIWNgM2J6w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7":
+    resolution:
+      {
+        integrity: sha512-r8j8escF+U2FUHo0KOhPUdMzUO+jp9fInva6+ACVAF3Y97Ev+5iNZwiqTghmzNeWwDkOPlYuTcfb1vDaoZKmAQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GE1TFSiuFeGsCxmYXZl8HwoPrVlwe4rHPFE8weieGKZqnDORK+Ar3vgWMgW+AOxQ6/2TgLSKx9p6W7O4rC6qgQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7":
+    resolution:
+      {
+        integrity: sha512-oBNVCvnO5tND+xSopWvV8WNGfpTfgP4Zr/YXXSj8zfmcPktp5Ku/aZlsIowgSD4fjmgHn6sGmB9APVsU5zOdhA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7":
+    resolution:
+      {
+        integrity: sha512-QQt9qKHZ2sg/kivaLr7lnQr8HVrQDdBNSfCsTjiDxRuX/K5ORyKq+Bu8Xr0cDE3Dfkv0cw28Ve0EKyKMvulkOw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.13.0
+
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7":
+    resolution:
+      {
+        integrity: sha512-pn6QacGLgvCcwc+syUhKE/qSjV2D1IHDB84RNxWYSt1mW3K/SCtjinZ2p0cETJxAWBjPy3K/1lHwG5BjjPxNlw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2":
+    resolution:
+      {
+        integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-assertions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-import-attributes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6":
+    resolution:
+      {
+        integrity: sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-arrow-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-generator-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-d98gXZkgswvkyohMBABkhm3GeXhYj8psWfwQ2C7gtfrKGTykQa/iOIi+JJhwMjPlZ6Vm2XN+DCf3Es1EoG4ZLA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-async-to-generator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoped-functions@7.29.7":
+    resolution:
+      {
+        integrity: sha512-cUSmjh72N+rN4PrkFlN1dJwNCwjVp5d38/CQrEsFggkD10UiFlBFgdH3tv5dNsLuHY+3S8db2xCHjhZcv5WgvA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-block-scoping@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ONyr4+AZhKh8yKWInVxU9AXA9EbsyeLcL6V0dJy6M2/62vuvpGm29zzuymbTpdc451GEpDIdAyPLP3r+P61yKQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-class-static-block@7.29.7":
+    resolution:
+      {
+        integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.12.0
+
+  "@babel/plugin-transform-classes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-computed-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RK7/IyU5phpuCdBAuig5VkzG/EnbDaui5SQGdU9BFrHdV+mV4cUjLMQ9lJDjLNtWHsqtiefpGZUXQP2BiTYMsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-destructuring@7.29.7":
+    resolution:
+      {
+        integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-dotall-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-3qc18hsD2RdZiyJNDNc7HQpv6xbncwh8FYtxNFFzclSyh/trPD9KkVR9BDECUjDLvb7yJVF15GfYUuC+LMkkiQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-keys@7.29.7":
+    resolution:
+      {
+        integrity: sha512-6IvRRriEMqnBwD6chtxdLpMYCHWEzN+oL5cyQtjykya19UgzbmKhxmhZgKC/LHxS2nYr9Q/qYPZ5Lr6jOL9+yQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-2wiIyo2BjtgU7HufSeDnL9L2O7zr8jmhFKuSr65VpRkUiRKRNpb0mdlk56+XPPKoIrfHqzbMuglDvZun0RISsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-dynamic-import@7.29.7":
+    resolution:
+      {
+        integrity: sha512-giOlEm/EFjfjr+te9NsdjkUo2v4f8rS/SXPumRVHAtbNcyNlvtREkU1dZzaIDclNpnaVhlCqRdFKhJBjBikzLg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-explicit-resource-management@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Rstj7coNz8sE+7Ju7ihpHLI564lsK5pUpNNlvptCIC/16E/S5hbl6n3kESPKdNRmqEWlpn5xpS5Q2dvXBsySLw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-exponentiation-operator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zFpMOTLZBdW5LfObqcSbL6kefg4R4eLdmvS0wbN9M6D5Mym/sKm9toOoWyVOa+xDjvCnuWcHls2YonXwHvH3CQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-export-namespace-from@7.29.7":
+    resolution:
+      {
+        integrity: sha512-24B2nOy2TeJSMheqwPD4DDQOV/elLSIlKxjZt4i05H5AgdPdWR3n18HnNrcJ+j76WJd9gbwb9jPjNYUy6RautA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-for-of@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zeSIHh0+E1Um1WJRXCFlHQYu2ieJNdivLLjlBEp+dIBu3S51n+SZZmIXjxnItw6pz56Cn+KvK68BIBVsxq2JiQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-function-name@7.29.7":
+    resolution:
+      {
+        integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-json-strings@7.29.7":
+    resolution:
+      {
+        integrity: sha512-RRnE2+eon1rJAq8MnoF1b5kTpY1vU88twHcvcKMrsqP/jxIRqDVs9iJB5fqPuqyeFAW0wJo4MlUIPpQCq/aRsg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-DZ/oLP21ZuWx1vKqnoNv6/tvEK48AQOBRai40CX9dTjGluvT/YZCyY3rryDtyUqCEoyNroy5KKPwX2iQCiRvyw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-logical-assignment-operators@7.29.7":
+    resolution:
+      {
+        integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-member-expression-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-hl1kwFZCCiDyfH25Xmco9jTrkPgnS9pmOzSG7W5I4SaGbLeqKv417hcU2RKmaxoPEgsoJh7ZPOrnPGq99bHoUg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-amd@7.29.7":
+    resolution:
+      {
+        integrity: sha512-fxtQoH3m5ywUSIfaH0FGCzWu4McsYon5bD3K4XnskC7f+OyQMj7rsOMi4NvvmJ83WwBAg4UCe+ov4VZlqEvyew==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-commonjs@7.29.7":
+    resolution:
+      {
+        integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-systemjs@7.29.7":
+    resolution:
+      {
+        integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-modules-umd@7.29.7":
+    resolution:
+      {
+        integrity: sha512-B4UkaTK3QpgCwJnrxKfMPKdo92CN7OKXAlpAAnM3UPu0Q0lCCk57ylA9AJbRy2v8dDKOPAAWcoR6CMyeoHwRCA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-new-target@7.29.7":
+    resolution:
+      {
+        integrity: sha512-fEo41GmsOUhOBlw8ioo6zvjX5Xc2Lqkzlyfqbpsk3eB6TReV18uhxZ0esfEokVbY2+PVJAQHNKxER6lGrzNd3A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-numeric-separator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-zR7fv/z14OjgHl4AgRtkDBvBMhIzCxqV/qN/2BCRC7LjFwvuzjYe7gDWxC4Wl/SNsLM6SE1IWvRPYMgSJaUvNw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-rest-spread@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-object-super@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Ea/diGcw0twB5IlZPO5sgET6fJsLJqPABqTuFWIR+iMPGPZJkATEIWx0wa+aEQ5UY1CBQyP/gkAiLEqn1vBiQA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-catch-binding@7.29.7":
+    resolution:
+      {
+        integrity: sha512-sLsyndxK2VwX6yNUOakMb7Sh553ZTe/vVM1XJ+9Z5aW1ytsc8xOIwmyk05NNjN60vkc5/KqoTH6hB4V41LJhng==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-optional-chaining@7.29.7":
+    resolution:
+      {
+        integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-parameters@7.29.7":
+    resolution:
+      {
+        integrity: sha512-ZDOBqV/qLYJI0YElr8DcENEyARsFQeESqWXH6gZlghYXuPPjvweuDhP4VyEi4BlUBlLRFZVjxoZDMjxhLW766g==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-methods@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-private-property-in-object@7.29.7":
+    resolution:
+      {
+        integrity: sha512-+BNo06dnrzdNNqCm1X6YUaVv0DKk8Q+JYcoZfOkLhYWNCXzlwTSRq8zGWayT1csjcpNXV9CQTBRRbmTLZac5cA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-property-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
 
   "@babel/plugin-transform-react-jsx-self@7.27.1":
     resolution:
@@ -352,6 +971,131 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
+  "@babel/plugin-transform-regenerator@7.29.7":
+    resolution:
+      {
+        integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-regexp-modifiers@7.29.7":
+    resolution:
+      {
+        integrity: sha512-mB5Fs0VWrJ42ZCmc8114v60qetdaUVNkj9PmSZRmanCZM3S9hm0CFRLjRmYIsuXav14l2jvZ+4T8iiCGnhj3nQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/plugin-transform-reserved-words@7.29.7":
+    resolution:
+      {
+        integrity: sha512-5+YhdpVgmfSmwZyLMftfaiffLRMHjzIRHFHHLdibcSyJm2pasMrKHrO3Ptrt2DRshjvpgjEJJ1zVW14WPq/6QA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-shorthand-properties@7.29.7":
+    resolution:
+      {
+        integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-spread@7.29.7":
+    resolution:
+      {
+        integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-sticky-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-template-literals@7.29.7":
+    resolution:
+      {
+        integrity: sha512-NCSEJ4sLFU2gqAub45HYh4fus2yQ36rr6ei6vpU7NdoJqCpxvEG8E6eJpscGyXP3VHD2Ny+fSXr04k1hoUrFqA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-typeof-symbol@7.29.7":
+    resolution:
+      {
+        integrity: sha512-223mNGoTkBiTEWFoK+Q6Go3tueMRclO8vxxxxquNCYuNI4jWOofFKJRRDu6SDrB8Sgo1UEGW9T4GAQ8ZyRso1A==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-escapes@7.29.7":
+    resolution:
+      {
+        integrity: sha512-jCfXxSjf94lf4E0hKE0AByxF6F3/pVFqRdUUNkDJhsY0m1ZKjnN6ZYyMeHNpzflxb/0q5b7t3p+BE+SLF1WOtA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-property-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-OgZ+zoAJgZLUCunsTRQ5LAjOywDv5zzZ2/hQ5aMw1pGXyY2rtE8/chXYUmu3AlVHKpm10KEdG9aMwbI/K76ZGw==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/plugin-transform-unicode-sets-regex@7.29.7":
+    resolution:
+      {
+        integrity: sha512-BLOhLht9DOJwIxlmp91wHvkXv1lguuHS3/FwUO8HL1H0u8s4hR1gASVFyilu9iGtcTRYqjTZmlsFFeQletntEg==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+
+  "@babel/preset-env@7.29.7":
+    resolution:
+      {
+        integrity: sha512-GYzX36n1nsciIb0uyH0GHwxwtNwPQIcpxSeiVLDtG/B7jB5xXgchnmL1f/jCX5o+pwnaDBtO60ONSJhEBJfxYA==,
+      }
+    engines: { node: ">=6.9.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
+
+  "@babel/preset-modules@0.1.6-no-external-plugins":
+    resolution:
+      {
+        integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0 || ^8.0.0-0 <8.0.0
+
   "@babel/runtime@7.28.4":
     resolution:
       {
@@ -366,6 +1110,13 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/template@7.29.7":
+    resolution:
+      {
+        integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/traverse@7.28.5":
     resolution:
       {
@@ -373,10 +1124,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/traverse@7.29.7":
+    resolution:
+      {
+        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/types@7.28.5":
     resolution:
       {
         integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==,
+      }
+    engines: { node: ">=6.9.0" }
+
+  "@babel/types@7.29.7":
+    resolution:
+      {
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -744,6 +1509,13 @@ packages:
         integrity: sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==,
       }
 
+  "@isaacs/cliui@9.0.0":
+    resolution:
+      {
+        integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==,
+      }
+    engines: { node: ">=18" }
+
   "@jridgewell/gen-mapping@0.3.13":
     resolution:
       {
@@ -1076,6 +1848,70 @@ packages:
       {
         integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==,
       }
+
+  "@rollup/plugin-babel@6.1.0":
+    resolution:
+      {
+        integrity: sha512-dFZNuFD2YRcoomP4oYf+DvQNSUA9ih+A3vUqopQx5EdtPGo3WBnQcI/S8pwpz91UsGfL0HsMSOlaMld8HrbubA==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+      "@types/babel__core": ^7.1.9
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      "@types/babel__core":
+        optional: true
+      rollup:
+        optional: true
+
+  "@rollup/plugin-node-resolve@16.0.3":
+    resolution:
+      {
+        integrity: sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      rollup: ^2.78.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  "@rollup/plugin-replace@6.0.3":
+    resolution:
+      {
+        integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  "@rollup/plugin-terser@1.0.0":
+    resolution:
+      {
+        integrity: sha512-FnCxhTBx6bMOYQrar6C8h3scPt8/JwIzw3+AJ2K++6guogH5fYaIFia+zZuhqv0eo1RN7W1Pz630SyvLbDjhtQ==,
+      }
+    engines: { node: ">=20.0.0" }
+    peerDependencies:
+      rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  "@rollup/pluginutils@5.4.0":
+    resolution:
+      {
+        integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==,
+      }
+    engines: { node: ">=14.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   "@rollup/rollup-android-arm-eabi@4.53.3":
     resolution:
@@ -1455,6 +2291,13 @@ packages:
         integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==,
       }
 
+  "@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1":
+    resolution:
+      {
+        integrity: sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==,
+      }
+    engines: { node: ">=12" }
+
   "@trivago/prettier-plugin-sort-imports@6.0.0":
     resolution:
       {
@@ -1605,6 +2448,12 @@ packages:
         integrity: sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==,
       }
 
+  "@types/resolve@1.20.2":
+    resolution:
+      {
+        integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==,
+      }
+
   "@types/send@0.17.6":
     resolution:
       {
@@ -1621,6 +2470,12 @@ packages:
     resolution:
       {
         integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==,
+      }
+
+  "@types/trusted-types@2.0.7":
+    resolution:
+      {
+        integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
       }
 
   "@vitejs/plugin-react@5.1.1":
@@ -1697,6 +2552,12 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  ajv@8.20.0:
+    resolution:
+      {
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
+      }
+
   ansi-escapes@7.2.0:
     resolution:
       {
@@ -1752,12 +2613,26 @@ packages:
         integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
       }
 
+  array-buffer-byte-length@1.0.2:
+    resolution:
+      {
+        integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==,
+      }
+    engines: { node: ">= 0.4" }
+
   array-union@2.1.0:
     resolution:
       {
         integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
       }
     engines: { node: ">=8" }
+
+  arraybuffer.prototype.slice@1.0.4:
+    resolution:
+      {
+        integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   assertion-error@2.0.1:
     resolution:
@@ -1766,11 +2641,77 @@ packages:
       }
     engines: { node: ">=12" }
 
+  async-function@1.0.0:
+    resolution:
+      {
+        integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  async@3.2.6:
+    resolution:
+      {
+        integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==,
+      }
+
+  at-least-node@1.0.0:
+    resolution:
+      {
+        integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
+      }
+    engines: { node: ">= 4.0.0" }
+
+  available-typed-arrays@1.0.7:
+    resolution:
+      {
+        integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  babel-plugin-polyfill-corejs2@0.4.17:
+    resolution:
+      {
+        integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.14.2:
+    resolution:
+      {
+        integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-regenerator@0.6.8:
+    resolution:
+      {
+        integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+
   balanced-match@1.0.2:
     resolution:
       {
         integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
       }
+
+  balanced-match@4.0.4:
+    resolution:
+      {
+        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
+  baseline-browser-mapping@2.10.35:
+    resolution:
+      {
+        integrity: sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
 
   baseline-browser-mapping@2.8.30:
     resolution:
@@ -1805,6 +2746,13 @@ packages:
         integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==,
       }
 
+  brace-expansion@5.0.6:
+    resolution:
+      {
+        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
   braces@3.0.3:
     resolution:
       {
@@ -1816,6 +2764,14 @@ packages:
     resolution:
       {
         integrity: sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution:
+      {
+        integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
@@ -1853,6 +2809,13 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  call-bind@1.0.9:
+    resolution:
+      {
+        integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==,
+      }
+    engines: { node: ">= 0.4" }
+
   call-bound@1.0.4:
     resolution:
       {
@@ -1864,6 +2827,12 @@ packages:
     resolution:
       {
         integrity: sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==,
+      }
+
+  caniuse-lite@1.0.30001797:
+    resolution:
+      {
+        integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==,
       }
 
   chai@5.3.3:
@@ -1968,6 +2937,13 @@ packages:
       }
     engines: { node: ^12.20.0 || >=14 }
 
+  common-tags@1.8.2:
+    resolution:
+      {
+        integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==,
+      }
+    engines: { node: ">=4.0.0" }
+
   concurrently@9.2.1:
     resolution:
       {
@@ -2017,6 +2993,12 @@ packages:
       }
     engines: { node: ">=18" }
 
+  core-js-compat@3.49.0:
+    resolution:
+      {
+        integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==,
+      }
+
   cors@2.8.5:
     resolution:
       {
@@ -2030,6 +3012,20 @@ packages:
         integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==,
       }
     engines: { node: ">=12.0.0" }
+
+  cross-spawn@7.0.6:
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
+
+  crypto-random-string@2.0.0:
+    resolution:
+      {
+        integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==,
+      }
+    engines: { node: ">=8" }
 
   css-tree@3.2.1:
     resolution:
@@ -2050,6 +3046,27 @@ packages:
         integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==,
       }
     engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
+
+  data-view-buffer@1.0.2:
+    resolution:
+      {
+        integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  data-view-byte-length@1.0.2:
+    resolution:
+      {
+        integrity: sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  data-view-byte-offset@1.0.1:
+    resolution:
+      {
+        integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   debug@4.4.3:
     resolution:
@@ -2075,6 +3092,27 @@ packages:
         integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
       }
     engines: { node: ">=6" }
+
+  deepmerge@4.3.1:
+    resolution:
+      {
+        integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  define-data-property@1.1.4:
+    resolution:
+      {
+        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  define-properties@1.2.1:
+    resolution:
+      {
+        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
+      }
+    engines: { node: ">= 0.4" }
 
   denque@2.1.0:
     resolution:
@@ -2137,10 +3175,24 @@ packages:
         integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
       }
 
+  ejs@3.1.10:
+    resolution:
+      {
+        integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==,
+      }
+    engines: { node: ">=0.10.0" }
+    hasBin: true
+
   electron-to-chromium@1.5.258:
     resolution:
       {
         integrity: sha512-rHUggNV5jKQ0sSdWwlaRDkFc3/rRJIVnOSe9yR4zrR07m3ZxhP4N27Hlg8VeJGGYgFTxK5NqDmWI4DSH72vIJg==,
+      }
+
+  electron-to-chromium@1.5.371:
+    resolution:
+      {
+        integrity: sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==,
       }
 
   emoji-regex@10.6.0:
@@ -2183,6 +3235,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  es-abstract@1.24.2:
+    resolution:
+      {
+        integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==,
+      }
+    engines: { node: ">= 0.4" }
+
   es-define-property@1.0.1:
     resolution:
       {
@@ -2210,6 +3269,27 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  es-object-atoms@1.1.2:
+    resolution:
+      {
+        integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-set-tostringtag@2.1.0:
+    resolution:
+      {
+        integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  es-to-primitive@1.3.0:
+    resolution:
+      {
+        integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==,
+      }
+    engines: { node: ">= 0.4" }
+
   esbuild@0.25.12:
     resolution:
       {
@@ -2231,11 +3311,31 @@ packages:
         integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
       }
 
+  estree-walker@2.0.2:
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
+
   estree-walker@3.0.3:
     resolution:
       {
         integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
       }
+
+  esutils@2.0.3:
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  eta@4.6.0:
+    resolution:
+      {
+        integrity: sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==,
+      }
+    engines: { node: ">=20" }
 
   etag@1.8.1:
     resolution:
@@ -2264,12 +3364,30 @@ packages:
       }
     engines: { node: ">= 18" }
 
+  fast-deep-equal@3.1.3:
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
+
   fast-glob@3.3.3:
     resolution:
       {
         integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
       }
     engines: { node: ">=8.6.0" }
+
+  fast-json-stable-stringify@2.1.0:
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
+
+  fast-uri@3.1.2:
+    resolution:
+      {
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+      }
 
   fastq@1.19.1:
     resolution:
@@ -2296,6 +3414,12 @@ packages:
       }
     engines: { node: ">=20" }
 
+  filelist@1.0.6:
+    resolution:
+      {
+        integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==,
+      }
+
   fill-range@7.1.1:
     resolution:
       {
@@ -2310,6 +3434,20 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  for-each@0.3.5:
+    resolution:
+      {
+        integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
+      }
+    engines: { node: ">= 0.4" }
+
+  foreground-child@3.3.1:
+    resolution:
+      {
+        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
+      }
+    engines: { node: ">=14" }
+
   forwarded@0.2.0:
     resolution:
       {
@@ -2323,6 +3461,13 @@ packages:
         integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==,
       }
     engines: { node: ">= 0.8" }
+
+  fs-extra@9.1.0:
+    resolution:
+      {
+        integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==,
+      }
+    engines: { node: ">=10" }
 
   fsevents@2.3.2:
     resolution:
@@ -2345,6 +3490,26 @@ packages:
       {
         integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
       }
+
+  function.prototype.name@1.1.8:
+    resolution:
+      {
+        integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==,
+      }
+    engines: { node: ">= 0.4" }
+
+  functions-have-names@1.2.3:
+    resolution:
+      {
+        integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==,
+      }
+
+  generator-function@2.0.1:
+    resolution:
+      {
+        integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==,
+      }
+    engines: { node: ">= 0.4" }
 
   gensync@1.0.0-beta.2:
     resolution:
@@ -2374,10 +3539,23 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  get-own-enumerable-property-symbols@3.0.2:
+    resolution:
+      {
+        integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==,
+      }
+
   get-proto@1.0.1:
     resolution:
       {
         integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  get-symbol-description@1.1.0:
+    resolution:
+      {
+        integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==,
       }
     engines: { node: ">= 0.4" }
 
@@ -2393,6 +3571,22 @@ packages:
         integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
       }
     engines: { node: ">= 6" }
+
+  glob@11.1.0:
+    resolution:
+      {
+        integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==,
+      }
+    engines: { node: 20 || >=22 }
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  globalthis@1.0.4:
+    resolution:
+      {
+        integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   globby@11.1.0:
     resolution:
@@ -2414,12 +3608,32 @@ packages:
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
 
+  has-bigints@1.1.0:
+    resolution:
+      {
+        integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==,
+      }
+    engines: { node: ">= 0.4" }
+
   has-flag@4.0.0:
     resolution:
       {
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: ">=8" }
+
+  has-property-descriptors@1.0.2:
+    resolution:
+      {
+        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
+      }
+
+  has-proto@1.2.0:
+    resolution:
+      {
+        integrity: sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   has-symbols@1.1.0:
     resolution:
@@ -2428,10 +3642,24 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
+  has-tostringtag@1.0.2:
+    resolution:
+      {
+        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
+      }
+    engines: { node: ">= 0.4" }
+
   hasown@2.0.2:
     resolution:
       {
         integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  hasown@2.0.4:
+    resolution:
+      {
+        integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
       }
     engines: { node: ">= 0.4" }
 
@@ -2501,6 +3729,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  idb@7.1.1:
+    resolution:
+      {
+        integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==,
+      }
+
   ieee754@1.2.1:
     resolution:
       {
@@ -2520,6 +3754,13 @@ packages:
         integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
       }
 
+  internal-slot@1.1.0:
+    resolution:
+      {
+        integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
+      }
+    engines: { node: ">= 0.4" }
+
   ioredis@5.8.2:
     resolution:
       {
@@ -2534,6 +3775,27 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
+  is-array-buffer@3.0.5:
+    resolution:
+      {
+        integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-async-function@2.1.1:
+    resolution:
+      {
+        integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-bigint@1.1.0:
+    resolution:
+      {
+        integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==,
+      }
+    engines: { node: ">= 0.4" }
+
   is-binary-path@2.1.0:
     resolution:
       {
@@ -2541,12 +3803,54 @@ packages:
       }
     engines: { node: ">=8" }
 
+  is-boolean-object@1.2.2:
+    resolution:
+      {
+        integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-callable@1.2.7:
+    resolution:
+      {
+        integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-core-module@2.16.2:
+    resolution:
+      {
+        integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-data-view@1.0.2:
+    resolution:
+      {
+        integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-date-object@1.1.0:
+    resolution:
+      {
+        integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==,
+      }
+    engines: { node: ">= 0.4" }
+
   is-extglob@2.1.1:
     resolution:
       {
         integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
       }
     engines: { node: ">=0.10.0" }
+
+  is-finalizationregistry@1.1.1:
+    resolution:
+      {
+        integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==,
+      }
+    engines: { node: ">= 0.4" }
 
   is-fullwidth-code-point@3.0.0:
     resolution:
@@ -2562,6 +3866,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  is-generator-function@1.1.2:
+    resolution:
+      {
+        integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==,
+      }
+    engines: { node: ">= 0.4" }
+
   is-glob@4.0.3:
     resolution:
       {
@@ -2569,12 +3880,46 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  is-map@2.0.3:
+    resolution:
+      {
+        integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-module@1.0.0:
+    resolution:
+      {
+        integrity: sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==,
+      }
+
+  is-negative-zero@2.0.3:
+    resolution:
+      {
+        integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-number-object@1.1.1:
+    resolution:
+      {
+        integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==,
+      }
+    engines: { node: ">= 0.4" }
+
   is-number@7.0.0:
     resolution:
       {
         integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
       }
     engines: { node: ">=0.12.0" }
+
+  is-obj@1.0.1:
+    resolution:
+      {
+        integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-potential-custom-element-name@1.0.1:
     resolution:
@@ -2587,6 +3932,110 @@ packages:
       {
         integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==,
       }
+
+  is-regex@1.2.1:
+    resolution:
+      {
+        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-regexp@1.0.0:
+    resolution:
+      {
+        integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  is-set@2.0.3:
+    resolution:
+      {
+        integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-shared-array-buffer@1.0.4:
+    resolution:
+      {
+        integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-stream@2.0.1:
+    resolution:
+      {
+        integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
+      }
+    engines: { node: ">=8" }
+
+  is-string@1.1.1:
+    resolution:
+      {
+        integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-symbol@1.1.1:
+    resolution:
+      {
+        integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-typed-array@1.1.15:
+    resolution:
+      {
+        integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-weakmap@2.0.2:
+    resolution:
+      {
+        integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-weakref@1.1.1:
+    resolution:
+      {
+        integrity: sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==,
+      }
+    engines: { node: ">= 0.4" }
+
+  is-weakset@2.0.4:
+    resolution:
+      {
+        integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  isarray@2.0.5:
+    resolution:
+      {
+        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
+      }
+
+  isexe@2.0.0:
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
+
+  jackspeak@4.2.3:
+    resolution:
+      {
+        integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==,
+      }
+    engines: { node: 20 || >=22 }
+
+  jake@10.9.4:
+    resolution:
+      {
+        integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
 
   javascript-natural-sort@0.7.1:
     resolution:
@@ -2633,6 +4082,12 @@ packages:
     engines: { node: ">=6" }
     hasBin: true
 
+  json-schema-traverse@1.0.0:
+    resolution:
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
+
   json5@2.2.3:
     resolution:
       {
@@ -2640,6 +4095,26 @@ packages:
       }
     engines: { node: ">=6" }
     hasBin: true
+
+  jsonfile@6.2.1:
+    resolution:
+      {
+        integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==,
+      }
+
+  jsonpointer@5.0.1:
+    resolution:
+      {
+        integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  leven@3.1.0:
+    resolution:
+      {
+        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
+      }
+    engines: { node: ">=6" }
 
   lightningcss-android-arm64@1.30.2:
     resolution:
@@ -2768,6 +4243,12 @@ packages:
         integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==,
       }
 
+  lodash.debounce@4.0.8:
+    resolution:
+      {
+        integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==,
+      }
+
   lodash.defaults@4.2.0:
     resolution:
       {
@@ -2778,6 +4259,12 @@ packages:
     resolution:
       {
         integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==,
+      }
+
+  lodash.sortby@4.7.0:
+    resolution:
+      {
+        integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==,
       }
 
   log-update@6.1.0:
@@ -2888,10 +4375,31 @@ packages:
       }
     engines: { node: ">=18" }
 
+  minimatch@10.2.5:
+    resolution:
+      {
+        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
+
+  minimatch@5.1.9:
+    resolution:
+      {
+        integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==,
+      }
+    engines: { node: ">=10" }
+
   minimatch@9.0.5:
     resolution:
       {
         integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==,
+      }
+    engines: { node: ">=16 || 14 >=14.17" }
+
+  minipass@7.1.3:
+    resolution:
+      {
+        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
       }
     engines: { node: ">=16 || 14 >=14.17" }
 
@@ -2982,6 +4490,13 @@ packages:
         integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==,
       }
 
+  node-releases@2.0.47:
+    resolution:
+      {
+        integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==,
+      }
+    engines: { node: ">=18" }
+
   normalize-path@3.0.0:
     resolution:
       {
@@ -3000,6 +4515,20 @@ packages:
     resolution:
       {
         integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
+      }
+    engines: { node: ">= 0.4" }
+
+  object-keys@1.1.1:
+    resolution:
+      {
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  object.assign@4.1.7:
+    resolution:
+      {
+        integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
       }
     engines: { node: ">= 0.4" }
 
@@ -3023,6 +4552,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  own-keys@1.0.1:
+    resolution:
+      {
+        integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==,
+      }
+    engines: { node: ">= 0.4" }
+
   oxlint@1.66.0:
     resolution:
       {
@@ -3035,6 +4571,12 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  package-json-from-dist@1.0.1:
+    resolution:
+      {
+        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
+      }
 
   parse-imports-exports@0.2.4:
     resolution:
@@ -3060,6 +4602,26 @@ packages:
         integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==,
       }
     engines: { node: ">= 0.8" }
+
+  path-key@3.1.1:
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
+
+  path-parse@1.0.7:
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
+
+  path-scurry@2.0.2:
+    resolution:
+      {
+        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
+      }
+    engines: { node: 18 || 20 || >=22 }
 
   path-to-regexp@8.3.0:
     resolution:
@@ -3138,6 +4700,13 @@ packages:
       }
     engines: { node: ">=12" }
 
+  possible-typed-array-names@1.1.0:
+    resolution:
+      {
+        integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
+      }
+    engines: { node: ">= 0.4" }
+
   postcss@8.5.6:
     resolution:
       {
@@ -3210,6 +4779,20 @@ packages:
       }
     engines: { node: ">=14" }
     hasBin: true
+
+  pretty-bytes@5.6.0:
+    resolution:
+      {
+        integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==,
+      }
+    engines: { node: ">=6" }
+
+  pretty-bytes@6.1.1:
+    resolution:
+      {
+        integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==,
+      }
+    engines: { node: ^14.13.1 || >=16.0.0 }
 
   pretty-format@27.5.1:
     resolution:
@@ -3374,6 +4957,53 @@ packages:
       }
     engines: { node: ">=4" }
 
+  reflect.getprototypeof@1.0.10:
+    resolution:
+      {
+        integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  regenerate-unicode-properties@10.2.2:
+    resolution:
+      {
+        integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==,
+      }
+    engines: { node: ">=4" }
+
+  regenerate@1.4.2:
+    resolution:
+      {
+        integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==,
+      }
+
+  regexp.prototype.flags@1.5.4:
+    resolution:
+      {
+        integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  regexpu-core@6.4.0:
+    resolution:
+      {
+        integrity: sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==,
+      }
+    engines: { node: ">=4" }
+
+  regjsgen@0.8.0:
+    resolution:
+      {
+        integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==,
+      }
+
+  regjsparser@0.13.1:
+    resolution:
+      {
+        integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==,
+      }
+    hasBin: true
+
   require-directory@2.1.1:
     resolution:
       {
@@ -3393,6 +5023,14 @@ packages:
       {
         integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
       }
+
+  resolve@1.22.12:
+    resolution:
+      {
+        integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
+      }
+    engines: { node: ">= 0.4" }
+    hasBin: true
 
   restore-cursor@5.1.0:
     resolution:
@@ -3441,6 +5079,27 @@ packages:
         integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==,
       }
 
+  safe-array-concat@1.1.4:
+    resolution:
+      {
+        integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==,
+      }
+    engines: { node: ">=0.4" }
+
+  safe-push-apply@1.0.0:
+    resolution:
+      {
+        integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  safe-regex-test@1.1.0:
+    resolution:
+      {
+        integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
+      }
+    engines: { node: ">= 0.4" }
+
   safer-buffer@2.1.2:
     resolution:
       {
@@ -3482,6 +5141,13 @@ packages:
       }
     engines: { node: ">= 18" }
 
+  serialize-javascript@7.0.5:
+    resolution:
+      {
+        integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==,
+      }
+    engines: { node: ">=20.0.0" }
+
   serve-static@2.2.0:
     resolution:
       {
@@ -3495,11 +5161,46 @@ packages:
         integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==,
       }
 
+  set-function-length@1.2.2:
+    resolution:
+      {
+        integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
+      }
+    engines: { node: ">= 0.4" }
+
+  set-function-name@2.0.2:
+    resolution:
+      {
+        integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  set-proto@1.0.0:
+    resolution:
+      {
+        integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==,
+      }
+    engines: { node: ">= 0.4" }
+
   setprototypeof@1.2.0:
     resolution:
       {
         integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==,
       }
+
+  shebang-command@2.0.0:
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
+
+  shebang-regex@3.0.0:
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   shell-quote@1.8.3:
     resolution:
@@ -3563,6 +5264,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  smob@1.6.2:
+    resolution:
+      {
+        integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==,
+      }
+    engines: { node: ">=20.0.0" }
+
   source-map-js@1.2.1:
     resolution:
       {
@@ -3582,6 +5290,14 @@ packages:
         integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
       }
     engines: { node: ">=0.10.0" }
+
+  source-map@0.8.0-beta.0:
+    resolution:
+      {
+        integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==,
+      }
+    engines: { node: ">= 8" }
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   stackback@0.0.2:
     resolution:
@@ -3607,6 +5323,13 @@ packages:
       {
         integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
       }
+
+  stop-iteration-iterator@1.1.0:
+    resolution:
+      {
+        integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==,
+      }
+    engines: { node: ">= 0.4" }
 
   string-argv@0.3.2:
     resolution:
@@ -3636,6 +5359,41 @@ packages:
       }
     engines: { node: ">=20" }
 
+  string.prototype.matchall@4.0.12:
+    resolution:
+      {
+        integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  string.prototype.trim@1.2.11:
+    resolution:
+      {
+        integrity: sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==,
+      }
+    engines: { node: ">= 0.4" }
+
+  string.prototype.trimend@1.0.10:
+    resolution:
+      {
+        integrity: sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  string.prototype.trimstart@1.0.8:
+    resolution:
+      {
+        integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==,
+      }
+    engines: { node: ">= 0.4" }
+
+  stringify-object@3.3.0:
+    resolution:
+      {
+        integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==,
+      }
+    engines: { node: ">=4" }
+
   strip-ansi@6.0.1:
     resolution:
       {
@@ -3649,6 +5407,13 @@ packages:
         integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==,
       }
     engines: { node: ">=12" }
+
+  strip-comments@2.0.1:
+    resolution:
+      {
+        integrity: sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==,
+      }
+    engines: { node: ">=10" }
 
   strip-literal@3.1.0:
     resolution:
@@ -3677,6 +5442,13 @@ packages:
       }
     engines: { node: ">=10" }
 
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: ">= 0.4" }
+
   symbol-tree@3.2.4:
     resolution:
       {
@@ -3701,6 +5473,20 @@ packages:
         integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==,
       }
     engines: { node: ">=6" }
+
+  temp-dir@2.0.0:
+    resolution:
+      {
+        integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==,
+      }
+    engines: { node: ">=8" }
+
+  tempy@0.6.0:
+    resolution:
+      {
+        integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==,
+      }
+    engines: { node: ">=10" }
 
   terser@5.44.1:
     resolution:
@@ -3791,6 +5577,12 @@ packages:
       }
     engines: { node: ">=16" }
 
+  tr46@1.0.1:
+    resolution:
+      {
+        integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==,
+      }
+
   tr46@6.0.0:
     resolution:
       {
@@ -3827,12 +5619,47 @@ packages:
     engines: { node: ">=18.0.0" }
     hasBin: true
 
+  type-fest@0.16.0:
+    resolution:
+      {
+        integrity: sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==,
+      }
+    engines: { node: ">=10" }
+
   type-is@2.0.1:
     resolution:
       {
         integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==,
       }
     engines: { node: ">= 0.6" }
+
+  typed-array-buffer@1.0.3:
+    resolution:
+      {
+        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  typed-array-byte-length@1.0.3:
+    resolution:
+      {
+        integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==,
+      }
+    engines: { node: ">= 0.4" }
+
+  typed-array-byte-offset@1.0.4:
+    resolution:
+      {
+        integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==,
+      }
+    engines: { node: ">= 0.4" }
+
+  typed-array-length@1.0.8:
+    resolution:
+      {
+        integrity: sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==,
+      }
+    engines: { node: ">= 0.4" }
 
   typescript@5.9.3:
     resolution:
@@ -3849,6 +5676,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  unbox-primitive@1.1.0:
+    resolution:
+      {
+        integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==,
+      }
+    engines: { node: ">= 0.4" }
+
   undici-types@7.16.0:
     resolution:
       {
@@ -3862,6 +5696,48 @@ packages:
       }
     engines: { node: ">=20.18.1" }
 
+  unicode-canonical-property-names-ecmascript@2.0.1:
+    resolution:
+      {
+        integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-match-property-ecmascript@2.0.0:
+    resolution:
+      {
+        integrity: sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-match-property-value-ecmascript@2.2.1:
+    resolution:
+      {
+        integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==,
+      }
+    engines: { node: ">=4" }
+
+  unicode-property-aliases-ecmascript@2.2.0:
+    resolution:
+      {
+        integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==,
+      }
+    engines: { node: ">=4" }
+
+  unique-string@2.0.0:
+    resolution:
+      {
+        integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==,
+      }
+    engines: { node: ">=8" }
+
+  universalify@2.0.1:
+    resolution:
+      {
+        integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
+      }
+    engines: { node: ">= 10.0.0" }
+
   unpipe@1.0.0:
     resolution:
       {
@@ -3869,10 +5745,26 @@ packages:
       }
     engines: { node: ">= 0.8" }
 
+  upath@1.2.0:
+    resolution:
+      {
+        integrity: sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==,
+      }
+    engines: { node: ">=4" }
+
   update-browserslist-db@1.1.4:
     resolution:
       {
         integrity: sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==,
+      }
+    hasBin: true
+    peerDependencies:
+      browserslist: ">= 4.21.0"
+
+  update-browserslist-db@1.2.3:
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
       }
     hasBin: true
     peerDependencies:
@@ -3914,6 +5806,21 @@ packages:
       }
     engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
     hasBin: true
+
+  vite-plugin-pwa@1.3.0:
+    resolution:
+      {
+        integrity: sha512-c5kMgN+ITrOtHXp8PAtk2uOIEea6XjP/unCGxOWWBzQ6qa65qj/awHg0wf+QF9E/2u9vh86LqxPwzEPNbM2r5A==,
+      }
+    engines: { node: ">=16.0.0" }
+    peerDependencies:
+      "@vite-pwa/assets-generator": ^1.0.0
+      vite: ^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      workbox-build: ^7.4.1
+      workbox-window: ^7.4.1
+    peerDependenciesMeta:
+      "@vite-pwa/assets-generator":
+        optional: true
 
   vite@7.2.7:
     resolution:
@@ -4003,6 +5910,12 @@ packages:
       }
     engines: { node: ">=18" }
 
+  webidl-conversions@4.0.2:
+    resolution:
+      {
+        integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==,
+      }
+
   webidl-conversions@8.0.1:
     resolution:
       {
@@ -4024,6 +5937,48 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
 
+  whatwg-url@7.1.0:
+    resolution:
+      {
+        integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==,
+      }
+
+  which-boxed-primitive@1.1.1:
+    resolution:
+      {
+        integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==,
+      }
+    engines: { node: ">= 0.4" }
+
+  which-builtin-type@1.2.1:
+    resolution:
+      {
+        integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==,
+      }
+    engines: { node: ">= 0.4" }
+
+  which-collection@1.0.2:
+    resolution:
+      {
+        integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  which-typed-array@1.1.22:
+    resolution:
+      {
+        integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==,
+      }
+    engines: { node: ">= 0.4" }
+
+  which@2.0.2:
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution:
       {
@@ -4036,6 +5991,103 @@ packages:
     resolution:
       {
         integrity: sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==,
+      }
+
+  workbox-background-sync@7.4.1:
+    resolution:
+      {
+        integrity: sha512-HhT7KE8tOWDm02wRNshXUnUPofMlhenF2DBdUnDPOubhizzPeItkYTmAB6td1Z2cjYPa98vzEiPLEuzn5hN66g==,
+      }
+
+  workbox-broadcast-update@7.4.1:
+    resolution:
+      {
+        integrity: sha512-uAlgslKLvbQY+suirIdnBCSYrcgBhjp81Nj4l1lj/Jmj0MJO2CJERnCJjT0GFVwmReV0N+zs78K6gqd5gr9/+A==,
+      }
+
+  workbox-build@7.4.1:
+    resolution:
+      {
+        integrity: sha512-SDhxIvEAde9Gy/5w4Yo1Jh/M49Z0qE3q0oteyE8zGq0DScxFqVBcCtIXFuLtmtxRQZCMbf0prco4VyEu3KBQuw==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  workbox-cacheable-response@7.4.1:
+    resolution:
+      {
+        integrity: sha512-8xaFoJdDc2OjrlbbL3gEeBO1WKcMwRqwLRupgqahYXu75yXajPLuwrbXMrIGZuWYXrQwk0xDjOxZ/ujCy/oJYw==,
+      }
+
+  workbox-core@7.4.1:
+    resolution:
+      {
+        integrity: sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==,
+      }
+
+  workbox-expiration@7.4.1:
+    resolution:
+      {
+        integrity: sha512-lRKUF7b+OGbeXkQk1s6MHXOa3d7Xxf7Of31W6c6hCfipfIyrtdWZ89stq21AHZMaoG7VNFoHply4Ox+rU31TWg==,
+      }
+
+  workbox-google-analytics@7.4.1:
+    resolution:
+      {
+        integrity: sha512-Mks1JwLEt++ZAkF6sS1OpSh9RtAMIsiDgRpK+codiHGIPXeaUOgi4cPc3GFadUl8V5QPeypEk8Oxgl3HlwVzHw==,
+      }
+
+  workbox-navigation-preload@7.4.1:
+    resolution:
+      {
+        integrity: sha512-C4KVsjPcYKJOhr631AxR9XoG2rLF3QiTk5aMv36MXOjtWvm8axwNFAtKUPGsWUwLXXAMgYM1En7fsvndaXeXRQ==,
+      }
+
+  workbox-precaching@7.4.1:
+    resolution:
+      {
+        integrity: sha512-cdr/9qByww7yzEp7zg/qI4ukUrrNjQLgN+ONQRpjy/VqGQXwkgHwr00KksGJK8v0VifwDXBb8a4cWNZH71jn3Q==,
+      }
+
+  workbox-range-requests@7.4.1:
+    resolution:
+      {
+        integrity: sha512-7i2oxAUE82gHdAJBCAQ04JzNOdRPqzuOzGfoUyJpFSmeqBNYGPrAH8GPoPjUQTfp+NycwrD2H68VtuF8qxv0vQ==,
+      }
+
+  workbox-recipes@7.4.1:
+    resolution:
+      {
+        integrity: sha512-gnbVfmV4/TtmQaM4x9AtuXhcdstJsep3XMVeztOrQVPT+R6+6DeBjGTCQ7fFCXm+4GEHUA5VEBTyi5+4gWGeog==,
+      }
+
+  workbox-routing@7.4.1:
+    resolution:
+      {
+        integrity: sha512-yubJGErZOusuidAenaL5ypfhQOa7urxP/f8E0ws7FPb4039RiWXUWBAyUkmUoOL/BcQGen3h0J8872d51IYxtA==,
+      }
+
+  workbox-strategies@7.4.1:
+    resolution:
+      {
+        integrity: sha512-GZxpaw9NbmOelj7667uZ2kpk5BFpOGbO4X0qjwh5ls8XQ8C+Lha5LQchTiUzsTFSS+NlUpftYAyOVXvQUrcqOQ==,
+      }
+
+  workbox-streams@7.4.1:
+    resolution:
+      {
+        integrity: sha512-HWWtraKUbJknd9kgqGcpQ3G114HOPYvqs8HaJMDs2ebLNAimDkVDaWfAXE6Ybl+m8U6KsCE6pWyLYuigWmnAXw==,
+      }
+
+  workbox-sw@7.4.1:
+    resolution:
+      {
+        integrity: sha512-fez5f2DUlDJWTFYkCWQpY10N8gtztd849NswCbVFk0QlcSM4HT5A8x4g4ii650yem4I8tHY0R7JZahwp3ltIPw==,
+      }
+
+  workbox-window@7.4.1:
+    resolution:
+      {
+        integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==,
       }
 
   wrap-ansi@7.0.0:
@@ -4142,6 +6194,12 @@ packages:
         optional: true
 
 snapshots:
+  "@apideck/better-ajv-errors@0.3.7(ajv@8.20.0)":
+    dependencies:
+      ajv: 8.20.0
+      jsonpointer: 5.0.1
+      leven: 3.1.0
+
   "@asamuzakjp/css-color@5.1.11":
     dependencies:
       "@asamuzakjp/generational-cache": 1.0.1
@@ -4168,7 +6226,15 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  "@babel/code-frame@7.29.7":
+    dependencies:
+      "@babel/helper-validator-identifier": 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   "@babel/compat-data@7.28.5": {}
+
+  "@babel/compat-data@7.29.7": {}
 
   "@babel/core@7.28.5":
     dependencies:
@@ -4198,6 +6264,18 @@ snapshots:
       "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
 
+  "@babel/generator@7.29.7":
+    dependencies:
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+      jsesc: 3.1.0
+
+  "@babel/helper-annotate-as-pure@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
   "@babel/helper-compilation-targets@7.27.2":
     dependencies:
       "@babel/compat-data": 7.28.5
@@ -4206,12 +6284,67 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  "@babel/helper-compilation-targets@7.29.7":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      browserslist: 4.28.0
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  "@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/helper-optimise-call-expression": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/traverse": 7.29.7
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-annotate-as-pure": 7.29.7
+      regexpu-core: 6.4.0
+      semver: 6.3.1
+
+  "@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/helper-globals@7.28.0": {}
+
+  "@babel/helper-globals@7.29.7": {}
+
+  "@babel/helper-member-expression-to-functions@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   "@babel/helper-module-imports@7.27.1":
     dependencies:
       "@babel/traverse": 7.28.5
       "@babel/types": 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-module-imports@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -4224,13 +6357,67 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/helper-module-transforms@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-optimise-call-expression@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
   "@babel/helper-plugin-utils@7.27.1": {}
+
+  "@babel/helper-plugin-utils@7.29.7": {}
+
+  "@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-wrap-function": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-replace-supers@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/helper-optimise-call-expression": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+    dependencies:
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   "@babel/helper-string-parser@7.27.1": {}
 
+  "@babel/helper-string-parser@7.29.7": {}
+
   "@babel/helper-validator-identifier@7.28.5": {}
 
+  "@babel/helper-validator-identifier@7.29.7": {}
+
   "@babel/helper-validator-option@7.27.1": {}
+
+  "@babel/helper-validator-option@7.29.7": {}
+
+  "@babel/helper-wrap-function@7.29.7":
+    dependencies:
+      "@babel/template": 7.29.7
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
 
   "@babel/helpers@7.28.4":
     dependencies:
@@ -4240,6 +6427,339 @@ snapshots:
   "@babel/parser@7.28.5":
     dependencies:
       "@babel/types": 7.28.5
+
+  "@babel/parser@7.29.7":
+    dependencies:
+      "@babel/types": 7.29.7
+
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+
+  "@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.28.5)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-classes@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-globals": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.28.5)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/template": 7.29.7
+
+  "@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-for-of@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-function-name@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-literals@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-new-target@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.28.5)
+      "@babel/traverse": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-object-super@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-parameters@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-annotate-as-pure": 7.29.7
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
 
   "@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.5)":
     dependencies:
@@ -4251,6 +6771,157 @@ snapshots:
       "@babel/core": 7.28.5
       "@babel/helper-plugin-utils": 7.27.1
 
+  "@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-spread@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.28.5)
+      "@babel/helper-plugin-utils": 7.29.7
+
+  "@babel/preset-env@7.29.7(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/core": 7.28.5
+      "@babel/helper-compilation-targets": 7.29.7
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/helper-validator-option": 7.29.7
+      "@babel/plugin-bugfix-firefox-class-in-computed-class-key": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-bugfix-safari-class-field-initializer-scope": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
+      "@babel/plugin-syntax-import-assertions": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-syntax-unicode-sets-regex": 7.18.6(@babel/core@7.28.5)
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-async-generator-functions": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-block-scoped-functions": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-class-properties": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-class-static-block": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-dotall-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-duplicate-keys": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-duplicate-named-capturing-groups-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-dynamic-import": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-explicit-resource-management": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-exponentiation-operator": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-export-namespace-from": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-for-of": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-json-strings": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-logical-assignment-operators": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-member-expression-literals": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-modules-amd": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-modules-systemjs": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-modules-umd": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-new-target": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-numeric-separator": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-object-rest-spread": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-object-super": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-optional-catch-binding": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-private-methods": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-private-property-in-object": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-property-literals": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-regenerator": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-regexp-modifiers": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-reserved-words": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-template-literals": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-typeof-symbol": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-unicode-escapes": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-unicode-property-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/plugin-transform-unicode-sets-regex": 7.29.7(@babel/core@7.28.5)
+      "@babel/preset-modules": 0.1.6-no-external-plugins(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.28.5)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.28.5)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.28.5)
+      core-js-compat: 3.49.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-plugin-utils": 7.29.7
+      "@babel/types": 7.28.5
+      esutils: 2.0.3
+
   "@babel/runtime@7.28.4": {}
 
   "@babel/template@7.27.2":
@@ -4258,6 +6929,12 @@ snapshots:
       "@babel/code-frame": 7.27.1
       "@babel/parser": 7.28.5
       "@babel/types": 7.28.5
+
+  "@babel/template@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
 
   "@babel/traverse@7.28.5":
     dependencies:
@@ -4271,10 +6948,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  "@babel/traverse@7.29.7":
+    dependencies:
+      "@babel/code-frame": 7.29.7
+      "@babel/generator": 7.29.7
+      "@babel/helper-globals": 7.29.7
+      "@babel/parser": 7.29.7
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   "@babel/types@7.28.5":
     dependencies:
       "@babel/helper-string-parser": 7.27.1
       "@babel/helper-validator-identifier": 7.28.5
+
+  "@babel/types@7.29.7":
+    dependencies:
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
 
   "@borewit/text-codec@0.2.1": {}
 
@@ -4411,6 +7105,8 @@ snapshots:
 
   "@ioredis/commands@1.4.0": {}
 
+  "@isaacs/cliui@9.0.0": {}
+
   "@jridgewell/gen-mapping@0.3.13":
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
@@ -4427,7 +7123,6 @@ snapshots:
     dependencies:
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
-    optional: true
 
   "@jridgewell/sourcemap-codec@1.5.5": {}
 
@@ -4553,6 +7248,50 @@ snapshots:
       "@prisma/debug": 5.22.0
 
   "@rolldown/pluginutils@1.0.0-beta.47": {}
+
+  "@rollup/plugin-babel@6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.53.3)":
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-module-imports": 7.27.1
+      "@rollup/pluginutils": 5.4.0(rollup@4.53.3)
+    optionalDependencies:
+      "@types/babel__core": 7.20.5
+      rollup: 4.53.3
+    transitivePeerDependencies:
+      - supports-color
+
+  "@rollup/plugin-node-resolve@16.0.3(rollup@4.53.3)":
+    dependencies:
+      "@rollup/pluginutils": 5.4.0(rollup@4.53.3)
+      "@types/resolve": 1.20.2
+      deepmerge: 4.3.1
+      is-module: 1.0.0
+      resolve: 1.22.12
+    optionalDependencies:
+      rollup: 4.53.3
+
+  "@rollup/plugin-replace@6.0.3(rollup@4.53.3)":
+    dependencies:
+      "@rollup/pluginutils": 5.4.0(rollup@4.53.3)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.53.3
+
+  "@rollup/plugin-terser@1.0.0(rollup@4.53.3)":
+    dependencies:
+      serialize-javascript: 7.0.5
+      smob: 1.6.2
+      terser: 5.44.1
+    optionalDependencies:
+      rollup: 4.53.3
+
+  "@rollup/pluginutils@5.4.0(rollup@4.53.3)":
+    dependencies:
+      "@types/estree": 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.53.3
 
   "@rollup/rollup-android-arm-eabi@4.53.3":
     optional: true
@@ -4733,6 +7472,13 @@ snapshots:
 
   "@tokenizer/token@0.3.0": {}
 
+  "@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1":
+    dependencies:
+      ejs: 3.1.10
+      json5: 2.2.3
+      magic-string: 0.30.21
+      string.prototype.matchall: 4.0.12
+
   "@trivago/prettier-plugin-sort-imports@6.0.0(prettier@3.7.4)":
     dependencies:
       "@babel/generator": 7.28.5
@@ -4827,6 +7573,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  "@types/resolve@1.20.2": {}
+
   "@types/send@0.17.6":
     dependencies:
       "@types/mime": 1.3.5
@@ -4841,6 +7589,8 @@ snapshots:
       "@types/http-errors": 2.0.5
       "@types/node": 24.10.1
       "@types/send": 0.17.6
+
+  "@types/trusted-types@2.0.7": {}
 
   "@vitejs/plugin-react@5.1.1(vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))":
     dependencies:
@@ -4901,8 +7651,14 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
-  acorn@8.15.0:
-    optional: true
+  acorn@8.15.0: {}
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@7.2.0:
     dependencies:
@@ -4929,11 +7685,64 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
   array-union@2.1.0: {}
+
+  arraybuffer.prototype.slice@1.0.4:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      is-array-buffer: 3.0.5
 
   assertion-error@2.0.1: {}
 
+  async-function@1.0.0: {}
+
+  async@3.2.6: {}
+
+  at-least-node@1.0.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
+
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.28.5):
+    dependencies:
+      "@babel/compat-data": 7.29.7
+      "@babel/core": 7.28.5
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.28.5)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.28.5):
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.28.5)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.28.5):
+    dependencies:
+      "@babel/core": 7.28.5
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.28.5)
+    transitivePeerDependencies:
+      - supports-color
+
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.35: {}
 
   baseline-browser-mapping@2.8.30: {}
 
@@ -4961,6 +7770,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -4973,8 +7786,15 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
-  buffer-from@1.1.2:
-    optional: true
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.35
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.371
+      node-releases: 2.0.47
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-from@1.1.2: {}
 
   bullmq@5.65.1:
     dependencies:
@@ -4997,12 +7817,21 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
   caniuse-lite@1.0.30001756: {}
+
+  caniuse-lite@1.0.30001797: {}
 
   chai@5.3.3:
     dependencies:
@@ -5060,10 +7889,11 @@ snapshots:
 
   commander@14.0.2: {}
 
-  commander@2.20.3:
-    optional: true
+  commander@2.20.3: {}
 
   commander@9.5.0: {}
+
+  common-tags@1.8.2: {}
 
   concurrently@9.2.1:
     dependencies:
@@ -5086,6 +7916,10 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-js-compat@3.49.0:
+    dependencies:
+      browserslist: 4.28.2
+
   cors@2.8.5:
     dependencies:
       object-assign: 4.1.1
@@ -5094,6 +7928,14 @@ snapshots:
   cron-parser@4.9.0:
     dependencies:
       luxon: 3.7.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  crypto-random-string@2.0.0: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -5109,6 +7951,24 @@ snapshots:
     transitivePeerDependencies:
       - "@noble/hashes"
 
+  data-view-buffer@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
+  data-view-byte-offset@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-data-view: 1.0.2
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -5116,6 +7976,20 @@ snapshots:
   decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
+
+  deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   denque@2.1.0: {}
 
@@ -5141,7 +8015,13 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
   electron-to-chromium@1.5.258: {}
+
+  electron-to-chromium@1.5.371: {}
 
   emoji-regex@10.6.0: {}
 
@@ -5158,6 +8038,63 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-abstract@1.24.2:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      arraybuffer.prototype.slice: 1.0.4
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      data-view-buffer: 1.0.2
+      data-view-byte-length: 1.0.2
+      data-view-byte-offset: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      es-set-tostringtag: 2.1.0
+      es-to-primitive: 1.3.0
+      function.prototype.name: 1.1.8
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      get-symbol-description: 1.1.0
+      globalthis: 1.0.4
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+      has-proto: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      internal-slot: 1.1.0
+      is-array-buffer: 3.0.5
+      is-callable: 1.2.7
+      is-data-view: 1.0.2
+      is-negative-zero: 2.0.3
+      is-regex: 1.2.1
+      is-set: 2.0.3
+      is-shared-array-buffer: 1.0.4
+      is-string: 1.1.1
+      is-typed-array: 1.1.15
+      is-weakref: 1.1.1
+      math-intrinsics: 1.1.0
+      object-inspect: 1.13.4
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      own-keys: 1.0.1
+      regexp.prototype.flags: 1.5.4
+      safe-array-concat: 1.1.4
+      safe-push-apply: 1.0.0
+      safe-regex-test: 1.1.0
+      set-proto: 1.0.0
+      stop-iteration-iterator: 1.1.0
+      string.prototype.trim: 1.2.11
+      string.prototype.trimend: 1.0.10
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.3
+      typed-array-byte-length: 1.0.3
+      typed-array-byte-offset: 1.0.4
+      typed-array-length: 1.0.8
+      unbox-primitive: 1.1.0
+      which-typed-array: 1.1.22
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -5167,6 +8104,23 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  es-to-primitive@1.3.0:
+    dependencies:
+      is-callable: 1.2.7
+      is-date-object: 1.1.0
+      is-symbol: 1.1.1
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5201,9 +8155,15 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       "@types/estree": 1.0.8
+
+  esutils@2.0.3: {}
+
+  eta@4.6.0: {}
 
   etag@1.8.1: {}
 
@@ -5244,6 +8204,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       "@nodelib/fs.stat": 2.0.5
@@ -5251,6 +8213,10 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -5269,6 +8235,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -5284,9 +8254,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fsevents@2.3.2:
     optional: true
@@ -5295,6 +8281,19 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  function.prototype.name@1.1.8:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      functions-have-names: 1.2.3
+      hasown: 2.0.2
+      is-callable: 1.2.7
+
+  functions-have-names@1.2.3: {}
+
+  generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -5315,10 +8314,18 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-own-enumerable-property-symbols@3.0.2: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-symbol-description@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
 
   get-tsconfig@4.13.0:
     dependencies:
@@ -5327,6 +8334,20 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@11.1.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 4.2.3
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 2.0.2
+
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.2.0
 
   globby@11.1.0:
     dependencies:
@@ -5341,11 +8362,29 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  has-bigints@1.1.0: {}
+
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-proto@1.2.0:
+    dependencies:
+      dunder-proto: 1.0.1
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -5389,11 +8428,19 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb@7.1.1: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
   inherits@2.0.4: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
 
   ioredis@5.8.2:
     dependencies:
@@ -5411,11 +8458,55 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-async-function@2.1.1:
+    dependencies:
+      async-function: 1.0.0
+      call-bound: 1.0.4
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
 
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-data-view@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      is-typed-array: 1.1.15
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-extglob@2.1.1: {}
+
+  is-finalizationregistry@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -5423,15 +8514,93 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.4.0
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-map@2.0.3: {}
+
+  is-module@1.0.0: {}
+
+  is-negative-zero@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
+
+  is-obj@1.0.1: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-regexp@1.0.0: {}
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-stream@2.0.1: {}
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
+
+  is-weakmap@2.0.2: {}
+
+  is-weakref@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@4.2.3:
+    dependencies:
+      "@isaacs/cliui": 9.0.0
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
 
   javascript-natural-sort@0.7.1: {}
 
@@ -5469,7 +8638,19 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json5@2.2.3: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonpointer@5.0.1: {}
+
+  leven@3.1.0: {}
 
   lightningcss-android-arm64@1.30.2:
     optional: true
@@ -5541,9 +8722,13 @@ snapshots:
 
   lodash-es@4.17.21: {}
 
+  lodash.debounce@4.0.8: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.isarguments@3.1.0: {}
+
+  lodash.sortby@4.7.0: {}
 
   log-update@6.1.0:
     dependencies:
@@ -5592,9 +8777,19 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -5652,11 +8847,24 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-releases@2.0.47: {}
+
   normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
 
   on-finished@2.4.1:
     dependencies:
@@ -5669,6 +8877,12 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  own-keys@1.0.1:
+    dependencies:
+      get-intrinsic: 1.3.0
+      object-keys: 1.1.1
+      safe-push-apply: 1.0.0
 
   oxlint@1.66.0:
     optionalDependencies:
@@ -5692,6 +8906,8 @@ snapshots:
       "@oxlint/binding-win32-ia32-msvc": 1.66.0
       "@oxlint/binding-win32-x64-msvc": 1.66.0
 
+  package-json-from-dist@1.0.1: {}
+
   parse-imports-exports@0.2.4:
     dependencies:
       parse-statements: 1.0.11
@@ -5703,6 +8919,15 @@ snapshots:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
 
   path-to-regexp@8.3.0: {}
 
@@ -5732,6 +8957,8 @@ snapshots:
     dependencies:
       queue-lit: 1.5.2
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -5745,6 +8972,10 @@ snapshots:
       "@trivago/prettier-plugin-sort-imports": 6.0.0(prettier@3.7.4)
 
   prettier@3.7.4: {}
+
+  pretty-bytes@5.6.0: {}
+
+  pretty-bytes@6.1.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -5833,11 +9064,59 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  reflect.getprototypeof@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      get-proto: 1.0.1
+      which-builtin-type: 1.2.1
+
+  regenerate-unicode-properties@10.2.2:
+    dependencies:
+      regenerate: 1.4.2
+
+  regenerate@1.4.2: {}
+
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
+  regexpu-core@6.4.0:
+    dependencies:
+      regenerate: 1.4.2
+      regenerate-unicode-properties: 10.2.2
+      regjsgen: 0.8.0
+      regjsparser: 0.13.1
+      unicode-match-property-ecmascript: 2.0.0
+      unicode-match-property-value-ecmascript: 2.2.1
+
+  regjsgen@0.8.0: {}
+
+  regjsparser@0.13.1:
+    dependencies:
+      jsesc: 3.1.0
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@5.1.0:
     dependencies:
@@ -5894,6 +9173,25 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  safe-array-concat@1.1.4:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      isarray: 2.0.5
+
+  safe-push-apply@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      isarray: 2.0.5
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -5922,6 +9220,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  serialize-javascript@7.0.5: {}
+
   serve-static@2.2.0:
     dependencies:
       encodeurl: 2.0.0
@@ -5933,7 +9233,35 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
+  set-proto@1.0.0:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+
   setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
 
@@ -5976,16 +9304,20 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smob@1.6.2: {}
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    optional: true
 
-  source-map@0.6.1:
-    optional: true
+  source-map@0.6.1: {}
+
+  source-map@0.8.0-beta.0:
+    dependencies:
+      whatwg-url: 7.1.0
 
   stackback@0.0.2: {}
 
@@ -5994,6 +9326,11 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
 
   string-argv@0.3.2: {}
 
@@ -6014,6 +9351,52 @@ snapshots:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
 
+  string.prototype.matchall@4.0.12:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      internal-slot: 1.1.0
+      regexp.prototype.flags: 1.5.4
+      set-function-name: 2.0.2
+      side-channel: 1.1.0
+
+  string.prototype.trim@1.2.11:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-data-property: 1.1.4
+      define-properties: 1.2.1
+      es-abstract: 1.24.2
+      es-object-atoms: 1.1.2
+      has-property-descriptors: 1.0.2
+      safe-regex-test: 1.1.0
+
+  string.prototype.trimend@1.0.10:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+
+  string.prototype.trimstart@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+
+  stringify-object@3.3.0:
+    dependencies:
+      get-own-enumerable-property-symbols: 3.0.2
+      is-obj: 1.0.1
+      is-regexp: 1.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -6021,6 +9404,8 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-comments@2.0.1: {}
 
   strip-literal@3.1.0:
     dependencies:
@@ -6038,6 +9423,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-preserve-symlinks-flag@1.0.0: {}
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.4.0: {}
@@ -6046,13 +9433,21 @@ snapshots:
 
   tapable@2.3.0: {}
 
+  temp-dir@2.0.0: {}
+
+  tempy@0.6.0:
+    dependencies:
+      is-stream: 2.0.1
+      temp-dir: 2.0.0
+      type-fest: 0.16.0
+      unique-string: 2.0.0
+
   terser@5.44.1:
     dependencies:
       "@jridgewell/source-map": 0.3.11
       acorn: 8.15.0
       commander: 2.20.3
       source-map-support: 0.5.21
-    optional: true
 
   tinybench@2.9.0: {}
 
@@ -6091,6 +9486,10 @@ snapshots:
     dependencies:
       tldts: 7.0.30
 
+  tr46@1.0.1:
+    dependencies:
+      punycode: 2.3.1
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -6116,25 +9515,92 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-fest@0.16.0: {}
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typed-array-buffer@1.0.3:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-length@1.0.3:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+
+  typed-array-byte-offset@1.0.4:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      has-proto: 1.2.0
+      is-typed-array: 1.1.15
+      reflect.getprototypeof: 1.0.10
+
+  typed-array-length@1.0.8:
+    dependencies:
+      call-bind: 1.0.9
+      for-each: 0.3.5
+      gopd: 1.2.0
+      is-typed-array: 1.1.15
+      possible-typed-array-names: 1.1.0
+      reflect.getprototypeof: 1.0.10
+
   typescript@5.9.3: {}
 
   uint8array-extras@1.5.0: {}
+
+  unbox-primitive@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-bigints: 1.1.0
+      has-symbols: 1.1.0
+      which-boxed-primitive: 1.1.1
 
   undici-types@7.16.0: {}
 
   undici@7.25.0: {}
 
+  unicode-canonical-property-names-ecmascript@2.0.1: {}
+
+  unicode-match-property-ecmascript@2.0.0:
+    dependencies:
+      unicode-canonical-property-names-ecmascript: 2.0.1
+      unicode-property-aliases-ecmascript: 2.2.0
+
+  unicode-match-property-value-ecmascript@2.2.1: {}
+
+  unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unique-string@2.0.0:
+    dependencies:
+      crypto-random-string: 2.0.0
+
+  universalify@2.0.1: {}
+
   unpipe@1.0.0: {}
+
+  upath@1.2.0: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
     dependencies:
       browserslist: 4.28.0
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -6168,6 +9634,17 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vite-plugin-pwa@1.3.0(vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1):
+    dependencies:
+      debug: 4.4.3
+      pretty-bytes: 6.1.1
+      tinyglobby: 0.2.15
+      vite: 7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
+      workbox-build: 7.4.1(@types/babel__core@7.20.5)
+      workbox-window: 7.4.1
+    transitivePeerDependencies:
+      - supports-color
 
   vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1):
     dependencies:
@@ -6234,6 +9711,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@4.0.2: {}
+
   webidl-conversions@8.0.1: {}
 
   whatwg-mimetype@5.0.0: {}
@@ -6246,12 +9725,176 @@ snapshots:
     transitivePeerDependencies:
       - "@noble/hashes"
 
+  whatwg-url@7.1.0:
+    dependencies:
+      lodash.sortby: 4.7.0
+      tr46: 1.0.1
+      webidl-conversions: 4.0.2
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-builtin-type@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      function.prototype.name: 1.1.8
+      has-tostringtag: 1.0.2
+      is-async-function: 2.1.1
+      is-date-object: 1.1.0
+      is-finalizationregistry: 1.1.1
+      is-generator-function: 1.1.2
+      is-regex: 1.2.1
+      is-weakref: 1.1.1
+      isarray: 2.0.5
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.22
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
   win-guid@0.2.1: {}
+
+  workbox-background-sync@7.4.1:
+    dependencies:
+      idb: 7.1.1
+      workbox-core: 7.4.1
+
+  workbox-broadcast-update@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-build@7.4.1(@types/babel__core@7.20.5):
+    dependencies:
+      "@apideck/better-ajv-errors": 0.3.7(ajv@8.20.0)
+      "@babel/core": 7.28.5
+      "@babel/preset-env": 7.29.7(@babel/core@7.28.5)
+      "@babel/runtime": 7.28.4
+      "@rollup/plugin-babel": 6.1.0(@babel/core@7.28.5)(@types/babel__core@7.20.5)(rollup@4.53.3)
+      "@rollup/plugin-node-resolve": 16.0.3(rollup@4.53.3)
+      "@rollup/plugin-replace": 6.0.3(rollup@4.53.3)
+      "@rollup/plugin-terser": 1.0.0(rollup@4.53.3)
+      "@trickfilm400/rollup-plugin-off-main-thread": 3.0.0-pre1
+      ajv: 8.20.0
+      common-tags: 1.8.2
+      eta: 4.6.0
+      fast-json-stable-stringify: 2.1.0
+      fs-extra: 9.1.0
+      glob: 11.1.0
+      pretty-bytes: 5.6.0
+      rollup: 4.53.3
+      source-map: 0.8.0-beta.0
+      stringify-object: 3.3.0
+      strip-comments: 2.0.1
+      tempy: 0.6.0
+      upath: 1.2.0
+      workbox-background-sync: 7.4.1
+      workbox-broadcast-update: 7.4.1
+      workbox-cacheable-response: 7.4.1
+      workbox-core: 7.4.1
+      workbox-expiration: 7.4.1
+      workbox-google-analytics: 7.4.1
+      workbox-navigation-preload: 7.4.1
+      workbox-precaching: 7.4.1
+      workbox-range-requests: 7.4.1
+      workbox-recipes: 7.4.1
+      workbox-routing: 7.4.1
+      workbox-strategies: 7.4.1
+      workbox-streams: 7.4.1
+      workbox-sw: 7.4.1
+      workbox-window: 7.4.1
+    transitivePeerDependencies:
+      - "@types/babel__core"
+      - supports-color
+
+  workbox-cacheable-response@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-core@7.4.1: {}
+
+  workbox-expiration@7.4.1:
+    dependencies:
+      idb: 7.1.1
+      workbox-core: 7.4.1
+
+  workbox-google-analytics@7.4.1:
+    dependencies:
+      workbox-background-sync: 7.4.1
+      workbox-core: 7.4.1
+      workbox-routing: 7.4.1
+      workbox-strategies: 7.4.1
+
+  workbox-navigation-preload@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-precaching@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+      workbox-routing: 7.4.1
+      workbox-strategies: 7.4.1
+
+  workbox-range-requests@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-recipes@7.4.1:
+    dependencies:
+      workbox-cacheable-response: 7.4.1
+      workbox-core: 7.4.1
+      workbox-expiration: 7.4.1
+      workbox-precaching: 7.4.1
+      workbox-routing: 7.4.1
+      workbox-strategies: 7.4.1
+
+  workbox-routing@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-strategies@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+
+  workbox-streams@7.4.1:
+    dependencies:
+      workbox-core: 7.4.1
+      workbox-routing: 7.4.1
+
+  workbox-sw@7.4.1: {}
+
+  workbox-window@7.4.1:
+    dependencies:
+      "@types/trusted-types": 2.0.7
+      workbox-core: 7.4.1
 
   wrap-ansi@7.0.0:
     dependencies:


### PR DESCRIPTION
## What

- **PWA**: add `vite-plugin-pwa` (Workbox service worker, `autoUpdate`) with a plugin-owned manifest and iOS Safari meta tags. The app is now installable to the home screen and launches standalone.
- **iOS zoom fix**: force `16px` font-size on form controls on touch devices so Safari stops auto-zooming when focusing inputs styled with `text-sm`/`text-xs`.

## Why

Allow adding SpotiArr to the iPhone home screen and treat it as a native-like app, and remove the jarring full-page zoom when tapping inputs on mobile.

## How it works / key decisions

- **API + SSE are never touched by the SW.** `/api` and `/api/events` (EventSource) are excluded via `navigateFallbackDenylist: [/^\/api/]` plus a `NetworkOnly` runtime handler. Without this the SW would swallow the SPA fallback and serve stale API responses, breaking real-time download status.
- Plugin owns the manifest; the manual `site.webmanifest` link was removed to avoid a duplicate.
- `devOptions.enabled: false` — SW is off in dev to avoid caching during development.
- Input zoom fix is scoped to `@media (pointer: coarse)` and uses `!important` to beat Tailwind utilities. Desktop styling and pinch-zoom are untouched.

## Verification

- `pnpm --filter frontend build` → emits `sw.js` + `manifest.webmanifest`, 62 assets precached (~943 KiB). `/api` denylist confirmed in built `sw.js`.
- `pnpm --filter frontend lint` → clean.
- `pnpm --filter frontend test:run` → 474 passed, 0 regressions.