### PR TITLE
feat(ai-chat): frontend Chat view, SSE progress, i18n, e2e [3/4]

### DIFF
--- a/apps/frontend/src/components/layouts/Sidebar.tsx
+++ b/apps/frontend/src/components/layouts/Sidebar.tsx
@@ -20,6 +20,7 @@ const NAV_TRANSLATION_KEYS = {
   Releases: "navigation.releases",
   "My Playlists": "navigation.myPlaylists",
   Artists: "navigation.artists",
+  "AI Chat": "navigation.aiChat",
   Settings: "navigation.settings",
 } as const;
 

--- a/apps/frontend/src/config/navigation.ts
+++ b/apps/frontend/src/config/navigation.ts
@@ -4,6 +4,7 @@ import {
   faClockRotateLeft,
   faHouse,
   faListUl,
+  faRobot,
   faSliders,
   faUserGroup,
 } from "@fortawesome/free-solid-svg-icons";
@@ -21,6 +22,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: "Releases", icon: faBell, to: Path.RELEASES },
   { label: "My Playlists", icon: faListUl, to: Path.MY_PLAYLISTS },
   { label: "Artists", icon: faUserGroup, to: Path.ARTISTS },
+  { label: "AI Chat", icon: faRobot, to: Path.CHAT },
   { label: "Settings", icon: faSliders, to: Path.SETTINGS },
 ];
 

--- a/apps/frontend/src/hooks/controllers/useChatController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useChatController.test.ts
@@ -1,0 +1,245 @@
+import { type AiPlaylistProgressEvent } from "@spotiarr/shared";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMutateAsync = vi.fn();
+
+vi.mock("../mutations/useGenerateAiPlaylistMutation", () => ({
+  useGenerateAiPlaylistMutation: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+}));
+
+let busListeners: Array<(e: AiPlaylistProgressEvent) => void> = [];
+
+vi.mock("@/lib/aiProgressBus", () => ({
+  aiProgressBus: {
+    on: (fn: (e: AiPlaylistProgressEvent) => void) => busListeners.push(fn),
+    off: (fn: (e: AiPlaylistProgressEvent) => void) => {
+      busListeners = busListeners.filter((l) => l !== fn);
+    },
+  },
+}));
+
+const mockInvalidateQueries = vi.fn();
+
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+  };
+});
+
+const emitProgress = (event: AiPlaylistProgressEvent) => {
+  busListeners.forEach((fn) => fn(event));
+};
+
+const { useChatController } = await import("./useChatController");
+
+afterEach(() => {
+  vi.clearAllMocks();
+  busListeners = [];
+});
+
+describe("useChatController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    busListeners = [];
+  });
+
+  it("initial state has empty prompt and idle stage", () => {
+    const { result } = renderHook(() => useChatController());
+
+    expect(result.current.prompt).toBe("");
+    expect(result.current.stage).toBeNull();
+    expect(result.current.isGenerating).toBe(false);
+    expect(result.current.messages).toEqual([]);
+  });
+
+  it("setPrompt updates the prompt value", () => {
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("jazz for a rainy day");
+    });
+
+    expect(result.current.prompt).toBe("jazz for a rainy day");
+  });
+
+  it("submit calls mutation with the current prompt and sets jobId", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-abc" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("latin jazz");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith("latin jazz");
+    expect(result.current.isGenerating).toBe(true);
+  });
+
+  it("does not call mutation when prompt is empty", async () => {
+    const { result } = renderHook(() => useChatController());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("does not call mutation when prompt is whitespace only", async () => {
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("   ");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("progress events update stage", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-1" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("chill beats");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    act(() => {
+      emitProgress({ jobId: "job-1", stage: "llm", progress: 0.2 });
+    });
+
+    expect(result.current.stage).toBe("llm");
+
+    act(() => {
+      emitProgress({ jobId: "job-1", stage: "validating", progress: 0.5 });
+    });
+
+    expect(result.current.stage).toBe("validating");
+
+    act(() => {
+      emitProgress({ jobId: "job-1", stage: "saving", progress: 0.8 });
+    });
+
+    expect(result.current.stage).toBe("saving");
+  });
+
+  it("done stage updates resolvedCount, droppedTitles, and ends generation", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-2" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("hip hop classics");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    await act(async () => {
+      emitProgress({
+        jobId: "job-2",
+        stage: "done",
+        progress: 1,
+        resolvedCount: 8,
+        droppedTitles: ["Ghost Song"],
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("done");
+      expect(result.current.resolvedCount).toBe(8);
+      expect(result.current.droppedTitles).toEqual(["Ghost Song"]);
+      expect(result.current.isGenerating).toBe(false);
+    });
+  });
+
+  it("done stage invalidates playlist queries", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-3" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("r&b");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    act(() => {
+      emitProgress({ jobId: "job-3", stage: "done", progress: 1, resolvedCount: 3 });
+    });
+
+    await waitFor(() => {
+      expect(mockInvalidateQueries).toHaveBeenCalled();
+    });
+  });
+
+  it("error stage sets error and ends generation", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-4" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("metal");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    await act(async () => {
+      emitProgress({
+        jobId: "job-4",
+        stage: "error",
+        progress: 0,
+        error: { code: "provider-misconfig", message: "Missing API key" },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.stage).toBe("error");
+      expect(result.current.error?.code).toBe("provider-misconfig");
+      expect(result.current.isGenerating).toBe(false);
+    });
+  });
+
+  it("ignores progress events from a different jobId", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ jobId: "job-5" });
+
+    const { result } = renderHook(() => useChatController());
+
+    act(() => {
+      result.current.setPrompt("bossa nova");
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    act(() => {
+      emitProgress({ jobId: "other-job", stage: "done", progress: 1, resolvedCount: 5 });
+    });
+
+    expect(result.current.stage).not.toBe("done");
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useChatController.ts
+++ b/apps/frontend/src/hooks/controllers/useChatController.ts
@@ -1,0 +1,88 @@
+import { type AiPlaylistErrorCode, type AiPlaylistStage } from "@spotiarr/shared";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { aiProgressBus } from "@/lib/aiProgressBus";
+import { useGenerateAiPlaylistMutation } from "../mutations/useGenerateAiPlaylistMutation";
+import { queryKeys } from "../queryKeys";
+
+interface ChatError {
+  code: AiPlaylistErrorCode;
+  message: string;
+}
+
+export const useChatController = () => {
+  const [prompt, setPrompt] = useState("");
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [stage, setStage] = useState<AiPlaylistStage | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [resolvedCount, setResolvedCount] = useState<number | undefined>(undefined);
+  const [droppedTitles, setDroppedTitles] = useState<string[]>([]);
+  const [error, setError] = useState<ChatError | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [messages, setMessages] = useState<{ role: string; text: string }[]>([]);
+
+  const mutation = useGenerateAiPlaylistMutation();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const handler = (event: {
+      jobId: string;
+      stage: AiPlaylistStage;
+      progress: number;
+      resolvedCount?: number;
+      droppedTitles?: string[];
+      error?: ChatError;
+    }) => {
+      if (event.jobId !== jobId) return;
+
+      setStage(event.stage);
+      setProgress(event.progress);
+
+      if (event.stage === "done") {
+        setResolvedCount(event.resolvedCount);
+        setDroppedTitles(event.droppedTitles ?? []);
+        setIsGenerating(false);
+        void queryClient.invalidateQueries({ queryKey: queryKeys.playlists });
+      }
+
+      if (event.stage === "error") {
+        setError(event.error ?? null);
+        setIsGenerating(false);
+        void queryClient.invalidateQueries({ queryKey: queryKeys.playlists });
+      }
+    };
+
+    aiProgressBus.on(handler);
+    return () => {
+      aiProgressBus.off(handler);
+    };
+  }, [jobId, queryClient]);
+
+  const handleSubmit = async () => {
+    if (!prompt.trim()) return;
+
+    setError(null);
+    setStage(null);
+    setResolvedCount(undefined);
+    setDroppedTitles([]);
+
+    setMessages((prev) => [...prev, { role: "user", text: prompt }]);
+
+    const result = await mutation.mutateAsync(prompt);
+    setJobId(result.jobId);
+    setIsGenerating(true);
+  };
+
+  return {
+    prompt,
+    setPrompt,
+    stage,
+    progress,
+    resolvedCount,
+    droppedTitles,
+    error,
+    isGenerating,
+    messages,
+    handleSubmit,
+  };
+};

--- a/apps/frontend/src/hooks/mutations/useGenerateAiPlaylistMutation.test.tsx
+++ b/apps/frontend/src/hooks/mutations/useGenerateAiPlaylistMutation.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { aiChatService } from "@/services/aiChat.service";
+import { useGenerateAiPlaylistMutation } from "./useGenerateAiPlaylistMutation";
+
+vi.mock("@/services/aiChat.service", () => ({
+  aiChatService: {
+    generate: vi.fn(),
+  },
+}));
+
+let queryClient: QueryClient;
+
+const createWrapper = () => {
+  queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useGenerateAiPlaylistMutation", () => {
+  it("calls aiChatService.generate with the prompt", async () => {
+    vi.mocked(aiChatService.generate).mockResolvedValueOnce({ jobId: "job-xyz" });
+
+    const { result } = renderHook(() => useGenerateAiPlaylistMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("top jazz tracks");
+    });
+
+    expect(aiChatService.generate).toHaveBeenCalledWith("top jazz tracks");
+  });
+
+  it("returns the jobId on success", async () => {
+    vi.mocked(aiChatService.generate).mockResolvedValueOnce({ jobId: "job-xyz" });
+
+    const { result } = renderHook(() => useGenerateAiPlaylistMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    let returnedData: { jobId: string } | undefined;
+    await act(async () => {
+      returnedData = await result.current.mutateAsync("chill vibes");
+    });
+
+    expect(returnedData?.jobId).toBe("job-xyz");
+  });
+
+  it("is in error state when service throws", async () => {
+    vi.mocked(aiChatService.generate).mockRejectedValueOnce(new Error("Service unavailable"));
+
+    const { result } = renderHook(() => useGenerateAiPlaylistMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync("test prompt").catch(() => undefined);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/apps/frontend/src/hooks/mutations/useGenerateAiPlaylistMutation.ts
+++ b/apps/frontend/src/hooks/mutations/useGenerateAiPlaylistMutation.ts
@@ -1,0 +1,7 @@
+import { useMutation } from "@tanstack/react-query";
+import { aiChatService } from "@/services/aiChat.service";
+
+export const useGenerateAiPlaylistMutation = () =>
+  useMutation({
+    mutationFn: (prompt: string) => aiChatService.generate(prompt),
+  });

--- a/apps/frontend/src/hooks/useServerEvents.test.ts
+++ b/apps/frontend/src/hooks/useServerEvents.test.ts
@@ -1,0 +1,113 @@
+import { QueryClient } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { aiProgressBus } from "@/lib/aiProgressBus";
+import { queryKeys } from "./queryKeys";
+
+const addEventListenerMock = vi.fn();
+const closeMock = vi.fn();
+
+vi.mock("@/lib/aiProgressBus", () => ({
+  aiProgressBus: {
+    emit: vi.fn(),
+  },
+}));
+
+let mockQueryClient: QueryClient;
+vi.mock("@tanstack/react-query", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-query")>();
+  return {
+    ...actual,
+    useQueryClient: () => mockQueryClient,
+  };
+});
+
+const eventHandlers: Record<string, (event: MessageEvent) => void> = {};
+
+beforeEach(() => {
+  mockQueryClient = new QueryClient();
+  vi.spyOn(mockQueryClient, "invalidateQueries");
+
+  vi.stubGlobal(
+    "EventSource",
+    vi.fn().mockImplementation(() => ({
+      addEventListener: (name: string, handler: (event: MessageEvent) => void) => {
+        eventHandlers[name] = handler;
+        addEventListenerMock(name, handler);
+      },
+      onerror: null,
+      close: closeMock,
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  for (const key of Object.keys(eventHandlers)) {
+    delete eventHandlers[key];
+  }
+});
+
+const { useServerEvents } = await import("./useServerEvents");
+
+describe("useServerEvents — ai-playlist-progress", () => {
+  it("registers an ai-playlist-progress listener", () => {
+    renderHook(() => useServerEvents());
+    expect(addEventListenerMock).toHaveBeenCalledWith("ai-playlist-progress", expect.any(Function));
+  });
+
+  it("emits to aiProgressBus when ai-playlist-progress event fires", () => {
+    renderHook(() => useServerEvents());
+
+    const payload = { jobId: "j1", stage: "llm", progress: 0.3 };
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    eventHandlers["ai-playlist-progress"]?.(event);
+
+    expect(aiProgressBus.emit).toHaveBeenCalledWith(payload);
+  });
+
+  it("invalidates playlists query on done stage", () => {
+    renderHook(() => useServerEvents());
+
+    const payload = { jobId: "j1", stage: "done", progress: 1, resolvedCount: 3 };
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    eventHandlers["ai-playlist-progress"]?.(event);
+
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.playlists,
+    });
+  });
+
+  it("invalidates playlists query on error stage", () => {
+    renderHook(() => useServerEvents());
+
+    const payload = {
+      jobId: "j1",
+      stage: "error",
+      progress: 0,
+      error: { code: "provider-misconfig", message: "bad" },
+    };
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    eventHandlers["ai-playlist-progress"]?.(event);
+
+    expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.playlists,
+    });
+  });
+
+  it("does not invalidate playlists query for intermediate stages", () => {
+    renderHook(() => useServerEvents());
+
+    const payload = { jobId: "j1", stage: "validating", progress: 0.5 };
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    eventHandlers["ai-playlist-progress"]?.(event);
+
+    expect(aiProgressBus.emit).toHaveBeenCalledWith(payload);
+    const invalidateCalls = vi.mocked(mockQueryClient.invalidateQueries).mock.calls;
+    const playlistInvalidation = invalidateCalls.find(
+      ([arg]) => JSON.stringify(arg) === JSON.stringify({ queryKey: queryKeys.playlists }),
+    );
+    expect(playlistInvalidation).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/hooks/useServerEvents.ts
+++ b/apps/frontend/src/hooks/useServerEvents.ts
@@ -1,7 +1,8 @@
-import { ApiRoutes } from "@spotiarr/shared";
+import { type AiPlaylistProgressEvent, ApiRoutes } from "@spotiarr/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { queryKeys } from "@/hooks/queryKeys";
+import { aiProgressBus } from "@/lib/aiProgressBus";
 
 interface ArtworkBackfillUpdatedEvent {
   status?: string;
@@ -14,6 +15,15 @@ const parseArtworkBackfillEvent = (event: MessageEvent): ArtworkBackfillUpdatedE
     return JSON.parse(String(event.data)) as ArtworkBackfillUpdatedEvent;
   } catch {
     return {};
+  }
+};
+
+const parseAiProgressEvent = (event: MessageEvent): AiPlaylistProgressEvent | null => {
+  if (!event.data) return null;
+  try {
+    return JSON.parse(String(event.data)) as AiPlaylistProgressEvent;
+  } catch {
+    return null;
   }
 };
 
@@ -71,6 +81,17 @@ export const useServerEvents = () => {
             query.queryKey[0] === "library" &&
             query.queryKey[1] === "artist",
         });
+      }
+    });
+
+    eventSource.addEventListener("ai-playlist-progress", (event) => {
+      const payload = parseAiProgressEvent(event);
+      if (!payload) return;
+
+      aiProgressBus.emit(payload);
+
+      if (payload.stage === "done" || payload.stage === "error") {
+        queryClient.invalidateQueries({ queryKey: queryKeys.playlists });
       }
     });
 

--- a/apps/frontend/src/lib/aiProgressBus.test.ts
+++ b/apps/frontend/src/lib/aiProgressBus.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { type AiProgressListener, aiProgressBus } from "./aiProgressBus";
+
+describe("aiProgressBus", () => {
+  afterEach(() => {
+    aiProgressBus.removeAllListeners();
+  });
+
+  it("calls registered listener when an event is emitted", () => {
+    const listener = vi.fn();
+    aiProgressBus.on(listener);
+
+    const event = {
+      jobId: "job-1",
+      stage: "llm" as const,
+      progress: 0.2,
+    };
+    aiProgressBus.emit(event);
+
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it("calls multiple listeners", () => {
+    const listenerA = vi.fn<AiProgressListener>();
+    const listenerB = vi.fn<AiProgressListener>();
+    aiProgressBus.on(listenerA);
+    aiProgressBus.on(listenerB);
+
+    aiProgressBus.emit({ jobId: "j", stage: "done", progress: 1, resolvedCount: 5 });
+
+    expect(listenerA).toHaveBeenCalledOnce();
+    expect(listenerB).toHaveBeenCalledOnce();
+  });
+
+  it("off() removes a specific listener", () => {
+    const listener = vi.fn();
+    aiProgressBus.on(listener);
+    aiProgressBus.off(listener);
+
+    aiProgressBus.emit({
+      jobId: "j",
+      stage: "error",
+      progress: 0,
+      error: { code: "llm-bad-output", message: "fail" },
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("removeAllListeners clears all subscribers", () => {
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    aiProgressBus.on(l1);
+    aiProgressBus.on(l2);
+    aiProgressBus.removeAllListeners();
+
+    aiProgressBus.emit({ jobId: "j", stage: "saving", progress: 0.8 });
+
+    expect(l1).not.toHaveBeenCalled();
+    expect(l2).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/lib/aiProgressBus.ts
+++ b/apps/frontend/src/lib/aiProgressBus.ts
@@ -1,0 +1,20 @@
+import type { AiPlaylistProgressEvent } from "@spotiarr/shared";
+
+export type AiProgressListener = (event: AiPlaylistProgressEvent) => void;
+
+const listeners = new Set<AiProgressListener>();
+
+export const aiProgressBus = {
+  on: (listener: AiProgressListener): void => {
+    listeners.add(listener);
+  },
+  off: (listener: AiProgressListener): void => {
+    listeners.delete(listener);
+  },
+  emit: (event: AiPlaylistProgressEvent): void => {
+    listeners.forEach((fn) => fn(event));
+  },
+  removeAllListeners: (): void => {
+    listeners.clear();
+  },
+};

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -89,6 +89,7 @@
     "releases": "Releases",
     "myPlaylists": "My Playlists",
     "artists": "My Artists",
+    "aiChat": "AI Chat",
     "settings": "Settings",
     "collapse": "Collapse Sidebar",
     "expand": "Expand Sidebar",

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -411,5 +411,31 @@
       "repeatAll": "Repeat all",
       "repeatOne": "Repeat one"
     }
+  },
+  "ai": {
+    "title": "AI Chat",
+    "promptPlaceholder": "Describe the playlist you want... (e.g. \"jazz for a rainy afternoon\")",
+    "sendButton": "Generate",
+    "stages": {
+      "llm": "Generating track suggestions...",
+      "validating": "Validating tracks on Spotify...",
+      "saving": "Saving playlist...",
+      "done": "Done",
+      "error": "Error"
+    },
+    "result": {
+      "tracksAdded": "{{count}} tracks added to your library",
+      "tracksAdded_one": "{{count}} track added to your library",
+      "tracksAdded_other": "{{count}} tracks added to your library",
+      "droppedTitles": "{{count}} track could not be found",
+      "droppedTitles_one": "{{count}} track could not be found",
+      "droppedTitles_other": "{{count}} tracks could not be found"
+    },
+    "errors": {
+      "provider-misconfig": "AI provider is not configured. Please go to Settings > AI to add your credentials.",
+      "provider-unreachable": "Could not reach the AI provider. Please check your URL and API key, then retry.",
+      "llm-bad-output": "The AI returned an unexpected response. Try rephrasing your prompt.",
+      "zero-resolved": "None of the suggested tracks could be found on Spotify. Try rephrasing your prompt."
+    }
   }
 }

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -89,6 +89,7 @@
     "releases": "Lanzamientos",
     "myPlaylists": "Mis Listas",
     "artists": "Mis Artistas",
+    "aiChat": "Chat con IA",
     "settings": "Ajustes",
     "collapse": "Ocultar menú",
     "expand": "Mostrar menú",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -411,5 +411,31 @@
       "repeatAll": "Repetir todo",
       "repeatOne": "Repetir una"
     }
+  },
+  "ai": {
+    "title": "Chat con IA",
+    "promptPlaceholder": "Describe la lista de reproducción que quieres... (p. ej. \"jazz para una tarde lluviosa\")",
+    "sendButton": "Generar",
+    "stages": {
+      "llm": "Generando sugerencias de canciones...",
+      "validating": "Validando canciones en Spotify...",
+      "saving": "Guardando lista de reproducción...",
+      "done": "Listo",
+      "error": "Error"
+    },
+    "result": {
+      "tracksAdded": "{{count}} canciones añadidas a tu biblioteca",
+      "tracksAdded_one": "{{count}} canción añadida a tu biblioteca",
+      "tracksAdded_other": "{{count}} canciones añadidas a tu biblioteca",
+      "droppedTitles": "{{count}} canción no pudo encontrarse",
+      "droppedTitles_one": "{{count}} canción no pudo encontrarse",
+      "droppedTitles_other": "{{count}} canciones no pudieron encontrarse"
+    },
+    "errors": {
+      "provider-misconfig": "El proveedor de IA no está configurado. Ve a Ajustes > IA para añadir tus credenciales.",
+      "provider-unreachable": "No se pudo conectar con el proveedor de IA. Verifica la URL y la clave de API e inténtalo de nuevo.",
+      "llm-bad-output": "La IA devolvió una respuesta inesperada. Intenta reformular tu petición.",
+      "zero-resolved": "Ninguna de las canciones sugeridas pudo encontrarse en Spotify. Intenta reformular tu petición."
+    }
   }
 }

--- a/apps/frontend/src/routes/Routing.tsx
+++ b/apps/frontend/src/routes/Routing.tsx
@@ -43,6 +43,7 @@ const Search = lazy(() => import("../views/Search").then((module) => ({ default:
 const AlbumDetail = lazy(() =>
   import("../views/AlbumDetail").then((module) => ({ default: module.AlbumDetail })),
 );
+const Chat = lazy(() => import("../views/Chat").then((module) => ({ default: module.Chat })));
 
 interface RoutingProps {
   pathname: Path;
@@ -74,6 +75,7 @@ export const Routing: FC<RoutingProps> = ({ pathname, version }) => (
         <Route path={Path.SETTINGS} element={<Settings />} />
         <Route path={Path.SEARCH} element={<Search />} />
         <Route path={Path.ALBUM_DETAIL} element={<AlbumDetail />} />
+        <Route path={Path.CHAT} element={<Chat />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Route>

--- a/apps/frontend/src/routes/routes.ts
+++ b/apps/frontend/src/routes/routes.ts
@@ -12,4 +12,5 @@ export enum Path {
   MY_PLAYLISTS = "/my-playlists",
   SEARCH = "/search",
   ALBUM_DETAIL = "/album/:artistId/:albumId",
+  CHAT = "/chat",
 }

--- a/apps/frontend/src/services/aiChat.service.test.ts
+++ b/apps/frontend/src/services/aiChat.service.test.ts
@@ -1,0 +1,37 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { aiChatService } from "./aiChat.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    post: vi.fn(),
+  },
+}));
+
+describe("aiChatService", () => {
+  it("generate posts to AI chat/generate endpoint and returns jobId", async () => {
+    vi.mocked(httpClient.post).mockResolvedValueOnce({ data: { jobId: "job-123" } });
+
+    const result = await aiChatService.generate("jazz for a rainy afternoon");
+
+    expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.AI}/chat/generate`, {
+      prompt: "jazz for a rainy afternoon",
+    });
+    expect(result).toEqual({ jobId: "job-123" });
+  });
+
+  it("unwraps data envelope and returns jobId only", async () => {
+    vi.mocked(httpClient.post).mockResolvedValueOnce({ data: { jobId: "abc-456" } });
+
+    const result = await aiChatService.generate("chill beats");
+
+    expect(result.jobId).toBe("abc-456");
+  });
+
+  it("propagates errors thrown by httpClient", async () => {
+    vi.mocked(httpClient.post).mockRejectedValueOnce(new Error("Network error"));
+
+    await expect(aiChatService.generate("test")).rejects.toThrow("Network error");
+  });
+});

--- a/apps/frontend/src/services/aiChat.service.ts
+++ b/apps/frontend/src/services/aiChat.service.ts
@@ -1,0 +1,12 @@
+import { ApiRoutes, type GenerateAiPlaylistResponse } from "@spotiarr/shared";
+import { httpClient } from "./httpClient";
+
+export const aiChatService = {
+  generate: async (prompt: string): Promise<GenerateAiPlaylistResponse> => {
+    const response = await httpClient.post<{ data: GenerateAiPlaylistResponse }>(
+      `${ApiRoutes.AI}/chat/generate`,
+      { prompt },
+    );
+    return response.data;
+  },
+};

--- a/apps/frontend/src/views/Chat.test.tsx
+++ b/apps/frontend/src/views/Chat.test.tsx
@@ -1,0 +1,135 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseChatController = vi.fn();
+
+vi.mock("@/hooks/controllers/useChatController", () => ({
+  useChatController: () => mockUseChatController(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockSetPrompt = vi.fn();
+const mockHandleSubmit = vi.fn();
+
+const defaultController = {
+  prompt: "",
+  setPrompt: mockSetPrompt,
+  stage: null,
+  progress: 0,
+  resolvedCount: undefined,
+  droppedTitles: [],
+  error: null,
+  isGenerating: false,
+  messages: [],
+  handleSubmit: mockHandleSubmit,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseChatController.mockReturnValue(defaultController);
+});
+
+const { Chat } = await import("./Chat");
+
+describe("Chat view", () => {
+  it("renders the page title", () => {
+    render(<Chat />);
+    expect(screen.getByRole("heading", { level: 1 })).toBeDefined();
+  });
+
+  it("renders the prompt textarea", () => {
+    render(<Chat />);
+    expect(screen.getByRole("textbox")).toBeDefined();
+  });
+
+  it("renders the send button", () => {
+    render(<Chat />);
+    expect(screen.getByRole("button")).toBeDefined();
+  });
+
+  it("send button is disabled when prompt is empty", () => {
+    mockUseChatController.mockReturnValue({ ...defaultController, prompt: "" });
+    render(<Chat />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("send button is enabled when prompt has content", () => {
+    mockUseChatController.mockReturnValue({ ...defaultController, prompt: "jazz" });
+    render(<Chat />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("send button is disabled while generating", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      prompt: "jazz",
+      isGenerating: true,
+    });
+    render(<Chat />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("calls setPrompt on textarea change", () => {
+    render(<Chat />);
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "hip hop" } });
+    expect(mockSetPrompt).toHaveBeenCalledWith("hip hop");
+  });
+
+  it("calls handleSubmit when send button is clicked", () => {
+    mockUseChatController.mockReturnValue({ ...defaultController, prompt: "jazz" });
+    render(<Chat />);
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    expect(mockHandleSubmit).toHaveBeenCalled();
+  });
+
+  it("shows current stage when generating", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      isGenerating: true,
+      stage: "llm",
+    });
+    render(<Chat />);
+    expect(screen.getByText("ai.stages.llm")).toBeDefined();
+  });
+
+  it("shows resolved count and dropped titles on done stage", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      stage: "done",
+      resolvedCount: 8,
+      droppedTitles: ["Ghost Song"],
+    });
+    render(<Chat />);
+    expect(screen.getByText(/ai\.result\.tracksAdded/)).toBeDefined();
+    expect(screen.getByText(/Ghost Song/)).toBeDefined();
+  });
+
+  it("shows error message on error stage", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      stage: "error",
+      error: { code: "provider-misconfig", message: "Missing API key" },
+    });
+    render(<Chat />);
+    expect(screen.getByText(/ai\.errors\.provider-misconfig/)).toBeDefined();
+  });
+
+  it("renders user messages from messages list", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      messages: [{ role: "user", text: "my prompt text" }],
+    });
+    render(<Chat />);
+    expect(screen.getByText("my prompt text")).toBeDefined();
+  });
+});

--- a/apps/frontend/src/views/Chat.tsx
+++ b/apps/frontend/src/views/Chat.tsx
@@ -1,0 +1,96 @@
+import { faRobot } from "@fortawesome/free-solid-svg-icons";
+import { FC } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/atoms/Button";
+import { useChatController } from "@/hooks/controllers/useChatController";
+import { cn } from "@/utils/cn";
+
+export const Chat: FC = () => {
+  const { t } = useTranslation();
+  const {
+    prompt,
+    setPrompt,
+    stage,
+    resolvedCount,
+    droppedTitles,
+    error,
+    isGenerating,
+    messages,
+    handleSubmit,
+  } = useChatController();
+
+  const canSubmit = prompt.trim().length > 0 && !isGenerating;
+
+  return (
+    <section className="bg-background flex h-full w-full flex-col px-4 py-6 md:px-8">
+      <h1 className="text-text-primary mb-6 text-2xl font-bold">{t("ai.title")}</h1>
+
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+        <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
+          {messages.map((msg, i) => (
+            <div
+              key={i}
+              className={cn(
+                "max-w-[80%] rounded-xl px-4 py-3 text-sm",
+                msg.role === "user"
+                  ? "bg-primary self-end text-black"
+                  : "bg-background-elevated text-text-primary self-start",
+              )}
+            >
+              {msg.text}
+            </div>
+          ))}
+
+          {isGenerating && stage && (
+            <div className="text-text-secondary flex items-center gap-2 self-start text-sm">
+              <span className="animate-pulse">{t(`ai.stages.${stage}`)}</span>
+            </div>
+          )}
+
+          {stage === "done" && (
+            <div className="bg-background-elevated self-start rounded-xl px-4 py-3 text-sm">
+              <p className="text-text-primary font-medium">
+                {t("ai.result.tracksAdded", { count: resolvedCount ?? 0 })}
+              </p>
+              {droppedTitles && droppedTitles.length > 0 && (
+                <p className="text-text-secondary mt-1">
+                  {t("ai.result.droppedTitles", { count: droppedTitles.length })}:{" "}
+                  {droppedTitles.join(", ")}
+                </p>
+              )}
+            </div>
+          )}
+
+          {stage === "error" && error && (
+            <div className="self-start rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400">
+              {t(`ai.errors.${error.code}`, error.message)}
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            placeholder={t("ai.promptPlaceholder")}
+            disabled={isGenerating}
+            maxLength={500}
+            rows={3}
+            className="bg-background-elevated text-text-primary placeholder:text-text-secondary focus:ring-primary flex-1 resize-none rounded-xl border border-white/10 px-4 py-3 text-sm focus:ring-2 focus:outline-none"
+          />
+          <Button
+            variant="primary"
+            icon={faRobot}
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            loading={isGenerating}
+            ariaLabel={t("ai.sendButton")}
+            className="self-end"
+          >
+            {t("ai.sendButton")}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "../../fixtures/test";
+
+const JOB_ID = "test-job-abc-123";
+
+function buildSseEvent(eventName: string, data: object): string {
+  return `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function buildAiProgressEvents(jobId: string): string {
+  return (
+    ": connected\n\n" +
+    buildSseEvent("ai-playlist-progress", { jobId, stage: "llm", progress: 0.2 }) +
+    buildSseEvent("ai-playlist-progress", { jobId, stage: "validating", progress: 0.5 }) +
+    buildSseEvent("ai-playlist-progress", { jobId, stage: "saving", progress: 0.8 }) +
+    buildSseEvent("ai-playlist-progress", {
+      jobId,
+      stage: "done",
+      progress: 1,
+      resolvedCount: 5,
+      droppedTitles: [],
+    })
+  );
+}
+
+function buildAiErrorEvents(jobId: string): string {
+  return (
+    ": connected\n\n" +
+    buildSseEvent("ai-playlist-progress", {
+      jobId,
+      stage: "error",
+      progress: 0,
+      error: { code: "provider-misconfig", message: "Missing API key" },
+    })
+  );
+}
+
+test.describe("Mocked AI Chat flows", () => {
+  test("happy path: prompt submit triggers progress stages and shows playlist created", async ({
+    page,
+  }) => {
+    await page.route("**/api/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache", connection: "keep-alive" },
+        body: buildAiProgressEvents(JOB_ID),
+      });
+    });
+
+    await page.route("**/api/ai/chat/generate", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 202,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { jobId: JOB_ID } }),
+        });
+        return;
+      }
+      await route.abort("failed");
+    });
+
+    await page.route("**/api/playlist", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [] }),
+      });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const textarea = page.getByRole("textbox", { name: /Describe the playlist/i });
+    await expect(textarea).toBeVisible();
+
+    const sendBtn = page.getByRole("button", { name: /Generate/i });
+    await expect(sendBtn).toBeDisabled();
+
+    await textarea.fill("jazz for a rainy afternoon");
+    await expect(sendBtn).toBeEnabled();
+
+    await sendBtn.click();
+
+    await expect(page.getByText("jazz for a rainy afternoon").first()).toBeVisible();
+
+    await expect(page.getByText(/tracks added/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("error path: provider-misconfig shows settings redirect message", async ({ page }) => {
+    await page.route("**/api/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache", connection: "keep-alive" },
+        body: buildAiErrorEvents(JOB_ID),
+      });
+    });
+
+    await page.route("**/api/ai/chat/generate", async (route) => {
+      if (route.request().method() === "POST") {
+        await route.fulfill({
+          status: 202,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { jobId: JOB_ID } }),
+        });
+        return;
+      }
+      await route.abort("failed");
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    const textarea = page.getByRole("textbox", { name: /Describe the playlist/i });
+    await textarea.fill("metal classics");
+
+    const sendBtn = page.getByRole("button", { name: /Generate/i });
+    await sendBtn.click();
+
+    await expect(page.getByText(/Settings/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test("empty prompt guard: send button is disabled when textarea is empty", async ({ page }) => {
+    await page.route("**/api/events", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache", connection: "keep-alive" },
+        body: ": connected\n\n",
+      });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    const sendBtn = page.getByRole("button", { name: /Generate/i });
+    await expect(sendBtn).toBeDisabled();
+
+    const textarea = page.getByRole("textbox", { name: /Describe the playlist/i });
+    await textarea.fill("  ");
+    await expect(sendBtn).toBeDisabled();
+
+    await textarea.fill("actual content");
+    await expect(sendBtn).toBeEnabled();
+  });
+});


### PR DESCRIPTION
**PR 3 of 4** (final) — stacked on #143. GitHub retargets as the chain merges. Completes #124.

## Scope (frontend, tasks 11-18)
- **Service + mutation**: `aiChat.service.ts` → POST `/api/ai/chat/generate`; `useGenerateAiPlaylistMutation` (TanStack).
- **SSE bridge**: `ai-playlist-progress` wired into the single `useServerEvents` EventSource owner via a module-level `aiProgressBus` — **no 4th Zustand store** (3-store ceiling preserved).
- **`useChatController`**: ephemeral `useState`, correlates progress events by `jobId`, builds the chat timeline, invalidates playlist queries on `done` so the new AI playlist appears.
- **`Chat.tsx`**: input + plain message list + live stage/resolved/dropped display. All strings i18n-keyed, Tailwind v4.
- **Routing + nav**: lazy `Path.CHAT` route + sidebar nav item (with i18n key for the label).
- **i18n**: `en.json` + `es.json` (neutral Spanish).
- **E2E**: mocked Playwright — happy path, provider-error path, empty-prompt guard.

## Tests (strict TDD)
Frontend: **532 passing**, e2e **3/3**, tsc clean.

## Whole-feature coherence
No contract drift: endpoint path, `{ data: { jobId } }` envelope, SSE event name, and `AiPlaylistProgressEvent`/`AiPlaylistStage`/`AiPlaylistErrorCode` all flow through `@spotiarr/shared` on both sides.

## Fix included (from fresh-context verify)
Sidebar nav label "AI Chat" was rendering `undefined` (missing `navigation.aiChat` key + `NAV_TRANSLATION_KEYS` entry) — fixed in `Sidebar.tsx` + both locale files.

## Notes (non-blocking)
- Client length guard relies on `textarea maxLength={500}`; over-length paste is rejected by the backend 400.