### PR TITLE
chore(security): tighten wide-open CORS on the API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,9 @@ DOWNLOADS_DIR=/path/to/your/downloads/folder
 # so that the secure cookie and rate-limiting IP detection work correctly.
 # Set to 1 for a single proxy in front of SpotiArr.
 # SPOTIARR_TRUST_PROXY=1
+
+# CORS allowlist (Optional, default: unset = CORS disabled / same-origin only).
+# The SPA and API are served by the same process, so CORS is normally not needed.
+# Only set this if a separate-origin client must call the API. Comma-separated
+# explicit origins; wildcard "*" is rejected. Never combined with wildcard.
+# SPOTIARR_CORS_ORIGIN=https://app.example.com,https://admin.example.com

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ pnpm --filter frontend run test:e2e
 | `SPOTIARR_SESSION_TTL_HOURS` | `168`   | Session lifetime in hours (default: 7 days). Cookie expires after this period.                                                                |
 | `SPOTIARR_UNLOCK_RATELIMIT`  | `5`     | Max unlock attempts per minute per IP before returning 429.                                                                                   |
 | `SPOTIARR_TRUST_PROXY`       | -       | Number of proxy hops (e.g. `1`), or `true`/`false`/preset. **Required** behind any reverse proxy for correct IP resolution and Secure cookie. |
+| `SPOTIARR_CORS_ORIGIN`       | -       | Comma-separated CORS origin allowlist. Unset = no CORS (the SPA and API are same-origin, so none is needed). Wildcard `*` is rejected.        |
 
 ### Exposing SpotiArr to the internet
 

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -51,6 +51,7 @@ src/
 - Environment access through `getEnv()` from `infrastructure/setup/environment.ts` — never `process.env` directly.
 - Instance token auth: `createRequireTokenMiddleware` is mounted at `ApiRoutes.BASE` before the API router. Public routes must be added to the allowlist in `presentation/middleware/require-token.ts` (currently POST /auth/unlock, GET /health, GET /auth/spotify/callback). GET /auth/session is intentionally NOT allowlisted.
 - `app.set("trust proxy", ...)` is driven by `SPOTIARR_TRUST_PROXY`; it MUST be set behind a reverse proxy or `req.secure` (cookie Secure flag) and `req.ip` (rate-limit bucket) break.
+- CORS is opt-in via `SPOTIARR_CORS_ORIGIN` (explicit origin allowlist, wildcard rejected). `cors()` is registered only when it is set; same-origin deployments get none. The SSE controller mirrors the policy through an injected allowlist getter — do NOT import `getEnv` into presentation; wire it from `container.ts`.
 
 ## Validation
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -5,6 +5,7 @@ import helmet from "helmet";
 import path from "path";
 import type { Container } from "./container";
 import { getEnv } from "./infrastructure/setup/environment";
+import { buildCorsOptions } from "./presentation/middleware/cors";
 import { errorHandler } from "./presentation/middleware/error-handler";
 import { createRequireTokenMiddleware } from "./presentation/middleware/require-token";
 import { createRoutes } from "./presentation/routes";
@@ -31,7 +32,12 @@ export function createApp(container: Container): Express {
       originAgentCluster: false,
     }),
   );
-  app.use(cors());
+  // CORS is opt-in: same-origin deployments need none. When an explicit
+  // allowlist is configured, restrict to it with credentials — never wildcard.
+  const corsOptions = buildCorsOptions(getEnv().SPOTIARR_CORS_ORIGIN);
+  if (corsOptions) {
+    app.use(cors(corsOptions));
+  }
 
   // Body parsing
   app.use(express.json());

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -206,7 +206,7 @@ export function createContainer(env: Env) {
 
   const queueService = new BullMqTrackQueueService();
   const artworkBackfillQueueService = new BullMqArtworkBackfillQueueService();
-  const eventsController = new EventsController();
+  const eventsController = new EventsController(() => env.SPOTIARR_CORS_ORIGIN);
   const eventBus = new AppEventBus(eventsController.emit);
 
   let spotifyUserLibraryService: ComposedSpotifyUserLibrary | null = null;

--- a/apps/backend/src/infrastructure/setup/environment.test.ts
+++ b/apps/backend/src/infrastructure/setup/environment.test.ts
@@ -6,6 +6,7 @@ type AnyDef = { _def: { in: { _def: { shape: Record<string, z.ZodTypeAny> } } } 
 const innerShape = (envSchema as unknown as AnyDef)._def.in._def.shape;
 
 const tokenSchema = innerShape.SPOTIARR_TOKEN;
+const corsOriginSchema = innerShape.SPOTIARR_CORS_ORIGIN;
 const trustProxySchema = innerShape.SPOTIARR_TRUST_PROXY;
 const sessionTtlSchema = innerShape.SPOTIARR_SESSION_TTL_HOURS;
 const unlockRatelimitSchema = innerShape.SPOTIARR_UNLOCK_RATELIMIT;
@@ -42,6 +43,46 @@ describe("SPOTIARR_TOKEN schema", () => {
 
   it("rejects an empty string", () => {
     expect(tokenSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("SPOTIARR_CORS_ORIGIN schema", () => {
+  it("accepts undefined and returns undefined (no CORS)", () => {
+    const result = corsOriginSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("returns undefined for an empty string", () => {
+    const result = corsOriginSchema.safeParse("");
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("returns undefined for a whitespace-only string", () => {
+    const result = corsOriginSchema.safeParse("   ");
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+  });
+
+  it("parses a single origin into an array", () => {
+    const result = corsOriginSchema.safeParse("https://app.example.com");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(["https://app.example.com"]);
+  });
+
+  it("parses a comma-separated list and trims each entry", () => {
+    const result = corsOriginSchema.safeParse("https://a.com, https://b.com ,https://c.com");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(["https://a.com", "https://b.com", "https://c.com"]);
+  });
+
+  it("rejects a wildcard origin", () => {
+    expect(corsOriginSchema.safeParse("*").success).toBe(false);
+  });
+
+  it("rejects a list containing a wildcard", () => {
+    expect(corsOriginSchema.safeParse("https://a.com,*").success).toBe(false);
   });
 });
 

--- a/apps/backend/src/infrastructure/setup/environment.ts
+++ b/apps/backend/src/infrastructure/setup/environment.ts
@@ -142,6 +142,26 @@ export const envSchema = z
       .transform((t) => t?.trim() || undefined),
     SPOTIARR_SESSION_TTL_HOURS: z.coerce.number().int().min(1).max(8760).default(168),
     SPOTIARR_UNLOCK_RATELIMIT: z.coerce.number().int().min(1).max(100).default(5),
+    SPOTIARR_CORS_ORIGIN: z
+      .string()
+      .optional()
+      .transform((val, ctx) => {
+        if (val === undefined) return undefined;
+        const origins = val
+          .split(",")
+          .map((o) => o.trim())
+          .filter(Boolean);
+        if (origins.length === 0) return undefined;
+        if (origins.includes("*")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              'SPOTIARR_CORS_ORIGIN must be an explicit origin allowlist; wildcard "*" is not allowed.',
+          });
+          return z.NEVER;
+        }
+        return origins;
+      }),
     SPOTIARR_TRUST_PROXY: z
       .string()
       .optional()

--- a/apps/backend/src/presentation/controllers/events.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/events.controller.test.ts
@@ -1,0 +1,87 @@
+import type { Request, Response } from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventsController } from "./events.controller";
+
+interface FakeResponse {
+  headers: Record<string, string>;
+  res: Response;
+}
+
+function createFakeResponse(): FakeResponse {
+  const headers: Record<string, string> = {};
+  const res = {
+    setHeader: vi.fn((name: string, value: string) => {
+      headers[name] = value;
+    }),
+    write: vi.fn(),
+  } as unknown as Response;
+  return { headers, res };
+}
+
+function createFakeRequest(origin?: string): Request {
+  return {
+    headers: origin ? { origin } : {},
+    on: vi.fn(),
+  } as unknown as Request;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EventsController SSE CORS", () => {
+  it("sets no CORS headers when no allowlist is configured", () => {
+    const { headers, res } = createFakeResponse();
+
+    new EventsController(() => undefined).connect(
+      createFakeRequest("https://app.example.com"),
+      res,
+    );
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(headers["Access-Control-Allow-Credentials"]).toBeUndefined();
+    expect(headers["Vary"]).toBeUndefined();
+    expect(headers["Content-Type"]).toBe("text/event-stream");
+  });
+
+  it("echoes the origin when it is on the allowlist", () => {
+    const { headers, res } = createFakeResponse();
+
+    new EventsController(() => ["https://app.example.com"]).connect(
+      createFakeRequest("https://app.example.com"),
+      res,
+    );
+
+    expect(headers["Access-Control-Allow-Origin"]).toBe("https://app.example.com");
+    expect(headers["Access-Control-Allow-Credentials"]).toBe("true");
+    expect(headers["Vary"]).toBe("Origin");
+  });
+
+  it("sets no CORS origin header for an origin not on the allowlist", () => {
+    const { headers, res } = createFakeResponse();
+
+    new EventsController(() => ["https://app.example.com"]).connect(
+      createFakeRequest("https://evil.example.com"),
+      res,
+    );
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+    expect(headers["Access-Control-Allow-Credentials"]).toBeUndefined();
+  });
+
+  it("sets no CORS origin header when the request has no Origin", () => {
+    const { headers, res } = createFakeResponse();
+
+    new EventsController(() => ["https://app.example.com"]).connect(createFakeRequest(), res);
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+
+  it("defaults to no allowlist when no getter is provided", () => {
+    const { headers, res } = createFakeResponse();
+
+    new EventsController().connect(createFakeRequest("https://app.example.com"), res);
+
+    expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+});

--- a/apps/backend/src/presentation/controllers/events.controller.ts
+++ b/apps/backend/src/presentation/controllers/events.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { resolveAllowedOrigin } from "../middleware/cors";
 
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -13,13 +14,21 @@ export class EventsController {
   private clients: SseClient[] = [];
   private clientId = 0;
 
+  constructor(private readonly getCorsAllowlist: () => string[] | undefined = () => undefined) {}
+
   connect = (req: Request, res: Response) => {
     res.setHeader("Content-Type", "text/event-stream");
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Connection", "keep-alive");
 
-    // Allow CORS for dev if needed
-    res.setHeader("Access-Control-Allow-Origin", "*");
+    // Align SSE with the global CORS policy: echo the origin only when it is
+    // on the explicit allowlist. Same-origin deployments send no CORS header.
+    const allowedOrigin = resolveAllowedOrigin(req.headers.origin, this.getCorsAllowlist());
+    if (allowedOrigin) {
+      res.setHeader("Access-Control-Allow-Origin", allowedOrigin);
+      res.setHeader("Access-Control-Allow-Credentials", "true");
+      res.setHeader("Vary", "Origin");
+    }
 
     // Initial comment to keep connection open
     res.write(": connected\n\n");

--- a/apps/backend/src/presentation/middleware/cors.test.ts
+++ b/apps/backend/src/presentation/middleware/cors.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildCorsOptions, resolveAllowedOrigin } from "./cors";
+
+describe("buildCorsOptions", () => {
+  it("returns null when allowlist is undefined", () => {
+    expect(buildCorsOptions(undefined)).toBeNull();
+  });
+
+  it("returns null when allowlist is empty", () => {
+    expect(buildCorsOptions([])).toBeNull();
+  });
+
+  it("returns options with the allowlist and credentials when origins are present", () => {
+    const options = buildCorsOptions(["https://app.example.com"]);
+    expect(options).toEqual({
+      origin: ["https://app.example.com"],
+      credentials: true,
+    });
+  });
+
+  it("never produces a wildcard origin", () => {
+    const options = buildCorsOptions(["https://a.com", "https://b.com"]);
+    expect(options?.origin).not.toBe("*");
+    expect(options?.origin).toEqual(["https://a.com", "https://b.com"]);
+  });
+
+  it("returns null when the only entry is a wildcard", () => {
+    expect(buildCorsOptions(["*"])).toBeNull();
+  });
+
+  it("strips a wildcard mixed into an explicit list", () => {
+    const options = buildCorsOptions(["https://a.com", "*"]);
+    expect(options).toEqual({ origin: ["https://a.com"], credentials: true });
+  });
+});
+
+describe("resolveAllowedOrigin", () => {
+  it("returns null when no request origin", () => {
+    expect(resolveAllowedOrigin(undefined, ["https://app.example.com"])).toBeNull();
+  });
+
+  it("returns null when no allowlist", () => {
+    expect(resolveAllowedOrigin("https://app.example.com", undefined)).toBeNull();
+  });
+
+  it("returns null when allowlist is empty", () => {
+    expect(resolveAllowedOrigin("https://app.example.com", [])).toBeNull();
+  });
+
+  it("echoes the origin when it is on the allowlist", () => {
+    expect(resolveAllowedOrigin("https://app.example.com", ["https://app.example.com"])).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  it("returns null when the origin is not on the allowlist", () => {
+    expect(
+      resolveAllowedOrigin("https://evil.example.com", ["https://app.example.com"]),
+    ).toBeNull();
+  });
+});

--- a/apps/backend/src/presentation/middleware/cors.ts
+++ b/apps/backend/src/presentation/middleware/cors.ts
@@ -1,0 +1,26 @@
+import type { CorsOptions } from "cors";
+
+export function buildCorsOptions(allowlist: string[] | undefined): CorsOptions | null {
+  // Defense in depth: never let a wildcard reach the cors middleware, since
+  // `origin: "*"` combined with `credentials: true` would defeat the policy.
+  const origins = allowlist?.filter((origin) => origin !== "*") ?? [];
+  if (origins.length === 0) {
+    return null;
+  }
+
+  return {
+    origin: origins,
+    credentials: true,
+  };
+}
+
+export function resolveAllowedOrigin(
+  requestOrigin: string | undefined,
+  allowlist: string[] | undefined,
+): string | null {
+  if (!requestOrigin || !allowlist || allowlist.length === 0) {
+    return null;
+  }
+
+  return allowlist.includes(requestOrigin) ? requestOrigin : null;
+}

--- a/docs/ARCHITECTURE.en.md
+++ b/docs/ARCHITECTURE.en.md
@@ -250,6 +250,16 @@ We implement a **fail-fast** strategy and strict data validation.
 
 **Frontend counterpart:** When the backend returns `401`, the React app renders `<TokenGate>` — a full-screen unlock form — instead of the normal UI. Once the cookie is set, the app resumes normally without a page reload.
 
+### 8.2. CORS Policy
+
+**Threat model:** The SPA and API are served by the same Express process, so the app is same-origin and needs no CORS at all. A wildcard `Access-Control-Allow-Origin: *` is therefore pure attack surface, especially for internet-exposed instances.
+
+**Design:**
+
+- **Opt-in, env-gated.** CORS is disabled by default. The `cors()` middleware is mounted only when `SPOTIARR_CORS_ORIGIN` is set; same-origin deployments never see a CORS header.
+- **Explicit allowlist, never wildcard.** `SPOTIARR_CORS_ORIGIN` is a comma-separated list of exact origins, validated at startup to reject `*`. When enabled, CORS runs with `credentials: true` against that allowlist — the `*` + credentials combination is impossible by construction (`buildCorsOptions` also strips any wildcard as defense in depth).
+- **Layer placement.** The allowlist is injected from `container.ts` into the `EventsController` constructor, so the SSE transport mirrors the global policy (echoing the request origin only when allowlisted) without the `presentation/` layer importing `getEnv` — the same R4-respecting pattern as `require-token`.
+
 ## 9. Download Lifecycle
 
 The most critical process of the application works like this:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -250,6 +250,16 @@ Implementamos una estrategia de **fail-fast** y validación estricta de datos.
 
 **Contraparte en el frontend:** Cuando el backend devuelve `401`, la aplicación React muestra `<TokenGate>` — un formulario de desbloqueo a pantalla completa — en lugar de la UI normal. Una vez que la cookie está establecida, la aplicación se reanuda sin recargar la página.
 
+### 8.2. Política CORS
+
+**Modelo de amenaza:** El SPA y la API se sirven desde el mismo proceso Express, así que la aplicación es del mismo origen y no necesita CORS en absoluto. Un comodín `Access-Control-Allow-Origin: *` es, por tanto, pura superficie de ataque, especialmente en instancias expuestas a internet.
+
+**Diseño:**
+
+- **Opcional, activado por variable de entorno.** CORS está deshabilitado por defecto. El middleware `cors()` se monta solo cuando `SPOTIARR_CORS_ORIGIN` está definida; los despliegues del mismo origen nunca ven una cabecera CORS.
+- **Lista explícita, nunca comodín.** `SPOTIARR_CORS_ORIGIN` es una lista de orígenes exactos separados por comas, validada al arranque para rechazar `*`. Cuando se habilita, CORS se ejecuta con `credentials: true` contra esa lista — la combinación `*` + credenciales es imposible por construcción (`buildCorsOptions` también elimina cualquier comodín como defensa en profundidad).
+- **Ubicación de capa.** La lista se inyecta desde `container.ts` en el constructor de `EventsController`, de modo que el transporte SSE refleja la política global (devolviendo el origen de la petición solo cuando está en la lista) sin que la capa `presentation/` importe `getEnv` — el mismo patrón que respeta R4 que usa `require-token`.
+
 ## 9. Ciclo de Vida de una Descarga
 
 El proceso más crítico de la aplicación funciona así:

--- a/skills/spotiarr-docker/SKILL.md
+++ b/skills/spotiarr-docker/SKILL.md
@@ -62,6 +62,8 @@ SPOTIARR_UNLOCK_RATELIMIT=5       # default: 5 per IP per minute
 SPOTIARR_TRUST_PROXY=1            # hop count (e.g. 1) or Express preset; REQUIRED behind Traefik/any
                                   # reverse proxy — otherwise req.ip is the proxy IP and rate-limiting
                                   # locks out everyone together
+SPOTIARR_CORS_ORIGIN=             # comma-separated CORS origin allowlist; omit for same-origin (default).
+                                  # Wildcard "*" is rejected. Only needed for a separate-origin client.
 ```
 
 ## Update Flow


### PR DESCRIPTION
Closes #116

## What
Replaces the default wildcard `cors()` and the hardcoded SSE `Access-Control-Allow-Origin: *` with an opt-in, explicit-origin CORS policy.

- New optional env var **`SPOTIARR_CORS_ORIGIN`** — comma-separated origin allowlist, validated to **reject the wildcard `*`** (including inside a list).
- `app.ts` registers `cors()` **only when** the allowlist is set, with `credentials: true` and never a wildcard origin. Unset (the normal same-origin deployment) → no CORS middleware at all.
- SSE controller aligned with the same policy via an **injected allowlist getter** (no `getEnv` import in presentation — matches the existing `require-token` DI pattern). Echoes the request origin only when allowlisted, with `Allow-Credentials` + `Vary: Origin`.
- `buildCorsOptions` strips any `*` entries as defense in depth.
- Documented in `.env.example`.

## Why
Pre-existing hygiene/defense-in-depth gap flagged during PR #114's review. Not a live auth bypass (browsers won't send credentialed requests to a wildcard origin), but worth hardening for internet-exposed instances.

## Acceptance criteria
- [x] No `Access-Control-Allow-Origin: *` served by default.
- [x] App + SSE still work same-origin (unchanged code path; only the unneeded wildcard header removed).
- [x] Cross-origin is opt-in via explicit config, never wildcard+credentials.
- [x] SSE CORS aligned with the global policy.

## Verification
- `pnpm --filter backend run lint` — clean
- `pnpm --filter backend run test:run` — **493 pass** (+7 new tests: CORS helper, SSE controller, env schema)
- `pnpm --filter backend run build` — clean

## Notes
No browser E2E added: the frontend Playwright suite mocks the backend, so it would not exercise real CORS headers. Backend unit/integration tests are the correct layer and cover the security properties (no-wildcard, exact-origin match, missing-origin, credentials gating).