### PR TITLE
chore(backend): harden runtime — selective Docker COPY, Redis health, graceful shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
     name: E2E
     runs-on: ubuntu-latest
 
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ COPY --chown=node:node --from=builder /spotiarr/apps/backend/node_modules ./apps
 COPY --chown=node:node --from=builder /spotiarr/apps/backend/package.json ./apps/backend/
 COPY --chown=node:node --from=builder /spotiarr/apps/backend/dist ./apps/backend/dist
 COPY --chown=node:node --from=builder /spotiarr/apps/backend/prisma ./apps/backend/prisma
+# The Playwright real-stack harness is build-time test tooling; drop it from prod.
+RUN rm -rf /spotiarr/apps/backend/dist/testing
 COPY --chown=node:node --from=builder /spotiarr/apps/frontend/package.json ./apps/frontend/
 COPY --chown=node:node --from=builder /spotiarr/apps/frontend/dist ./apps/frontend/dist
 COPY --chown=node:node --from=builder /spotiarr/packages/shared/package.json ./packages/shared/

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,18 @@ COPY --chown=node:node --from=builder /spotiarr/package.json /spotiarr/pnpm-work
 COPY --chown=node:node docker-entrypoint.sh ./
 RUN chmod +x docker-entrypoint.sh
 
-# Copy application artifacts (node_modules, dist, prisma) from builder
+# Copy built artifacts only — keep TS source and tests out of the runtime image.
+# Selective COPY ships only node_modules, compiled dist, and the Prisma
+# schema/migrations, reducing image size and attack surface.
 COPY --chown=node:node --from=builder /spotiarr/node_modules ./node_modules
-COPY --chown=node:node --from=builder /spotiarr/apps ./apps
-COPY --chown=node:node --from=builder /spotiarr/packages ./packages
+COPY --chown=node:node --from=builder /spotiarr/apps/backend/node_modules ./apps/backend/node_modules
+COPY --chown=node:node --from=builder /spotiarr/apps/backend/package.json ./apps/backend/
+COPY --chown=node:node --from=builder /spotiarr/apps/backend/dist ./apps/backend/dist
+COPY --chown=node:node --from=builder /spotiarr/apps/backend/prisma ./apps/backend/prisma
+COPY --chown=node:node --from=builder /spotiarr/apps/frontend/package.json ./apps/frontend/
+COPY --chown=node:node --from=builder /spotiarr/apps/frontend/dist ./apps/frontend/dist
+COPY --chown=node:node --from=builder /spotiarr/packages/shared/package.json ./packages/shared/
+COPY --chown=node:node --from=builder /spotiarr/packages/shared/dist ./packages/shared/dist
 
 # Prisma writes engine binaries at startup; make those dirs world-writable
 # so they work when PUID != 1000 (the build uid).

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "build": "pnpm prisma:generate && tsc && tsc-alias",
+    "build": "pnpm prisma:generate && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "start": "node dist/index.js",
     "lint": "oxlint src --fix",
     "format": "prettier --write \"src/**/*.{ts,json}\"",

--- a/apps/backend/src/application/ports/connectivity.port.ts
+++ b/apps/backend/src/application/ports/connectivity.port.ts
@@ -1,3 +1,4 @@
 export interface ConnectivityPort {
   pingDatabase(): Promise<void>;
+  pingRedis(): Promise<void>;
 }

--- a/apps/backend/src/application/services/health.service.test.ts
+++ b/apps/backend/src/application/services/health.service.test.ts
@@ -2,23 +2,55 @@ import { describe, expect, it, vi } from "vitest";
 import { HealthService } from "@/application/services/health.service";
 
 describe("HealthService", () => {
-  it("returns ok when database ping succeeds", async () => {
-    const connectivity = { pingDatabase: vi.fn().mockResolvedValue(undefined) };
+  it("returns ok when both database and redis pings succeed", async () => {
+    const connectivity = {
+      pingDatabase: vi.fn().mockResolvedValue(undefined),
+      pingRedis: vi.fn().mockResolvedValue(undefined),
+    };
     const service = new HealthService(connectivity);
 
     await expect(service.check()).resolves.toEqual({
       status: "ok",
-      components: { db: "ok" },
+      components: { db: "ok", redis: "ok" },
     });
   });
 
-  it("returns degraded when database ping fails", async () => {
-    const connectivity = { pingDatabase: vi.fn().mockRejectedValue(new Error("db down")) };
+  it("returns degraded with redis down when redis ping fails", async () => {
+    const connectivity = {
+      pingDatabase: vi.fn().mockResolvedValue(undefined),
+      pingRedis: vi.fn().mockRejectedValue(new Error("redis down")),
+    };
     const service = new HealthService(connectivity);
 
     await expect(service.check()).resolves.toEqual({
       status: "degraded",
-      components: { db: "down" },
+      components: { db: "ok", redis: "down" },
+    });
+  });
+
+  it("returns degraded with db down when database ping fails", async () => {
+    const connectivity = {
+      pingDatabase: vi.fn().mockRejectedValue(new Error("db down")),
+      pingRedis: vi.fn().mockResolvedValue(undefined),
+    };
+    const service = new HealthService(connectivity);
+
+    await expect(service.check()).resolves.toEqual({
+      status: "degraded",
+      components: { db: "down", redis: "ok" },
+    });
+  });
+
+  it("returns degraded with both down when both pings fail", async () => {
+    const connectivity = {
+      pingDatabase: vi.fn().mockRejectedValue(new Error("db down")),
+      pingRedis: vi.fn().mockRejectedValue(new Error("redis down")),
+    };
+    const service = new HealthService(connectivity);
+
+    await expect(service.check()).resolves.toEqual({
+      status: "degraded",
+      components: { db: "down", redis: "down" },
     });
   });
 });

--- a/apps/backend/src/application/services/health.service.ts
+++ b/apps/backend/src/application/services/health.service.ts
@@ -2,10 +2,13 @@ import type { ConnectivityPort } from "@/application/ports/connectivity.port";
 
 export type HealthStatus = "ok" | "degraded";
 
+type ComponentStatus = "ok" | "down";
+
 export interface HealthReport {
   status: HealthStatus;
   components: {
-    db: "ok" | "down";
+    db: ComponentStatus;
+    redis: ComponentStatus;
   };
 }
 
@@ -13,11 +16,21 @@ export class HealthService {
   constructor(private readonly connectivity: ConnectivityPort) {}
 
   async check(): Promise<HealthReport> {
+    const [db, redis] = await Promise.all([
+      this.probe(() => this.connectivity.pingDatabase()),
+      this.probe(() => this.connectivity.pingRedis()),
+    ]);
+
+    const status: HealthStatus = db === "ok" && redis === "ok" ? "ok" : "degraded";
+    return { status, components: { db, redis } };
+  }
+
+  private async probe(ping: () => Promise<void>): Promise<ComponentStatus> {
     try {
-      await this.connectivity.pingDatabase();
-      return { status: "ok", components: { db: "ok" } };
+      await ping();
+      return "ok";
     } catch {
-      return { status: "degraded", components: { db: "down" } };
+      return "down";
     }
   }
 }

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -45,11 +45,11 @@ import { NoopAlbumTracksCache } from "./infrastructure/cache/noop-album-tracks-c
 import { ArtistAlbumCacheRepository } from "./infrastructure/database/artist-album-cache.repository";
 import { ArtistReleaseCacheRepository } from "./infrastructure/database/artist-release-cache.repository";
 import { PrismaArtworkBackfillRepository } from "./infrastructure/database/artwork-backfill.repository";
+import { ConnectivityAdapter } from "./infrastructure/database/connectivity.adapter";
 import { ExternalUrlCacheRepository } from "./infrastructure/database/external-url-cache.repository";
 import { FeedCacheEvictionRepository } from "./infrastructure/database/feed-cache-eviction.repository";
 import { FeedSyncStateRepository } from "./infrastructure/database/feed-sync-state.repository";
 import { FollowedArtistRepository } from "./infrastructure/database/followed-artist.repository";
-import { PrismaConnectivityAdapter } from "./infrastructure/database/prisma-connectivity.adapter";
 import { PrismaHistoryRepository } from "./infrastructure/database/prisma-history.repository";
 import { PrismaPlaylistRepository } from "./infrastructure/database/prisma-playlist.repository";
 import { PrismaSettingsRepository } from "./infrastructure/database/prisma-settings.repository";
@@ -185,7 +185,7 @@ export function createContainer(env: Env) {
     setCatalogSyncState: (status, error) =>
       feedSyncStateRepository.setCatalogSyncState(status, error),
   };
-  const connectivityAdapter = new PrismaConnectivityAdapter();
+  const connectivityAdapter = new ConnectivityAdapter();
 
   const internalizedNumericSettingMap: Record<string, () => number> = {
     FEED_SYNC_INTERVAL_MINUTES: () => env.FEED_SYNC_INTERVAL_MINUTES,

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -136,12 +136,15 @@ async function bootstrap() {
 const gracefulShutdown = async (signal: string, server: http.Server) => {
   console.log(`\n[${signal}] Signal received: closing application...`);
 
-  // 1. Close HTTP Server
-  server.close(() => {
-    console.log("✅ HTTP server closed");
-  });
-
   try {
+    // 1. Close HTTP Server — await draining in-flight requests before tearing
+    // down queues/workers so SSE and HTTP responses are not cut off.
+    console.log("⏳ Closing HTTP server...");
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+    console.log("✅ HTTP server closed");
+
     // 2. Close Queues and Workers
     console.log("⏳ Closing queues and workers...");
     await Promise.allSettled([

--- a/apps/backend/src/infrastructure/database/connectivity.adapter.ts
+++ b/apps/backend/src/infrastructure/database/connectivity.adapter.ts
@@ -1,0 +1,33 @@
+import type { ConnectivityPort } from "@/application/ports/connectivity.port";
+import { prisma } from "@/infrastructure/setup/prisma";
+import { getTrackDownloadQueue } from "@/infrastructure/setup/queues";
+
+// When Redis is unreachable, ioredis queues commands offline and retries
+// indefinitely, so a bare ping() never settles. Cap it so /api/health always
+// responds (well under the Docker HEALTHCHECK timeout).
+const REDIS_PING_TIMEOUT_MS = 2000;
+
+export class ConnectivityAdapter implements ConnectivityPort {
+  async pingDatabase(): Promise<void> {
+    await prisma.$queryRaw`SELECT 1`;
+  }
+
+  async pingRedis(): Promise<void> {
+    // Reuse the BullMQ queue's Redis connection instead of opening a new socket.
+    await withTimeout(
+      (async () => {
+        const client = await getTrackDownloadQueue().client;
+        await client.ping();
+      })(),
+      REDIS_PING_TIMEOUT_MS,
+    );
+  }
+}
+
+function withTimeout<T>(operation: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("redis ping timed out")), ms);
+    timer.unref?.();
+    operation.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}

--- a/apps/backend/src/infrastructure/database/prisma-connectivity.adapter.ts
+++ b/apps/backend/src/infrastructure/database/prisma-connectivity.adapter.ts
@@ -1,8 +1,0 @@
-import type { ConnectivityPort } from "@/application/ports/connectivity.port";
-import { prisma } from "@/infrastructure/setup/prisma";
-
-export class PrismaConnectivityAdapter implements ConnectivityPort {
-  async pingDatabase(): Promise<void> {
-    await prisma.$queryRaw`SELECT 1`;
-  }
-}

--- a/apps/backend/src/presentation/controllers/health.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/health.controller.test.ts
@@ -16,7 +16,7 @@ function mockRes(): Response {
 describe("HealthController", () => {
   it("returns 200 with { status: 'ok' } for healthy report", async () => {
     const healthService = {
-      check: vi.fn().mockResolvedValue({ status: "ok", components: { db: "ok" } }),
+      check: vi.fn().mockResolvedValue({ status: "ok", components: { db: "ok", redis: "ok" } }),
     } as unknown as HealthService;
     const controller = new HealthController(healthService);
 
@@ -27,9 +27,11 @@ describe("HealthController", () => {
     expect(res.json).toHaveBeenCalledWith({ status: "ok" });
   });
 
-  it("returns 503 with degraded components shape when db is down", async () => {
+  it("returns 503 with degraded components shape when redis is down", async () => {
     const healthService = {
-      check: vi.fn().mockResolvedValue({ status: "degraded", components: { db: "down" } }),
+      check: vi
+        .fn()
+        .mockResolvedValue({ status: "degraded", components: { db: "ok", redis: "down" } }),
     } as unknown as HealthService;
     const controller = new HealthController(healthService);
 
@@ -39,7 +41,7 @@ describe("HealthController", () => {
     expect(res.status).toHaveBeenCalledWith(503);
     expect(res.json).toHaveBeenCalledWith({
       status: "degraded",
-      components: { db: "down" },
+      components: { db: "ok", redis: "down" },
     });
   });
 });

--- a/apps/backend/src/testing/playwright-real-stack-server.ts
+++ b/apps/backend/src/testing/playwright-real-stack-server.ts
@@ -4,6 +4,14 @@ import { initializeContainer } from "../container";
 import { configureSpotifyRateLimiters } from "../infrastructure/external/spotify-http.client";
 import { getEnv, validateEnvironment } from "../infrastructure/setup/environment";
 import { prisma } from "../infrastructure/setup/prisma";
+import {
+  getArtworkBackfillQueue,
+  getCatalogSyncQueue,
+  getFeedSyncQueue,
+  getTrackDownloadQueue,
+  getTrackSearchQueue,
+  initializeQueues,
+} from "../infrastructure/setup/queues";
 
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 3000;
@@ -37,6 +45,10 @@ export async function startPlaywrightRealStackServer(
   validateEnvironment();
   const env = getEnv();
   configureSpotifyRateLimiters(env);
+
+  // Mirror the production bootstrap so the BullMQ Redis connection exists and
+  // /api/health can ping it. Without this, getTrackDownloadQueue() throws.
+  initializeQueues();
 
   const container = initializeContainer(env);
   const app = createApp(container);
@@ -73,6 +85,14 @@ async function closeServer(server: http.Server): Promise<void> {
   });
 
   await Promise.race([closeServer, forceClose]);
+
+  await Promise.allSettled([
+    getTrackDownloadQueue().close(),
+    getTrackSearchQueue().close(),
+    getFeedSyncQueue().close(),
+    getCatalogSyncQueue().close(),
+    getArtworkBackfillQueue().close(),
+  ]);
 
   await prisma.$disconnect();
 }

--- a/apps/backend/tsconfig.build.json
+++ b/apps/backend/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}


### PR DESCRIPTION
## What

Three independent runtime hardening items from the repo audit (BUILD-3, OBS-2, OBS-3).

### 1. Dockerfile — selective COPY (BUILD-3)
The runtime stage copied the entire `apps/` and `packages/` trees, shipping TS source + tests into the prod image. Now copies only built artifacts: root + backend `node_modules`, `apps/backend/dist`, `apps/backend/prisma`, `apps/frontend/dist`, `packages/shared/dist`, and the workspace `package.json` files.

Tests were also being compiled into `dist/`, so added `apps/backend/tsconfig.build.json` (excludes `*.test.ts`) and pointed the `build` script at it. The dev typecheck still uses the default `tsconfig.json` (tests included).

### 2. Health check — Redis ping (OBS-2)
`HealthService` checked only SQLite, so a Redis outage still returned `status: "ok"`. Added `pingRedis()` to `ConnectivityPort`; `ConnectivityAdapter` reuses the BullMQ Redis connection. Wrapped the ping in a **2s timeout** — without it, ioredis queues commands offline and `ping()` never settles, hanging `/api/health`.

### 3. Graceful shutdown — drain HTTP first (OBS-3)
`gracefulShutdown` called `server.close()` (callback) without awaiting before closing BullMQ queues, cutting off in-flight SSE/HTTP. Now `await`s `server.close()` before tearing down queues/workers.

## Verification

Built the production image and validated end-to-end:

- ✅ No source/test files in the image (`find dist -name '*.test.*'` → 0; no `src/` dirs).
- ✅ Module resolution + Prisma client load OK in the prod image.
- ✅ `/api/health` → `200 {"status":"ok"}` (3ms) with Redis up.
- ✅ `/api/health` → `503 {"status":"degraded","components":{"db":"ok","redis":"down"}}` (~2s, no hang) with Redis stopped.
- ✅ SIGTERM log order: HTTP server closed → queues/workers closed → DB disconnected.
- ✅ 558 backend tests pass.

## Acceptance

- [x] Prod image contains no source/test files.
- [x] `/api/health` reports `redis: down` when Redis is unreachable.
- [x] Shutdown drains HTTP before closing queues.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)