### PR TITLE
refactor(player): extract useReorderable hook for queue surfaces

### DIFF
--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -2,6 +2,7 @@ import { faChevronDown, faGripLines } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useReorderable } from "@/hooks/useReorderable";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
 import { Image } from "../atoms/Image";
@@ -39,10 +40,17 @@ export const NowPlayingFullscreen: FC = () => {
 
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
-  const draggingIndexRef = useRef<number | null>(null);
-  const dragOverIndexRef = useRef<number | null>(null);
+  const {
+    draggingIndex,
+    dragOverIndex,
+    draggingIndexRef,
+    startDrag,
+    setDropTarget,
+    commit,
+    cancelDrag,
+    moveUp,
+    moveDown,
+  } = useReorderable(reorderQueue);
 
   const swipeStartYRef = useRef<number | null>(null);
   const [dragOffsetY, setDragOffsetY] = useState(0);
@@ -73,40 +81,25 @@ export const NowPlayingFullscreen: FC = () => {
 
   const onHandlePointerDown = (e: React.PointerEvent, index: number) => {
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    draggingIndexRef.current = index;
-    dragOverIndexRef.current = null;
-    setDraggingIndex(index);
+    startDrag(index);
   };
 
   const onHandlePointerMove = (e: React.PointerEvent) => {
     if (draggingIndexRef.current === null) return;
     const el = document.elementFromPoint(e.clientX, e.clientY);
     const row = el?.closest("[data-row-index]") as HTMLElement | null;
-    const overIndex = row ? Number(row.dataset.rowIndex) : null;
-    if (overIndex !== null && overIndex !== dragOverIndexRef.current) {
-      dragOverIndexRef.current = overIndex;
-      setDragOverIndex(overIndex);
-    }
+    if (row) setDropTarget(Number(row.dataset.rowIndex));
   };
 
   const onHandlePointerUp = (e: React.PointerEvent) => {
     if (draggingIndexRef.current === null) return;
-    const from = draggingIndexRef.current;
     const el = document.elementFromPoint(e.clientX, e.clientY);
     const row = el?.closest("[data-row-index]") as HTMLElement | null;
-    const to = row ? Number(row.dataset.rowIndex) : (dragOverIndexRef.current ?? from);
-    draggingIndexRef.current = null;
-    dragOverIndexRef.current = null;
-    setDraggingIndex(null);
-    setDragOverIndex(null);
-    if (from !== to) reorderQueue(from, to);
+    commit(row ? Number(row.dataset.rowIndex) : undefined);
   };
 
   const onHandlePointerCancel = () => {
-    draggingIndexRef.current = null;
-    dragOverIndexRef.current = null;
-    setDraggingIndex(null);
-    setDragOverIndex(null);
+    cancelDrag();
   };
 
   const onSwipePointerDown = (e: React.PointerEvent) => {
@@ -283,7 +276,7 @@ export const NowPlayingFullscreen: FC = () => {
                   type="button"
                   aria-label={t("player.nowPlaying.moveUp", { name: item.name })}
                   disabled={index === 0}
-                  onClick={() => index > 0 && reorderQueue(index, index - 1)}
+                  onClick={() => moveUp(index)}
                   className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"
                 >
                   ↑
@@ -292,7 +285,7 @@ export const NowPlayingFullscreen: FC = () => {
                   type="button"
                   aria-label={t("player.nowPlaying.moveDown", { name: item.name })}
                   disabled={index === queue.length - 1}
-                  onClick={() => index < queue.length - 1 && reorderQueue(index, index + 1)}
+                  onClick={() => moveDown(index, queue.length)}
                   className="flex h-6 w-6 items-center justify-center rounded text-white/40 hover:text-white/80"
                 >
                   ↓

--- a/apps/frontend/src/components/organisms/QueueSidePanel.tsx
+++ b/apps/frontend/src/components/organisms/QueueSidePanel.tsx
@@ -1,15 +1,14 @@
 import { faChevronDown, faChevronUp, faShuffle, faTimes } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { useReorderable } from "@/hooks/useReorderable";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import { cn } from "@/utils/cn";
 
 export const QueueSidePanel: FC = () => {
   const { t } = useTranslation();
   const activeRowRef = useRef<HTMLLIElement>(null);
-  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
 
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
@@ -19,6 +18,18 @@ export const QueueSidePanel: FC = () => {
   const setQueuePanelOpen = usePlayerStore((s) => s.setQueuePanelOpen);
   const playFromIndex = usePlayerStore((s) => s.playFromIndex);
   const reorderQueue = usePlayerStore((s) => s.reorderQueue);
+
+  const {
+    draggingIndex,
+    dragOverIndex,
+    startDrag,
+    setDropTarget,
+    clearDropTarget,
+    cancelDrag,
+    commit,
+    moveUp,
+    moveDown,
+  } = useReorderable(reorderQueue);
 
   useEffect(() => {
     if (!isQueuePanelOpen) return;
@@ -109,28 +120,22 @@ export const QueueSidePanel: FC = () => {
                     onDragStart={(e) => {
                       e.dataTransfer.setData("text/plain", String(index));
                       e.dataTransfer.effectAllowed = "move";
-                      setDraggingIndex(index);
+                      startDrag(index);
                     }}
                     onDragOver={(e) => {
                       e.preventDefault();
                       if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
-                      if (dragOverIndex !== index) setDragOverIndex(index);
+                      setDropTarget(index);
                     }}
                     onDragLeave={(e) => {
-                      if (e.currentTarget === e.target) setDragOverIndex(null);
+                      if (e.currentTarget === e.target) clearDropTarget();
                     }}
                     onDrop={(e) => {
                       e.preventDefault();
-                      const raw = e.dataTransfer.getData("text/plain");
-                      const fromIndex = Number(raw);
-                      setDraggingIndex(null);
-                      setDragOverIndex(null);
-                      if (Number.isNaN(fromIndex)) return;
-                      reorderQueue(fromIndex, index);
+                      commit(index);
                     }}
                     onDragEnd={() => {
-                      setDraggingIndex(null);
-                      setDragOverIndex(null);
+                      cancelDrag();
                     }}
                   >
                     <button
@@ -153,7 +158,7 @@ export const QueueSidePanel: FC = () => {
                         type="button"
                         aria-label={t("player.queue.moveUp", { name: item.name })}
                         disabled={index === 0}
-                        onClick={() => index > 0 && reorderQueue(index, index - 1)}
+                        onClick={() => moveUp(index)}
                         className="flex h-7 w-7 items-center justify-center rounded text-white/40 transition-colors hover:text-white/80 disabled:cursor-not-allowed disabled:opacity-30"
                       >
                         <FontAwesomeIcon icon={faChevronUp} className="text-xs" />
@@ -162,7 +167,7 @@ export const QueueSidePanel: FC = () => {
                         type="button"
                         aria-label={t("player.queue.moveDown", { name: item.name })}
                         disabled={index === queue.length - 1}
-                        onClick={() => index < queue.length - 1 && reorderQueue(index, index + 1)}
+                        onClick={() => moveDown(index, queue.length)}
                         className="flex h-7 w-7 items-center justify-center rounded text-white/40 transition-colors hover:text-white/80 disabled:cursor-not-allowed disabled:opacity-30"
                       >
                         <FontAwesomeIcon icon={faChevronDown} className="text-xs" />

--- a/apps/frontend/src/hooks/useReorderable.test.ts
+++ b/apps/frontend/src/hooks/useReorderable.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useReorderable } from "./useReorderable";
+
+describe("useReorderable", () => {
+  it("starts with no drag state", () => {
+    const { result } = renderHook(() => useReorderable(vi.fn()));
+    expect(result.current.draggingIndex).toBeNull();
+    expect(result.current.dragOverIndex).toBeNull();
+  });
+
+  it("startDrag sets the dragging index", () => {
+    const { result } = renderHook(() => useReorderable(vi.fn()));
+    act(() => result.current.startDrag(2));
+    expect(result.current.draggingIndex).toBe(2);
+  });
+
+  it("setDropTarget sets the drag-over index", () => {
+    const { result } = renderHook(() => useReorderable(vi.fn()));
+    act(() => {
+      result.current.startDrag(0);
+      result.current.setDropTarget(3);
+    });
+    expect(result.current.dragOverIndex).toBe(3);
+  });
+
+  it("commit(to) calls onReorder(from, to) and resets state", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.startDrag(1));
+    act(() => result.current.commit(3));
+    expect(onReorder).toHaveBeenCalledWith(1, 3);
+    expect(result.current.draggingIndex).toBeNull();
+    expect(result.current.dragOverIndex).toBeNull();
+  });
+
+  it("commit() without an explicit target uses the current drop-over index", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => {
+      result.current.startDrag(0);
+      result.current.setDropTarget(2);
+    });
+    act(() => result.current.commit());
+    expect(onReorder).toHaveBeenCalledWith(0, 2);
+  });
+
+  it("commit does not call onReorder when from === to", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.startDrag(2));
+    act(() => result.current.commit(2));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("commit without an active drag is a no-op", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.commit(1));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("cancelDrag resets state without calling onReorder", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => {
+      result.current.startDrag(1);
+      result.current.setDropTarget(2);
+    });
+    act(() => result.current.cancelDrag());
+    expect(onReorder).not.toHaveBeenCalled();
+    expect(result.current.draggingIndex).toBeNull();
+    expect(result.current.dragOverIndex).toBeNull();
+  });
+
+  it("clearDropTarget clears only the drag-over index", () => {
+    const { result } = renderHook(() => useReorderable(vi.fn()));
+    act(() => {
+      result.current.startDrag(0);
+      result.current.setDropTarget(2);
+    });
+    act(() => result.current.clearDropTarget());
+    expect(result.current.dragOverIndex).toBeNull();
+    expect(result.current.draggingIndex).toBe(0);
+  });
+
+  it("moveUp calls onReorder(index, index - 1) above the first row", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.moveUp(2));
+    expect(onReorder).toHaveBeenCalledWith(2, 1);
+  });
+
+  it("moveUp on the first row is a no-op", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.moveUp(0));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  it("moveDown calls onReorder(index, index + 1) below the last row", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.moveDown(0, 3));
+    expect(onReorder).toHaveBeenCalledWith(0, 1);
+  });
+
+  it("moveDown on the last row is a no-op", () => {
+    const onReorder = vi.fn();
+    const { result } = renderHook(() => useReorderable(onReorder));
+    act(() => result.current.moveDown(2, 3));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useReorderable.ts
+++ b/apps/frontend/src/hooks/useReorderable.ts
@@ -1,0 +1,94 @@
+import { useCallback, useRef, useState } from "react";
+
+type ReorderHandler = (from: number, to: number) => void;
+
+export interface Reorderable {
+  draggingIndex: number | null;
+  dragOverIndex: number | null;
+  draggingIndexRef: React.MutableRefObject<number | null>;
+  dragOverIndexRef: React.MutableRefObject<number | null>;
+  startDrag: (index: number) => void;
+  setDropTarget: (index: number) => void;
+  clearDropTarget: () => void;
+  cancelDrag: () => void;
+  commit: (to?: number | null) => void;
+  moveUp: (index: number) => void;
+  moveDown: (index: number, itemCount: number) => void;
+}
+
+/**
+ * Owns the reorder state machine shared by the queue surfaces: the dragging /
+ * drop-over indices, the reset logic, the `from !== to` guard, and the keyboard
+ * move helpers. Each consumer wires its own input modality (native HTML5
+ * drag-and-drop, pointer events) to these handlers. Refs mirror the indices so
+ * pointer handlers can read the latest value synchronously.
+ */
+export function useReorderable(onReorder: ReorderHandler): Reorderable {
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const draggingIndexRef = useRef<number | null>(null);
+  const dragOverIndexRef = useRef<number | null>(null);
+
+  const reset = useCallback(() => {
+    draggingIndexRef.current = null;
+    dragOverIndexRef.current = null;
+    setDraggingIndex(null);
+    setDragOverIndex(null);
+  }, []);
+
+  const startDrag = useCallback((index: number) => {
+    draggingIndexRef.current = index;
+    dragOverIndexRef.current = null;
+    setDraggingIndex(index);
+    setDragOverIndex(null);
+  }, []);
+
+  const setDropTarget = useCallback((index: number) => {
+    if (dragOverIndexRef.current === index) return;
+    dragOverIndexRef.current = index;
+    setDragOverIndex(index);
+  }, []);
+
+  const clearDropTarget = useCallback(() => {
+    dragOverIndexRef.current = null;
+    setDragOverIndex(null);
+  }, []);
+
+  const commit = useCallback(
+    (to?: number | null) => {
+      const from = draggingIndexRef.current;
+      const target = to ?? dragOverIndexRef.current ?? from;
+      reset();
+      if (from !== null && target !== null && from !== target) onReorder(from, target);
+    },
+    [onReorder, reset],
+  );
+
+  const moveUp = useCallback(
+    (index: number) => {
+      if (index > 0) onReorder(index, index - 1);
+    },
+    [onReorder],
+  );
+
+  const moveDown = useCallback(
+    (index: number, itemCount: number) => {
+      if (index < itemCount - 1) onReorder(index, index + 1);
+    },
+    [onReorder],
+  );
+
+  return {
+    draggingIndex,
+    dragOverIndex,
+    draggingIndexRef,
+    dragOverIndexRef,
+    startDrag,
+    setDropTarget,
+    clearDropTarget,
+    cancelDrag: reset,
+    commit,
+    moveUp,
+    moveDown,
+  };
+}


### PR DESCRIPTION
## What

Extracts `useReorderable(onReorder)` and migrates both queue-reorder surfaces (`QueueSidePanel`, `NowPlayingFullscreen`) onto it.

## Why

The two surfaces duplicated the reorder **state machine**: dragging / drop-over indices, the reset logic, the `from !== to` guard, and the keyboard move up/down logic. They differ only in input modality — HTML5 drag-and-drop vs pointer events. After #123 added keyboard controls to both, the shared surface became real (not speculative), satisfying this issue's YAGNI trigger.

## The hook

`useReorderable(onReorder)` owns the state machine and exposes:
- `draggingIndex` / `dragOverIndex` (+ refs for synchronous reads in pointer handlers)
- `startDrag` / `setDropTarget` / `clearDropTarget` / `cancelDrag` / `commit(to?)`
- `moveUp(index)` / `moveDown(index, itemCount)` (keyboard, boundary-guarded)

Each surface keeps its own event plumbing and wires it to the hook — the hook stays modality-agnostic (no DnD- or pointer-specific code).

## Changes

- New `src/hooks/useReorderable.ts` + unit tests (state machine: start/over/commit/cancel, the `from === to` guard, no-active-drag no-op, keyboard bounds).
- `QueueSidePanel`: drop commits via the hook ref instead of decoding the `dataTransfer` index (`setData` still emitted for native DnD compat). Removes its local `useState` pair.
- `NowPlayingFullscreen`: drops the four local refs/handlers boilerplate; pointer-up passes the resolved target to `commit()`.

## Verification

```
pnpm --filter frontend run test:run    # 495 passed (+13 hook)
pnpm --filter frontend run lint        # exit 0
pnpm --filter frontend run build       # exit 0
PLAYWRIGHT_TARGET=mocked playwright test --project=mocked player.spec.ts   # 5 passed
```

Both input modalities remain covered by the existing component tests and the e2e DnD + keyboard scenarios. No behavior change.

Closes #106
