### PR TITLE
refactor(frontend): paginate playlist preview with useInfiniteQuery (lazy)

### DIFF
--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.test.ts
@@ -1,0 +1,281 @@
+import { PlaylistPreview, PlaylistPreviewTracksPage, PlaylistTypeEnum } from "@spotiarr/shared";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlaylistPreviewController } from "./usePlaylistPreviewController";
+
+const PLAYLIST_URL = "https://open.spotify.com/playlist/test-id";
+
+const makeTrack = (name: string, trackUrl?: string): PlaylistPreview["tracks"][number] => ({
+  name,
+  artists: [{ name: "Artist" }],
+  album: "Album",
+  duration: 180000,
+  trackUrl,
+});
+
+const makePreview = (overrides: Partial<PlaylistPreview> = {}): PlaylistPreview => ({
+  name: "Test Playlist",
+  type: PlaylistTypeEnum.Playlist,
+  description: null,
+  coverUrl: null,
+  totalTracks: 3,
+  tracks: [makeTrack("Track 1", "https://open.spotify.com/track/1")],
+  ...overrides,
+});
+
+const mockFetchNextPage = vi.fn();
+let mockPreviewData: PlaylistPreview | undefined;
+let mockInfiniteData: { pages: PlaylistPreviewTracksPage[] } | undefined;
+let mockHasNextPage = false;
+let mockIsFetchingNextPage = false;
+let mockIsFetching = false;
+let mockLastEnabledArg: boolean | undefined;
+let mockSearchParams = new URLSearchParams(`url=${encodeURIComponent(PLAYLIST_URL)}`);
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useSearchParams: () => [mockSearchParams, vi.fn()],
+    useNavigate: () => vi.fn(),
+  };
+});
+
+vi.mock("../queries/usePlaylistPreviewQuery", () => ({
+  usePlaylistPreviewQuery: () => ({
+    data: mockPreviewData,
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+vi.mock("../queries/usePlaylistPreviewTracksInfiniteQuery", () => ({
+  PLAYLIST_PREVIEW_PAGE_SIZE: 100,
+  usePlaylistPreviewTracksInfiniteQuery: (_url: unknown, _offset: unknown, enabled: boolean) => {
+    mockLastEnabledArg = enabled;
+    return {
+      data: mockInfiniteData,
+      hasNextPage: mockHasNextPage,
+      isFetchingNextPage: mockIsFetchingNextPage,
+      isFetching: mockIsFetching,
+      fetchNextPage: mockFetchNextPage,
+    };
+  },
+}));
+
+vi.mock("../queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: () => ({ data: [] }),
+}));
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkTrackStatus: () => new Map(),
+}));
+
+vi.mock("./usePlaylistController", () => ({
+  usePlaylistController: () => ({
+    isDownloaded: false,
+    isButtonLoading: false,
+    hasFailed: false,
+    completedCount: 0,
+    displayTitle: "Test Playlist",
+    handleDownload: vi.fn(),
+    handleToggleSubscription: vi.fn(),
+    handleDelete: vi.fn(),
+    handleRetryFailed: vi.fn(),
+    handleRetryTrack: vi.fn(),
+  }),
+}));
+
+vi.mock("../useNavigationHelpers", () => ({
+  useNavigationHelpers: () => ({
+    handleGoBack: vi.fn(),
+    handleGoHome: vi.fn(),
+  }),
+}));
+
+describe("usePlaylistPreviewController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPreviewData = makePreview();
+    mockInfiniteData = undefined;
+    mockHasNextPage = false;
+    mockIsFetchingNextPage = false;
+    mockIsFetching = false;
+    mockLastEnabledArg = undefined;
+    mockSearchParams = new URLSearchParams(`url=${encodeURIComponent(PLAYLIST_URL)}`);
+  });
+
+  it("UPPC-1: initial state — tracks from preview only, hasMoreTracks true before pagination starts, isLoadingMoreTracks false", () => {
+    mockHasNextPage = false;
+    mockIsFetchingNextPage = false;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.tracks).toHaveLength(1);
+    expect(result.current.tracks[0].name).toBe("Track 1");
+    expect(result.current.hasMoreTracks).toBe(true);
+    expect(result.current.isLoadingMoreTracks).toBe(false);
+  });
+
+  it("UPPC-2: hasMoreTracks is false when shouldLoadMore is false (album type)", () => {
+    mockPreviewData = makePreview({ type: PlaylistTypeEnum.Album });
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.hasMoreTracks).toBe(false);
+  });
+
+  it("UPPC-3: loadMore appends and deduplicates pages from infinite query", () => {
+    const page2Track = makeTrack("Track 2", "https://open.spotify.com/track/2");
+    const duplicateTrack = makeTrack("Track 1", "https://open.spotify.com/track/1");
+
+    mockInfiniteData = {
+      pages: [
+        {
+          tracks: [page2Track, duplicateTrack],
+          total: 3,
+          hasMore: false,
+          nextOffset: null,
+        },
+      ],
+    };
+    mockHasNextPage = false;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.tracks).toHaveLength(2);
+    expect(result.current.tracks.map((t) => t.name)).toEqual(["Track 1", "Track 2"]);
+  });
+
+  it("UPPC-4: first handleLoadMoreTracks sets paginationStarted, does NOT call fetchNextPage yet", () => {
+    mockHasNextPage = false;
+    mockIsFetchingNextPage = false;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(mockFetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("UPPC-5: second handleLoadMoreTracks calls fetchNextPage when hasNextPage and not fetching", () => {
+    mockHasNextPage = true;
+    mockIsFetchingNextPage = false;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("UPPC-6: handleLoadMoreTracks does nothing when shouldLoadMore is false (album)", () => {
+    mockPreviewData = makePreview({ type: PlaylistTypeEnum.Album });
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(mockFetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("UPPC-7: totalCount uses previewData.totalTracks", () => {
+    mockPreviewData = makePreview({ totalTracks: 150 });
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.totalCount).toBe(150);
+  });
+
+  it("UPPC-8: URL change produces fresh accumulation (new query key would reset infinite data)", () => {
+    const { result, rerender } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.tracks).toHaveLength(1);
+
+    mockSearchParams = new URLSearchParams(
+      `url=${encodeURIComponent("https://open.spotify.com/playlist/other-id")}`,
+    );
+    mockPreviewData = makePreview({
+      name: "Other Playlist",
+      tracks: [makeTrack("Other Track", "https://open.spotify.com/track/other")],
+    });
+    mockInfiniteData = undefined;
+
+    rerender();
+
+    expect(result.current.tracks).toHaveLength(1);
+    expect(result.current.tracks[0].name).toBe("Other Track");
+  });
+
+  it("UPPC-9: isLoadingMoreTracks true when isFetchingNextPage is true", () => {
+    mockIsFetchingNextPage = true;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.isLoadingMoreTracks).toBe(true);
+  });
+
+  it("UPPC-10: album type — hasMoreTracks false, query never enabled, handleLoadMoreTracks does nothing", () => {
+    mockPreviewData = makePreview({ type: PlaylistTypeEnum.Album, totalTracks: 5 });
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.hasMoreTracks).toBe(false);
+    expect(mockLastEnabledArg).toBe(false);
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(mockFetchNextPage).not.toHaveBeenCalled();
+    expect(mockLastEnabledArg).toBe(false);
+  });
+
+  it("UPPC-11: undefined previewData — tracks empty, hasMoreTracks false, no fetch", () => {
+    mockPreviewData = undefined;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(result.current.tracks).toHaveLength(0);
+    expect(result.current.hasMoreTracks).toBe(false);
+    expect(mockLastEnabledArg).toBe(false);
+  });
+
+  it("UPPC-12: lazy gate — query not enabled on mount; enabled only after first handleLoadMoreTracks", () => {
+    mockPreviewData = makePreview({ totalTracks: 150 });
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    expect(mockLastEnabledArg).toBe(false);
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(mockLastEnabledArg).toBe(true);
+    expect(mockFetchNextPage).not.toHaveBeenCalled();
+  });
+
+  it("UPPC-13: isLoadingMoreTracks true during initial gated fetch (paginationStarted + isFetching + no data)", () => {
+    mockPreviewData = makePreview({ totalTracks: 150 });
+    mockIsFetching = true;
+    mockInfiniteData = undefined;
+
+    const { result } = renderHook(() => usePlaylistPreviewController());
+
+    act(() => {
+      result.current.handleLoadMoreTracks();
+    });
+
+    expect(result.current.isLoadingMoreTracks).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistPreviewController.ts
@@ -1,17 +1,19 @@
 import { PlaylistPreview, PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useBulkTrackStatus } from "@/hooks/queries/useDownloadStatus";
-import { playlistService } from "@/services/playlist.service";
 import { PlaylistWithStats } from "@/types";
 import { Track } from "@/types";
 import { buildZeroStats } from "@/utils/playlist";
 import { usePlaylistPreviewQuery } from "../queries/usePlaylistPreviewQuery";
+import {
+  PLAYLIST_PREVIEW_PAGE_SIZE,
+  usePlaylistPreviewTracksInfiniteQuery,
+} from "../queries/usePlaylistPreviewTracksInfiniteQuery";
 import { usePlaylistsQuery } from "../queries/usePlaylistsQuery";
 import { useNavigationHelpers } from "../useNavigationHelpers";
 import { usePlaylistController } from "./usePlaylistController";
 
-const PLAYLIST_PREVIEW_PAGE_SIZE = 100;
 type PlaylistPreviewTrack = PlaylistPreview["tracks"][number];
 
 const createPreviewTrackKey = (track: PlaylistPreviewTrack): string => {
@@ -40,70 +42,54 @@ export const usePlaylistPreviewController = () => {
 
   const { data: previewData, isLoading, error } = usePlaylistPreviewQuery(spotifyUrl);
   const { data: playlists } = usePlaylistsQuery();
-  const [pagedTracks, setPagedTracks] = useState<PlaylistPreviewTrack[]>([]);
-  const [hasMoreTracks, setHasMoreTracks] = useState(false);
-  const [nextOffset, setNextOffset] = useState<number | null>(null);
-  const [isLoadingMoreTracks, setIsLoadingMoreTracks] = useState(false);
-  const requestedOffsetsRef = useRef<Set<number>>(new Set());
+
+  const [paginationStarted, setPaginationStarted] = useState(false);
 
   useEffect(() => {
-    requestedOffsetsRef.current = new Set();
+    setPaginationStarted(false);
+  }, [spotifyUrl]);
 
-    if (!previewData || !spotifyUrl) {
-      setPagedTracks([]);
-      setHasMoreTracks(false);
-      setNextOffset(null);
-      return;
-    }
+  const initialTrackCount = previewData?.tracks.length ?? 0;
+  const isPlaylistPreview = previewData?.type === PlaylistTypeEnum.Playlist;
+  const shouldLoadMore =
+    isPlaylistPreview &&
+    previewData != null &&
+    (previewData.totalTracks > initialTrackCount ||
+      initialTrackCount >= PLAYLIST_PREVIEW_PAGE_SIZE);
 
-    const initialTrackCount = previewData.tracks.length;
-    const isPlaylistPreview = previewData.type === PlaylistTypeEnum.Playlist;
-    const shouldLoadMore =
-      isPlaylistPreview &&
-      (previewData.totalTracks > initialTrackCount ||
-        initialTrackCount >= PLAYLIST_PREVIEW_PAGE_SIZE);
+  const queryEnabled = !!spotifyUrl && previewData != null && shouldLoadMore && paginationStarted;
 
-    setPagedTracks([]);
-    setHasMoreTracks(shouldLoadMore);
-    setNextOffset(shouldLoadMore ? initialTrackCount : null);
-  }, [previewData, spotifyUrl]);
+  const {
+    data: infiniteData,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetching: isInfiniteFetching,
+    fetchNextPage,
+  } = usePlaylistPreviewTracksInfiniteQuery(spotifyUrl, initialTrackCount, queryEnabled);
+
+  const infinitePages = useMemo(
+    () => infiniteData?.pages.flatMap((p) => p.tracks) ?? [],
+    [infiniteData],
+  );
 
   const accumulatedPreviewTracks = useMemo(() => {
     if (!previewData) {
       return [];
     }
 
-    return mergeUniquePreviewTracks([...previewData.tracks, ...pagedTracks]);
-  }, [previewData, pagedTracks]);
+    return mergeUniquePreviewTracks([...previewData.tracks, ...infinitePages]);
+  }, [previewData, infinitePages]);
 
-  const handleLoadMoreTracks = useCallback(async () => {
-    if (!spotifyUrl || !hasMoreTracks || nextOffset === null || isLoadingMoreTracks) {
+  const handleLoadMoreTracks = useCallback(() => {
+    if (!shouldLoadMore) return;
+    if (!paginationStarted) {
+      setPaginationStarted(true);
       return;
     }
-
-    if (requestedOffsetsRef.current.has(nextOffset)) {
-      return;
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
     }
-
-    requestedOffsetsRef.current.add(nextOffset);
-    setIsLoadingMoreTracks(true);
-
-    try {
-      const page = await playlistService.getPlaylistPreviewTracksPage(
-        spotifyUrl,
-        nextOffset,
-        PLAYLIST_PREVIEW_PAGE_SIZE,
-      );
-
-      setPagedTracks((previous) => mergeUniquePreviewTracks([...previous, ...page.tracks]));
-      setHasMoreTracks(page.hasMore);
-      setNextOffset(page.nextOffset);
-    } catch {
-      requestedOffsetsRef.current.delete(nextOffset);
-    } finally {
-      setIsLoadingMoreTracks(false);
-    }
-  }, [hasMoreTracks, isLoadingMoreTracks, nextOffset, spotifyUrl]);
+  }, [shouldLoadMore, paginationStarted, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const savedPlaylist = useMemo(() => {
     return playlists?.find((p) => p.spotifyUrl === spotifyUrl);
@@ -188,8 +174,9 @@ export const usePlaylistPreviewController = () => {
     isLoading,
     error,
     isButtonLoading,
-    hasMoreTracks,
-    isLoadingMoreTracks,
+    hasMoreTracks: shouldLoadMore && (!paginationStarted || hasNextPage),
+    isLoadingMoreTracks:
+      isFetchingNextPage || (paginationStarted && isInfiniteFetching && !infiniteData),
     isDownloaded,
     isSaved,
     hasFailed,

--- a/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.test.tsx
@@ -1,0 +1,113 @@
+import type { PlaylistPreviewTracksPage } from "@spotiarr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlistService } from "@/services/playlist.service";
+import {
+  PLAYLIST_PREVIEW_PAGE_SIZE,
+  usePlaylistPreviewTracksInfiniteQuery,
+} from "./usePlaylistPreviewTracksInfiniteQuery";
+
+vi.mock("@/services/playlist.service", () => ({
+  playlistService: {
+    getPlaylistPreviewTracksPage: vi.fn(),
+  },
+}));
+
+const URL = "https://open.spotify.com/playlist/abc";
+
+const makePage = (
+  overrides: Partial<PlaylistPreviewTracksPage> = {},
+): PlaylistPreviewTracksPage => ({
+  tracks: [{ name: "Track", artists: [{ name: "Artist" }], album: "Album", duration: 1000 }],
+  total: 250,
+  hasMore: true,
+  nextOffset: 200,
+  ...overrides,
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePlaylistPreviewTracksInfiniteQuery", () => {
+  it("does not fetch while disabled", async () => {
+    const { result } = renderHook(() => usePlaylistPreviewTracksInfiniteQuery(URL, 100, false), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(playlistService.getPlaylistPreviewTracksPage).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when spotifyUrl is null even if enabled", async () => {
+    const { result } = renderHook(() => usePlaylistPreviewTracksInfiniteQuery(null, 100, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(playlistService.getPlaylistPreviewTracksPage).not.toHaveBeenCalled();
+  });
+
+  it("fetches the first page from initialPageParam with the page size", async () => {
+    vi.mocked(playlistService.getPlaylistPreviewTracksPage).mockResolvedValueOnce(makePage());
+
+    const { result } = renderHook(() => usePlaylistPreviewTracksInfiniteQuery(URL, 100, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(playlistService.getPlaylistPreviewTracksPage).toHaveBeenCalledWith(
+      URL,
+      100,
+      PLAYLIST_PREVIEW_PAGE_SIZE,
+    );
+    expect(result.current.data?.pages).toHaveLength(1);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it("derives hasNextPage=false when nextOffset is null", async () => {
+    vi.mocked(playlistService.getPlaylistPreviewTracksPage).mockResolvedValueOnce(
+      makePage({ hasMore: false, nextOffset: null }),
+    );
+
+    const { result } = renderHook(() => usePlaylistPreviewTracksInfiniteQuery(URL, 100, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  it("accumulates pages and advances the offset on fetchNextPage", async () => {
+    vi.mocked(playlistService.getPlaylistPreviewTracksPage)
+      .mockResolvedValueOnce(makePage({ nextOffset: 200 }))
+      .mockResolvedValueOnce(makePage({ hasMore: false, nextOffset: null }));
+
+    const { result } = renderHook(() => usePlaylistPreviewTracksInfiniteQuery(URL, 100, true), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    result.current.fetchNextPage();
+
+    await waitFor(() => expect(result.current.data?.pages).toHaveLength(2));
+    expect(playlistService.getPlaylistPreviewTracksPage).toHaveBeenNthCalledWith(
+      2,
+      URL,
+      200,
+      PLAYLIST_PREVIEW_PAGE_SIZE,
+    );
+    expect(result.current.hasNextPage).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.ts
+++ b/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.ts
@@ -1,5 +1,5 @@
 import { PlaylistPreviewTracksPage } from "@spotiarr/shared";
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { InfiniteData, useInfiniteQuery } from "@tanstack/react-query";
 import { playlistService } from "@/services/playlist.service";
 import { STALE_TIME_MEDIUM } from "@/utils/cache";
 import { queryKeys } from "../queryKeys";
@@ -14,7 +14,7 @@ export const usePlaylistPreviewTracksInfiniteQuery = (
   return useInfiniteQuery<
     PlaylistPreviewTracksPage,
     Error,
-    import("@tanstack/react-query").InfiniteData<PlaylistPreviewTracksPage>,
+    InfiniteData<PlaylistPreviewTracksPage>,
     ReturnType<typeof queryKeys.playlistPreviewTracks>,
     number
   >({

--- a/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.ts
+++ b/apps/frontend/src/hooks/queries/usePlaylistPreviewTracksInfiniteQuery.ts
@@ -1,0 +1,33 @@
+import { PlaylistPreviewTracksPage } from "@spotiarr/shared";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { playlistService } from "@/services/playlist.service";
+import { STALE_TIME_MEDIUM } from "@/utils/cache";
+import { queryKeys } from "../queryKeys";
+
+export const PLAYLIST_PREVIEW_PAGE_SIZE = 100;
+
+export const usePlaylistPreviewTracksInfiniteQuery = (
+  spotifyUrl: string | null,
+  initialPageParam: number,
+  enabled: boolean,
+) => {
+  return useInfiniteQuery<
+    PlaylistPreviewTracksPage,
+    Error,
+    import("@tanstack/react-query").InfiniteData<PlaylistPreviewTracksPage>,
+    ReturnType<typeof queryKeys.playlistPreviewTracks>,
+    number
+  >({
+    queryKey: queryKeys.playlistPreviewTracks(spotifyUrl ?? ""),
+    queryFn: ({ pageParam }) =>
+      playlistService.getPlaylistPreviewTracksPage(
+        spotifyUrl!,
+        pageParam,
+        PLAYLIST_PREVIEW_PAGE_SIZE,
+      ),
+    initialPageParam,
+    getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
+    enabled: !!spotifyUrl && enabled,
+    staleTime: STALE_TIME_MEDIUM,
+  });
+};

--- a/apps/frontend/src/hooks/queryKeys.ts
+++ b/apps/frontend/src/hooks/queryKeys.ts
@@ -5,6 +5,7 @@ export const queryKeys = {
   playlistPreview: (spotifyUrl: string) => ["playlist-preview", spotifyUrl] as const,
   playlistPreviewTracksPage: (spotifyUrl: string, offset: number, limit: number) =>
     ["playlist-preview-tracks-page", spotifyUrl, offset, limit] as const,
+  playlistPreviewTracks: (spotifyUrl: string) => ["playlist-preview-tracks", spotifyUrl] as const,
   downloadHistory: ["download-history"] as const,
   downloadStatus: ["download-status"] as const,
   settings: ["settings"] as const,


### PR DESCRIPTION
## What

Replace the manual `useState` pagination in `usePlaylistPreviewController` with TanStack `useInfiniteQuery`, **keeping the lazy on-scroll fetch behavior**.

| | |
|---|---|
| **New** | `hooks/queries/usePlaylistPreviewTracksInfiniteQuery.ts` (owns `PAGE_SIZE`; `enabled` controlled by caller) |
| **Removed** | manual `pagedTracks`/`nextOffset` state, the `requestedOffsetsRef` dedup guard, and the reset `useEffect` — TanStack keys on the URL (auto-reset) and dedups in-flight fetches |
| **Kept** | `usePlaylistPreviewQuery` for metadata + page 0; `mergeUniquePreviewTracks` (TanStack doesn't dedup track content); `trackUrls`/`useBulkTrackStatus`; `totalCount` |
| **Tests** | controller was **untested** — added initial state, accumulation+dedup, lazy gate, album (non-paginating), undefined preview, load-more guards |

## Why lazy (not eager)

`useInfiniteQuery` with `enabled: true` auto-fetches the first page on mount. That would eager-prefetch a 100-track page every time a large-playlist preview opens — but the Spotify backend is **rate-limited (circuit breaker)**, and previews are transient (opened/closed frequently while browsing). A `paginationStarted` gate keeps the query disabled until the first `onEndReached`, so **nothing is fetched until the user scrolls** — identical to the old behavior, API-friendly.

- `hasMoreTracks = shouldLoadMore && (!paginationStarted || hasNextPage)` — armed before the first fetch, then follows `hasNextPage`.
- `isLoadingMoreTracks` covers the initial gated fetch (`isFetching`) and subsequent `isFetchingNextPage`.
- `handleLoadMoreTracks` flips the gate on first call (enables → fetches page 1), `fetchNextPage` after.

## Verification

- `pnpm --filter frontend run lint` ✅ · `build` ✅ · `test:run` ✅ **521 passed**
- Fresh adversarial review caught the eager-vs-lazy semantic change; this PR resolves it to strict lazy and adds the album / undefined-preview / lazy-gate test cases the review flagged.

Behavior-preserving; no API or UI change.