### PR TITLE
feat(player): keyboard-accessible queue reorder in QueueSidePanel

### DIFF
--- a/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.test.tsx
@@ -22,7 +22,7 @@ vi.mock("react-i18next", async () => {
   return {
     ...actual,
     useTranslation: () => ({
-      t: (key: string) => {
+      t: (key: string, opts?: Record<string, string>) => {
         const map: Record<string, string> = {
           "player.queue.title": "Queue",
           "player.queue.empty": "No tracks in queue",
@@ -32,8 +32,16 @@ vi.mock("react-i18next", async () => {
           "player.queue.repeatAll": "Repeat all",
           "player.queue.repeatOne": "Repeat one",
           "player.queue.shuffleOn": "Shuffle on",
+          "player.queue.moveUp": "Move {{name}} up",
+          "player.queue.moveDown": "Move {{name}} down",
         };
-        return map[key] ?? key;
+        let value = map[key] ?? key;
+        if (opts) {
+          for (const [token, replacement] of Object.entries(opts)) {
+            value = value.replace(`{{${token}}}`, String(replacement));
+          }
+        }
+        return value;
       },
     }),
   };
@@ -375,5 +383,58 @@ describe("drag and drop", () => {
     const buttons = screen.getAllByRole("button").filter((b) => /Track/i.test(b.textContent ?? ""));
     fireEvent.click(buttons[1]!);
     expect(mockStore.playFromIndex).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("keyboard reorder (a11y)", () => {
+  beforeEach(() => {
+    mockStore.isQueuePanelOpen = true;
+    mockStore.queue = [makeItem("a"), makeItem("b"), makeItem("c")];
+    mockStore.currentIndex = 0;
+  });
+
+  it("renders move up/down buttons with track-specific accessible names", () => {
+    render(<QueueSidePanel />);
+    expect(screen.getByRole("button", { name: "Move Track a up" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Move Track c down" })).not.toBeNull();
+  });
+
+  it("disables move up on the first row and enables it elsewhere", () => {
+    render(<QueueSidePanel />);
+    expect(
+      (screen.getByRole("button", { name: "Move Track a up" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Move Track b up" }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("disables move down on the last row and enables it elsewhere", () => {
+    render(<QueueSidePanel />);
+    expect(
+      (screen.getByRole("button", { name: "Move Track c down" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Move Track b down" }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("click move up calls reorderQueue(index, index - 1)", () => {
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Move Track b up" }));
+    expect(mockStore.reorderQueue).toHaveBeenCalledWith(1, 0);
+  });
+
+  it("click move down calls reorderQueue(index, index + 1)", () => {
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Move Track a down" }));
+    expect(mockStore.reorderQueue).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("clicking a disabled boundary control is a no-op", () => {
+    render(<QueueSidePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Move Track a up" }));
+    fireEvent.click(screen.getByRole("button", { name: "Move Track c down" }));
+    expect(mockStore.reorderQueue).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/components/organisms/QueueSidePanel.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.tsx
@@ -1,4 +1,4 @@
-import { faShuffle, faTimes } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faChevronUp, faShuffle, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -101,6 +101,7 @@ export const QueueSidePanel: FC = () => {
                     aria-current={isCurrent ? "true" : undefined}
                     draggable
                     className={cn(
+                      "flex items-center",
                       isDragging && "cursor-grabbing opacity-50",
                       isDropTarget && "border-t-2 border-green-500",
                       !isDragging && "cursor-grab",
@@ -135,7 +136,7 @@ export const QueueSidePanel: FC = () => {
                     <button
                       type="button"
                       className={cn(
-                        "flex w-full flex-col items-start px-4 py-2 text-left transition-colors hover:bg-white/5",
+                        "flex min-w-0 flex-1 flex-col items-start px-4 py-2 text-left transition-colors hover:bg-white/5",
                         isCurrent ? "bg-white/5 text-green-400" : "text-white",
                       )}
                       onClick={() => playFromIndex(index)}
@@ -146,6 +147,27 @@ export const QueueSidePanel: FC = () => {
                       <span className="w-full truncate text-sm font-medium">{item.name}</span>
                       <span className="w-full truncate text-xs text-white/50">{item.artist}</span>
                     </button>
+
+                    <div className="flex items-center gap-1 pr-2">
+                      <button
+                        type="button"
+                        aria-label={t("player.queue.moveUp", { name: item.name })}
+                        disabled={index === 0}
+                        onClick={() => index > 0 && reorderQueue(index, index - 1)}
+                        className="flex h-7 w-7 items-center justify-center rounded text-white/40 transition-colors hover:text-white/80 disabled:cursor-not-allowed disabled:opacity-30"
+                      >
+                        <FontAwesomeIcon icon={faChevronUp} className="text-xs" />
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={t("player.queue.moveDown", { name: item.name })}
+                        disabled={index === queue.length - 1}
+                        onClick={() => index < queue.length - 1 && reorderQueue(index, index + 1)}
+                        className="flex h-7 w-7 items-center justify-center rounded text-white/40 transition-colors hover:text-white/80 disabled:cursor-not-allowed disabled:opacity-30"
+                      >
+                        <FontAwesomeIcon icon={faChevronDown} className="text-xs" />
+                      </button>
+                    </div>
                   </li>
                 );
               })}

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -383,7 +383,9 @@
       "close": "Close",
       "repeatAll": "Repeat all",
       "repeatOne": "Repeat one",
-      "shuffleOn": "Shuffle on"
+      "shuffleOn": "Shuffle on",
+      "moveUp": "Move {{name}} up",
+      "moveDown": "Move {{name}} down"
     },
     "nowPlaying": {
       "title": "Now Playing",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -383,7 +383,9 @@
       "close": "Cerrar",
       "repeatAll": "Repetir todo",
       "repeatOne": "Repetir una",
-      "shuffleOn": "Aleatorio activado"
+      "shuffleOn": "Aleatorio activado",
+      "moveUp": "Subir {{name}}",
+      "moveDown": "Bajar {{name}}"
     },
     "nowPlaying": {
       "title": "Reproduciendo ahora",

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -108,11 +108,13 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
 });
 
 test.describe("player — queue reorder @smoke", () => {
-  test("native drag-and-drop reorders the second queue track above the first", async ({ page }) => {
+  // Open the side queue with two known tracks (Dayvan Cowboy, then Awake) and
+  // return the queue list items, so each scenario only asserts the reorder path.
+  async function openQueueWithTwoTracks(page: import("@playwright/test").Page) {
     const libraryPlaylist = buildPlaylist({
-      id: "dnd-reorder-playlist",
+      id: "queue-reorder-playlist",
       name: "Reorder Queue",
-      spotifyUrl: "spotiarr://dnd-reorder-playlist",
+      spotifyUrl: "spotiarr://queue-reorder-playlist",
       subscribed: true,
       tracks: [],
     });
@@ -125,7 +127,7 @@ test.describe("player — queue reorder @smoke", () => {
             album: "Album One",
             artist: "Boards of Canada",
             audioUrl: "/api/library/audio?path=/library/boards/track-1.mp3",
-            id: "dnd-track-1",
+            id: "queue-track-1",
             name: "Dayvan Cowboy",
             playlistId: libraryPlaylist.id,
           }),
@@ -133,7 +135,7 @@ test.describe("player — queue reorder @smoke", () => {
             album: "Album Two",
             artist: "Tycho",
             audioUrl: "/api/library/audio?path=/library/tycho/track-2.mp3",
-            id: "dnd-track-2",
+            id: "queue-track-2",
             name: "Awake",
             playlistId: libraryPlaylist.id,
           }),
@@ -161,6 +163,11 @@ test.describe("player — queue reorder @smoke", () => {
     const queueItems = queuePanel.getByRole("listitem");
     await expect(queueItems.first()).toContainText("Dayvan Cowboy");
     await expect(queueItems.nth(1)).toContainText("Awake");
+    return queueItems;
+  }
+
+  test("native drag-and-drop reorders the second queue track above the first", async ({ page }) => {
+    const queueItems = await openQueueWithTwoTracks(page);
 
     // Lock the native HTML5 drag path: each queue <li> is draggable, so dragging
     // "Awake" onto "Dayvan Cowboy" drives the dragstart/dragover/drop sequence the
@@ -169,6 +176,19 @@ test.describe("player — queue reorder @smoke", () => {
     const dayvanCowboy = queueItems.filter({ hasText: "Dayvan Cowboy" });
 
     await awake.dragTo(dayvanCowboy);
+
+    await expect(queueItems.first()).toContainText("Awake");
+    await expect(queueItems.nth(1)).toContainText("Dayvan Cowboy");
+  });
+
+  test("keyboard-accessible move-up control reorders the second queue track above the first", async ({
+    page,
+  }) => {
+    const queueItems = await openQueueWithTwoTracks(page);
+
+    // Accessible path: the per-row move-up button is keyboard- and screen-reader-
+    // operable, unlike native drag-and-drop. It must reorder the same queue.
+    await page.getByRole("button", { name: "Move Awake up" }).click();
 
     await expect(queueItems.first()).toContainText("Awake");
     await expect(queueItems.nth(1)).toContainText("Dayvan Cowboy");


### PR DESCRIPTION
## What

Adds keyboard- and screen-reader-operable **move up / move down** controls to each `QueueSidePanel` row, reaching a11y parity with `NowPlayingFullscreen`. Native HTML5 drag-and-drop is preserved.

## Why

`QueueSidePanel` only shipped native HTML5 drag-and-drop on a `draggable <li>` — keyboard and assistive-tech users had **no way to reorder the side queue** (WCAG 2.1.1 Keyboard gap). `NowPlayingFullscreen` already had accessible move controls. This closes the divergence.

Surfaced from #105 (the original `moveUp` e2e scenario targeted a button that never existed — it was aspirational for this feature).

## Changes

- **Component**: per-row move up / move down buttons, disabled at queue boundaries, i18n `aria-label`s (`player.queue.moveUp`/`moveDown`, en + es). Mirrors the `NowPlayingFullscreen` pattern.
- **Unit tests** (strict TDD, written first → red → green): accessible names, boundary disabling, `reorderQueue` wiring, disabled no-op.
- **e2e**: new keyboard-control reorder scenario alongside the native DnD one (shared setup helper), re-establishing the accessible baseline #105 assumed.

## Verification

```
pnpm --filter frontend run test:run    # 482 passed (+6)
pnpm --filter frontend run lint        # exit 0
pnpm --filter frontend run build       # exit 0
PLAYWRIGHT_TARGET=mocked playwright test --project=mocked player.spec.ts   # 5 passed
```

~110 insertions / 11 deletions across 5 files. Single PR (well under the 400-LOC policy).

## Unblocks

Once merged, #106 (`useReorderable(onReorder)` extraction) has its legitimate trigger: both surfaces now share keyboard-move logic and the a11y divergence is resolved.

Closes #123