### PR TITLE
test(e2e): un-skip player scenarios + native queue DnD; fix mobile Close

### DIFF
--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -174,6 +174,7 @@ export const NowPlayingFullscreen: FC = () => {
           <button
             type="button"
             ref={closeButtonRef}
+            data-no-swipe
             aria-label={t("player.nowPlaying.close")}
             onClick={() => setNowPlayingOpen(false)}
             className="flex h-10 w-10 items-center justify-center rounded-full text-white/80 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60"

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -1,98 +1,60 @@
 import { expect, test } from "../../fixtures/test";
 import {
+  buildLibraryAlbum,
+  buildLibraryArtist,
+  buildLibraryTrack,
   buildPlaylist,
   buildTrack,
   installLibraryAudioMocks,
+  installLibraryMocks,
   installPlaylistMocks,
   installTrackMocks,
 } from "../../helpers/api-mocks";
 
-const MOCK_AUDIO_URL = "/api/library/audio?path=%2Ftest%2Ftrack1.mp3";
-const MOCK_AUDIO_URL_2 = "/api/library/audio?path=%2Ftest%2Ftrack2.mp3";
-const MOCK_AUDIO_URL_3 = "/api/library/audio?path=%2Ftest%2Ftrack3.mp3";
-
-const MOCK_ARTIST = {
+const libraryArtist = buildLibraryArtist({
   name: "Test Artist",
-  path: "/library/Test Artist",
-  imageUrl: null,
+  image: undefined,
   albums: [
-    {
+    buildLibraryAlbum({
       name: "Test Album",
+      artist: "Test Artist",
+      image: undefined,
+      path: "/library/artists/test-artist/test-album",
       year: 2024,
-      coverUrl: null,
       tracks: [
-        {
-          id: "track-1",
+        buildLibraryTrack({
           name: "Track Alpha",
           artist: "Test Artist",
           album: "Test Album",
-          trackUrl: MOCK_AUDIO_URL,
-          durationMs: 180_000,
-          artworkUrl: null,
-        },
-        {
-          id: "track-2",
+          filePath: "/library/artists/test-artist/test-album/01 Track Alpha.mp3",
+          trackNumber: 1,
+        }),
+        buildLibraryTrack({
           name: "Track Beta",
           artist: "Test Artist",
           album: "Test Album",
-          trackUrl: MOCK_AUDIO_URL_2,
-          durationMs: 180_000,
-          artworkUrl: null,
-        },
-        {
-          id: "track-3",
-          name: "Track Gamma",
-          artist: "Test Artist",
-          album: "Test Album",
-          trackUrl: MOCK_AUDIO_URL_3,
-          durationMs: 180_000,
-          artworkUrl: null,
-        },
+          filePath: "/library/artists/test-artist/test-album/02 Track Beta.mp3",
+          trackNumber: 2,
+        }),
       ],
-    },
-  ],
-};
-
-async function mockAudioRequests(page: import("@playwright/test").Page) {
-  for (const url of [MOCK_AUDIO_URL, MOCK_AUDIO_URL_2, MOCK_AUDIO_URL_3]) {
-    await page.route(`**${url}`, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "audio/mpeg",
-        body: Buffer.alloc(0),
-      }),
-    );
-  }
-}
-
-async function mockLibraryArtist(page: import("@playwright/test").Page) {
-  await page.route("**/api/library/artists/**", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ data: MOCK_ARTIST }),
     }),
-  );
+  ],
+});
+
+async function gotoLibraryAlbum(page: import("@playwright/test").Page) {
+  await installLibraryMocks(page, { artists: [libraryArtist], artistDetail: libraryArtist });
+  await installLibraryAudioMocks(page);
+
+  await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
+    waitUntil: "domcontentloaded",
+  });
 }
 
 test.describe("player — transport controls labels @smoke", () => {
   test("transport buttons have accessible names derived from i18n keys", async ({ page }) => {
-    await mockLibraryArtist(page);
-    await mockAudioRequests(page);
+    await gotoLibraryAlbum(page);
 
-    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
-      waitUntil: "domcontentloaded",
-    });
-
-    const playAlbumBtn = page.getByRole("button", { name: "Play album" });
-    const isPlayable = await playAlbumBtn.isVisible().catch(() => false);
-
-    if (!isPlayable) {
-      test.skip();
-      return;
-    }
-
-    await playAlbumBtn.click();
+    await page.getByRole("button", { name: "Play album" }).click();
 
     const playerBar = page.getByRole("region", { name: "Now playing" });
     await expect(playerBar).toBeVisible();
@@ -115,22 +77,9 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
   test.use({ viewport: { width: 375, height: 812 } });
 
   test("mobile trigger opens and closes fullscreen overlay", async ({ page }) => {
-    await mockLibraryArtist(page);
-    await mockAudioRequests(page);
+    await gotoLibraryAlbum(page);
 
-    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
-      waitUntil: "domcontentloaded",
-    });
-
-    const playBtn = page.getByRole("button", { name: "Play album" });
-    const isPlayable = await playBtn.isVisible().catch(() => false);
-
-    if (!isPlayable) {
-      test.skip();
-      return;
-    }
-
-    await playBtn.click();
+    await page.getByRole("button", { name: "Play album" }).click();
 
     const playerBar = page.getByRole("region", { name: "Now playing" });
     await expect(playerBar).toBeVisible();
@@ -139,8 +88,11 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
     await expect(nowPlayingTrigger).toBeVisible();
     await nowPlayingTrigger.click();
 
+    // The fullscreen dialog is a persistent off-canvas panel toggled via
+    // transform (translate-y), so assert viewport presence rather than DOM
+    // visibility — the element stays mounted whether open or closed.
     const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
+    await expect(dialog).toBeInViewport();
 
     const transport = dialog.getByRole("button", { name: /(Pause|Play)/ });
     await expect(transport).toBeVisible();
@@ -148,7 +100,7 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
     const closeBtn = dialog.getByRole("button", { name: "Close" });
     await closeBtn.click();
 
-    await expect(dialog).not.toBeVisible();
+    await expect(dialog).not.toBeInViewport();
 
     // Focus returns to the now-playing trigger after close
     await expect(nowPlayingTrigger).toBeFocused();
@@ -156,49 +108,6 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
 });
 
 test.describe("player — queue reorder @smoke", () => {
-  test("moveUp button reorders second track above first", async ({ page }) => {
-    await mockLibraryArtist(page);
-    await mockAudioRequests(page);
-
-    await page.goto("/library/artist/Test%20Artist/album/Test%20Album", {
-      waitUntil: "domcontentloaded",
-    });
-
-    const playBtn = page.getByRole("button", { name: "Play album" });
-    const isPlayable = await playBtn.isVisible().catch(() => false);
-
-    if (!isPlayable) {
-      test.skip();
-      return;
-    }
-
-    await playBtn.click();
-
-    const playerBar = page.getByRole("region", { name: "Now playing" });
-    const queueBtn = playerBar.getByRole("button", { name: "Open queue" });
-    await expect(queueBtn).toBeVisible();
-    await queueBtn.click();
-
-    const queuePanel = page.getByRole("complementary");
-    await expect(queuePanel).toBeVisible();
-
-    // Get all track rows in queue — move Track Beta up above Track Alpha
-    const moveUpBetaBtn = page.getByRole("button", { name: "Move Track Beta up" });
-    const isMoveVisible = await moveUpBetaBtn.isVisible().catch(() => false);
-
-    if (!isMoveVisible) {
-      test.skip();
-      return;
-    }
-
-    await moveUpBetaBtn.click();
-
-    // After moving up, Track Beta should now be before Track Alpha in queue
-    const queueItems = queuePanel.getByRole("listitem");
-    const firstItemText = await queueItems.first().textContent();
-    expect(firstItemText).toContain("Track Beta");
-  });
-
   test("native drag-and-drop reorders the second queue track above the first", async ({ page }) => {
     const libraryPlaylist = buildPlaylist({
       id: "dnd-reorder-playlist",

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -198,6 +198,72 @@ test.describe("player — queue reorder @smoke", () => {
     const firstItemText = await queueItems.first().textContent();
     expect(firstItemText).toContain("Track Beta");
   });
+
+  test("native drag-and-drop reorders the second queue track above the first", async ({ page }) => {
+    const libraryPlaylist = buildPlaylist({
+      id: "dnd-reorder-playlist",
+      name: "Reorder Queue",
+      spotifyUrl: "spotiarr://dnd-reorder-playlist",
+      subscribed: true,
+      tracks: [],
+    });
+
+    await installPlaylistMocks(page, { playlists: [libraryPlaylist] });
+    await installTrackMocks(page, {
+      tracksByPlaylistId: {
+        [libraryPlaylist.id]: [
+          buildTrack({
+            album: "Album One",
+            artist: "Boards of Canada",
+            audioUrl: "/api/library/audio?path=/library/boards/track-1.mp3",
+            id: "dnd-track-1",
+            name: "Dayvan Cowboy",
+            playlistId: libraryPlaylist.id,
+          }),
+          buildTrack({
+            album: "Album Two",
+            artist: "Tycho",
+            audioUrl: "/api/library/audio?path=/library/tycho/track-2.mp3",
+            id: "dnd-track-2",
+            name: "Awake",
+            playlistId: libraryPlaylist.id,
+          }),
+        ],
+      },
+    });
+    await installLibraryAudioMocks(page);
+
+    await page.goto(`/playlist/${libraryPlaylist.id}?mode=library`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await page.getByRole("button", { name: "Play track" }).first().click();
+
+    const playerBar = page.getByRole("region", { name: "Now playing" });
+    await expect(playerBar).toBeVisible();
+
+    const queueBtn = playerBar.getByRole("button", { name: "Open queue" });
+    await expect(queueBtn).toBeVisible();
+    await queueBtn.click();
+
+    const queuePanel = page.getByRole("complementary", { name: "Queue" });
+    await expect(queuePanel).toBeVisible();
+
+    const queueItems = queuePanel.getByRole("listitem");
+    await expect(queueItems.first()).toContainText("Dayvan Cowboy");
+    await expect(queueItems.nth(1)).toContainText("Awake");
+
+    // Lock the native HTML5 drag path: each queue <li> is draggable, so dragging
+    // "Awake" onto "Dayvan Cowboy" drives the dragstart/dragover/drop sequence the
+    // QueueSidePanel listens for, exercising reorderQueue end to end.
+    const awake = queueItems.filter({ hasText: "Awake" });
+    const dayvanCowboy = queueItems.filter({ hasText: "Dayvan Cowboy" });
+
+    await awake.dragTo(dayvanCowboy);
+
+    await expect(queueItems.first()).toContainText("Awake");
+    await expect(queueItems.nth(1)).toContainText("Dayvan Cowboy");
+  });
 });
 test.describe("Mocked global player flows", () => {
   test("updates the GlobalPlayerBar while playing a library-backed playlist queue", async ({


### PR DESCRIPTION
## What

Makes the player e2e scenarios in `player.spec.ts` actually run, adds native HTML5 drag-and-drop coverage for queue reorder, and fixes a real mobile bug surfaced along the way.

## The zombie tests (#105 premise was wrong)

The issue assumed the `moveUp` scenario ran as an a11y baseline. **It did not.** All three album-page scenarios (transport labels, mobile fullscreen, `moveUp` reorder) silently **skipped** — the local `MOCK_ARTIST` used a stale shape (`coverUrl`/`imageUrl`, missing `path`/`trackCount`/`totalSize`) so the album never rendered, tripping the `isPlayable` guard → `test.skip()`.

## Changes

1. **Un-skip transport + mobile fullscreen** — swap the ad-hoc `MOCK_ARTIST` + hand-rolled routes for the shared `installLibraryMocks` + `buildLibraryArtist/Album/Track` helpers (same setup `library.spec.ts` uses). Scenarios now run.
2. **New native DnD scenario** — drag the second queue track onto the first via Playwright `dragTo`, exercising the `QueueSidePanel` `dragstart`/`dragover`/`drop` handlers and `reorderQueue` end to end. Built on the library-playlist mock foundation (the one player scenario that already ran).
3. **Drop the `moveUp` scenario** — it targeted a `Move … up` button that does not exist in `QueueSidePanel`; native DnD now covers reorder.
4. **Fix a real mobile bug** — the fullscreen Close button sits inside the swipe-zone, whose `onSwipePointerDown` calls `setPointerCapture`. Pointer capture swallowed the button's click on touch/pointer devices, so tapping Close did not dismiss the overlay. Marked it `data-no-swipe` (matching the queue region). The un-skipped fullscreen test is the regression guard — a unit test can't catch this (jsdom `fireEvent.click` bypasses pointer capture).

Persistent panels are asserted with `toBeInViewport` (toggled by transform, never unmounted) rather than `toBeVisible`.

## Verification

```
pnpm --filter frontend run test:run    # 476 passed
pnpm --filter frontend run lint        # exit 0
PLAYWRIGHT_TARGET=mocked playwright test --project=mocked player.spec.ts
# 4 passed, 0 skipped
```

Net: +37 / −127 in the spec (removed dead mock + zombie), +1 line component fix.

Closes #105