### PR TITLE
style(player): strip verbose comments from reorder hook and e2e

### DIFF
--- a/apps/frontend/src/hooks/useReorderable.ts
+++ b/apps/frontend/src/hooks/useReorderable.ts
@@ -16,13 +16,6 @@ export interface Reorderable {
   moveDown: (index: number, itemCount: number) => void;
 }
 
-/**
- * Owns the reorder state machine shared by the queue surfaces: the dragging /
- * drop-over indices, the reset logic, the `from !== to` guard, and the keyboard
- * move helpers. Each consumer wires its own input modality (native HTML5
- * drag-and-drop, pointer events) to these handlers. Refs mirror the indices so
- * pointer handlers can read the latest value synchronously.
- */
 export function useReorderable(onReorder: ReorderHandler): Reorderable {
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -88,9 +88,7 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
     await expect(nowPlayingTrigger).toBeVisible();
     await nowPlayingTrigger.click();
 
-    // The fullscreen dialog is a persistent off-canvas panel toggled via
-    // transform (translate-y), so assert viewport presence rather than DOM
-    // visibility — the element stays mounted whether open or closed.
+    // Panel stays mounted (toggled via transform), so assert viewport presence, not DOM visibility.
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeInViewport();
 
@@ -108,8 +106,6 @@ test.describe("player — mobile now-playing fullscreen @smoke", () => {
 });
 
 test.describe("player — queue reorder @smoke", () => {
-  // Open the side queue with two known tracks (Dayvan Cowboy, then Awake) and
-  // return the queue list items, so each scenario only asserts the reorder path.
   async function openQueueWithTwoTracks(page: import("@playwright/test").Page) {
     const libraryPlaylist = buildPlaylist({
       id: "queue-reorder-playlist",
@@ -169,9 +165,7 @@ test.describe("player — queue reorder @smoke", () => {
   test("native drag-and-drop reorders the second queue track above the first", async ({ page }) => {
     const queueItems = await openQueueWithTwoTracks(page);
 
-    // Lock the native HTML5 drag path: each queue <li> is draggable, so dragging
-    // "Awake" onto "Dayvan Cowboy" drives the dragstart/dragover/drop sequence the
-    // QueueSidePanel listens for, exercising reorderQueue end to end.
+    // Native HTML5 drag path (each <li> is draggable).
     const awake = queueItems.filter({ hasText: "Awake" });
     const dayvanCowboy = queueItems.filter({ hasText: "Dayvan Cowboy" });
 
@@ -186,8 +180,7 @@ test.describe("player — queue reorder @smoke", () => {
   }) => {
     const queueItems = await openQueueWithTwoTracks(page);
 
-    // Accessible path: the per-row move-up button is keyboard- and screen-reader-
-    // operable, unlike native drag-and-drop. It must reorder the same queue.
+    // Accessible path: keyboard/screen-reader operable, unlike native DnD.
     await page.getByRole("button", { name: "Move Awake up" }).click();
 
     await expect(queueItems.first()).toContainText("Awake");


### PR DESCRIPTION
Removes the JSDoc block on `useReorderable` (types + identifiers convey intent) and trims multi-line narration comments in `player.spec.ts` to single-line rationale where a genuine *why* remains.

Follow-up on the reorder work (#106/#123/#105) to match the project's no-verbose-comments convention.

## Verification

```
pnpm --filter frontend run lint        # exit 0
pnpm --filter frontend exec vitest run useReorderable QueueSidePanel   # passed
PLAYWRIGHT_TARGET=mocked playwright test --project=mocked player.spec.ts   # 5 passed
```

No behavior change — comments only.