### PR TITLE
test(backend): cover critical backend paths (#148)

### DIFF
--- a/apps/backend/src/application/use-cases/history/history.use-cases.test.ts
+++ b/apps/backend/src/application/use-cases/history/history.use-cases.test.ts
@@ -1,0 +1,137 @@
+import type { DownloadHistoryItem } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HistoryUseCases } from "./history.use-cases";
+
+function makeItem(overrides: Partial<DownloadHistoryItem> = {}): DownloadHistoryItem {
+  return {
+    id: "h-1",
+    playlistId: "pl-1",
+    playlistName: "Playlist",
+    playlistSpotifyUrl: "https://open.spotify.com/playlist/abc",
+    trackId: "t-1",
+    trackName: "Song",
+    artist: "Artist",
+    album: "Album",
+    trackUrl: null,
+    completedAt: 1000,
+    ...overrides,
+  };
+}
+
+describe("HistoryUseCases.getRecentDownloads", () => {
+  let repository: { findAll: ReturnType<typeof vi.fn> };
+  let useCases: HistoryUseCases;
+
+  beforeEach(() => {
+    repository = { findAll: vi.fn() };
+    useCases = new HistoryUseCases({ repository: repository as never });
+  });
+
+  it("dedups entries that share the same playlist id and counts unique tracks", async () => {
+    repository.findAll.mockResolvedValue([
+      makeItem({ id: "h-1", trackId: "t-1", completedAt: 1000 }),
+      makeItem({ id: "h-2", trackId: "t-2", completedAt: 2000 }),
+      makeItem({ id: "h-3", trackId: "t-1", completedAt: 1500 }), // duplicate track
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].trackCount).toBe(2);
+    expect(result[0].lastCompletedAt).toBe(2000);
+  });
+
+  it("normalizes the Spotify URL by stripping the /intl-xx/ segment when merging", async () => {
+    repository.findAll.mockResolvedValue([
+      makeItem({
+        id: "h-1",
+        playlistId: null,
+        trackId: "t-1",
+        playlistSpotifyUrl: "https://open.spotify.com/playlist/abc",
+      }),
+      makeItem({
+        id: "h-2",
+        playlistId: null,
+        trackId: "t-2",
+        playlistSpotifyUrl: "https://open.spotify.com/intl-es/playlist/abc",
+      }),
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].trackCount).toBe(2);
+    expect(result[0].playlistSpotifyUrl).toBe("https://open.spotify.com/playlist/abc");
+  });
+
+  it("merges cross-run entries that share a url but where only one carries the id", async () => {
+    repository.findAll.mockResolvedValue([
+      makeItem({
+        id: "h-1",
+        playlistId: null,
+        trackId: "t-1",
+        playlistSpotifyUrl: "https://open.spotify.com/playlist/abc",
+      }),
+      makeItem({
+        id: "h-2",
+        playlistId: "pl-1",
+        trackId: "t-2",
+        playlistSpotifyUrl: "https://open.spotify.com/playlist/abc",
+      }),
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].trackCount).toBe(2);
+    // Enrichment backfills the id discovered on the later entry.
+    expect(result[0].playlistId).toBe("pl-1");
+  });
+
+  it("keeps the playlist name from the most recently completed entry", async () => {
+    repository.findAll.mockResolvedValue([
+      makeItem({ id: "h-1", playlistName: "Old Name", completedAt: 1000 }),
+      makeItem({ id: "h-2", playlistName: "New Name", completedAt: 5000 }),
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+
+    expect(result[0].playlistName).toBe("New Name");
+  });
+
+  it("sorts the resulting playlists by lastCompletedAt descending", async () => {
+    repository.findAll.mockResolvedValue([
+      makeItem({ id: "h-1", playlistId: "pl-a", playlistSpotifyUrl: null, completedAt: 1000 }),
+      makeItem({ id: "h-2", playlistId: "pl-b", playlistSpotifyUrl: null, completedAt: 3000 }),
+      makeItem({ id: "h-3", playlistId: "pl-c", playlistSpotifyUrl: null, completedAt: 2000 }),
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+
+    expect(result.map((p) => p.playlistId)).toEqual(["pl-b", "pl-c", "pl-a"]);
+  });
+
+  it("groups identifier-less entries into a single fallback bucket within the same tick", async () => {
+    // With no playlistId and no url, the key falls back to `unknown-${Date.now()}`.
+    // Pin the clock so the fallback key is stable and the merge is deterministic.
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    repository.findAll.mockResolvedValue([
+      makeItem({ id: "h-1", playlistId: null, playlistSpotifyUrl: null, trackId: "t-1" }),
+      makeItem({ id: "h-2", playlistId: null, playlistSpotifyUrl: null, trackId: "t-2" }),
+    ]);
+
+    const result = await useCases.getRecentDownloads();
+    vi.useRealTimers();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].trackCount).toBe(2);
+    expect(result[0].playlistId).toBeNull();
+  });
+
+  it("forwards the limit to the repository", async () => {
+    repository.findAll.mockResolvedValue([]);
+    await useCases.getRecentDownloads(50);
+    expect(repository.findAll).toHaveBeenCalledWith(50);
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
@@ -1,0 +1,164 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { DownloadTrackUseCase } from "./download-track.use-case";
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Song",
+    artist: "Artist",
+    status: TrackStatusEnum.New,
+    playlistId: "pl-1",
+    ...overrides,
+  };
+}
+
+describe("DownloadTrackUseCase", () => {
+  let trackRepository: {
+    findOne: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    findOneWithPlaylist: ReturnType<typeof vi.fn>;
+  };
+  let youtubeDownloadService: { downloadAndFormat: ReturnType<typeof vi.fn> };
+  let trackFileHelper: {
+    getFolderName: ReturnType<typeof vi.fn>;
+    ensureParentDirectory: ReturnType<typeof vi.fn>;
+  };
+  let playlistRepository: { findOne: ReturnType<typeof vi.fn> };
+  let downloadHistoryRepository: { createFromTrack: ReturnType<typeof vi.fn> };
+  let eventBus: { emit: ReturnType<typeof vi.fn> };
+  let trackPostProcessingService: {
+    process: ReturnType<typeof vi.fn>;
+    updatePlaylistM3u: ReturnType<typeof vi.fn>;
+  };
+  let useCase: DownloadTrackUseCase;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    trackRepository = {
+      findOne: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+      findOneWithPlaylist: vi.fn(),
+    };
+    youtubeDownloadService = { downloadAndFormat: vi.fn().mockResolvedValue(undefined) };
+    trackFileHelper = {
+      getFolderName: vi.fn().mockResolvedValue("/music/Artist/Song"),
+      ensureParentDirectory: vi.fn().mockResolvedValue(undefined),
+    };
+    playlistRepository = { findOne: vi.fn().mockResolvedValue(null) };
+    downloadHistoryRepository = { createFromTrack: vi.fn().mockResolvedValue(undefined) };
+    eventBus = { emit: vi.fn() };
+    trackPostProcessingService = {
+      process: vi.fn().mockResolvedValue(undefined),
+      updatePlaylistM3u: vi.fn().mockResolvedValue(undefined),
+    };
+
+    useCase = new DownloadTrackUseCase(
+      trackRepository as never,
+      youtubeDownloadService as never,
+      trackFileHelper as never,
+      playlistRepository as never,
+      downloadHistoryRepository as never,
+      eventBus as never,
+      trackPostProcessingService as never,
+    );
+  });
+
+  it("returns early when track data has no id", async () => {
+    await useCase.execute(makeTrack({ id: undefined }));
+    expect(trackRepository.findOne).not.toHaveBeenCalled();
+  });
+
+  it("returns early when the track is not found", async () => {
+    trackRepository.findOne.mockResolvedValue(null);
+    await useCase.execute(makeTrack());
+    expect(youtubeDownloadService.downloadAndFormat).not.toHaveBeenCalled();
+  });
+
+  it("throws a 400 AppError when required fields are missing", async () => {
+    const track = new Track(makeTrack({ name: "" }));
+    trackRepository.findOne.mockResolvedValue(track);
+
+    await expect(useCase.execute(makeTrack({ name: "" }))).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("transitions New -> Downloading -> Completed and persists each step", async () => {
+    const track = new Track(makeTrack());
+    trackRepository.findOne.mockResolvedValue(track);
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+
+    // The same entity instance is mutated in place, so snapshot the status at
+    // each persist call instead of reading the shared reference afterwards.
+    const persistedStatuses: (string | undefined)[] = [];
+    trackRepository.update.mockImplementation((_id, entity: Track) => {
+      persistedStatuses.push(entity.status);
+      return Promise.resolve(undefined);
+    });
+
+    await useCase.execute(makeTrack());
+
+    expect(persistedStatuses).toEqual([TrackStatusEnum.Downloading, TrackStatusEnum.Completed]);
+  });
+
+  it("writes history and updates the M3U only after the track is marked completed", async () => {
+    const track = new Track(makeTrack());
+    trackRepository.findOne.mockResolvedValue(track);
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+
+    await useCase.execute(makeTrack());
+
+    // Final DB persist (Completed) must happen before M3U generation.
+    const completedUpdateOrder = trackRepository.update.mock.invocationCallOrder[1];
+    const m3uOrder = trackPostProcessingService.updatePlaylistM3u.mock.invocationCallOrder[0];
+    const historyOrder = downloadHistoryRepository.createFromTrack.mock.invocationCallOrder[0];
+
+    expect(completedUpdateOrder).toBeLessThan(historyOrder);
+    expect(historyOrder).toBeLessThan(m3uOrder);
+    expect(eventBus.emit).toHaveBeenCalledWith("download-history-updated");
+  });
+
+  it("emits playlists-updated when entering Downloading and after completion", async () => {
+    const track = new Track(makeTrack());
+    trackRepository.findOne.mockResolvedValue(track);
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+
+    await useCase.execute(makeTrack());
+
+    const playlistEmits = eventBus.emit.mock.calls.filter((c) => c[0] === "playlists-updated");
+    expect(playlistEmits).toHaveLength(2);
+  });
+
+  it("marks the track as Error and skips history/M3U when the download fails", async () => {
+    const track = new Track(makeTrack());
+    trackRepository.findOne.mockResolvedValue(track);
+    youtubeDownloadService.downloadAndFormat.mockRejectedValue(new Error("boom"));
+
+    const persisted: { status?: string; error?: string }[] = [];
+    trackRepository.update.mockImplementation((_id, entity: Track) => {
+      const { status, error } = entity.toPrimitive();
+      persisted.push({ status, error });
+      return Promise.resolve(undefined);
+    });
+
+    await useCase.execute(makeTrack());
+
+    expect(persisted.at(-1)).toEqual({ status: TrackStatusEnum.Error, error: "boom" });
+    expect(downloadHistoryRepository.createFromTrack).not.toHaveBeenCalled();
+    expect(trackPostProcessingService.updatePlaylistM3u).not.toHaveBeenCalled();
+  });
+
+  it("passes the playlist name to the file helper only for real playlists", async () => {
+    const track = new Track(makeTrack({ playlistId: "pl-1" }));
+    trackRepository.findOne.mockResolvedValue(track);
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+    playlistRepository.findOne.mockResolvedValue({ type: "playlist", name: "My Mix" });
+
+    await useCase.execute(makeTrack());
+
+    expect(trackFileHelper.getFolderName).toHaveBeenCalledWith(expect.anything(), "My Mix");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
@@ -1,0 +1,129 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { SearchTrackOnYoutubeUseCase } from "./search-track-on-youtube.use-case";
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Song",
+    artist: "Artist",
+    status: TrackStatusEnum.New,
+    ...overrides,
+  };
+}
+
+describe("SearchTrackOnYoutubeUseCase", () => {
+  let trackRepository: {
+    findOneWithPlaylist: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  let youtubeSearchService: { findOnYoutubeOne: ReturnType<typeof vi.fn> };
+  let settingsService: { getNumber: ReturnType<typeof vi.fn> };
+  let queueService: { enqueueDownloadTrack: ReturnType<typeof vi.fn> };
+  let eventBus: { emit: ReturnType<typeof vi.fn> };
+  let useCase: SearchTrackOnYoutubeUseCase;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    trackRepository = {
+      findOneWithPlaylist: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    youtubeSearchService = { findOnYoutubeOne: vi.fn() };
+    settingsService = { getNumber: vi.fn().mockResolvedValue(3) };
+    queueService = { enqueueDownloadTrack: vi.fn().mockResolvedValue(undefined) };
+    eventBus = { emit: vi.fn() };
+
+    useCase = new SearchTrackOnYoutubeUseCase(
+      trackRepository as never,
+      youtubeSearchService as never,
+      settingsService as never,
+      queueService as never,
+      eventBus as never,
+    );
+  });
+
+  it("returns early when the track has no id", async () => {
+    await useCase.execute(makeTrack({ id: undefined }));
+    expect(trackRepository.findOneWithPlaylist).not.toHaveBeenCalled();
+  });
+
+  it("returns early when the track is not found", async () => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(null);
+    await useCase.execute(makeTrack());
+    expect(youtubeSearchService.findOnYoutubeOne).not.toHaveBeenCalled();
+  });
+
+  it("searches, queues, and fans out to the download queue on success", async () => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+    youtubeSearchService.findOnYoutubeOne.mockResolvedValue("https://youtu.be/abc");
+
+    await useCase.execute(makeTrack());
+
+    expect(queueService.enqueueDownloadTrack).toHaveBeenCalledTimes(1);
+    const [enqueued, opts] = queueService.enqueueDownloadTrack.mock.calls[0];
+    expect(enqueued.status).toBe(TrackStatusEnum.Queued);
+    expect(enqueued.youtubeUrl).toBe("https://youtu.be/abc");
+    expect(opts).toEqual({ maxRetries: 3 });
+  });
+
+  it("skips the search when a youtubeUrl is already set", async () => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(
+      new Track(makeTrack({ youtubeUrl: "https://youtu.be/preset" })),
+    );
+
+    await useCase.execute(makeTrack());
+
+    expect(youtubeSearchService.findOnYoutubeOne).not.toHaveBeenCalled();
+    expect(queueService.enqueueDownloadTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks the track as Error and does not enqueue when no url is found", async () => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+    youtubeSearchService.findOnYoutubeOne.mockResolvedValue("");
+
+    await useCase.execute(makeTrack());
+
+    const finalStatus = trackRepository.update.mock.calls.at(-1)?.[1].status;
+    expect(finalStatus).toBe(TrackStatusEnum.Error);
+    expect(queueService.enqueueDownloadTrack).not.toHaveBeenCalled();
+  });
+
+  it("captures the error message and does not enqueue when the search throws", async () => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+    youtubeSearchService.findOnYoutubeOne.mockRejectedValue(new Error("yt down"));
+
+    const persisted: { status?: string; error?: string }[] = [];
+    trackRepository.update.mockImplementation((_id, entity: Track) => {
+      const { status, error } = entity.toPrimitive();
+      persisted.push({ status, error });
+      return Promise.resolve(undefined);
+    });
+
+    await useCase.execute(makeTrack());
+
+    expect(persisted.at(-1)).toEqual({ status: TrackStatusEnum.Error, error: "yt down" });
+    expect(queueService.enqueueDownloadTrack).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [0, 3],
+    [11, 3],
+    [-1, 3],
+    [5, 5],
+    [1, 1],
+    [10, 10],
+  ])("clamps DOWNLOAD_MAX_RETRIES %i to %i", async (setting, expected) => {
+    trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+    youtubeSearchService.findOnYoutubeOne.mockResolvedValue("https://youtu.be/abc");
+    settingsService.getNumber.mockResolvedValue(setting);
+
+    await useCase.execute(makeTrack());
+
+    expect(queueService.enqueueDownloadTrack).toHaveBeenCalledWith(expect.anything(), {
+      maxRetries: expected,
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/circuit-breaker.test.ts
+++ b/apps/backend/src/infrastructure/external/circuit-breaker.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CircuitBreaker } from "./circuit-breaker";
+
+const START = 1_700_000_000_000;
+
+function makeResponse(status: number, retryAfter?: string): Response {
+  return {
+    status,
+    headers: {
+      get: (header: string) => (header === "Retry-After" ? (retryAfter ?? null) : null),
+    },
+  } as unknown as Response;
+}
+
+describe("CircuitBreaker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("runs the function directly while CLOSED", async () => {
+    const breaker = new CircuitBreaker();
+    const fn = vi.fn().mockResolvedValue(makeResponse(200));
+
+    const response = await breaker.execute(fn);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it("opens the circuit and throws on a 429 response, honoring Retry-After", async () => {
+    const onOpen = vi.fn();
+    const breaker = new CircuitBreaker({ onOpen });
+    const fn = vi.fn().mockResolvedValue(makeResponse(429, "30"));
+
+    await expect(breaker.execute(fn)).rejects.toMatchObject({
+      statusCode: 429,
+      errorCode: "spotify_rate_limited",
+    });
+
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.getOpenUntil()).toBe(START + 30_000);
+    expect(onOpen).toHaveBeenCalledWith(START + 30_000);
+  });
+
+  it("fails fast with a 503 while OPEN when failFast is requested", () => {
+    const breaker = new CircuitBreaker();
+    breaker.notifyRateLimit(60);
+
+    expect(() => breaker.execute(vi.fn(), { failFast: true })).toThrowError(
+      expect.objectContaining({ statusCode: 503, errorCode: "circuit_open" }),
+    );
+  });
+
+  it("queues waiters while OPEN and rejects overflow beyond maxWaiters", () => {
+    const breaker = new CircuitBreaker({ maxWaiters: 1 });
+    breaker.notifyRateLimit(60);
+
+    // First waiter is accepted and parked as a pending promise.
+    const pending = breaker.execute(vi.fn().mockResolvedValue(makeResponse(200)));
+    expect(pending).toBeInstanceOf(Promise);
+
+    // Second waiter overflows the queue and is rejected synchronously.
+    expect(() => breaker.execute(vi.fn())).toThrowError(
+      expect.objectContaining({ statusCode: 503, errorCode: "circuit_open" }),
+    );
+  });
+
+  it("applies an exponential backoff multiplier on consecutive opens", () => {
+    const breaker = new CircuitBreaker();
+
+    breaker.notifyRateLimit(60); // multiplier 2^0 = 1 -> 60s
+    expect(breaker.getOpenUntil()).toBe(START + 60_000);
+
+    breaker.notifyRateLimit(60); // multiplier 2^1 = 2 -> 120s
+    expect(breaker.getOpenUntil()).toBe(START + 120_000);
+
+    breaker.notifyRateLimit(60); // multiplier 2^2 = 4 -> 240s
+    expect(breaker.getOpenUntil()).toBe(START + 240_000);
+  });
+
+  it("caps the backoff window at 4 hours", () => {
+    const breaker = new CircuitBreaker();
+    // A huge Retry-After must never exceed the 4h ceiling.
+    breaker.notifyRateLimit(10 * 60 * 60);
+    expect(breaker.getOpenUntil()).toBe(START + 4 * 60 * 60 * 1000);
+  });
+
+  it("transitions OPEN -> HALF-OPEN -> CLOSED on a successful probe and flushes waiters", async () => {
+    const breaker = new CircuitBreaker();
+    breaker.notifyRateLimit(30);
+
+    const waiterFn = vi.fn().mockResolvedValue(makeResponse(200));
+    const waiterPromise = breaker.execute(waiterFn);
+
+    // Move past the open window so the next call probes (HALF-OPEN).
+    vi.setSystemTime(START + 31_000);
+
+    const probeFn = vi.fn().mockResolvedValue(makeResponse(200));
+    const probeResponse = await breaker.execute(probeFn);
+
+    expect(probeResponse.status).toBe(200);
+    expect(breaker.isOpen()).toBe(false);
+
+    // The parked waiter is replayed once the circuit closes.
+    await expect(waiterPromise).resolves.toMatchObject({ status: 200 });
+    expect(waiterFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("reopens for 30s when a HALF-OPEN probe fails for a non-rate-limit reason", async () => {
+    const breaker = new CircuitBreaker();
+    breaker.notifyRateLimit(30);
+    vi.setSystemTime(START + 31_000);
+
+    const probeFn = vi.fn().mockRejectedValue(new Error("network down"));
+
+    await expect(breaker.execute(probeFn)).rejects.toThrow("network down");
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.getOpenUntil()).toBe(START + 31_000 + 30_000);
+  });
+
+  it("restores a persisted open window from the constructor", () => {
+    const breaker = new CircuitBreaker({ initialOpenUntilMs: START + 60_000 });
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.getOpenUntil()).toBe(START + 60_000);
+  });
+
+  it("ignores a constructor restore whose window has already passed", () => {
+    const breaker = new CircuitBreaker({ initialOpenUntilMs: START - 1 });
+    expect(breaker.isOpen()).toBe(false);
+  });
+
+  it("restore() extends the open window only when the timestamp is in the future and later", () => {
+    const breaker = new CircuitBreaker();
+
+    breaker.restore(START - 1); // past -> no-op
+    expect(breaker.isOpen()).toBe(false);
+
+    breaker.restore(START + 90_000); // future -> opens
+    expect(breaker.isOpen()).toBe(true);
+    expect(breaker.getOpenUntil()).toBe(START + 90_000);
+
+    breaker.restore(START + 10_000); // earlier than current -> no-op
+    expect(breaker.getOpenUntil()).toBe(START + 90_000);
+  });
+
+  it("invokes the onOpen callback set via setOnOpenCallback", () => {
+    const breaker = new CircuitBreaker();
+    const onOpen = vi.fn();
+    breaker.setOnOpenCallback(onOpen);
+
+    breaker.notifyRateLimit(60);
+
+    expect(onOpen).toHaveBeenCalledWith(START + 60_000);
+  });
+});

--- a/apps/backend/src/infrastructure/external/circuit-breaker.ts
+++ b/apps/backend/src/infrastructure/external/circuit-breaker.ts
@@ -109,9 +109,13 @@ export class CircuitBreaker {
 
       this.probeInFlight = true;
       const promise = this.runFn(fn);
-      promise.finally(() => {
-        this.probeInFlight = false;
-      });
+      // Reset the in-flight flag without leaving a floating rejection: the
+      // caller owns `promise`, so swallow the rejection on this side chain only.
+      promise
+        .finally(() => {
+          this.probeInFlight = false;
+        })
+        .catch(() => {});
       return promise;
     }
 

--- a/apps/backend/src/infrastructure/external/youtube-search.service.test.ts
+++ b/apps/backend/src/infrastructure/external/youtube-search.service.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { YoutubeSearchService } from "./youtube-search.service";
+
+const execFileMock = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+vi.mock("./youtube-binary", () => ({
+  detectYtDlpPath: () => "/usr/bin/yt-dlp",
+}));
+
+vi.mock("./youtube.constants", () => ({
+  YOUTUBE_USER_AGENT: "test-agent",
+}));
+
+interface SettingsStub {
+  getNumber: ReturnType<typeof vi.fn>;
+  getString: ReturnType<typeof vi.fn>;
+}
+
+function makeService(settings?: Partial<SettingsStub>): {
+  service: YoutubeSearchService;
+  settings: SettingsStub;
+} {
+  const settingsService: SettingsStub = {
+    getNumber: vi.fn().mockResolvedValue(1000),
+    getString: vi.fn().mockResolvedValue(""),
+    ...settings,
+  };
+  return {
+    service: new YoutubeSearchService(settingsService as never),
+    settings: settingsService,
+  };
+}
+
+// Resolve the promisified execFile callback with a yt-dlp style payload.
+function resolveWith(stdout: string): void {
+  execFileMock.mockImplementation((_path, _args, cb: (e: unknown, r: unknown) => void) =>
+    cb(null, { stdout, stderr: "" }),
+  );
+}
+
+describe("YoutubeSearchService.findOnYoutubeOne", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    execFileMock.mockReset();
+    vi.spyOn(console, "debug").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("returns the first non-empty url from stdout", async () => {
+    resolveWith("https://youtu.be/abc\nhttps://youtu.be/def\n");
+    const { service } = makeService();
+
+    const promise = service.findOnYoutubeOne("Artist", "Song");
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe("https://youtu.be/abc");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws a 404 AppError when no results are returned", async () => {
+    resolveWith("\n  \n");
+    const { service } = makeService();
+
+    const promise = service.findOnYoutubeOne("Artist", "Song");
+    const caught = promise.catch((e) => e);
+    await vi.runAllTimersAsync();
+
+    const error = await caught;
+    expect(error).toBeInstanceOf(AppError);
+    expect(error).toMatchObject({ statusCode: 404, errorCode: "track_not_found" });
+  });
+
+  it("uses stdout when yt-dlp exits non-zero but still printed a url", async () => {
+    execFileMock.mockImplementation((_path, _args, cb: (e: unknown, r: unknown) => void) =>
+      cb(Object.assign(new Error("non-zero exit"), { stdout: "https://youtu.be/xyz\n" }), null),
+    );
+    const { service } = makeService();
+
+    const promise = service.findOnYoutubeOne("Artist", "Song");
+    await vi.runAllTimersAsync();
+
+    await expect(promise).resolves.toBe("https://youtu.be/xyz");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries with a 5s backoff on a rate-limit error, then succeeds", async () => {
+    execFileMock
+      .mockImplementationOnce((_p, _a, cb: (e: unknown, r: unknown) => void) =>
+        cb(Object.assign(new Error("fail"), { stderr: "Sign in to confirm rate-limited" }), null),
+      )
+      .mockImplementationOnce((_p, _a, cb: (e: unknown, r: unknown) => void) =>
+        cb(null, { stdout: "https://youtu.be/ok\n", stderr: "" }),
+      );
+    const { service } = makeService();
+
+    const promise = service.findOnYoutubeOne("Artist", "Song");
+
+    // Flush the first attempt; the retry must wait for the 5s backoff window.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+
+    await expect(promise).resolves.toBe("https://youtu.be/ok");
+  });
+
+  it("gives up after exhausting the retry budget", async () => {
+    execFileMock.mockImplementation((_p, _a, cb: (e: unknown, r: unknown) => void) =>
+      cb(Object.assign(new Error("fail"), { stderr: "rate limited" }), null),
+    );
+    const { service } = makeService();
+
+    const promise = service.findOnYoutubeOne("Artist", "Song");
+    const assertion = expect(promise).rejects.toThrow();
+    await vi.runAllTimersAsync();
+    await assertion;
+
+    // Initial attempt + 3 retries.
+    expect(execFileMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("passes --cookies for a file path and --cookies-from-browser for a browser name", async () => {
+    resolveWith("https://youtu.be/abc\n");
+    const { service } = makeService({
+      getString: vi.fn().mockResolvedValue("/config/cookies.txt"),
+    });
+
+    const filePromise = service.findOnYoutubeOne("Artist", "Song");
+    await vi.runAllTimersAsync();
+    await filePromise;
+
+    expect(execFileMock.mock.calls[0][1]).toContain("--cookies");
+    expect(execFileMock.mock.calls[0][1]).toContain("/config/cookies.txt");
+
+    execFileMock.mockReset();
+    resolveWith("https://youtu.be/abc\n");
+    const { service: browserService } = makeService({
+      getString: vi.fn().mockResolvedValue("firefox"),
+    });
+
+    const browserPromise = browserService.findOnYoutubeOne("Artist", "Song");
+    await vi.runAllTimersAsync();
+    await browserPromise;
+
+    expect(execFileMock.mock.calls[0][1]).toContain("--cookies-from-browser");
+    expect(execFileMock.mock.calls[0][1]).toContain("firefox");
+  });
+});

--- a/apps/backend/src/infrastructure/workers/track-download.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/track-download.worker.test.ts
@@ -1,0 +1,98 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerListeners: Record<string, (...args: unknown[]) => unknown> = {};
+
+const workerOn = vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
+  workerListeners[event] = cb;
+});
+
+const WorkerMock = vi.fn((..._args: unknown[]) => ({ on: workerOn }));
+
+const trackService = {
+  downloadFromYoutube: vi.fn(),
+  update: vi.fn(),
+};
+const settingsService = { getNumber: vi.fn() };
+const libraryService = { scan: vi.fn() };
+const eventsController = { emit: vi.fn() };
+
+vi.mock("bullmq", () => ({ Worker: WorkerMock }));
+
+vi.mock("../../container", () => ({
+  getContainer: () => ({ trackService, settingsService, libraryService, eventsController }),
+}));
+
+vi.mock("../setup/environment", () => ({
+  getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
+}));
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return { id: "track-1", name: "Song", artist: "Artist", ...overrides };
+}
+
+describe("createTrackDownloadWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(workerListeners).forEach((key) => delete workerListeners[key]);
+    settingsService.getNumber.mockResolvedValue(10);
+    libraryService.scan.mockResolvedValue(undefined);
+    trackService.update.mockResolvedValue(undefined);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("configures the BullMQ limiter from the per-minute setting", async () => {
+    const { createTrackDownloadWorker } = await import("./track-download.worker");
+    settingsService.getNumber.mockResolvedValue(25);
+
+    await createTrackDownloadWorker();
+
+    const options = WorkerMock.mock.calls[0][2] as unknown as {
+      limiter: { max: number; duration: number };
+    };
+    expect(options.limiter).toEqual({ max: 25, duration: 60000 });
+  });
+
+  it("scans the library and emits library-updated when the queue drains", async () => {
+    const { createTrackDownloadWorker } = await import("./track-download.worker");
+    await createTrackDownloadWorker();
+
+    await workerListeners.drained?.();
+
+    expect(libraryService.scan).toHaveBeenCalledTimes(1);
+    expect(eventsController.emit).toHaveBeenCalledWith("library-updated");
+  });
+
+  it("does not throw and skips the event when the post-drain scan fails", async () => {
+    const { createTrackDownloadWorker } = await import("./track-download.worker");
+    await createTrackDownloadWorker();
+    libraryService.scan.mockRejectedValueOnce(new Error("scan failed"));
+
+    await expect(workerListeners.drained?.()).resolves.toBeUndefined();
+    expect(eventsController.emit).not.toHaveBeenCalledWith("library-updated");
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("marks the track as Error and emits playlists-updated on a failed job", async () => {
+    const { createTrackDownloadWorker } = await import("./track-download.worker");
+    await createTrackDownloadWorker();
+
+    await workerListeners.failed?.({ id: "job-1", data: makeTrack() }, new Error("download died"));
+
+    expect(trackService.update).toHaveBeenCalledWith(
+      "track-1",
+      expect.objectContaining({ status: TrackStatusEnum.Error, error: "download died" }),
+    );
+    expect(eventsController.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("ignores a failed job whose payload carries no track id", async () => {
+    const { createTrackDownloadWorker } = await import("./track-download.worker");
+    await createTrackDownloadWorker();
+
+    await workerListeners.failed?.({ id: "job-2", data: {} }, new Error("download died"));
+
+    expect(trackService.update).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Adds behavior-level unit tests for the highest-risk backend logic that previously had **zero coverage**, per issue #148. Also fixes a latent floating promise rejection surfaced while writing the circuit-breaker FSM tests.

50 new tests. Full backend suite: **556/556 green**. Lint + typecheck clean.

## Coverage added
- **`download-track.use-case`** — status transitions (New→Downloading→Completed), history-then-M3U write ordering, event emission, and the failure path (no history/M3U write on error).
- **`search-track-on-youtube.use-case`** — queue fan-out, preset-URL skip, not-found/error handling, `DOWNLOAD_MAX_RETRIES` clamping.
- **`infrastructure/external/circuit-breaker`** — CLOSED→OPEN→HALF-OPEN→CLOSED FSM, `maxWaiters` overflow, exponential backoff cap (4h), `onOpen` persistence restore.
- **`infrastructure/external/youtube-search.service`** — rate-limit detection with exponential backoff (mocked `execFile`, pinned clock), cookies file vs browser branching.
- **`infrastructure/workers/track-download.worker`** — `completed`/`drained`/`failed` handlers via a mocked container + BullMQ Worker (no live Redis).
- **`application/use-cases/history/history.use-cases`** — `getRecentDownloads` dedup: Spotify URL normalization, cross-run merge, fallback bucketing, date sort.

## Bug fixed
`CircuitBreaker.execute` (HALF-OPEN branch) attached a side `.finally()` chain to reset `probeInFlight` without handling its rejection, leaking an unhandled promise rejection whenever a probe failed. Added a terminal `.catch()` on that side chain only — the caller still owns the original promise.

## Notes
- Time-based logic uses pinned clocks (`vi.useFakeTimers` + `setSystemTime`).
- No snapshot/over-mock tests; assertions are behavior-level.

Closes #148.