### PR TITLE
feat(ai-chat): backend generation core — port, adapter, queue, use-case [2a/4]

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -17,8 +17,10 @@
     "prisma:migrate:deploy": "prisma migrate deploy"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.69",
     "@prisma/client": "5.22.0",
     "@spotiarr/shared": "workspace:*",
+    "ai": "^6.0.200",
     "bullmq": "^5.65.1",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",

--- a/apps/backend/src/application/ports/ai-chat.port.ts
+++ b/apps/backend/src/application/ports/ai-chat.port.ts
@@ -1,0 +1,8 @@
+export interface AiTrackSuggestion {
+  title: string;
+  artist: string;
+}
+
+export interface AiChatPort {
+  generateTracks(prompt: string): Promise<AiTrackSuggestion[]>;
+}

--- a/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.test.ts
@@ -1,0 +1,170 @@
+import { PlaylistTypeEnum, type AiPlaylistProgressEvent } from "@spotiarr/shared";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AiChatPort, AiTrackSuggestion } from "@/application/ports/ai-chat.port";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+import { GenerateAiPlaylistUseCase } from "./generate-ai-playlist.use-case";
+
+const makeTrack = (title: string, artist: string): AiTrackSuggestion => ({ title, artist });
+
+const makeDeps = (overrides: Partial<ReturnType<typeof buildDeps>> = {}) => {
+  return { ...buildDeps(), ...overrides };
+};
+
+function buildDeps() {
+  return {
+    aiChatPort: {
+      generateTracks: vi.fn<AiChatPort["generateTracks"]>(),
+    } satisfies AiChatPort,
+    resolveTrackUrl: vi.fn<(title: string, artist: string) => Promise<string | null>>(),
+    playlistRepository: {
+      findAll: vi.fn().mockResolvedValue([]),
+      save: vi.fn().mockImplementation((p) => Promise.resolve(p)),
+    },
+    trackService: {
+      create: vi.fn().mockResolvedValue(undefined),
+    },
+    eventBus: {
+      emit: vi.fn(),
+    },
+    onProgress: vi.fn<(event: AiPlaylistProgressEvent) => void>(),
+  };
+}
+
+describe("GenerateAiPlaylistUseCase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("happy path", () => {
+    it("creates a playlist with all resolved tracks and emits stages in order", async () => {
+      const deps = makeDeps();
+      const suggestions = [makeTrack("Song A", "Artist A"), makeTrack("Song B", "Artist B")];
+      deps.aiChatPort.generateTracks.mockResolvedValueOnce(suggestions);
+      deps.resolveTrackUrl
+        .mockResolvedValueOnce("spotify:track:aaa")
+        .mockResolvedValueOnce("spotify:track:bbb");
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-1", prompt: "classic rock" });
+
+      expect(deps.playlistRepository.save).toHaveBeenCalledOnce();
+      const savedPlaylist = deps.playlistRepository.save.mock.calls[0][0];
+      expect(savedPlaylist.type).toBe(PlaylistTypeEnum.Ai);
+      expect(savedPlaylist.spotifyUrl).toMatch(/^spotiarr:\/\/ai\//);
+
+      expect(deps.trackService.create).toHaveBeenCalledTimes(2);
+
+      const stages = deps.onProgress.mock.calls.map((c) => c[0].stage);
+      expect(stages).toContain("llm");
+      expect(stages).toContain("validating");
+      expect(stages).toContain("saving");
+      expect(stages).toContain("done");
+
+      const doneEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "done")?.[0];
+      expect(doneEvent?.resolvedCount).toBe(2);
+      expect(doneEvent?.droppedTitles).toEqual([]);
+    });
+  });
+
+  describe("partial resolution", () => {
+    it("creates playlist with only resolved tracks and reports dropped titles", async () => {
+      const deps = makeDeps();
+      deps.aiChatPort.generateTracks.mockResolvedValueOnce([
+        makeTrack("Resolved Song", "Artist A"),
+        makeTrack("Unresolved Song", "Artist B"),
+      ]);
+      deps.resolveTrackUrl.mockResolvedValueOnce("spotify:track:aaa").mockResolvedValueOnce(null);
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-2", prompt: "test" });
+
+      expect(deps.trackService.create).toHaveBeenCalledOnce();
+      const doneEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "done")?.[0];
+      expect(doneEvent?.resolvedCount).toBe(1);
+      expect(doneEvent?.droppedTitles).toEqual(["Unresolved Song"]);
+    });
+  });
+
+  describe("zero resolved", () => {
+    it("does not create a playlist and emits error stage with zero-resolved code", async () => {
+      const deps = makeDeps();
+      deps.aiChatPort.generateTracks.mockResolvedValueOnce([
+        makeTrack("Ghost Track", "Phantom Artist"),
+      ]);
+      deps.resolveTrackUrl.mockResolvedValueOnce(null);
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-3", prompt: "impossible" });
+
+      expect(deps.playlistRepository.save).not.toHaveBeenCalled();
+      expect(deps.trackService.create).not.toHaveBeenCalled();
+
+      const errorEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "error")?.[0];
+      expect(errorEvent?.error?.code).toBe("zero-resolved");
+    });
+  });
+
+  describe("cap enforcement", () => {
+    it("caps tracks at 50 before resolving", async () => {
+      const deps = makeDeps();
+      const suggestions = Array.from({ length: 60 }, (_, i) =>
+        makeTrack(`Song ${i}`, `Artist ${i}`),
+      );
+      deps.aiChatPort.generateTracks.mockResolvedValueOnce(suggestions);
+      deps.resolveTrackUrl.mockImplementation(
+        async (title) => `spotify:track:${title.replace(" ", "-")}`,
+      );
+
+      const useCase = new GenerateAiPlaylistUseCase({ ...deps, delayMs: 0 });
+      await useCase.execute({ jobId: "job-4", prompt: "big list" });
+
+      expect(deps.resolveTrackUrl).toHaveBeenCalledTimes(50);
+      expect(deps.trackService.create).toHaveBeenCalledTimes(50);
+    });
+  });
+
+  describe("provider error propagation", () => {
+    it("emits error stage with provider error code when aiChatPort throws", async () => {
+      const deps = makeDeps();
+      deps.aiChatPort.generateTracks.mockRejectedValueOnce(
+        new AiChatError("provider-unreachable", "network down"),
+      );
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-5", prompt: "test" });
+
+      expect(deps.playlistRepository.save).not.toHaveBeenCalled();
+      const errorEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "error")?.[0];
+      expect(errorEvent?.error?.code).toBe("provider-unreachable");
+    });
+
+    it("emits error stage with llm-bad-output code on bad output error", async () => {
+      const deps = makeDeps();
+      deps.aiChatPort.generateTracks.mockRejectedValueOnce(
+        new AiChatError("llm-bad-output", "schema mismatch"),
+      );
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-6", prompt: "test" });
+
+      const errorEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "error")?.[0];
+      expect(errorEvent?.error?.code).toBe("llm-bad-output");
+    });
+  });
+
+  describe("deduplication", () => {
+    it("deduplicates tracks by resolved URL before creating", async () => {
+      const deps = makeDeps();
+      deps.aiChatPort.generateTracks.mockResolvedValueOnce([
+        makeTrack("Same Song", "Artist"),
+        makeTrack("Same Song Again", "Artist"),
+      ]);
+      deps.resolveTrackUrl.mockResolvedValue("spotify:track:same-url");
+
+      const useCase = new GenerateAiPlaylistUseCase(deps);
+      await useCase.execute({ jobId: "job-7", prompt: "dupes" });
+
+      expect(deps.trackService.create).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.test.ts
@@ -1,4 +1,8 @@
-import { PlaylistTypeEnum, type AiPlaylistProgressEvent } from "@spotiarr/shared";
+import {
+  PlaylistTypeEnum,
+  type AiPlaylistProgressEvent,
+  type AiPlaylistStage,
+} from "@spotiarr/shared";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { AiChatPort, AiTrackSuggestion } from "@/application/ports/ai-chat.port";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
@@ -55,10 +59,13 @@ describe("GenerateAiPlaylistUseCase", () => {
       expect(deps.trackService.create).toHaveBeenCalledTimes(2);
 
       const stages = deps.onProgress.mock.calls.map((c) => c[0].stage);
-      expect(stages).toContain("llm");
-      expect(stages).toContain("validating");
-      expect(stages).toContain("saving");
-      expect(stages).toContain("done");
+      const firstIndexOf = (stage: AiPlaylistStage) => stages.indexOf(stage);
+      expect(firstIndexOf("llm")).toBeGreaterThanOrEqual(0);
+      expect(firstIndexOf("llm")).toBeLessThan(firstIndexOf("validating"));
+      expect(firstIndexOf("validating")).toBeLessThan(firstIndexOf("saving"));
+      expect(firstIndexOf("saving")).toBeLessThan(firstIndexOf("done"));
+
+      expect(deps.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
 
       const doneEvent = deps.onProgress.mock.calls.find((c) => c[0].stage === "done")?.[0];
       expect(doneEvent?.resolvedCount).toBe(2);

--- a/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
@@ -4,6 +4,7 @@ import {
   type AiPlaylistProgressEvent,
 } from "@spotiarr/shared";
 import type { AiChatPort } from "@/application/ports/ai-chat.port";
+import { Playlist } from "@/domain/entities/playlist.entity";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
 import type { EventBus } from "@/domain/events/event-bus";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
@@ -27,7 +28,7 @@ interface UseCaseInput {
 interface UseCaseDeps {
   aiChatPort: AiChatPort;
   resolveTrackUrl: (title: string, artist: string) => Promise<string | null>;
-  playlistRepository: PlaylistRepository;
+  playlistRepository: Pick<PlaylistRepository, "save">;
   trackService: Pick<TrackService, "create">;
   eventBus: EventBus;
   onProgress?: (event: AiPlaylistProgressEvent) => void;
@@ -37,7 +38,7 @@ interface UseCaseDeps {
 export class GenerateAiPlaylistUseCase {
   private readonly aiChatPort: AiChatPort;
   private readonly resolveTrackUrl: (title: string, artist: string) => Promise<string | null>;
-  private readonly playlistRepository: PlaylistRepository;
+  private readonly playlistRepository: Pick<PlaylistRepository, "save">;
   private readonly trackService: Pick<TrackService, "create">;
   private readonly eventBus: EventBus;
   private readonly onProgress: (event: AiPlaylistProgressEvent) => void;
@@ -92,14 +93,14 @@ export class GenerateAiPlaylistUseCase {
       const playlistName = `AI: ${prompt.slice(0, 80)}`;
       const playlistId = crypto.randomUUID();
 
-      const playlist = {
+      const playlist = new Playlist({
         id: playlistId,
         name: playlistName,
         type: PlaylistTypeEnum.Ai,
         spotifyUrl: syntheticUrl,
         subscribed: false,
-        createdAt: new Date(),
-      };
+        createdAt: Date.now(),
+      });
 
       await this.playlistRepository.save(playlist);
 

--- a/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
@@ -1,0 +1,169 @@
+import {
+  PlaylistTypeEnum,
+  type AiPlaylistErrorCode,
+  type AiPlaylistProgressEvent,
+} from "@spotiarr/shared";
+import type { AiChatPort } from "@/application/ports/ai-chat.port";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+import type { EventBus } from "@/domain/events/event-bus";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import type { TrackService } from "../../services/track.service";
+
+const MAX_TRACKS = 50;
+const RESOLVE_MAX_CONCURRENCY = 2;
+const RESOLVE_INTERVAL_MS = 300;
+
+interface ResolvedTrack {
+  title: string;
+  artist: string;
+  trackUrl: string;
+}
+
+interface UseCaseInput {
+  jobId: string;
+  prompt: string;
+}
+
+interface UseCaseDeps {
+  aiChatPort: AiChatPort;
+  resolveTrackUrl: (title: string, artist: string) => Promise<string | null>;
+  playlistRepository: PlaylistRepository;
+  trackService: Pick<TrackService, "create">;
+  eventBus: EventBus;
+  onProgress?: (event: AiPlaylistProgressEvent) => void;
+  delayMs?: number;
+}
+
+export class GenerateAiPlaylistUseCase {
+  private readonly aiChatPort: AiChatPort;
+  private readonly resolveTrackUrl: (title: string, artist: string) => Promise<string | null>;
+  private readonly playlistRepository: PlaylistRepository;
+  private readonly trackService: Pick<TrackService, "create">;
+  private readonly eventBus: EventBus;
+  private readonly onProgress: (event: AiPlaylistProgressEvent) => void;
+  private readonly resolveDelayMs: number;
+
+  constructor(deps: UseCaseDeps) {
+    this.aiChatPort = deps.aiChatPort;
+    this.resolveTrackUrl = deps.resolveTrackUrl;
+    this.playlistRepository = deps.playlistRepository;
+    this.trackService = deps.trackService;
+    this.eventBus = deps.eventBus;
+    this.onProgress = deps.onProgress ?? (() => {});
+    this.resolveDelayMs = deps.delayMs ?? RESOLVE_INTERVAL_MS;
+  }
+
+  async execute(input: UseCaseInput): Promise<void> {
+    const { jobId, prompt } = input;
+
+    const emit = (
+      stage: AiPlaylistProgressEvent["stage"],
+      extra?: Partial<AiPlaylistProgressEvent>,
+    ) => {
+      this.onProgress({ jobId, stage, progress: 0, ...extra });
+    };
+
+    try {
+      emit("llm", { progress: 0 });
+      const rawSuggestions = await this.aiChatPort.generateTracks(prompt);
+      const suggestions = rawSuggestions.slice(0, MAX_TRACKS);
+
+      emit("validating", { progress: 0 });
+      const resolved = await this.resolveSequentially(suggestions);
+      const resolvedTracks = resolved.filter(
+        (r): r is ResolvedTrack => r.trackUrl !== null,
+      ) as ResolvedTrack[];
+
+      const deduped = deduplicateByUrl(resolvedTracks);
+      const droppedTitles = resolved.filter((r) => r.trackUrl === null).map((r) => r.title);
+
+      if (deduped.length === 0) {
+        emit("error", {
+          progress: 0,
+          error: { code: "zero-resolved", message: "No tracks could be found on Spotify" },
+          droppedTitles,
+        });
+        return;
+      }
+
+      emit("saving", { progress: 0 });
+
+      const syntheticUrl = `spotiarr://ai/${jobId}`;
+      const playlistName = `AI: ${prompt.slice(0, 80)}`;
+      const playlistId = crypto.randomUUID();
+
+      const playlist = {
+        id: playlistId,
+        name: playlistName,
+        type: PlaylistTypeEnum.Ai,
+        spotifyUrl: syntheticUrl,
+        subscribed: false,
+        createdAt: new Date(),
+      };
+
+      await this.playlistRepository.save(playlist);
+
+      for (const track of deduped) {
+        await this.trackService.create({
+          artist: track.artist,
+          name: track.title,
+          album: playlistName,
+          trackUrl: track.trackUrl,
+          playlistId,
+        });
+      }
+
+      this.eventBus.emit("playlists-updated");
+
+      emit("done", {
+        progress: 1,
+        resolvedCount: deduped.length,
+        droppedTitles,
+      });
+    } catch (err) {
+      const code =
+        err instanceof AiChatError ? (err.code as AiPlaylistErrorCode) : "provider-unreachable";
+      const message = err instanceof Error ? err.message : String(err);
+
+      emit("error", {
+        progress: 0,
+        error: { code, message },
+      });
+    }
+  }
+
+  private async resolveSequentially(
+    suggestions: Array<{ title: string; artist: string }>,
+  ): Promise<Array<{ title: string; artist: string; trackUrl: string | null }>> {
+    const results: Array<{ title: string; artist: string; trackUrl: string | null }> = [];
+
+    for (let i = 0; i < suggestions.length; i += RESOLVE_MAX_CONCURRENCY) {
+      const batch = suggestions.slice(i, i + RESOLVE_MAX_CONCURRENCY);
+      const batchResults = await Promise.all(
+        batch.map(async ({ title, artist }) => {
+          const trackUrl = await this.resolveTrackUrl(title, artist);
+          return { title, artist, trackUrl };
+        }),
+      );
+      results.push(...batchResults);
+      if (i + RESOLVE_MAX_CONCURRENCY < suggestions.length && this.resolveDelayMs > 0) {
+        await delay(this.resolveDelayMs);
+      }
+    }
+
+    return results;
+  }
+}
+
+function deduplicateByUrl(tracks: ResolvedTrack[]): ResolvedTrack[] {
+  const seen = new Set<string>();
+  return tracks.filter((t) => {
+    if (seen.has(t.trackUrl)) return false;
+    seen.add(t.trackUrl);
+    return true;
+  });
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/backend/src/domain/errors/ai-chat.error.test.ts
+++ b/apps/backend/src/domain/errors/ai-chat.error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { AiChatError, type AiChatErrorCode } from "./ai-chat.error";
+
+describe("AiChatError", () => {
+  it.each([
+    "provider-misconfig",
+    "provider-unreachable",
+    "llm-bad-output",
+  ] satisfies AiChatErrorCode[])("constructs with code %s", (code) => {
+    const err = new AiChatError(code, "test message");
+    expect(err.code).toBe(code);
+    expect(err.message).toBe("test message");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("uses code as message when message omitted", () => {
+    const err = new AiChatError("provider-misconfig");
+    expect(err.message).toBe("provider-misconfig");
+  });
+
+  it("is identifiable by instanceof", () => {
+    const err = new AiChatError("llm-bad-output");
+    expect(err instanceof AiChatError).toBe(true);
+  });
+});

--- a/apps/backend/src/domain/errors/ai-chat.error.ts
+++ b/apps/backend/src/domain/errors/ai-chat.error.ts
@@ -1,0 +1,11 @@
+export type AiChatErrorCode = "provider-misconfig" | "provider-unreachable" | "llm-bad-output";
+
+export class AiChatError extends Error {
+  constructor(
+    public readonly code: AiChatErrorCode,
+    message?: string,
+  ) {
+    super(message ?? code);
+    Object.setPrototypeOf(this, AiChatError.prototype);
+  }
+}

--- a/apps/backend/src/domain/services/ai-playlist-queue.service.ts
+++ b/apps/backend/src/domain/services/ai-playlist-queue.service.ts
@@ -1,0 +1,8 @@
+export interface AiPlaylistGenerateJobData {
+  jobId: string;
+  prompt: string;
+}
+
+export interface AiPlaylistQueueService {
+  enqueueGenerate(data: AiPlaylistGenerateJobData): Promise<void>;
+}

--- a/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AiTrackSuggestion } from "@/application/ports/ai-chat.port";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+import { OpenAiCompatibleAdapter, type GenerateObjectFn } from "./openai-compatible.adapter";
+
+const makeAdapter = (
+  overrides: Partial<{
+    baseURL: string;
+    apiKey: string;
+    model: string;
+    generateFn: GenerateObjectFn;
+  }> = {},
+) => {
+  const generateFn = overrides.generateFn ?? vi.fn();
+  return {
+    adapter: new OpenAiCompatibleAdapter({
+      baseURL: overrides.baseURL ?? "http://localhost:11434/v1",
+      apiKey: overrides.apiKey ?? "test-key",
+      model: overrides.model ?? "llama3",
+      generateFn,
+    }),
+    generateFn: generateFn as ReturnType<typeof vi.fn>,
+  };
+};
+
+describe("OpenAiCompatibleAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("generateTracks — success", () => {
+    it("returns tracks from the LLM response", async () => {
+      const tracks: AiTrackSuggestion[] = [
+        { title: "Bohemian Rhapsody", artist: "Queen" },
+        { title: "Hotel California", artist: "Eagles" },
+      ];
+      const { adapter, generateFn } = makeAdapter();
+      generateFn.mockResolvedValueOnce({ object: { tracks } });
+
+      const result = await adapter.generateTracks("epic rock playlist");
+
+      expect(result).toEqual(tracks);
+      expect(generateFn).toHaveBeenCalledOnce();
+    });
+
+    it("passes the prompt to the generate function", async () => {
+      const { adapter, generateFn } = makeAdapter();
+      generateFn.mockResolvedValueOnce({ object: { tracks: [] } });
+
+      await adapter.generateTracks("chill jazz for studying");
+
+      const callArg = generateFn.mock.calls[0][0];
+      expect(callArg.prompt).toBe("chill jazz for studying");
+    });
+  });
+
+  describe("generateTracks — error mapping", () => {
+    it("maps missing baseURL/apiKey to provider-misconfig", async () => {
+      const { adapter, generateFn } = makeAdapter({ baseURL: "", apiKey: "" });
+      generateFn.mockRejectedValueOnce(new Error("invalid url"));
+
+      await expect(adapter.generateTracks("test")).rejects.toThrow(AiChatError);
+      await expect(adapter.generateTracks("test")).rejects.toMatchObject({
+        code: "provider-misconfig",
+      });
+    });
+
+    it("maps network error to provider-unreachable", async () => {
+      const { adapter, generateFn } = makeAdapter();
+      const networkErr = new TypeError("fetch failed");
+      generateFn.mockRejectedValue(networkErr);
+
+      await expect(adapter.generateTracks("test")).rejects.toMatchObject({
+        code: "provider-unreachable",
+      });
+    });
+
+    it("maps NoObjectGeneratedError to llm-bad-output", async () => {
+      const { adapter, generateFn } = makeAdapter();
+      const noObjErr = Object.assign(new Error("no object generated"), {
+        name: "AI_NoObjectGeneratedError",
+      });
+      generateFn.mockRejectedValue(noObjErr);
+
+      await expect(adapter.generateTracks("test")).rejects.toMatchObject({
+        code: "llm-bad-output",
+      });
+    });
+
+    it("maps ZodError to llm-bad-output", async () => {
+      const { adapter, generateFn } = makeAdapter();
+      const zodErr = Object.assign(new Error("zod parse failed"), {
+        name: "ZodError",
+      });
+      generateFn.mockRejectedValue(zodErr);
+
+      await expect(adapter.generateTracks("test")).rejects.toMatchObject({
+        code: "llm-bad-output",
+      });
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.ts
@@ -1,0 +1,121 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateObject, NoObjectGeneratedError } from "ai";
+import { z } from "zod";
+import type { AiChatPort, AiTrackSuggestion } from "@/application/ports/ai-chat.port";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+
+const tracksSchema = z.object({
+  tracks: z
+    .array(
+      z.object({
+        title: z.string().min(1),
+        artist: z.string().min(1),
+      }),
+    )
+    .min(1)
+    .max(50),
+});
+
+type GenerateObjectParams = {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  schema: typeof tracksSchema;
+  system: string;
+  prompt: string;
+};
+
+export type GenerateObjectFn = (
+  params: GenerateObjectParams,
+) => Promise<{ object: { tracks: AiTrackSuggestion[] } }>;
+
+interface AdapterConfig {
+  baseURL: string;
+  apiKey: string;
+  model: string;
+  generateFn?: GenerateObjectFn;
+}
+
+function mapError(err: unknown): never {
+  if (err instanceof AiChatError) throw err;
+
+  if (err instanceof Error) {
+    if (
+      err.name === "AI_NoObjectGeneratedError" ||
+      err instanceof NoObjectGeneratedError ||
+      err.name === "ZodError"
+    ) {
+      throw new AiChatError("llm-bad-output", err.message);
+    }
+
+    if (
+      err.name === "TypeError" ||
+      err.message.includes("fetch") ||
+      err.message.includes("network") ||
+      err.message.includes("ECONNREFUSED") ||
+      err.message.includes("timeout") ||
+      err.message.includes("abort")
+    ) {
+      throw new AiChatError("provider-unreachable", err.message);
+    }
+  }
+
+  throw new AiChatError("provider-unreachable", String(err));
+}
+
+export class OpenAiCompatibleAdapter implements AiChatPort {
+  private readonly config: Required<AdapterConfig>;
+
+  constructor(config: AdapterConfig) {
+    this.config = {
+      ...config,
+      generateFn: config.generateFn ?? (generateObject as unknown as GenerateObjectFn),
+    };
+  }
+
+  async generateTracks(prompt: string): Promise<AiTrackSuggestion[]> {
+    const { baseURL, apiKey, model, generateFn } = this.config;
+
+    if (!baseURL || !apiKey) {
+      throw new AiChatError("provider-misconfig", "AI_BASE_URL and AI_API_KEY must be configured");
+    }
+
+    try {
+      const provider = createOpenAI({ baseURL, apiKey });
+      const result = await generateFn({
+        model: provider(model),
+        schema: tracksSchema,
+        system: SYSTEM_PROMPT,
+        prompt,
+      });
+      return result.object.tracks;
+    } catch (err) {
+      mapError(err);
+    }
+  }
+}
+
+const SYSTEM_PROMPT = `You are a music curator. Given a playlist description, return a JSON list of real, existing tracks.
+Only suggest tracks that genuinely exist. Be accurate about artist names and track titles.
+Return at most 50 tracks.`;
+
+export function createAiChatPort(settingsService: SettingsService): AiChatPort {
+  return {
+    async generateTracks(prompt: string): Promise<AiTrackSuggestion[]> {
+      const [baseURL, apiKey, model] = await Promise.all([
+        settingsService.getString("AI_BASE_URL", ""),
+        settingsService.getString("AI_API_KEY", ""),
+        settingsService.getString("AI_MODEL", ""),
+      ]);
+
+      if (!baseURL || !apiKey || !model) {
+        throw new AiChatError(
+          "provider-misconfig",
+          "AI_BASE_URL, AI_API_KEY, and AI_MODEL must all be configured in Settings",
+        );
+      }
+
+      const adapter = new OpenAiCompatibleAdapter({ baseURL, apiKey, model });
+      return adapter.generateTracks(prompt);
+    },
+  };
+}

--- a/apps/backend/src/infrastructure/messaging/bullmq-ai-playlist-queue.service.test.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-ai-playlist-queue.service.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const addMock = vi.fn();
+
+vi.mock("../setup/queues", () => ({
+  getAiPlaylistQueue: () => ({ add: addMock }),
+}));
+
+describe("BullMqAiPlaylistQueueService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a generate job with the given jobId and prompt", async () => {
+    const { BullMqAiPlaylistQueueService } = await import("./bullmq-ai-playlist-queue.service");
+    const service = new BullMqAiPlaylistQueueService();
+
+    await service.enqueueGenerate({ jobId: "job-abc", prompt: "chill vibes" });
+
+    expect(addMock).toHaveBeenCalledOnce();
+    expect(addMock).toHaveBeenCalledWith(
+      "generate-ai-playlist",
+      { jobId: "job-abc", prompt: "chill vibes" },
+      { jobId: "job-abc", attempts: 1, removeOnComplete: true },
+    );
+  });
+
+  it("propagates queue errors", async () => {
+    const { BullMqAiPlaylistQueueService } = await import("./bullmq-ai-playlist-queue.service");
+    const service = new BullMqAiPlaylistQueueService();
+    addMock.mockRejectedValueOnce(new Error("redis down"));
+
+    await expect(service.enqueueGenerate({ jobId: "job-1", prompt: "test" })).rejects.toThrow(
+      "redis down",
+    );
+  });
+});

--- a/apps/backend/src/infrastructure/messaging/bullmq-ai-playlist-queue.service.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-ai-playlist-queue.service.ts
@@ -1,0 +1,15 @@
+import type {
+  AiPlaylistGenerateJobData,
+  AiPlaylistQueueService,
+} from "@/domain/services/ai-playlist-queue.service";
+import { getAiPlaylistQueue } from "../setup/queues";
+
+export class BullMqAiPlaylistQueueService implements AiPlaylistQueueService {
+  async enqueueGenerate(data: AiPlaylistGenerateJobData): Promise<void> {
+    await getAiPlaylistQueue().add("generate-ai-playlist", data, {
+      jobId: data.jobId,
+      attempts: 1,
+      removeOnComplete: true,
+    });
+  }
+}

--- a/apps/backend/src/infrastructure/setup/queues.ts
+++ b/apps/backend/src/infrastructure/setup/queues.ts
@@ -5,12 +5,14 @@ import { getEnv } from "../setup/environment";
 export const FEED_SYNC_QUEUE = "feed-sync-queue";
 export const CATALOG_SYNC_QUEUE = "catalog-sync-queue";
 export const ARTWORK_BACKFILL_QUEUE = "artwork-backfill-queue";
+export const AI_PLAYLIST_QUEUE = "ai-playlist-processor";
 
 let trackDownloadQueue: Queue;
 let trackSearchQueue: Queue;
 let feedSyncQueue: Queue;
 let catalogSyncQueue: Queue;
 let artworkBackfillQueue: Queue;
+let aiPlaylistQueue: Queue;
 
 export function initializeQueues(): void {
   const env = getEnv();
@@ -54,6 +56,13 @@ export function initializeQueues(): void {
     },
   });
 
+  aiPlaylistQueue = new Queue(AI_PLAYLIST_QUEUE, {
+    connection,
+    defaultJobOptions: {
+      removeOnComplete: true,
+    },
+  });
+
   console.log("✅ BullMQ queues initialized");
 }
 
@@ -90,4 +99,11 @@ export function getArtworkBackfillQueue(): Queue {
     throw new AppError(500, "internal_server_error", "Artwork backfill queue not initialized");
   }
   return artworkBackfillQueue;
+}
+
+export function getAiPlaylistQueue(): Queue {
+  if (!aiPlaylistQueue) {
+    throw new AppError(500, "internal_server_error", "AI playlist queue not initialized");
+  }
+  return aiPlaylistQueue;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,12 +31,18 @@ importers:
 
   apps/backend:
     dependencies:
+      "@ai-sdk/openai":
+        specifier: ^3.0.69
+        version: 3.0.69(zod@4.1.13)
       "@prisma/client":
         specifier: 5.22.0
         version: 5.22.0(prisma@5.22.0)
       "@spotiarr/shared":
         specifier: workspace:*
         version: link:../../packages/shared
+      ai:
+        specifier: ^6.0.200
+        version: 6.0.200(zod@4.1.13)
       bullmq:
         specifier: ^5.65.1
         version: 5.65.1
@@ -212,6 +218,40 @@ importers:
         version: 5.9.3
 
 packages:
+  "@ai-sdk/gateway@3.0.127":
+    resolution:
+      {
+        integrity: sha512-Obmw5hmE5x+ccRrMp/Djx5r0rpFVX87YqE6OY06g5fwYlRI30dA84ARfTzX45ivCvkW4eCnBpOVXVWQ/pjH85w==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  "@ai-sdk/openai@3.0.69":
+    resolution:
+      {
+        integrity: sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  "@ai-sdk/provider-utils@4.0.27":
+    resolution:
+      {
+        integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  "@ai-sdk/provider@3.0.10":
+    resolution:
+      {
+        integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==,
+      }
+    engines: { node: ">=18" }
+
   "@ampproject/remapping@2.3.0":
     resolution:
       {
@@ -1653,6 +1693,13 @@ packages:
       }
     engines: { node: ">= 8" }
 
+  "@opentelemetry/api@1.9.1":
+    resolution:
+      {
+        integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==,
+      }
+    engines: { node: ">=8.0.0" }
+
   "@oxlint/binding-android-arm-eabi@1.66.0":
     resolution:
       {
@@ -2127,6 +2174,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
   "@tailwindcss/node@4.1.17":
     resolution:
       {
@@ -2516,6 +2569,13 @@ packages:
         integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==,
       }
 
+  "@vercel/oidc@3.2.0":
+    resolution:
+      {
+        integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==,
+      }
+    engines: { node: ">= 20" }
+
   "@vitejs/plugin-react@5.1.1":
     resolution:
       {
@@ -2601,6 +2661,15 @@ packages:
       }
     engines: { node: ">=0.4.0" }
     hasBin: true
+
+  ai@6.0.200:
+    resolution:
+      {
+        integrity: sha512-kme8AWPy7om8s5Isj/uIE0T3hVf8d5QEIpd2WJ/RiAansglud92fIEurCaz/ZYgjW5abcxuyhv55soQnLIWYEA==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv@8.20.0:
     resolution:
@@ -3418,6 +3487,13 @@ packages:
         integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
       }
 
+  eventsource-parser@3.1.0:
+    resolution:
+      {
+        integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==,
+      }
+    engines: { node: ">=18.0.0" }
+
   expect-type@1.3.0:
     resolution:
       {
@@ -4208,6 +4284,12 @@ packages:
     resolution:
       {
         integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
+
+  json-schema@0.4.0:
+    resolution:
+      {
+        integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==,
       }
 
   json5@2.2.3:
@@ -6356,6 +6438,30 @@ packages:
         optional: true
 
 snapshots:
+  "@ai-sdk/gateway@3.0.127(zod@4.1.13)":
+    dependencies:
+      "@ai-sdk/provider": 3.0.10
+      "@ai-sdk/provider-utils": 4.0.27(zod@4.1.13)
+      "@vercel/oidc": 3.2.0
+      zod: 4.1.13
+
+  "@ai-sdk/openai@3.0.69(zod@4.1.13)":
+    dependencies:
+      "@ai-sdk/provider": 3.0.10
+      "@ai-sdk/provider-utils": 4.0.27(zod@4.1.13)
+      zod: 4.1.13
+
+  "@ai-sdk/provider-utils@4.0.27(zod@4.1.13)":
+    dependencies:
+      "@ai-sdk/provider": 3.0.10
+      "@standard-schema/spec": 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.1.13
+
+  "@ai-sdk/provider@3.0.10":
+    dependencies:
+      json-schema: 0.4.0
+
   "@ampproject/remapping@2.3.0":
     dependencies:
       "@jridgewell/gen-mapping": 0.3.13
@@ -7341,6 +7447,8 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.19.1
 
+  "@opentelemetry/api@1.9.1": {}
+
   "@oxlint/binding-android-arm-eabi@1.66.0":
     optional: true
 
@@ -7541,6 +7649,8 @@ snapshots:
 
   "@rollup/rollup-win32-x64-msvc@4.53.3":
     optional: true
+
+  "@standard-schema/spec@1.1.0": {}
 
   "@tailwindcss/node@4.1.17":
     dependencies:
@@ -7775,6 +7885,8 @@ snapshots:
 
   "@types/trusted-types@2.0.7": {}
 
+  "@vercel/oidc@3.2.0": {}
+
   "@vitejs/plugin-react@5.1.1(vite@7.2.7(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1))":
     dependencies:
       "@babel/core": 7.28.5
@@ -7854,6 +7966,14 @@ snapshots:
       negotiator: 1.0.0
 
   acorn@8.15.0: {}
+
+  ai@6.0.200(zod@4.1.13):
+    dependencies:
+      "@ai-sdk/gateway": 3.0.127(zod@4.1.13)
+      "@ai-sdk/provider": 3.0.10
+      "@ai-sdk/provider-utils": 4.0.27(zod@4.1.13)
+      "@opentelemetry/api": 1.9.1
+      zod: 4.1.13
 
   ajv@8.20.0:
     dependencies:
@@ -8381,6 +8501,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  eventsource-parser@3.1.0: {}
+
   expect-type@1.3.0: {}
 
   express@5.2.1:
@@ -8891,6 +9013,8 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 


### PR DESCRIPTION
**PR 2a of 4** — stacked on #138. GitHub will retarget this to `main` once #138 merges. Part of #124.

## Scope (backend generation core, tasks 4-7)
- **`AiChatPort`** (`application/ports`) + **`AiChatError`** taxonomy: `provider-misconfig`, `provider-unreachable`, `llm-bad-output`.
- **`OpenAiCompatibleAdapter`** (`infrastructure/external/providers/ai`): AI SDK `generateObject` with a Zod `{ tracks: [{title, artist}] }` schema. The SDK call is behind an **injectable generate fn** (ADR-7) so the adapter is unit-tested without network. SDK errors mapped to the taxonomy. Factory reads `SettingsService` (AI_PROVIDER/BASE_URL/API_KEY/MODEL).
- **`ai-playlist-processor`** BullMQ queue + queue service.
- **`GenerateAiPlaylistUseCase`**: LLM → bounded `resolveTrackUrl` validation (respects the interactive Spotify rate-limiter) → zero-resolved guard (no empty playlist) → `PlaylistTypeEnum.Ai` + synthetic `spotiarr://ai/<uuid>` → `TrackService.create()` per resolved track → injected stage emitter (`llm`→`validating`→`saving`→`done`/`error`) → 50-track cap → dedup by resolved URL.

## Dependencies added
`ai@6.0.200`, `@ai-sdk/openai@3.0.69` (compatible with existing `zod@4.1.13`). `generateObject` API surface verified against the installed v6 types.

## Tests (strict TDD)
Backend suite: 526 passing. Use-case covers happy path, partial resolution, zero-resolved, 50-cap, provider-error propagation, dedup, stage-order, and the `playlists-updated` SSE emit. tsc clean.

The single failing `release-feed` test is a pre-existing date-sensitive flake on `origin/main`.

## Not in this PR
- PR-2b: BullMQ worker + controller/route + container wiring (makes this runnable end-to-end)
- PR-3: frontend chat view + e2e

## Review notes (from fresh-context verify, non-blocking)
- `AI_PROVIDER` not in the misconfig guard (has a metadata default; only selects adapter type).
- Spec text for zero-resolved is stale (design overrode `done+noTracksFound` → `error+zero-resolved`); implementation follows the design.
- Adapter tests mock the injected fn, so a real-SDK API change on future upgrades won't be caught — smoke test deferred.