### PR TITLE
fix(playlists): retry errored tracks on subscribed playlist sync

### DIFF
--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -111,8 +111,6 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
 
     await useCase.execute();
 
-    // Spotify returns the same single track, so nothing new is created, but the
-    // stranded errored track must be retried so the subscription can complete.
     expect(trackService.create).not.toHaveBeenCalled();
     expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-err");
   });

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -1,4 +1,4 @@
-import { PlaylistTypeEnum, type ITrack } from "@spotiarr/shared";
+import { PlaylistTypeEnum, TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Playlist } from "@/domain/entities/playlist.entity";
 import { AppError } from "@/domain/errors/app-error";
@@ -6,6 +6,10 @@ import { SyncSubscribedPlaylistsUseCase } from "./sync-subscribed-playlists.use-
 
 const spotifyCircuitBreaker = {
   isOpen: vi.fn(() => false),
+};
+
+const retryTrackDownloadUseCase = {
+  execute: vi.fn(),
 };
 
 describe("SyncSubscribedPlaylistsUseCase", () => {
@@ -78,11 +82,63 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       trackService as never,
       eventBus as never,
       spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
     );
 
     await useCase.execute();
 
     expect(trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("re-enqueues previously errored tracks on subscribed playlists", async () => {
+    const erroredTrack: ITrack = {
+      id: "track-err",
+      name: "Song",
+      artist: "Artist",
+      trackUrl: "https://open.spotify.com/track/track-1",
+      status: TrackStatusEnum.Error,
+    };
+    trackService.getAllByPlaylist.mockResolvedValue([erroredTrack]);
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
+    );
+
+    await useCase.execute();
+
+    // Spotify returns the same single track, so nothing new is created, but the
+    // stranded errored track must be retried so the subscription can complete.
+    expect(trackService.create).not.toHaveBeenCalled();
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-err");
+  });
+
+  it("does not re-enqueue completed tracks", async () => {
+    const completedTrack: ITrack = {
+      id: "track-ok",
+      name: "Song",
+      artist: "Artist",
+      trackUrl: "https://open.spotify.com/track/track-1",
+      status: TrackStatusEnum.Completed,
+    };
+    trackService.getAllByPlaylist.mockResolvedValue([completedTrack]);
+
+    const useCase = new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
+    );
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
   });
 
   it("skips the run entirely when the Spotify circuit breaker is open", async () => {
@@ -94,6 +150,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       trackService as never,
       eventBus as never,
       spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
     );
 
     await useCase.execute();
@@ -121,6 +178,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       trackService as never,
       eventBus as never,
       spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
     );
 
     await useCase.execute();
@@ -149,6 +207,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       trackService as never,
       eventBus as never,
       spotifyCircuitBreaker as never,
+      retryTrackDownloadUseCase as never,
     );
 
     await useCase.execute();

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -1,4 +1,4 @@
-import { PlaylistTypeEnum } from "@spotiarr/shared";
+import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
 import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
 import { SpotifyService, type PlaylistTrack } from "@/application/services/spotify.service";
 import { AppError } from "@/domain/errors/app-error";
@@ -6,6 +6,7 @@ import { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackService } from "../../services/track.service";
+import type { RetryTrackDownloadUseCase } from "../tracks/retry-track-download.use-case";
 
 const PERMANENTLY_UNAVAILABLE_ERROR_CODES = new Set([
   "playlist_not_accessible",
@@ -23,6 +24,7 @@ export class SyncSubscribedPlaylistsUseCase {
     private readonly trackService: TrackService,
     private readonly eventBus: EventBus,
     private readonly spotifyCircuitBreaker: SpotifyCircuitBreakerPort,
+    private readonly retryTrackDownloadUseCase: RetryTrackDownloadUseCase,
   ) {}
 
   async execute(): Promise<void> {
@@ -146,6 +148,20 @@ export class SyncSubscribedPlaylistsUseCase {
               });
             }),
           );
+        }
+        this.eventBus.emit("playlists-updated");
+      }
+
+      // Subscribed playlists should keep trying to complete. Tracks that failed
+      // to download land in Error state with no automatic recovery (the startup
+      // rescue only handles non-terminal statuses), so re-enqueue them here on
+      // every sync. This is what lets newly-added tracks that hit a transient
+      // failure eventually finish instead of stranding the playlist below 100%.
+      const erroredTracks = existingTracks.filter((t) => t.status === TrackStatusEnum.Error);
+      if (erroredTracks.length > 0) {
+        for (const track of erroredTracks) {
+          if (!track.id) continue;
+          await this.retryTrackDownloadUseCase.execute(track.id);
         }
         this.eventBus.emit("playlists-updated");
       }

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -152,11 +152,7 @@ export class SyncSubscribedPlaylistsUseCase {
         this.eventBus.emit("playlists-updated");
       }
 
-      // Subscribed playlists should keep trying to complete. Tracks that failed
-      // to download land in Error state with no automatic recovery (the startup
-      // rescue only handles non-terminal statuses), so re-enqueue them here on
-      // every sync. This is what lets newly-added tracks that hit a transient
-      // failure eventually finish instead of stranding the playlist below 100%.
+      // Error is terminal with no auto-recovery (startup rescue skips it), so re-enqueue stranded tracks each sync.
       const erroredTracks = existingTracks.filter((t) => t.status === TrackStatusEnum.Error);
       if (erroredTracks.length > 0) {
         for (const track of erroredTracks) {

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -438,6 +438,7 @@ export function createContainer(env: Env) {
     trackService,
     eventBus,
     spotifyCircuitBreakerAdapter,
+    retryTrackDownloadUseCase,
   );
   const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(
     playlistRepository,

--- a/apps/backend/src/infrastructure/external/release-feed.service.ts
+++ b/apps/backend/src/infrastructure/external/release-feed.service.ts
@@ -189,7 +189,12 @@ export class ReleaseFeedService {
   }
 
   private filterByLookback(releases: ArtistRelease[], lookbackDays: number): ArtistRelease[] {
-    const cutoff = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+    // Release dates are date-only ("YYYY-MM-DD"), so the cutoff must also be
+    // date-only. Anchoring it to the start of the day avoids a time-of-day
+    // boundary where a release exactly N days old flickers in and out of the
+    // window depending on the current wall-clock time and timezone.
+    const now = new Date();
+    const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate() - lookbackDays);
 
     return releases.filter((item) => {
       if (!item.releaseDate) return false;

--- a/apps/backend/src/infrastructure/external/release-feed.service.ts
+++ b/apps/backend/src/infrastructure/external/release-feed.service.ts
@@ -189,10 +189,7 @@ export class ReleaseFeedService {
   }
 
   private filterByLookback(releases: ArtistRelease[], lookbackDays: number): ArtistRelease[] {
-    // Release dates are date-only ("YYYY-MM-DD"), so the cutoff must also be
-    // date-only. Anchoring it to the start of the day avoids a time-of-day
-    // boundary where a release exactly N days old flickers in and out of the
-    // window depending on the current wall-clock time and timezone.
+    // Date-only cutoff: a datetime cutoff flickers N-day-old releases in/out by time-of-day and timezone.
     const now = new Date();
     const cutoff = new Date(now.getFullYear(), now.getMonth(), now.getDate() - lookbackDays);
 


### PR DESCRIPTION
## What

Two fixes:
1. **(#27)** Subscribed playlists now re-enqueue tracks stranded in `Error` state on every periodic sync, so newly-added tracks that hit a transient download failure eventually complete instead of leaving the playlist stuck below 100%.
2. A bundled fix for a date-boundary bug in the release-feed lookback filter (was producing an intermittent test failure on `main`).

## Why (#27)

A user subscribed to a playlist, added 2 songs on Spotify, and the playlist sat at "30/32" forever. Root cause traced end to end:

- The subscribed-playlist sync **correctly detects and creates** the new tracks and enqueues them for search/download.
- A track that fails to download lands in `Error` status. `Error` is **terminal with no automatic recovery**: `cleanStuckTracksJob` only moves *non-terminal* stuck tracks (`Queued/Searching/Downloading`) to `Error`, and `RescueStuckTracksUseCase` only rescues those same non-terminal statuses **and runs only at startup**.
- So after any transient failure, the new tracks are stranded in `Error` and never retried.

There is no per-track retry counter (`DOWNLOAD_MAX_RETRIES` governs retries *within* a single search attempt, not across attempts).

### Change

`SyncSubscribedPlaylistsUseCase` now, after the new-track diff, re-enqueues any existing `Error`-status tracks for each subscribed playlist via `RetryTrackDownloadUseCase` (resets the track to `New` and re-enqueues search). "Subscribed" means "keep trying to complete", and the sync cadence (default 60 min) acts as a natural rate limit.

- Injects `RetryTrackDownloadUseCase` into the use case (wired in `container.ts`).
- Unit tests (TDD, red→green): errored tracks are retried; completed tracks are not.

#### Known limitation / follow-up

Retry is currently **unbounded** — a track that is genuinely unfindable (e.g. the YouTube extraction issue in #5) will be retried each cycle. Acceptable at the hourly cadence; a bounded per-track retry counter is a sensible follow-up if it proves noisy.

## Why (release-feed fix)

`filterByLookback` built its cutoff from `Date.now()` minus N days, which carries the current time-of-day, while release dates are date-only ("YYYY-MM-DD") parsed at local midnight. A release exactly N days old then flickered in/out of the window depending on the current wall-clock time and the runner timezone — surfacing as an intermittent failure of the default-30-day-window test. Cutoff is now anchored to the start of the current day so the comparison is date-to-date and deterministic.

## Verification

```
pnpm --filter backend run test:run    # 495 passed
pnpm --filter backend run lint        # exit 0
pnpm --filter backend run build       # exit 0
```

Closes #27
