### PR TITLE
fix(frontend): make album/artist cards keyboard-accessible (#146)

### DIFF
--- a/apps/frontend/src/components/molecules/AlbumCard.test.tsx
+++ b/apps/frontend/src/components/molecules/AlbumCard.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AlbumCard } from "./AlbumCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallbackOrOptions?: string | Record<string, unknown>) => {
+      if (key === "common.cards.albumCardAriaLabel") {
+        const opts = fallbackOrOptions as { name: string; artist: string };
+        return `${opts.name} by ${opts.artist}`;
+      }
+      if (key === "common.cards.viewArtist") {
+        const opts = fallbackOrOptions as { name: string };
+        return `View artist ${opts.name}`;
+      }
+      if (key === "common.cards.tooltips.download") return "Download";
+      if (key === "common.cards.tooltips.alreadyDownloaded") return "Already downloaded";
+      if (key === "common.cards.tooltips.downloading") return "Downloading...";
+      return typeof fallbackOrOptions === "string" ? fallbackOrOptions : key;
+    },
+  }),
+}));
+
+vi.mock("@/utils/date", () => ({
+  formatRelativeDate: () => "2 years ago",
+}));
+
+const baseProps = {
+  albumId: "album-1",
+  artistId: "artist-1",
+  albumName: "Discovery",
+  artistName: "Daft Punk",
+  onCardClick: vi.fn(),
+  onArtistClick: vi.fn(),
+};
+
+describe("AlbumCard", () => {
+  it("renders album name and artist name", () => {
+    render(<AlbumCard {...baseProps} />);
+
+    expect(screen.getByText("Discovery")).not.toBeNull();
+    expect(screen.getByText("Daft Punk")).not.toBeNull();
+  });
+
+  it("exposes the card as an accessible button with album aria-label", () => {
+    render(<AlbumCard {...baseProps} />);
+
+    const button = screen.getByRole("button", { name: "Discovery by Daft Punk" });
+    expect(button).not.toBeNull();
+  });
+
+  it("calls onCardClick when the overlay button is clicked", () => {
+    const onCardClick = vi.fn();
+    render(<AlbumCard {...baseProps} onCardClick={onCardClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Discovery by Daft Punk" }));
+    expect(onCardClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onArtistClick with artistId when artist button is clicked", () => {
+    const onArtistClick = vi.fn();
+    const onCardClick = vi.fn();
+    render(<AlbumCard {...baseProps} onArtistClick={onArtistClick} onCardClick={onCardClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View artist Daft Punk" }));
+    expect(onArtistClick).toHaveBeenCalledWith("artist-1");
+  });
+
+  it("does not call onCardClick when artist button is clicked (stopPropagation)", () => {
+    const onArtistClick = vi.fn();
+    const onCardClick = vi.fn();
+    render(<AlbumCard {...baseProps} onArtistClick={onArtistClick} onCardClick={onCardClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "View artist Daft Punk" }));
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+
+  it("calls onDownloadClick when download button is clicked and does not call onCardClick", () => {
+    const onDownloadClick = vi.fn();
+    const onCardClick = vi.fn();
+    render(
+      <AlbumCard
+        {...baseProps}
+        onCardClick={onCardClick}
+        onDownloadClick={onDownloadClick}
+        spotifyUrl="https://open.spotify.com/album/123"
+      />,
+    );
+
+    const downloadBtn = screen.getByTitle("Download");
+    fireEvent.click(downloadBtn);
+    expect(onDownloadClick).toHaveBeenCalledTimes(1);
+    expect(onCardClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/molecules/AlbumCard.tsx
+++ b/apps/frontend/src/components/molecules/AlbumCard.tsx
@@ -38,6 +38,7 @@ export const AlbumCard: FC<AlbumCardProps> = memo(
     onArtistClick,
   }) => {
     const { t } = useTranslation();
+
     const handleArtistClick = useCallback(
       (e: MouseEvent) => {
         e.stopPropagation();
@@ -66,9 +67,15 @@ export const AlbumCard: FC<AlbumCardProps> = memo(
     return (
       <article
         key={`${albumId}-${artistId}`}
-        className="group bg-background-elevated hover:bg-background-hover cursor-pointer rounded-md p-4 transition-all"
-        onClick={onCardClick}
+        className="group bg-background-elevated hover:bg-background-hover relative rounded-md p-4 transition-all"
       >
+        <button
+          type="button"
+          onClick={onCardClick}
+          aria-label={t("common.cards.albumCardAriaLabel", { name: albumName, artist: artistName })}
+          className="focus-visible:ring-primary absolute inset-0 z-10 cursor-pointer rounded-md focus-visible:ring-2 focus-visible:outline-none"
+        />
+
         <div className="bg-background-hover relative mb-4 aspect-square overflow-hidden rounded-md shadow-lg">
           <Image
             src={coverUrl || undefined}
@@ -88,7 +95,7 @@ export const AlbumCard: FC<AlbumCardProps> = memo(
                 <button
                   onClick={onDownloadClick}
                   disabled={isDownloaded || isDownloading}
-                  className={`flex h-12 w-12 items-center justify-center rounded-full shadow-xl transition-all ${
+                  className={`relative z-20 flex h-12 w-12 items-center justify-center rounded-full shadow-xl transition-all focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none ${
                     isDownloaded
                       ? "cursor-not-allowed bg-green-500"
                       : isDownloading
@@ -121,12 +128,14 @@ export const AlbumCard: FC<AlbumCardProps> = memo(
           <h3 className="text-text-primary truncate text-sm font-bold group-hover:underline">
             {albumName}
           </h3>
-          <span
-            className="text-text-secondary hover:text-text-primary block cursor-pointer truncate text-xs hover:underline"
+          <button
+            type="button"
             onClick={handleArtistClick}
+            aria-label={t("common.cards.viewArtist", { name: artistName })}
+            className="text-text-secondary hover:text-text-primary relative z-20 block cursor-pointer truncate text-left text-xs hover:underline focus-visible:ring-2 focus-visible:ring-white focus-visible:outline-none"
           >
             {artistName}
-          </span>
+          </button>
           <div className="text-text-secondary flex items-center gap-1 truncate text-xs">
             <span>{typeLabel}</span>
             {dateDisplay && (
@@ -141,3 +150,5 @@ export const AlbumCard: FC<AlbumCardProps> = memo(
     );
   },
 );
+
+AlbumCard.displayName = "AlbumCard";

--- a/apps/frontend/src/components/molecules/ArtistCard.test.tsx
+++ b/apps/frontend/src/components/molecules/ArtistCard.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ArtistCard } from "./ArtistCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => {
+      if (key === "artist.type") return "Artist";
+      return fallback ?? key;
+    },
+  }),
+}));
+
+describe("ArtistCard", () => {
+  const baseProps = {
+    id: "artist-1",
+    name: "Daft Punk",
+    image: null,
+    onClick: vi.fn(),
+  };
+
+  it("renders name and artist type label", () => {
+    render(<ArtistCard {...baseProps} />);
+
+    expect(screen.getByText("Daft Punk")).not.toBeNull();
+    expect(screen.getByText("Artist")).not.toBeNull();
+  });
+
+  it("exposes the card as an accessible button with the artist name", () => {
+    render(<ArtistCard {...baseProps} />);
+
+    const button = screen.getByRole("button", { name: "Daft Punk" });
+    expect(button).not.toBeNull();
+  });
+
+  it("fires onClick with the artist id when clicked", () => {
+    const onClick = vi.fn();
+    render(<ArtistCard {...baseProps} onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Daft Punk" }));
+    expect(onClick).toHaveBeenCalledWith("artist-1");
+  });
+});

--- a/apps/frontend/src/components/molecules/ArtistCard.tsx
+++ b/apps/frontend/src/components/molecules/ArtistCard.tsx
@@ -12,15 +12,13 @@ interface ArtistCardProps {
 
 export const ArtistCard: FC<ArtistCardProps> = memo(({ id, name, image, onClick }) => {
   const { t } = useTranslation();
-  const handleCardClick = () => {
-    onClick(id);
-  };
 
   return (
-    <article
-      key={id}
-      className="group hover:bg-background-hover flex cursor-pointer flex-col gap-3 rounded-md p-3 transition-colors"
-      onClick={handleCardClick}
+    <button
+      type="button"
+      onClick={() => onClick(id)}
+      aria-label={name}
+      className="group hover:bg-background-hover focus-visible:ring-primary flex w-full cursor-pointer flex-col gap-3 rounded-md p-3 text-left transition-colors focus-visible:ring-2 focus-visible:outline-none"
     >
       <div className="relative aspect-square w-full overflow-hidden rounded-full bg-zinc-800 shadow-lg">
         <Image
@@ -35,6 +33,8 @@ export const ArtistCard: FC<ArtistCardProps> = memo(({ id, name, image, onClick 
         <h3 className="truncate text-base font-bold text-white">{name}</h3>
         <p className="text-sm text-zinc-400">{t("artist.type")}</p>
       </div>
-    </article>
+    </button>
   );
 });
+
+ArtistCard.displayName = "ArtistCard";

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -293,6 +293,7 @@ export const NowPlayingFullscreen: FC = () => {
 
                 <span
                   role="button"
+                  tabIndex={0}
                   data-drag-handle
                   aria-label={t("player.nowPlaying.dragHandle", { name: item.name })}
                   onPointerDown={(e) => onHandlePointerDown(e, index)}

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -74,7 +74,9 @@
         "tracks_one": "track",
         "tracks_other": "tracks"
       },
-      "unnamedPlaylist": "Unnamed Playlist"
+      "unnamedPlaylist": "Unnamed Playlist",
+      "albumCardAriaLabel": "{{name}} by {{artist}}",
+      "viewArtist": "View artist {{name}}"
     }
   },
   "header": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -74,7 +74,9 @@
         "tracks_one": "canción",
         "tracks_other": "canciones"
       },
-      "unnamedPlaylist": "Lista sin nombre"
+      "unnamedPlaylist": "Lista sin nombre",
+      "albumCardAriaLabel": "{{name}} de {{artist}}",
+      "viewArtist": "Ver artista {{name}}"
     }
   },
   "header": {


### PR DESCRIPTION
Closes #146

## What
Make clickable cards keyboard-accessible (WCAG 2.1.1). Previously several cards used non-interactive elements (`<article onClick>`, `<span onClick>`) — unreachable by keyboard and screen readers.

## Why
Repo a11y audit finding F-10 (P2). Keyboard-only and screen-reader users could not reach or activate these click targets.

## Changes
| File | Change |
|------|--------|
| `molecules/AlbumCard.tsx` | Stretched-button (overlay) pattern: `<article>` is a `relative` container; primary action is an `absolute inset-0 z-10` `<button>` with aria-label. Artist `<span onClick>` → `<button>` (`z-20`). Download button lifted to `z-20`. Passive content (image/title/meta) stays below the overlay so the whole card navigates while nested buttons stay independently clickable. |
| `molecules/ArtistCard.tsx` | `<article onClick>` → `<button type="button">` with aria-label + focus-visible ring (matches `LibraryArtistCard`). |
| `organisms/NowPlayingFullscreen.tsx` | Drag-handle `<span role="button">` gets `tabIndex={0}`. Keyboard reordering already provided by the ↑/↓ buttons (WCAG 2.5.7 single-pointer alternative). |
| `locales/en.json`, `locales/es.json` | New i18n keys: `common.cards.albumCardAriaLabel`, `common.cards.viewArtist`. |
| `molecules/AlbumCard.test.tsx` | New — 6 tests (card/artist/download activation + stopPropagation). |
| `molecules/ArtistCard.test.tsx` | New — 3 tests (render, accessible button name, onClick). |

HistoryList `<div onClick>` was reviewed and left unchanged: its handler only calls `stopPropagation()` and wraps a real keyboard-accessible `<Button>`, so it is not an a11y barrier.

## Verification
- [x] `pnpm --filter frontend run lint` — clean
- [x] `pnpm --filter frontend run test:run` — 535/535 pass
- [x] `pnpm --filter frontend run build` — pass
- [ ] Manual/visual: jsdom tests cannot validate z-index hit-testing. Verify in browser: clicking cover/title navigates to album, clicking artist navigates to artist, clicking download triggers download, all reachable via Tab and activatable with Enter/Space.

## Acceptance
- All click targets reachable via Tab and activatable with Enter/Space ✓ (native buttons)
- No visual regression — overlay pattern preserves whole-card click + hover states
