### PR TITLE
fix(backend): resolve yt-dlp from system path, refresh tmp copy on upgrade

### DIFF
--- a/apps/backend/src/infrastructure/external/youtube-binary.test.ts
+++ b/apps/backend/src/infrastructure/external/youtube-binary.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveYtDlpPath, type YtDlpResolverDeps } from "./youtube-binary";
+
+const buildDeps = (overrides: Partial<YtDlpResolverDeps> = {}): YtDlpResolverDeps => ({
+  which: () => "/opt/homebrew/bin/yt-dlp",
+  isWritable: () => true,
+  copyFile: vi.fn(),
+  chmod: vi.fn(),
+  tmpFile: "/tmp/yt-dlp",
+  ...overrides,
+});
+
+describe("resolveYtDlpPath", () => {
+  it("uses the system path directly when the binary is writable", () => {
+    const copyFile = vi.fn();
+    const deps = buildDeps({ isWritable: () => true, copyFile });
+
+    expect(resolveYtDlpPath(deps)).toBe("/opt/homebrew/bin/yt-dlp");
+    expect(copyFile).not.toHaveBeenCalled();
+  });
+
+  it("copies to the writable tmp path when the system binary is not writable", () => {
+    const copyFile = vi.fn();
+    const chmod = vi.fn();
+    const deps = buildDeps({
+      which: () => "/usr/bin/yt-dlp",
+      isWritable: () => false,
+      copyFile,
+      chmod,
+      tmpFile: "/tmp/yt-dlp",
+    });
+
+    expect(resolveYtDlpPath(deps)).toBe("/tmp/yt-dlp");
+    expect(copyFile).toHaveBeenCalledWith("/usr/bin/yt-dlp", "/tmp/yt-dlp");
+    expect(chmod).toHaveBeenCalledWith("/tmp/yt-dlp", 0o755);
+  });
+
+  it("always refreshes the tmp copy so an upgraded binary propagates", () => {
+    const copyFile = vi.fn();
+    const deps = buildDeps({ isWritable: () => false, copyFile });
+
+    resolveYtDlpPath(deps);
+    resolveYtDlpPath(deps);
+
+    expect(copyFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when no system binary is found so the caller can fall back", () => {
+    const deps = buildDeps({ which: () => "" });
+
+    expect(() => resolveYtDlpPath(deps)).toThrow();
+  });
+});

--- a/apps/backend/src/infrastructure/external/youtube-binary.ts
+++ b/apps/backend/src/infrastructure/external/youtube-binary.ts
@@ -1,0 +1,44 @@
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as os from "os";
+import { join } from "path";
+
+export interface YtDlpResolverDeps {
+  which: () => string;
+  isWritable: (path: string) => boolean;
+  copyFile: (src: string, dest: string) => void;
+  chmod: (path: string, mode: number) => void;
+  tmpFile: string;
+}
+
+export function resolveYtDlpPath(deps: YtDlpResolverDeps): string {
+  const systemPath = deps.which();
+  if (!systemPath) {
+    throw new Error("yt-dlp not found in PATH");
+  }
+
+  if (deps.isWritable(systemPath)) {
+    return systemPath;
+  }
+
+  deps.copyFile(systemPath, deps.tmpFile);
+  deps.chmod(deps.tmpFile, 0o755);
+  return deps.tmpFile;
+}
+
+export function detectYtDlpPath(): string {
+  return resolveYtDlpPath({
+    which: () => execSync("which yt-dlp", { encoding: "utf-8" }).trim(),
+    isWritable: (path) => {
+      try {
+        fs.accessSync(path, fs.constants.W_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    copyFile: (src, dest) => fs.copyFileSync(src, dest),
+    chmod: (path, mode) => fs.chmodSync(path, mode),
+    tmpFile: join(os.tmpdir(), "yt-dlp"),
+  });
+}

--- a/apps/backend/src/infrastructure/external/youtube-search.service.ts
+++ b/apps/backend/src/infrastructure/external/youtube-search.service.ts
@@ -1,10 +1,8 @@
-import { execFile, execSync } from "child_process";
-import * as fs from "fs";
-import * as os from "os";
-import { join } from "path";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import type { SettingsPort } from "@/application/ports/settings.port";
 import { AppError } from "@/domain/errors/app-error";
+import { detectYtDlpPath } from "./youtube-binary";
 import { YOUTUBE_USER_AGENT } from "./youtube.constants";
 
 const execFilePromise = promisify(execFile);
@@ -14,24 +12,12 @@ export class YoutubeSearchService {
   private lastSearchTime: number = 0;
 
   constructor(private readonly settingsService: SettingsPort) {
-    // Auto-detect yt-dlp path from system PATH
+    // Use the system binary directly when it is writable. ytdlp-nodejs chmods the
+    // binary, which only fails for a non-writable path (e.g. /usr/bin/yt-dlp in
+    // Docker); in that case we copy it to a writable tmp path, refreshing every
+    // start so an upgraded system binary propagates instead of going stale.
     try {
-      const systemPath = execSync("which yt-dlp", {
-        encoding: "utf-8",
-      }).trim();
-
-      // WORKAROUND: ytdlp-nodejs tries to chmod the binary, which fails for /usr/bin/yt-dlp in Docker
-      // We copy it to a local writable path (tmp dir) so the library can do its thing
-      const localPath = join(os.tmpdir(), "yt-dlp");
-
-      // Only copy if it doesn't exist or is different (simple check)
-      if (!fs.existsSync(localPath)) {
-        console.debug(`Copying system yt-dlp to ${localPath} to avoid permission issues`);
-        fs.copyFileSync(systemPath, localPath);
-        fs.chmodSync(localPath, 0o755);
-      }
-
-      this.ytDlpPath = localPath;
+      this.ytDlpPath = detectYtDlpPath();
       console.debug(`Using yt-dlp from: ${this.ytDlpPath}`);
     } catch (e) {
       console.warn("yt-dlp not found in PATH, will try default 'yt-dlp' command", e);


### PR DESCRIPTION
## What
Fix yt-dlp binary resolution so downloads keep working after a `yt-dlp` upgrade or a temp-dir purge.

## Why
All downloads failed with `spawn /var/folders/.../T/yt-dlp ENOENT`, tracks left in `error` status. Root cause in `youtube-search.service.ts`:
1. It copied the system yt-dlp to `os.tmpdir()/yt-dlp` only `if (!fs.existsSync(localPath))` — so the copy was never refreshed.
2. Homebrew's yt-dlp is a Python wrapper whose shebang points at a versioned Cellar python (`.../Cellar/yt-dlp/<ver>/libexec/bin/python`). After `brew upgrade yt-dlp`, that interpreter is deleted, so the stale copy's shebang resolves to a missing path → `ENOENT` (the interpreter, not yt-dlp).
3. `os.tmpdir()` is volatile on macOS and gets purged out from under a running backend.

## Fix
Extracted resolution into a testable `resolveYtDlpPath` (DI deps) + `detectYtDlpPath` wiring:
- If the system binary is writable, use it **directly** — no copy, so it can never go stale (covers macOS/host).
- Only when it is not writable (e.g. `/usr/bin/yt-dlp` in Docker, the original chmod reason) copy to a writable tmp path, **refreshing every start** so an upgraded binary propagates.

## Changes
| File | Change |
|------|--------|
| `external/youtube-binary.ts` | New. `resolveYtDlpPath(deps)` pure logic + `detectYtDlpPath()` real wiring. |
| `external/youtube-binary.test.ts` | New. 4 tests: writable→direct, non-writable→copy+chmod, always-refresh, not-found→throws. |
| `external/youtube-search.service.ts` | Constructor uses `detectYtDlpPath()`; dropped the stale `existsSync`-guarded tmp copy and now-unused imports. |

## Verification
- [x] `pnpm --filter backend run lint` — clean (pre-existing `any` warnings in unrelated artwork-backfill tests only)
- [x] `pnpm --filter backend run test:run` — 506/506 pass
- [x] `pnpm --filter backend run build` — pass
- [x] Manual: overwrote the stale tmp copy with the current binary; downloads + retries succeed again.

## Notes
Not a regression from any commit since v1.17.0 — the broken workaround predates it; `brew upgrade yt-dlp` triggered it. Separate from #5 (missing JS runtime / deno), which is a different download-failure cause.
