### PR TITLE
feat(ai-chat): worker, endpoint, and wiring — runnable backend [2b/4]

### DIFF
--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -78,6 +78,7 @@ import { SpotifyTrackClient } from "./infrastructure/external/spotify-track.clie
 import { YoutubeDownloadService } from "./infrastructure/external/youtube-download.service";
 import { YoutubeSearchService } from "./infrastructure/external/youtube-search.service";
 import { AppEventBus } from "./infrastructure/messaging/app-event-bus";
+import { BullMqAiPlaylistQueueService } from "./infrastructure/messaging/bullmq-ai-playlist-queue.service";
 import { BullMqArtworkBackfillQueueService } from "./infrastructure/messaging/bullmq-artwork-backfill-queue.service";
 import { BullMqTrackQueueService } from "./infrastructure/messaging/bullmq-track-queue.service";
 import { ArtworkAssetsService } from "./infrastructure/services/artwork-assets.service";
@@ -92,6 +93,7 @@ import { FileSystemLibraryImageService } from "./infrastructure/services/library
 import { MetadataService } from "./infrastructure/services/metadata.service";
 import type { Env } from "./infrastructure/setup/environment";
 import { prisma } from "./infrastructure/setup/prisma";
+import { AiChatController } from "./presentation/controllers/ai.controller";
 import { ArtistController } from "./presentation/controllers/artist.controller";
 import { ArtworkBackfillController } from "./presentation/controllers/artwork-backfill.controller";
 import { AuthController } from "./presentation/controllers/auth.controller";
@@ -597,6 +599,9 @@ export function createContainer(env: Env) {
   const searchController = new SearchController(catalogSearchPort);
   const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 
+  const aiPlaylistQueueService = new BullMqAiPlaylistQueueService();
+  const aiChatController = new AiChatController(aiPlaylistQueueService);
+
   const historyUseCases = new HistoryUseCases({ repository: historyRepository });
   const historyController = new HistoryController(historyUseCases);
   const getRecentReleasesUseCase = new GetRecentReleasesUseCase(
@@ -672,6 +677,10 @@ export function createContainer(env: Env) {
     feedRepository,
     artworkBackfillRepository,
     processArtworkBackfillBatchUseCase,
+    aiPlaylistQueueService,
+    aiChatController,
+    spotifyUrlLookupClient,
+    playlistRepository,
   };
 }
 

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -10,6 +10,7 @@ import { getEnv, validateEnvironment } from "./infrastructure/setup/environment"
 import { prisma } from "./infrastructure/setup/prisma";
 import { initializeQueues } from "./infrastructure/setup/queues";
 import {
+  getAiPlaylistQueue,
   getArtworkBackfillQueue,
   getCatalogSyncQueue,
   getFeedSyncQueue,
@@ -42,6 +43,7 @@ let searchWorker: import("bullmq").Worker;
 let feedSyncWorker: import("bullmq").Worker;
 let catalogSyncWorker: import("bullmq").Worker;
 let artworkBackfillWorker: import("bullmq").Worker;
+let aiPlaylistWorker: import("bullmq").Worker;
 
 async function bootstrap() {
   console.log("🚀 Starting SpotiArr Backend...\n");
@@ -89,6 +91,9 @@ async function bootstrap() {
   const { createArtworkBackfillWorker } =
     await import("./infrastructure/workers/artwork-backfill.worker");
   artworkBackfillWorker = createArtworkBackfillWorker();
+
+  const { createAiPlaylistWorker } = await import("./infrastructure/workers/ai-playlist.worker");
+  aiPlaylistWorker = createAiPlaylistWorker();
 
   // Listen for settings updates to hot-reload workers
   (container.eventBus as unknown as EventEmitter).on(
@@ -153,11 +158,13 @@ const gracefulShutdown = async (signal: string, server: http.Server) => {
       getFeedSyncQueue().close(),
       getCatalogSyncQueue().close(),
       getArtworkBackfillQueue().close(),
+      getAiPlaylistQueue().close(),
       downloadWorker?.close(),
       searchWorker?.close(),
       feedSyncWorker?.close(),
       catalogSyncWorker?.close(),
       artworkBackfillWorker?.close(),
+      aiPlaylistWorker?.close(),
     ]);
     console.log("✅ Queues and workers closed");
 

--- a/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
@@ -83,7 +83,7 @@ describe("createAiPlaylistWorker", () => {
     const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
     createAiPlaylistWorker();
 
-    const processor = WorkerMock.mock.calls[0][1] as (job: unknown) => Promise<void>;
+    const processor = (WorkerMock.mock.calls[0] as unknown[])[1] as (job: unknown) => Promise<void>;
     const job = { data: { jobId: "job-123", prompt: "upbeat 90s rock" } };
 
     executeUseCase.mockResolvedValueOnce(undefined);
@@ -96,15 +96,17 @@ describe("createAiPlaylistWorker", () => {
     const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
     createAiPlaylistWorker();
 
-    const processor = WorkerMock.mock.calls[0][1] as (job: unknown) => Promise<void>;
+    const processor = (WorkerMock.mock.calls[0] as unknown[])[1] as (job: unknown) => Promise<void>;
     const job = { data: { jobId: "job-456", prompt: "jazz standards" } };
 
     let capturedOnProgress: ((event: AiPlaylistProgressEvent) => void) | undefined;
     const { GenerateAiPlaylistUseCase } =
       await import("@/application/use-cases/ai/generate-ai-playlist.use-case");
-    vi.mocked(GenerateAiPlaylistUseCase).mockImplementationOnce(({ onProgress }) => {
-      capturedOnProgress = onProgress;
-      return { execute: executeUseCase };
+    vi.mocked(GenerateAiPlaylistUseCase).mockImplementationOnce((deps) => {
+      capturedOnProgress = deps.onProgress;
+      return { execute: executeUseCase } as unknown as InstanceType<
+        typeof GenerateAiPlaylistUseCase
+      >;
     });
 
     executeUseCase.mockResolvedValueOnce(undefined);

--- a/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
@@ -1,0 +1,134 @@
+import type { AiPlaylistProgressEvent } from "@spotiarr/shared";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const workerListeners: Record<string, (...args: unknown[]) => unknown> = {};
+
+const workerOn = vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
+  workerListeners[event] = cb;
+});
+
+const WorkerMock = vi.fn(() => ({
+  on: workerOn,
+}));
+
+const executeUseCase = vi.fn();
+const emitEventBus = vi.fn();
+
+vi.mock("bullmq", () => ({
+  Worker: WorkerMock,
+}));
+
+vi.mock("@/container", () => ({
+  getContainer: () => ({
+    aiPlaylistQueueService: {},
+    aiChatPort: {},
+    settingsService: {},
+    spotifyUrlLookupClient: { resolveTrackUrl: vi.fn() },
+    playlistRepository: { save: vi.fn() },
+    trackService: { create: vi.fn() },
+    eventBus: { emit: emitEventBus, on: vi.fn() },
+  }),
+  initializeContainer: vi.fn(),
+  getContainerOrThrow: vi.fn(),
+  getContainerUnsafe: vi.fn(),
+  getContainerState: vi.fn(),
+  __esModule: true,
+}));
+
+vi.mock("../setup/environment", () => ({
+  getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
+}));
+
+vi.mock("../setup/queues", () => ({
+  AI_PLAYLIST_QUEUE: "ai-playlist-processor",
+}));
+
+vi.mock("@/application/use-cases/ai/generate-ai-playlist.use-case", () => ({
+  GenerateAiPlaylistUseCase: vi.fn().mockImplementation(() => ({
+    execute: executeUseCase,
+  })),
+}));
+
+describe("createAiPlaylistWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(workerListeners).forEach((key) => {
+      delete workerListeners[key];
+    });
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("creates a Worker with the AI_PLAYLIST_QUEUE and concurrency 1", async () => {
+    const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
+    createAiPlaylistWorker();
+
+    expect(WorkerMock).toHaveBeenCalledWith(
+      "ai-playlist-processor",
+      expect.any(Function),
+      expect.objectContaining({ concurrency: 1 }),
+    );
+  });
+
+  it("registers completed and failed handlers", async () => {
+    const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
+    createAiPlaylistWorker();
+
+    expect(workerOn).toHaveBeenCalledWith("completed", expect.any(Function));
+    expect(workerOn).toHaveBeenCalledWith("failed", expect.any(Function));
+  });
+
+  it("processor delegates to GenerateAiPlaylistUseCase.execute with job data", async () => {
+    const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
+    createAiPlaylistWorker();
+
+    const processor = WorkerMock.mock.calls[0][1] as (job: unknown) => Promise<void>;
+    const job = { data: { jobId: "job-123", prompt: "upbeat 90s rock" } };
+
+    executeUseCase.mockResolvedValueOnce(undefined);
+    await processor(job);
+
+    expect(executeUseCase).toHaveBeenCalledWith({ jobId: "job-123", prompt: "upbeat 90s rock" });
+  });
+
+  it("onProgress emits ai-playlist-progress via eventBus", async () => {
+    const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
+    createAiPlaylistWorker();
+
+    const processor = WorkerMock.mock.calls[0][1] as (job: unknown) => Promise<void>;
+    const job = { data: { jobId: "job-456", prompt: "jazz standards" } };
+
+    let capturedOnProgress: ((event: AiPlaylistProgressEvent) => void) | undefined;
+    const { GenerateAiPlaylistUseCase } =
+      await import("@/application/use-cases/ai/generate-ai-playlist.use-case");
+    vi.mocked(GenerateAiPlaylistUseCase).mockImplementationOnce(({ onProgress }) => {
+      capturedOnProgress = onProgress;
+      return { execute: executeUseCase };
+    });
+
+    executeUseCase.mockResolvedValueOnce(undefined);
+    await processor(job);
+
+    const event: AiPlaylistProgressEvent = {
+      jobId: "job-456",
+      stage: "llm",
+      progress: 0,
+    };
+    capturedOnProgress?.(event);
+
+    expect(emitEventBus).toHaveBeenCalledWith("ai-playlist-progress", event);
+  });
+
+  it("failed handler logs the error", async () => {
+    const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
+    createAiPlaylistWorker();
+
+    const failedHandler = workerListeners.failed;
+    expect(failedHandler).toBeTypeOf("function");
+
+    failedHandler?.({ id: "job-1" }, new Error("job failed"));
+
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/infrastructure/workers/ai-playlist.worker.ts
+++ b/apps/backend/src/infrastructure/workers/ai-playlist.worker.ts
@@ -1,0 +1,55 @@
+import type { AiPlaylistProgressEvent } from "@spotiarr/shared";
+import { Worker } from "bullmq";
+import { GenerateAiPlaylistUseCase } from "@/application/use-cases/ai/generate-ai-playlist.use-case";
+import { getContainer } from "@/container";
+import { createAiChatPort } from "../external/providers/ai/openai-compatible.adapter";
+import { getEnv } from "../setup/environment";
+import { AI_PLAYLIST_QUEUE } from "../setup/queues";
+
+export function createAiPlaylistWorker(): Worker {
+  const { spotifyUrlLookupClient, playlistRepository, trackService, eventBus, settingsService } =
+    getContainer();
+
+  const worker = new Worker(
+    AI_PLAYLIST_QUEUE,
+    async (job) => {
+      const { jobId, prompt } = job.data as { jobId: string; prompt: string };
+
+      const onProgress = (event: AiPlaylistProgressEvent) => {
+        eventBus.emit("ai-playlist-progress", event);
+      };
+
+      const aiChatPort = createAiChatPort(settingsService);
+
+      const useCase = new GenerateAiPlaylistUseCase({
+        aiChatPort,
+        resolveTrackUrl: (title, artist) => spotifyUrlLookupClient.resolveTrackUrl(title, artist),
+        playlistRepository,
+        trackService,
+        eventBus,
+        onProgress,
+      });
+
+      await useCase.execute({ jobId, prompt });
+    },
+    {
+      connection: {
+        host: getEnv().REDIS_HOST,
+        port: getEnv().REDIS_PORT,
+      },
+      concurrency: 1,
+      lockDuration: 10 * 60_000,
+    },
+  );
+
+  worker.on("completed", (job) => {
+    console.log(`[AiPlaylistWorker] Job ${job.id} completed`);
+  });
+
+  worker.on("failed", (job, error) => {
+    console.error(`[AiPlaylistWorker] Job ${job?.id} failed`, error);
+  });
+
+  console.log("✅ AI playlist worker initialized");
+  return worker;
+}

--- a/apps/backend/src/presentation/controllers/ai.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.test.ts
@@ -1,0 +1,66 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AiPlaylistQueueService } from "@/domain/services/ai-playlist-queue.service";
+import { AiChatController } from "./ai.controller";
+
+function mockRes(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+function makeQueueService(): AiPlaylistQueueService {
+  return {
+    enqueueGenerate: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("AiChatController.generate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 202 with a jobId when prompt is valid", async () => {
+    const queueService = makeQueueService();
+    const controller = new AiChatController(queueService);
+    const req = { body: { prompt: "upbeat 90s rock" } } as Request;
+    const res = mockRes();
+
+    await controller.generate(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(202);
+    const jsonCall = vi.mocked(res.json).mock.calls[0][0] as { data: { jobId: string } };
+    expect(jsonCall).toHaveProperty("data.jobId");
+    expect(typeof jsonCall.data.jobId).toBe("string");
+    expect(jsonCall.data.jobId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("enqueues a job with the prompt and generated jobId", async () => {
+    const queueService = makeQueueService();
+    const controller = new AiChatController(queueService);
+    const req = { body: { prompt: "jazz standards" } } as Request;
+    const res = mockRes();
+
+    await controller.generate(req, res);
+
+    const jsonCall = vi.mocked(res.json).mock.calls[0][0] as { data: { jobId: string } };
+    expect(queueService.enqueueGenerate).toHaveBeenCalledWith({
+      jobId: jsonCall.data.jobId,
+      prompt: "jazz standards",
+    });
+  });
+
+  it("enqueues exactly once per request", async () => {
+    const queueService = makeQueueService();
+    const controller = new AiChatController(queueService);
+    const req = { body: { prompt: "chill lofi" } } as Request;
+    const res = mockRes();
+
+    await controller.generate(req, res);
+
+    expect(queueService.enqueueGenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/presentation/controllers/ai.controller.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.ts
@@ -1,0 +1,15 @@
+import type { Request, Response } from "express";
+import type { AiPlaylistQueueService } from "@/domain/services/ai-playlist-queue.service";
+
+export class AiChatController {
+  constructor(private readonly aiPlaylistQueueService: AiPlaylistQueueService) {}
+
+  generate = async (req: Request, res: Response) => {
+    const { prompt } = req.body as { prompt: string };
+    const jobId = crypto.randomUUID();
+
+    await this.aiPlaylistQueueService.enqueueGenerate({ jobId, prompt });
+
+    res.status(202).json({ data: { jobId } });
+  };
+}

--- a/apps/backend/src/presentation/routes/ai.routes.test.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.test.ts
@@ -1,0 +1,148 @@
+import express, { type Express } from "express";
+import http from "node:http";
+import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
+import type { Container } from "@/container";
+import { AiChatController } from "../controllers/ai.controller";
+import { createAiRoutes } from "./ai.routes";
+
+const servers: http.Server[] = [];
+
+function makeQueueService(enqueueGenerate = vi.fn().mockResolvedValue(undefined)) {
+  return { enqueueGenerate };
+}
+
+function buildApp(container: Container): Express {
+  const app = express();
+  app.use(express.json());
+  app.use("/api/ai", createAiRoutes(container));
+  return app;
+}
+
+async function startServer(app: Express): Promise<string> {
+  const server = await new Promise<http.Server>((resolve) => {
+    const s = app.listen(0, () => resolve(s));
+  });
+  servers.push(server);
+  const address = server.address();
+  if (address && typeof address === "object") {
+    return `http://127.0.0.1:${address.port}`;
+  }
+  throw new Error("Unable to resolve server address");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("POST /api/ai/chat/generate", () => {
+  let enqueueGenerate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    enqueueGenerate = vi.fn().mockResolvedValue(undefined);
+    vi.clearAllMocks();
+  });
+
+  it("returns 202 with jobId for a valid prompt", async () => {
+    const queueService = makeQueueService(enqueueGenerate);
+    const aiChatController = new AiChatController(queueService);
+    const container = {
+      aiChatController,
+      aiPlaylistQueueService: queueService,
+    } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/chat/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "upbeat 90s rock" }),
+    });
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { data: { jobId: string } };
+    expect(body).toHaveProperty("data.jobId");
+    expect(typeof body.data.jobId).toBe("string");
+  });
+
+  it("returns 400 for an empty prompt — enqueue NOT called", async () => {
+    const queueService = makeQueueService(enqueueGenerate);
+    const aiChatController = new AiChatController(queueService);
+    const container = {
+      aiChatController,
+      aiPlaylistQueueService: queueService,
+    } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/chat/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(enqueueGenerate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a whitespace-only prompt — enqueue NOT called", async () => {
+    const queueService = makeQueueService(enqueueGenerate);
+    const aiChatController = new AiChatController(queueService);
+    const container = {
+      aiChatController,
+      aiPlaylistQueueService: queueService,
+    } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/chat/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "   " }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(enqueueGenerate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when prompt exceeds 500 characters — enqueue NOT called", async () => {
+    const queueService = makeQueueService(enqueueGenerate);
+    const aiChatController = new AiChatController(queueService);
+    const container = {
+      aiChatController,
+      aiPlaylistQueueService: queueService,
+    } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/chat/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "a".repeat(501) }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(enqueueGenerate).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when prompt is missing from body — enqueue NOT called", async () => {
+    const queueService = makeQueueService(enqueueGenerate);
+    const aiChatController = new AiChatController(queueService);
+    const container = {
+      aiChatController,
+      aiPlaylistQueueService: queueService,
+    } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/chat/generate`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    expect(enqueueGenerate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/presentation/routes/ai.routes.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.ts
@@ -1,0 +1,18 @@
+import { Router, type Router as ExpressRouter } from "express";
+import type { Container } from "../../container";
+import { asyncHandler } from "../middleware/async-handler";
+import { validate } from "../middleware/validate";
+import { generateAiPlaylistSchema } from "./schemas/ai.schema";
+
+export function createAiRoutes(container: Container): ExpressRouter {
+  const router: ExpressRouter = Router();
+  const { aiChatController } = container;
+
+  router.post(
+    "/chat/generate",
+    validate(generateAiPlaylistSchema),
+    asyncHandler(aiChatController.generate),
+  );
+
+  return router;
+}

--- a/apps/backend/src/presentation/routes/index.ts
+++ b/apps/backend/src/presentation/routes/index.ts
@@ -1,6 +1,7 @@
 import { ApiRoutes } from "@spotiarr/shared";
 import { Router, type Router as ExpressRouter } from "express";
 import type { Container } from "../../container";
+import { createAiRoutes } from "./ai.routes";
 import { createArtistRoutes } from "./artist.routes";
 import { createAuthRoutes } from "./auth.routes";
 import { createEventsRoutes } from "./events.routes";
@@ -29,6 +30,7 @@ export function createRoutes(container: Container): ExpressRouter {
   router.use(ApiRoutes.LIBRARY, createLibraryRoutes(container));
   router.use(ApiRoutes.SEARCH, createSearchRoutes(container));
   router.use(ApiRoutes.EXTERNAL_URL, createExternalUrlRoutes(container));
+  router.use(ApiRoutes.AI, createAiRoutes(container));
 
   return router;
 }

--- a/apps/backend/src/presentation/routes/schemas/ai.schema.test.ts
+++ b/apps/backend/src/presentation/routes/schemas/ai.schema.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { generateAiPlaylistSchema } from "./ai.schema";
+
+describe("generateAiPlaylistSchema", () => {
+  it("accepts a valid prompt", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "upbeat 90s rock" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty prompt", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "" } });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a whitespace-only prompt", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "   " } });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a prompt exceeding 500 characters", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "a".repeat(501) } });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a prompt of exactly 500 characters", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "a".repeat(500) } });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims whitespace from the prompt", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: { prompt: "  jazz  " } });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.body.prompt).toBe("jazz");
+    }
+  });
+
+  it("rejects missing prompt field", () => {
+    const result = generateAiPlaylistSchema.safeParse({ body: {} });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/backend/src/presentation/routes/schemas/ai.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/ai.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const generateAiPlaylistSchema = z.object({
+  body: z.object({
+    prompt: z
+      .string()
+      .trim()
+      .min(1, "Prompt must not be empty")
+      .max(500, "Prompt must not exceed 500 characters"),
+  }),
+});


### PR DESCRIPTION
**PR 2b of 4** — stacked on #142. GitHub retargets to its parent as the chain merges. Part of #124. This slice makes the backend runnable end-to-end.

## Scope (tasks 8-10)
- **BullMQ worker** (`workers/ai-playlist.worker.ts`): `createAiPlaylistWorker()`, **concurrency 1** (avoids starving the shared interactive Spotify rate-limiter). Per job: builds `GenerateAiPlaylistUseCase`, wires an `onProgress` emitter that publishes the SSE `ai-playlist-progress` event via `AppEventBus`, runs the use-case. completed/failed handlers registered.
- **Endpoint** `POST /api/ai/chat/generate`: Zod schema (trim + min(1) + max(500)), controller generates a `jobId`, enqueues `{ jobId, prompt }`, returns `{ jobId }` immediately. Empty/whitespace/over-500 → 400, NOT enqueued.
- **Wiring**: container (`aiPlaylistQueueService`, `aiChatController`, `spotifyUrlLookupClient`, `playlistRepository`), routes mounted at `ApiRoutes.AI`, worker bootstrapped with graceful shutdown alongside existing workers.

## Tests (strict TDD)
Backend suite: 546 passing. Worker (run + SSE emit + failed handler), schema boundaries, controller success + each validation rejection, route integration (native http.Server + fetch, matching project convention). tsc clean. End-to-end payload + SSE trace verified — no broken links.

The single failing `release-feed` test is a pre-existing date-sensitive flake on `origin/main`.

## Not in this PR
- PR-3: frontend chat view, mutation, SSE listener, navigation, i18n, e2e.

## Review notes (from fresh-context verify, non-blocking)
- Design artifact is stale on prompt max length (says 2000); spec + implementation use 500 (correct).
- BullMQ `failed` handler has no SSE fallback for a synchronous processor crash before the use-case try/catch — same gap as all existing workers, acceptable for v1.