### PR TITLE
fix(frontend): only lock instance on the unauthorized 401

### DIFF
--- a/apps/frontend/src/services/httpClient.test.ts
+++ b/apps/frontend/src/services/httpClient.test.ts
@@ -26,7 +26,7 @@ describe("setUnauthorizedHandler / clearUnauthorizedHandler", () => {
   it("registers a handler that is called on 401 non-auth endpoint", async () => {
     const handler = vi.fn();
     setUnauthorizedHandler(handler);
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401, { error: "unauthorized" })));
 
     await expect(httpClient.get("/playlists")).rejects.toBeInstanceOf(ApiError);
     expect(handler).toHaveBeenCalledTimes(1);
@@ -36,7 +36,7 @@ describe("setUnauthorizedHandler / clearUnauthorizedHandler", () => {
     const handler = vi.fn();
     setUnauthorizedHandler(handler);
     clearUnauthorizedHandler();
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401, { error: "unauthorized" })));
 
     await expect(httpClient.get("/playlists")).rejects.toBeInstanceOf(ApiError);
     expect(handler).not.toHaveBeenCalled();
@@ -51,12 +51,36 @@ describe("401 handling", () => {
   it("fires the handler and throws ApiError(401) for non-auth endpoint", async () => {
     const handler = vi.fn();
     setUnauthorizedHandler(handler);
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401, { error: "unauthorized" })));
 
     await expect(httpClient.get("/playlists")).rejects.toMatchObject({
       status: 401,
     });
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire handler on 401 with a non-instance error code", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeResponse(401, { error: "missing_user_access_token" })),
+    );
+
+    await expect(httpClient.get("/artists/followed")).rejects.toMatchObject({
+      status: 401,
+      code: "missing_user_access_token",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire handler on 401 with no error body", async () => {
+    const handler = vi.fn();
+    setUnauthorizedHandler(handler);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+
+    await expect(httpClient.get("/playlists")).rejects.toBeInstanceOf(ApiError);
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it("does NOT fire handler on 401 for /auth/session", async () => {
@@ -80,7 +104,7 @@ describe("401 handling", () => {
   it("fires onUnauthorized for /auth/sessionXYZ (not a real auth endpoint)", async () => {
     const handler = vi.fn();
     setUnauthorizedHandler(handler);
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401)));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeResponse(401, { error: "unauthorized" })));
 
     await expect(httpClient.get("/auth/sessionXYZ")).rejects.toBeInstanceOf(ApiError);
     expect(handler).toHaveBeenCalledTimes(1);

--- a/apps/frontend/src/services/httpClient.ts
+++ b/apps/frontend/src/services/httpClient.ts
@@ -29,26 +29,30 @@ class HttpClient {
       return undefined as unknown as T;
     }
 
+    const text = await response.text();
+    const data = text ? (JSON.parse(text) as unknown) : undefined;
+
+    let errorCode: ApiErrorCode | undefined;
+    let message: string | undefined;
+
+    if (typeof data === "object" && data !== null && "error" in data) {
+      const shape = data as ApiErrorShape;
+      errorCode = shape.error;
+      message = shape.message;
+    }
+
+    // Only the instance-token 401 ("unauthorized") triggers the lock screen.
+    // Other 401s (e.g. "missing_user_access_token" from Spotify) are unrelated
+    // to instance auth and must not force the gate when no token is configured.
     if (
       response.status === 401 &&
+      errorCode === "unauthorized" &&
       !AUTH_ENDPOINTS.some((e) => endpoint === e || endpoint.startsWith(e + "/"))
     ) {
       _onUnauthorized?.();
     }
 
-    const text = await response.text();
-    const data = text ? (JSON.parse(text) as unknown) : undefined;
-
     if (!response.ok) {
-      let errorCode: ApiErrorCode | undefined;
-      let message: string | undefined;
-
-      if (typeof data === "object" && data !== null && "error" in data) {
-        const shape = data as ApiErrorShape;
-        errorCode = shape.error;
-        message = shape.message;
-      }
-
       throw new ApiError(
         message ?? errorCode ?? `API Error: ${response.statusText}`,
         errorCode,

--- a/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
@@ -58,7 +58,11 @@ test.describe("SESSION EXPIRED re-lock", () => {
         });
       } else {
         await sessionSentGate;
-        await route.fulfill({ status: 401, contentType: "application/json", body: "{}" });
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "unauthorized" }),
+        });
       }
     });
 


### PR DESCRIPTION
## Problem

When `SPOTIARR_TOKEN` is **not set** (instance unprotected), users could still be kicked to the "Instancia protegida" gate. Reproduced when not logged into Spotify: a background call (e.g. followed artists / feed sync) returns `401 missing_user_access_token`, and the app shows the instance lock screen / "session expired".

## Root cause

`httpClient.handleResponse` fired the global `_onUnauthorized()` handler on **any** 401 (except auth endpoints) **before** parsing the error code. It conflated two unrelated 401s:

- `unauthorized` → instance token missing/expired → correct to show the gate
- `missing_user_access_token` (and other Spotify 401s) → unrelated to instance auth → must NOT touch the gate

The backend already treats the env var as the single source of truth (`require-token` middleware: no token → `next()`, never emits `unauthorized`; `/auth/session` returns `200 { tokenRequired: false }` when unset).

## Fix

Parse the error code first and trigger the lock screen only when `errorCode === "unauthorized"`. Because the backend never emits `unauthorized` without a configured token, this also guarantees the gate can never appear when `SPOTIARR_TOKEN` is unset.

## Verification

- New unit tests: `missing_user_access_token` 401 does NOT fire the handler (still throws `ApiError`); 401 with no body does NOT fire the handler; `unauthorized` 401 still fires it.
- `pnpm --filter frontend test:run` → 476 passed.
- `pnpm --filter frontend lint` → clean.