### PR TITLE
chore(workflow): document chained-PR sizing policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -290,6 +290,11 @@ This repo is configured for coding agents (Claude Code, Cursor, Copilot, etc.). 
 | No stray `console.log`         | Breaking changes (if any)      |
 | Docs/tests updated when needed | Related issue numbers          |
 
+**PR sizing**
+
+- Keep PRs reviewable. Slices over **400 LOC** are split into chained-to-main PRs by default.
+- `size:exception` is reserved for irreducible atomic refactors that cannot be split without breaking review or correctness—label the PR and justify it in the description.
+
 **Review process**
 
 - Maintainers review and may request tweaks

--- a/skills/spotiarr-workflow/SKILL.md
+++ b/skills/spotiarr-workflow/SKILL.md
@@ -4,7 +4,7 @@ description: "Trigger: command, validate, PR, branch, run lint, run build, secre
 license: Apache-2.0
 metadata:
   author: gentleman-programming
-  version: "2.0"
+  version: "2.1"
 ---
 
 ## Activation Contract
@@ -41,6 +41,16 @@ Load when running commands, validating changes, creating PRs, managing branches,
 | Chore    | `chore/`    | `chore/bump-deps`            |
 
 **PR checklist:** branch up to date with `main` · lint + build passing · PR body has what/why/verification · screenshots for UI changes.
+
+**PR sizing policy:**
+
+| Situation          | Action                                                                                                                                       |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| Slice over 400 LOC | Default: split into chained-to-main PRs (see `chained-pr` skill).                                                                             |
+| `ask-on-risk`      | Only when the requester explicitly asks to be consulted before splitting.                                                                    |
+| `size:exception`   | Reserved for irreducible atomic refactors that cannot be split without breaking review or correctness. Label the PR and justify in the body. |
+
+The 400 LOC threshold protects review focus. Prefer many small, sequentially reviewable PRs over one oversized PR. `size:exception` is the rare escape hatch, not a routine option.
 
 **Key commands:**
 


### PR DESCRIPTION
## What

Documents the **PR sizing policy** in two places:
- New section in the `spotiarr-workflow` skill (version 2.0 → 2.1).
- PR sizing note in `CONTRIBUTING.md` (under the PR checklist).

## Why

PR #101 shipped ~565 LOC under `size:exception`. Repeating this without a documented policy normalizes oversized PRs (#107).

## Policy

| Situation | Action |
| --- | --- |
| Slice over 400 LOC | Default: split into chained-to-main PRs (`chained-pr` skill). |
| `ask-on-risk` | Only when the requester explicitly asks to be consulted before splitting. |
| `size:exception` | Reserved for irreducible atomic refactors. Label + justify in PR body. |

## Verification

- Docs-only change (skill + CONTRIBUTING).
- Policy also persisted to engram (`workflow/pr-sizing`).

Closes #107