### PR TITLE
test: enforce coverage thresholds in CI (#149)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,18 @@ jobs:
       - name: Generate Prisma client
         run: pnpm --filter backend run prisma:generate
 
-      - name: Run tests
-        run: pnpm test
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: |
+            apps/backend/coverage/
+            apps/frontend/coverage/
+          if-no-files-found: ignore
 
   e2e:
     name: E2E

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write \"src/**/*.{ts,json}\"",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy"

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/**/index.ts", "src/infrastructure/setup/**"],
+      // Thresholds sit just under the currently measured coverage so the gate is
+      // green on merge. Ratchet these up as coverage improves (issue #149).
+      thresholds: {
+        lines: 52,
+        statements: 52,
+        functions: 53,
+        branches: 72,
+      },
     },
   },
   resolve: {

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:mocked": "PLAYWRIGHT_TARGET=mocked playwright test --project=mocked",
     "test:e2e:real": "PLAYWRIGHT_TARGET=real playwright test --project=real",

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
       reporter: ["text", "json", "html"],
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.test.{ts,tsx}", "src/**/index.{ts,tsx}", "src/index.tsx", "src/i18n.ts"],
+      // Thresholds sit just under the currently measured coverage so the gate is
+      // green on merge. Ratchet these up as coverage improves (issue #149).
+      thresholds: {
+        lines: 47,
+        statements: 47,
+        functions: 58,
+        branches: 74,
+      },
     },
   },
   resolve: {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build": "pnpm -r run build",
     "start": "node apps/backend/dist/index.js",
     "test": "pnpm -r --if-present run test:run",
+    "test:coverage": "pnpm -r --if-present run test:coverage",
     "lint": "pnpm -r --if-present run lint",
     "format": "pnpm -r --if-present run format",
     "clean": "pnpm -r --if-present run clean && rm -rf apps/*/dist packages/*/dist",


### PR DESCRIPTION
## Summary
Coverage was wired (PR #122) but never enforced — the CI test step ran without `--coverage`, so coverage could silently drop to zero with CI staying green. This adds enforced thresholds and runs coverage in CI.

## Changes
- **Thresholds** added to `apps/backend/vitest.config.ts` and `apps/frontend/vitest.config.ts`, set just under current measured coverage so the gate is green on merge and can be ratcheted up:
  - Backend: lines/statements 52, functions 53, branches 72 (measured ~55.8 / 56.7 / 76.4).
  - Frontend: lines/statements 47, functions 58, branches 74 (measured ~50.4 / 63.7 / 79.1).
- **`test:coverage`** scripts added (backend, frontend, root).
- **CI** test step switched to `pnpm test:coverage`; coverage reports uploaded as an artifact.

## Verification
- `pnpm test:coverage` green on both packages locally.
- Confirmed the gate fails when a threshold exceeds measured coverage (`--coverage.thresholds.lines=99` → exit 1).

Builds on #148. Closes #149.