### PR TITLE
refactor(backend): inject Settings/Token ports instead of concrete SettingsService

### DIFF
--- a/apps/backend/src/application/ports/settings.port.ts
+++ b/apps/backend/src/application/ports/settings.port.ts
@@ -1,4 +1,5 @@
 export interface SettingsPort {
   getString(key: string, fallback?: string): Promise<string>;
   getNumber(key: string, fallback?: number): Promise<number>;
+  getBoolean(key: string, fallback?: boolean): Promise<boolean>;
 }

--- a/apps/backend/src/application/ports/token-store.port.ts
+++ b/apps/backend/src/application/ports/token-store.port.ts
@@ -1,0 +1,5 @@
+export interface TokenStorePort {
+  getString(key: string, fallback?: string): Promise<string>;
+  setString(key: string, value: string): Promise<void>;
+  delete(key: string): Promise<void>;
+}

--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
@@ -2,8 +2,8 @@ import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
-import type { SettingsService } from "@/application/services/settings.service";
 import { GetRecentReleasesUseCase } from "./get-recent-releases.use-case";
 
 function makeArtist(overrides: Partial<FollowedArtist> = {}): FollowedArtist {
@@ -47,7 +47,7 @@ function makeDeps() {
 
   const settingsService = {
     getNumber: vi.fn().mockResolvedValue(30),
-  } as unknown as SettingsService;
+  } as unknown as SettingsPort;
 
   return { feedRepository, spotifyUserLibraryService, releaseFeedService, settingsService };
 }

--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
@@ -1,15 +1,15 @@
 import type { ArtistRelease } from "@spotiarr/shared";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
-import type { SettingsService } from "@/application/services/settings.service";
 
 export class GetRecentReleasesUseCase {
   constructor(
     private readonly feedRepository: FeedRepositoryPort,
     private readonly spotifyUserLibraryService: SpotifyUserLibraryPort,
     private readonly releaseFeedService: ReleaseFeedPort,
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
   ) {}
 
   async execute(): Promise<ArtistRelease[]> {

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -1,5 +1,6 @@
 import { PlaylistTypeEnum } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { Playlist } from "@/domain/entities/playlist.entity";
 import { AppError } from "@/domain/errors/app-error";
 import { CreatePlaylistUseCase } from "./create-playlist.use-case";
@@ -732,6 +733,62 @@ describe("CreatePlaylistUseCase — executePlaylistTrack branch", () => {
     });
 
     const savedArg = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedArg.toPrimitive().subscribed).toBe(true);
+  });
+});
+
+describe("CreatePlaylistUseCase — SettingsPort seam", () => {
+  it("is constructable with a FakeSettingsPort and auto-subscribes when getBoolean returns true", async () => {
+    const store = new Map<string, boolean>([["AUTO_SUBSCRIBE_NEW_PLAYLISTS", true]]);
+    const fakeSettings: SettingsPort = {
+      getString: async () => "",
+      getNumber: async () => 0,
+      getBoolean: async (key) => store.get(key) ?? false,
+    };
+
+    const savedEntity = new Playlist({
+      id: "pl-1",
+      spotifyUrl: "spotiarr://album/artist-1/album-1",
+      type: PlaylistTypeEnum.Album,
+    });
+
+    const playlistRepository = {
+      findAll: vi.fn().mockResolvedValue([]),
+      save: vi.fn().mockResolvedValue(savedEntity),
+    };
+    const spotifyService = { getPlaylistDetail: vi.fn(), getPlaylistMetadata: vi.fn() };
+    const trackService = { create: vi.fn(), getAllByPlaylist: vi.fn() };
+    const eventBus = { emit: vi.fn(), on: vi.fn() };
+    const getAlbumTracksUseCase = {
+      execute: vi
+        .fn()
+        .mockResolvedValue([{ name: "T1", artist: "A", trackNumber: 1, durationMs: 1000 }]),
+    };
+    const feedRepository = {
+      getArtistByAnyId: vi.fn().mockResolvedValue(null),
+      getArtistAlbumWithArtist: vi.fn().mockResolvedValue({
+        albumName: "Album",
+        artistName: "Artist",
+        coverUrl: undefined,
+      }),
+      getArtistReleaseWithArtist: vi.fn().mockResolvedValue(null),
+    };
+
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const useCase = new CreatePlaylistUseCase(
+      playlistRepository as any,
+      spotifyService as any,
+      trackService as any,
+      fakeSettings,
+      eventBus as any,
+      getAlbumTracksUseCase as any,
+      feedRepository as any,
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    await useCase.execute({ kind: "album", artistId: "artist-1", albumId: "album-1" });
+
+    const savedArg = playlistRepository.save.mock.calls[0]?.[0] as Playlist;
     expect(savedArg.toPrimitive().subscribed).toBe(true);
   });
 });

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -6,20 +6,16 @@ import {
   extractDeezerTrackId,
 } from "@spotiarr/shared";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyService } from "@/application/services/spotify.service";
+import { isPrismaUniqueViolation } from "@/application/utils/prisma-error.utils";
 import { Playlist } from "@/domain/entities/playlist.entity";
 import { AppError } from "@/domain/errors/app-error";
 import type { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
-import type { SettingsService } from "../../services/settings.service";
 import type { TrackService } from "../../services/track.service";
 import type { GetAlbumTracksUseCase } from "../artists/get-album-tracks.use-case";
-
-// Inline type guard: keeps application layer free of infrastructure imports.
-// Same guard exists in infrastructure/database/prisma-errors.ts for infra-layer use.
-const isUniqueConstraintViolation = (e: unknown): boolean =>
-  e instanceof Error && "code" in e && (e as { code?: string }).code === "P2002";
 
 interface DeezerAlbumTracksPort {
   getAlbumTracks(deezerAlbumId: string | number): Promise<NormalizedTrack[]>;
@@ -46,7 +42,7 @@ export class CreatePlaylistUseCase {
     private readonly playlistRepository: PlaylistRepository,
     private readonly spotifyService: SpotifyService,
     private readonly trackService: TrackService,
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     private readonly eventBus: EventBus,
     private readonly getAlbumTracksUseCase?: GetAlbumTracksUseCase,
     private readonly feedRepository?: FeedRepositoryPort,
@@ -327,7 +323,9 @@ export class CreatePlaylistUseCase {
     trackUrl: string,
   ): Promise<IPlaylist> {
     // 1. Find-or-create parent playlist (race-safe via unique constraint + P2002 recovery)
-    let parentRow = (await this.playlistRepository.findAll(false, { spotifyUrl: parentSpotifyUrl }))[0];
+    let parentRow = (
+      await this.playlistRepository.findAll(false, { spotifyUrl: parentSpotifyUrl })
+    )[0];
 
     if (!parentRow) {
       const meta = await this.spotifyService.getPlaylistMetadata(parentSpotifyUrl);
@@ -352,7 +350,7 @@ export class CreatePlaylistUseCase {
       try {
         parentRow = await this.playlistRepository.save(newParent);
       } catch (e) {
-        if (isUniqueConstraintViolation(e)) {
+        if (isPrismaUniqueViolation(e)) {
           // Another concurrent request won the race — re-read the winner
           parentRow = (
             await this.playlistRepository.findAll(false, { spotifyUrl: parentSpotifyUrl })

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
@@ -1,15 +1,15 @@
 import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { YoutubeSearchPort } from "@/application/ports/youtube.port";
 import { EventBus } from "@/domain/events/event-bus";
 import { TrackRepository } from "@/domain/repositories/track.repository";
 import type { TrackQueueService } from "@/domain/services/track-queue.service";
-import { SettingsService } from "../../services/settings.service";
 
 export class SearchTrackOnYoutubeUseCase {
   constructor(
     private readonly trackRepository: TrackRepository,
     private readonly youtubeSearchService: YoutubeSearchPort,
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     private readonly queueService: TrackQueueService,
     private readonly eventBus: EventBus,
   ) {}

--- a/apps/backend/src/application/utils/prisma-error.utils.test.ts
+++ b/apps/backend/src/application/utils/prisma-error.utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { isPrismaUniqueViolation } from "./prisma-error.utils";
+
+describe("isPrismaUniqueViolation", () => {
+  it("returns true for an Error with code P2002", () => {
+    const err = Object.assign(new Error("Unique constraint failed"), { code: "P2002" });
+    expect(isPrismaUniqueViolation(err)).toBe(true);
+  });
+
+  it("returns false for a plain Error without code", () => {
+    expect(isPrismaUniqueViolation(new Error("some error"))).toBe(false);
+  });
+
+  it("returns false for a non-Error value (string)", () => {
+    expect(isPrismaUniqueViolation("P2002")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isPrismaUniqueViolation(null)).toBe(false);
+  });
+});

--- a/apps/backend/src/application/utils/prisma-error.utils.ts
+++ b/apps/backend/src/application/utils/prisma-error.utils.ts
@@ -1,0 +1,2 @@
+export const isPrismaUniqueViolation = (e: unknown): e is { code: string } =>
+  e instanceof Error && "code" in e && (e as { code?: string }).code === "P2002";

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -218,7 +218,7 @@ export function createContainer(env: Env) {
   let spotifyFollowedArtistsService: SpotifyFollowedArtistsService | null = null;
   let spotifyFollowedArtistsSyncService: SpotifyFollowedArtistsService | null = null;
 
-  const spotifyAuthService = SpotifyAuthService.getInstance(settingsService, () => {
+  const spotifyAuthService = new SpotifyAuthService(settingsService, () => {
     spotifyUserLibraryService?.clearCache();
     spotifyUserLibrarySyncService?.clearCache();
   });

--- a/apps/backend/src/infrastructure/database/prisma-errors.ts
+++ b/apps/backend/src/infrastructure/database/prisma-errors.ts
@@ -1,10 +1,1 @@
-/**
- * Type guard for Prisma unique constraint violation (P2002).
- *
- * Use this in application-layer code (use cases) to detect and handle
- * concurrent-write races on unique-constrained columns.
- * Do NOT use this to silently swallow errors in the repository layer —
- * keep "find-or-create" semantics in the use case where intent is clear.
- */
-export const isPrismaUniqueViolation = (e: unknown): e is { code: string } =>
-  e instanceof Error && "code" in e && (e as { code?: string }).code === "P2002";
+export { isPrismaUniqueViolation } from "@/application/utils/prisma-error.utils";

--- a/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.ts
+++ b/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.ts
@@ -1,5 +1,5 @@
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUrlLookupPort } from "@/application/ports/spotify-url-lookup.port";
-import { SettingsService } from "@/application/services/settings.service";
 import { SpotifyAuthService } from "../../spotify-auth.service";
 import { SpotifyBaseClient } from "../../spotify-base.client";
 
@@ -13,7 +13,7 @@ import { SpotifyBaseClient } from "../../spotify-base.client";
  * All Spotify calls are routed through the existing CircuitBreaker via SpotifyBaseClient.
  */
 export class SpotifyUrlLookupClient extends SpotifyBaseClient implements SpotifyUrlLookupPort {
-  constructor(authService: SpotifyAuthService, settingsService: SettingsService) {
+  constructor(authService: SpotifyAuthService, settingsService: SettingsPort) {
     super(authService, settingsService, "SpotifyUrlLookupClient", "interactive");
   }
 

--- a/apps/backend/src/infrastructure/external/release-feed.service.test.ts
+++ b/apps/backend/src/infrastructure/external/release-feed.service.test.ts
@@ -1,5 +1,5 @@
 import type { ArtistRelease } from "@spotiarr/shared";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { DeezerClient } from "./providers/deezer/deezer.client";
 import type { MusicBrainzClient } from "./providers/musicbrainz/musicbrainz.client";
@@ -254,6 +254,15 @@ describe("ReleaseFeedService", () => {
   });
 
   describe("filterByLookback — lookbackDays parameter", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it("SHALL exclude releases older than the configured lookbackDays window (7d)", async () => {
       const artist = makeArtist();
       const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)

--- a/apps/backend/src/infrastructure/external/spotify-album.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-album.client.ts
@@ -1,5 +1,5 @@
 import { NormalizedTrack } from "@spotiarr/shared";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getErrorMessage } from "../utils/error.utils";
 import { PromiseCache } from "./promise-cache";
@@ -14,7 +14,7 @@ export class SpotifyAlbumClient extends SpotifyBaseClient {
 
   constructor(
     authService: SpotifyAuthService,
-    settingsService: SettingsService,
+    settingsService: SettingsPort,
     requestCache: PromiseCache,
     limiterMode: SpotifyLimiterMode = "interactive",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist-catalog.service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { validateEnvironment } from "@/infrastructure/setup/environment";
 import { SpotifyArtistCatalogService } from "./spotify-artist-catalog.service";
 import type { SpotifyAuthService } from "./spotify-auth.service";
@@ -23,7 +23,7 @@ const buildService = (market = "ES") =>
     {
       getNumber: vi.fn().mockResolvedValue(30),
       getString: vi.fn().mockResolvedValue(market),
-    } as unknown as SettingsService,
+    } as unknown as SettingsPort,
     {
       getAppToken: vi.fn().mockResolvedValue("app-token"),
       getUserToken: vi.fn().mockResolvedValue("user-token"),
@@ -83,5 +83,25 @@ describe("SpotifyArtistCatalogService", () => {
     await service.getArtistCatalogData(artists);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SpotifyArtistCatalogService — SettingsPort seam", () => {
+  it("is constructable with a FakeSettingsPort and no SettingsService import required", () => {
+    const fakeSettings = {
+      getString: async () => "ES",
+      getNumber: async () => 30,
+      getBoolean: async () => false,
+    };
+    const fakeAuth = {
+      getAppToken: vi.fn().mockResolvedValue("token"),
+      getUserToken: vi.fn(),
+      refreshUserToken: vi.fn(),
+    };
+
+    expect(
+      () =>
+        new SpotifyArtistCatalogService(fakeSettings, fakeAuth as unknown as SpotifyAuthService),
+    ).not.toThrow();
   });
 });

--- a/apps/backend/src/infrastructure/external/spotify-artist.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist.client.ts
@@ -1,4 +1,4 @@
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { getErrorMessage } from "../utils/error.utils";
 import { PromiseCache } from "./promise-cache";
 import { SpotifyAuthService } from "./spotify-auth.service";
@@ -11,7 +11,7 @@ export class SpotifyArtistClient extends SpotifyBaseClient {
 
   constructor(
     authService: SpotifyAuthService,
-    settingsService: SettingsService,
+    settingsService: SettingsPort,
     requestCache: PromiseCache,
     limiterMode: SpotifyLimiterMode = "interactive",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-auth.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-auth.service.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { TokenStorePort } from "@/application/ports/token-store.port";
 import { AppError } from "@/domain/errors/app-error";
 import { validateEnvironment } from "@/infrastructure/setup/environment";
 import { SpotifyAuthService } from "./spotify-auth.service";
@@ -26,7 +26,7 @@ describe("SpotifyAuthService invalidation", () => {
     getString: vi.fn(),
     setString: vi.fn(),
     delete: vi.fn(),
-  } as unknown as SettingsService;
+  } as unknown as TokenStorePort;
 
   let service: SpotifyAuthService;
 
@@ -108,5 +108,43 @@ describe("SpotifyAuthService invalidation", () => {
 
     await expect(service.exchangeCodeForToken("bad-code")).rejects.toBeInstanceOf(AppError);
     expect(invalidateUserLibraryCache).not.toHaveBeenCalled();
+  });
+});
+
+describe("SpotifyAuthService instance isolation", () => {
+  it("two instances do not share state", async () => {
+    const storeA = new Map<string, string>();
+    const storeB = new Map<string, string>();
+
+    const fakeStoreA: TokenStorePort = {
+      getString: async (key) => storeA.get(key) ?? "",
+      setString: async (key, val) => {
+        storeA.set(key, val);
+      },
+      delete: async (key) => {
+        storeA.delete(key);
+      },
+    };
+    const fakeStoreB: TokenStorePort = {
+      getString: async (key) => storeB.get(key) ?? "",
+      setString: async (key, val) => {
+        storeB.set(key, val);
+      },
+      delete: async (key) => {
+        storeB.delete(key);
+      },
+    };
+
+    const instanceA = new SpotifyAuthService(fakeStoreA);
+    const instanceB = new SpotifyAuthService(fakeStoreB);
+
+    await fakeStoreA.setString("some_key", "value-from-A");
+
+    const fromB = await instanceB["tokenStore"].getString("some_key");
+    expect(fromB).toBe("");
+    expect(storeA.get("some_key")).toBe("value-from-A");
+    expect(storeB.get("some_key")).toBeUndefined();
+
+    void instanceA;
   });
 });

--- a/apps/backend/src/infrastructure/external/spotify-auth.service.ts
+++ b/apps/backend/src/infrastructure/external/spotify-auth.service.ts
@@ -1,4 +1,4 @@
-import { SettingsService } from "@/application/services/settings.service";
+import type { TokenStorePort } from "@/application/ports/token-store.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getEnv } from "../setup/environment";
 import { getErrorMessage } from "../utils/error.utils";
@@ -9,28 +9,14 @@ interface SpotifyTokenResponse {
 }
 
 export class SpotifyAuthService {
-  private static instance: SpotifyAuthService | null = null;
   private accessToken: string | null = null;
   private tokenExpiry: number = 0;
   private appTokenPromise: Promise<string> | null = null;
 
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly tokenStore: TokenStorePort,
     private readonly invalidateUserLibraryCache: () => void = () => {},
   ) {}
-
-  static getInstance(
-    settingsService: SettingsService,
-    invalidateUserLibraryCache?: () => void,
-  ): SpotifyAuthService {
-    if (!SpotifyAuthService.instance) {
-      SpotifyAuthService.instance = new SpotifyAuthService(
-        settingsService,
-        invalidateUserLibraryCache,
-      );
-    }
-    return SpotifyAuthService.instance;
-  }
 
   private log(message: string, level: "debug" | "error" | "warn" = "debug") {
     const prefix = `[SpotifyAuthService]`;
@@ -107,7 +93,7 @@ export class SpotifyAuthService {
     // Check settings first (database persistence)
     let fromSettings: string | undefined;
     try {
-      fromSettings = await this.settingsService.getString(accessTokenKey);
+      fromSettings = await this.tokenStore.getString(accessTokenKey);
     } catch {
       fromSettings = undefined;
     }
@@ -131,7 +117,7 @@ export class SpotifyAuthService {
       const refreshTokenKey = "spotify_user_refresh_token";
       const accessTokenKey = "spotify_user_access_token";
 
-      const refreshToken = await this.settingsService.getString(refreshTokenKey);
+      const refreshToken = await this.tokenStore.getString(refreshTokenKey);
       if (!refreshToken) {
         this.log("No Spotify user refresh token available to refresh access token", "warn");
         return false;
@@ -178,10 +164,10 @@ export class SpotifyAuthService {
         scope?: string;
       };
 
-      await this.settingsService.setString(accessTokenKey, data.access_token);
+      await this.tokenStore.setString(accessTokenKey, data.access_token);
 
       if (data.refresh_token) {
-        await this.settingsService.setString(refreshTokenKey, data.refresh_token);
+        await this.tokenStore.setString(refreshTokenKey, data.refresh_token);
       }
 
       this.invalidateUserLibraryCache();
@@ -234,10 +220,10 @@ export class SpotifyAuthService {
       token_type: string;
     };
 
-    await this.settingsService.setString("spotify_user_access_token", data.access_token);
+    await this.tokenStore.setString("spotify_user_access_token", data.access_token);
 
     if (data.refresh_token) {
-      await this.settingsService.setString("spotify_user_refresh_token", data.refresh_token);
+      await this.tokenStore.setString("spotify_user_refresh_token", data.refresh_token);
     }
 
     this.invalidateUserLibraryCache();
@@ -245,8 +231,8 @@ export class SpotifyAuthService {
 
   async logout(): Promise<void> {
     try {
-      await this.settingsService.delete("spotify_user_access_token");
-      await this.settingsService.delete("spotify_user_refresh_token");
+      await this.tokenStore.delete("spotify_user_access_token");
+      await this.tokenStore.delete("spotify_user_refresh_token");
       this.invalidateUserLibraryCache();
       this.log("Successfully logged out from Spotify");
     } catch (error) {

--- a/apps/backend/src/infrastructure/external/spotify-base.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-base.client.ts
@@ -1,4 +1,4 @@
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { getEnv } from "../setup/environment";
 import { SpotifyAuthService } from "./spotify-auth.service";
 import { SpotifyHttpClient, type SpotifyLimiterMode } from "./spotify-http.client";
@@ -8,7 +8,7 @@ export abstract class SpotifyBaseClient extends SpotifyHttpClient {
 
   constructor(
     authService: SpotifyAuthService,
-    protected readonly settingsService: SettingsService,
+    protected readonly settingsService: SettingsPort,
     private readonly contextName: string,
     limiterMode: SpotifyLimiterMode = "interactive",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-followed-artists.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-followed-artists.service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { validateEnvironment } from "@/infrastructure/setup/environment";
 import type { SpotifyAuthService } from "./spotify-auth.service";
 import { SpotifyFollowedArtistsService } from "./spotify-followed-artists.service";
@@ -26,7 +26,7 @@ const buildService = () =>
         .mockImplementation((key: string) =>
           Promise.resolve(key === "FOLLOWED_ARTISTS_MAX" ? 10 : 30),
         ),
-    } as unknown as SettingsService,
+    } as unknown as SettingsPort,
     {
       getUserToken: vi.fn().mockResolvedValue("user-token"),
       refreshUserToken: vi.fn().mockResolvedValue(false),

--- a/apps/backend/src/infrastructure/external/spotify-playlist-library.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist-library.service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { validateEnvironment } from "@/infrastructure/setup/environment";
 import type { SpotifyAuthService } from "./spotify-auth.service";
 import {
@@ -44,7 +44,7 @@ const buildService = () =>
   new SpotifyPlaylistLibraryService(
     {
       getNumber: vi.fn().mockResolvedValue(30),
-    } as unknown as SettingsService,
+    } as unknown as SettingsPort,
     {
       getUserToken: vi.fn().mockResolvedValue("user-token"),
       refreshUserToken: vi.fn().mockResolvedValue(false),

--- a/apps/backend/src/infrastructure/external/spotify-playlist.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist.client.ts
@@ -1,5 +1,5 @@
 import { NormalizedTrack } from "@spotiarr/shared";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { SpotifyUrlHelper } from "@/domain/helpers/spotify-url.helper";
 import { getErrorMessage } from "../utils/error.utils";
@@ -24,7 +24,7 @@ export class SpotifyPlaylistClient extends SpotifyBaseClient {
 
   constructor(
     authService: SpotifyAuthService,
-    settingsService: SettingsService,
+    settingsService: SettingsPort,
     private readonly trackClient: SpotifyTrackClient,
     private readonly albumClient: SpotifyAlbumClient,
     requestCache: PromiseCache,
@@ -34,9 +34,7 @@ export class SpotifyPlaylistClient extends SpotifyBaseClient {
     this.requestCache = requestCache;
   }
 
-  async getPlaylistMetadata(
-    spotifyUrl: string,
-  ): Promise<{
+  async getPlaylistMetadata(spotifyUrl: string): Promise<{
     name: string;
     image: string;
     owner: string;

--- a/apps/backend/src/infrastructure/external/spotify-search.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-search.client.ts
@@ -1,5 +1,5 @@
 import type { AlbumType, SpotifySearchResults } from "@spotiarr/shared";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getErrorMessage } from "../utils/error.utils";
 import { PromiseCache } from "./promise-cache";
@@ -14,7 +14,7 @@ export class SpotifySearchClient extends SpotifyBaseClient {
 
   constructor(
     authService: SpotifyAuthService,
-    settingsService: SettingsService,
+    settingsService: SettingsPort,
     requestCache: PromiseCache,
     limiterMode: SpotifyLimiterMode = "interactive",
   ) {

--- a/apps/backend/src/infrastructure/external/spotify-track.client.ts
+++ b/apps/backend/src/infrastructure/external/spotify-track.client.ts
@@ -1,5 +1,5 @@
 import { NormalizedTrack } from "@spotiarr/shared";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { getErrorMessage } from "../utils/error.utils";
 import { PromiseCache } from "./promise-cache";
@@ -14,7 +14,7 @@ export class SpotifyTrackClient extends SpotifyBaseClient {
 
   constructor(
     authService: SpotifyAuthService,
-    settingsService: SettingsService,
+    settingsService: SettingsPort,
     limiterMode: SpotifyLimiterMode = "interactive",
     requestCache?: PromiseCache,
   ) {

--- a/apps/backend/src/infrastructure/external/youtube-download.service.ts
+++ b/apps/backend/src/infrastructure/external/youtube-download.service.ts
@@ -5,14 +5,14 @@ import {
   type SupportedAudioFormat,
 } from "@spotiarr/shared";
 import { YtDlp } from "ytdlp-nodejs";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import type { YoutubeSearchService } from "./youtube-search.service";
 import { YOUTUBE_HEADERS } from "./youtube.constants";
 
 export class YoutubeDownloadService {
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     private readonly searchService: YoutubeSearchService,
   ) {}
 

--- a/apps/backend/src/infrastructure/external/youtube-search.service.ts
+++ b/apps/backend/src/infrastructure/external/youtube-search.service.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 import { join } from "path";
 import { promisify } from "util";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
 import { YOUTUBE_USER_AGENT } from "./youtube.constants";
 
@@ -13,7 +13,7 @@ export class YoutubeSearchService {
   private readonly ytDlpPath: string;
   private lastSearchTime: number = 0;
 
-  constructor(private readonly settingsService: SettingsService) {
+  constructor(private readonly settingsService: SettingsPort) {
     // Auto-detect yt-dlp path from system PATH
     try {
       const systemPath = execSync("which yt-dlp", {

--- a/apps/backend/src/infrastructure/services/file-system-m3u.service.ts
+++ b/apps/backend/src/infrastructure/services/file-system-m3u.service.ts
@@ -1,13 +1,13 @@
 import { TrackStatusEnum, type IPlaylist, type ITrack } from "@spotiarr/shared";
 import * as fs from "fs";
 import * as path from "path";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { getErrorMessage } from "../utils/error.utils";
 import { FileSystemTrackPathService } from "./file-system-track-path.service";
 
 export class FileSystemM3uService {
   constructor(
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     private readonly trackPathService: FileSystemTrackPathService,
   ) {}
 

--- a/apps/backend/src/infrastructure/services/file-system-track-path.service.ts
+++ b/apps/backend/src/infrastructure/services/file-system-track-path.service.ts
@@ -2,11 +2,11 @@ import type { ITrack } from "@spotiarr/shared";
 import { mkdir } from "node:fs/promises";
 import { dirname, resolve } from "path";
 import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
-import { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { getEnv } from "../setup/environment";
 
 export class FileSystemTrackPathService implements FileSystemTrackPathPort {
-  constructor(private readonly settingsService: SettingsService) {}
+  constructor(private readonly settingsService: SettingsPort) {}
 
   /**
    * Get the base music library path

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
@@ -2,7 +2,7 @@ import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { runCatalogSyncJob, type CatalogSyncJobDependencies } from "./catalog-sync.worker";
 
@@ -49,7 +49,7 @@ function makeMockDeps(): CatalogSyncJobDependencies {
     } as unknown as AppEventBus,
     settingsService: {
       getNumber: vi.fn().mockResolvedValue(5),
-    } as unknown as SettingsService,
+    } as unknown as SettingsPort,
   };
 }
 

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
@@ -1,7 +1,7 @@
 import { Worker } from "bullmq";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { getContainer } from "@/container";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
@@ -11,7 +11,7 @@ export interface CatalogSyncJobDependencies {
   feedRepository: FeedRepositoryPort;
   releaseFeedService: ReleaseFeedPort;
   eventBus: AppEventBus;
-  settingsService: SettingsService;
+  settingsService: SettingsPort;
 }
 
 const CATALOG_SYNC_TTL_DAYS = 7;

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
@@ -1,8 +1,8 @@
 import type { ArtistRelease, FollowedArtist } from "@spotiarr/shared";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
-import type { SettingsService } from "@/application/services/settings.service";
 import type { ReleaseFeedService } from "../external/release-feed.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { runFeedSyncJob, type FeedSyncJobDependencies } from "./feed-sync.worker";
@@ -62,7 +62,7 @@ function makeMockDeps(): FeedSyncJobDependencies {
     } as unknown as AppEventBus,
     settingsService: {
       getNumber: vi.fn().mockResolvedValue(15),
-    } as unknown as SettingsService,
+    } as unknown as SettingsPort,
   };
 }
 

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -1,7 +1,7 @@
 import { Worker } from "bullmq";
 import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-repository.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
-import type { SettingsService } from "@/application/services/settings.service";
 import { getContainer } from "@/container";
 import type { ReleaseFeedService } from "../external/release-feed.service";
 import type { AppEventBus } from "../messaging/app-event-bus";
@@ -17,7 +17,7 @@ export interface FeedSyncJobDependencies {
   releaseFeedService: ReleaseFeedService;
   feedRepository: FeedRepositoryPort;
   eventBus: AppEventBus;
-  settingsService: SettingsService;
+  settingsService: SettingsPort;
 }
 
 /**

--- a/apps/backend/src/presentation/controllers/auth.controller.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.ts
@@ -1,7 +1,7 @@
 import { createHash, timingSafeEqual } from "crypto";
 import type { Request, Response } from "express";
 import { z } from "zod";
-import type { SettingsService } from "@/application/services/settings.service";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import { COOKIE_NAME, signCookie } from "../middleware/cookie";
 
 interface SpotifyAuthPort {
@@ -23,7 +23,7 @@ const unlockBodySchema = z.object({
 export class AuthController {
   constructor(
     private readonly spotifyAuthService: SpotifyAuthPort,
-    private readonly settingsService: SettingsService,
+    private readonly settingsService: SettingsPort,
     private readonly spotifyClientId: string,
     private readonly spotifyRedirectUri: string,
     private readonly spotiarrToken: string | undefined,


### PR DESCRIPTION
## What

Behavior-preserving DI cleanup from the repo audit (P1). No runtime change — the same `SettingsService` instance is wired throughout; the new ports are structural seams that decouple infrastructure from the concrete application service.

| Change | Detail |
|--------|--------|
| **Ports** | Add `getBoolean` to `SettingsPort`; add `TokenStorePort` (`getString`/`setString`/`delete`) for `SpotifyAuthService` token persistence. |
| **Decouple** | Swap **13 infra clients + 3 use cases + `auth.controller`** from the concrete `SettingsService` to the port interfaces, so each is unit-testable with a fake (no real `SettingsService`/Prisma). |
| **Singleton** | Remove the redundant `static instance`/`getInstance` from `SpotifyAuthService`; container constructs it with `new`. |
| **Layering** | Move the Prisma `P2002` unique-violation guard to `application/utils/prisma-error.utils.ts` (single source of truth); `infrastructure/database/prisma-errors.ts` re-exports it, so application code no longer imports from `infrastructure/`. |
| **Tests** | Seam unit tests with `FakeSettingsPort` / `FakeTokenStorePort`. |
| **Flake fix** | Pin the clock in the `release-feed` lookback tests (separate commit) — they built release dates from a live `Date.now()` and drifted with time-of-day. Pre-existing flake, surfaced today. |

## Why

Audit flagged the concrete `SettingsService` injected across the infrastructure layer as an upward dependency that blocks testability, plus a global singleton that breaks test isolation and an ORM error code leaked into the application layer. This closes all three without changing behavior.

## Verification

- `pnpm --filter backend run build` ✅ (tsc clean)
- `pnpm --filter backend run lint` ✅ (exit 0)
- `pnpm --filter backend run test:run` ✅ **500 passed**
- Fresh adversarial review: **SHIP**, 0 findings — confirmed every retyped consumer uses only port-declared methods, P2002 predicate is logically identical, container args unchanged, no `getInstance` callers remain.

## Out of scope (follow-up)

The module-level `appTokenRateLimiter` / `appTokenCircuitBreaker` singletons in `spotify-http.client.ts` and their `index.ts` persistence callback — deferred (touches the persistence path, higher risk).