### PR TITLE
feat(ai): model discovery — list provider models in Settings

### DIFF
--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -56,6 +56,7 @@ import { PrismaSettingsRepository } from "./infrastructure/database/prisma-setti
 import { PrismaTrackRepository } from "./infrastructure/database/prisma-track.repository";
 import { CircuitBreaker } from "./infrastructure/external/circuit-breaker";
 import { PromiseCache } from "./infrastructure/external/promise-cache";
+import { listAiModels } from "./infrastructure/external/providers/ai/list-ai-models";
 import { DeezerArtistLookupAdapter } from "./infrastructure/external/providers/deezer/deezer-artist-lookup.adapter";
 import { DeezerArtworkSourceService } from "./infrastructure/external/providers/deezer/deezer-artwork-source.service";
 import { DeezerCatalogSearchAdapter } from "./infrastructure/external/providers/deezer/deezer-catalog-search.adapter";
@@ -600,7 +601,9 @@ export function createContainer(env: Env) {
   const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 
   const aiPlaylistQueueService = new BullMqAiPlaylistQueueService();
-  const aiChatController = new AiChatController(aiPlaylistQueueService);
+  const aiChatController = new AiChatController(aiPlaylistQueueService, () =>
+    listAiModels(settingsService),
+  );
 
   const historyUseCases = new HistoryUseCases({ repository: historyRepository });
   const historyController = new HistoryController(historyUseCases);

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -601,8 +601,8 @@ export function createContainer(env: Env) {
   const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 
   const aiPlaylistQueueService = new BullMqAiPlaylistQueueService();
-  const aiChatController = new AiChatController(aiPlaylistQueueService, () =>
-    listAiModels(settingsService),
+  const aiChatController = new AiChatController(aiPlaylistQueueService, (overrides) =>
+    listAiModels(settingsService, overrides),
   );
 
   const historyUseCases = new HistoryUseCases({ repository: historyRepository });

--- a/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { resolveAiConnection } from "./ai-connection.resolver";
+
+const makeSettings = (values: Record<string, string>) =>
+  ({
+    getString: vi.fn(async (key: string, fallback = "") => values[key] ?? fallback),
+  }) as unknown as SettingsService;
+
+describe("resolveAiConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves preset baseURL for openai when AI_BASE_URL is empty", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-test",
+      AI_MODEL: "gpt-4o",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.baseURL).toBe("https://api.openai.com/v1");
+    expect(result.apiKey).toBe("sk-test");
+    expect(result.provider).toBe("openai");
+  });
+
+  it("uses AI_BASE_URL override over preset", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "https://my-proxy.example.com/v1",
+      AI_API_KEY: "sk-test",
+      AI_MODEL: "gpt-4o",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.baseURL).toBe("https://my-proxy.example.com/v1");
+  });
+
+  it("injects placeholder key for ollama (local provider)", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "ollama",
+      AI_BASE_URL: "",
+      AI_API_KEY: "",
+      AI_MODEL: "llama3",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.apiKey).toBe("local");
+    expect(result.baseURL).toBe("http://localhost:11434/v1");
+  });
+
+  it("injects placeholder key for lmstudio (local provider)", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "lmstudio",
+      AI_BASE_URL: "",
+      AI_API_KEY: "",
+      AI_MODEL: "mistral",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.apiKey).toBe("local");
+  });
+
+  it("throws provider-misconfig for non-local provider without API key", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "",
+      AI_MODEL: "gpt-4o",
+    });
+
+    await expect(resolveAiConnection(settings)).rejects.toMatchObject({
+      code: "provider-misconfig",
+    });
+  });
+
+  it("throws provider-misconfig for custom provider with empty base URL", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "custom",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-test",
+      AI_MODEL: "gpt-4o",
+    });
+
+    await expect(resolveAiConnection(settings)).rejects.toMatchObject({
+      code: "provider-misconfig",
+    });
+  });
+
+  it("normalizes an unknown provider to openai default", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai-compatible",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-test",
+      AI_MODEL: "gpt-4o",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.provider).toBe("openai");
+    expect(result.baseURL).toBe("https://api.openai.com/v1");
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.test.ts
@@ -107,3 +107,123 @@ describe("resolveAiConnection", () => {
     expect(result.baseURL).toBe("https://api.openai.com/v1");
   });
 });
+
+describe("resolveAiConnection — overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("override provider wins over stored provider", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      provider: "ollama",
+      apiKey: "",
+    });
+
+    expect(result.provider).toBe("ollama");
+    expect(result.apiKey).toBe("local");
+  });
+
+  it("override baseURL wins over preset", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      baseURL: "https://override.example.com/v1",
+    });
+
+    expect(result.baseURL).toBe("https://override.example.com/v1");
+  });
+
+  it("override apiKey wins over stored key", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      apiKey: "sk-override",
+    });
+
+    expect(result.apiKey).toBe("sk-override");
+  });
+
+  it("masked sentinel apiKey falls back to stored key", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      apiKey: "••••••••",
+    });
+
+    expect(result.apiKey).toBe("sk-stored");
+  });
+
+  it("blank override apiKey falls back to stored key", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      apiKey: "",
+    });
+
+    expect(result.apiKey).toBe("sk-stored");
+  });
+
+  it("empty baseURL override falls back to preset", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      baseURL: "   ",
+    });
+
+    expect(result.baseURL).toBe("https://api.openai.com/v1");
+  });
+
+  it("override provider is normalized", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-stored",
+    });
+
+    const result = await resolveAiConnection(settings, {
+      provider: "unknown-provider",
+    });
+
+    expect(result.provider).toBe("openai");
+  });
+
+  it("no overrides behaves exactly as before", async () => {
+    const settings = makeSettings({
+      AI_PROVIDER: "openai",
+      AI_BASE_URL: "",
+      AI_API_KEY: "sk-test",
+    });
+
+    const result = await resolveAiConnection(settings);
+
+    expect(result.provider).toBe("openai");
+    expect(result.baseURL).toBe("https://api.openai.com/v1");
+    expect(result.apiKey).toBe("sk-test");
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.ts
@@ -1,0 +1,36 @@
+import { AI_LOCAL_PROVIDERS, AI_PROVIDER_PRESETS, normalizeAiProvider } from "@spotiarr/shared";
+import type { AiProvider } from "@spotiarr/shared";
+import type { SettingsService } from "@/application/services/settings.service";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+
+export interface AiConnection {
+  provider: AiProvider;
+  baseURL: string;
+  apiKey: string;
+}
+
+export async function resolveAiConnection(settingsService: SettingsService): Promise<AiConnection> {
+  const [rawProvider, rawBaseURL, rawApiKey] = await Promise.all([
+    settingsService.getString("AI_PROVIDER", "openai"),
+    settingsService.getString("AI_BASE_URL", ""),
+    settingsService.getString("AI_API_KEY", ""),
+  ]);
+
+  const provider = normalizeAiProvider(rawProvider);
+  const baseURL = rawBaseURL.trim() || AI_PROVIDER_PRESETS[provider] || "";
+  const isLocal = AI_LOCAL_PROVIDERS.includes(provider);
+  const apiKey = rawApiKey.trim() || (isLocal ? "local" : "");
+
+  if (!baseURL) {
+    throw new AiChatError(
+      "provider-misconfig",
+      "AI_BASE_URL is required when using a custom provider",
+    );
+  }
+
+  if (!isLocal && !rawApiKey.trim()) {
+    throw new AiChatError("provider-misconfig", "AI_API_KEY must be configured in Settings");
+  }
+
+  return { provider, baseURL, apiKey };
+}

--- a/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/ai-connection.resolver.ts
@@ -1,6 +1,7 @@
 import { AI_LOCAL_PROVIDERS, AI_PROVIDER_PRESETS, normalizeAiProvider } from "@spotiarr/shared";
 import type { AiProvider } from "@spotiarr/shared";
 import type { SettingsService } from "@/application/services/settings.service";
+import { MASKED_SENTINEL } from "@/application/use-cases/settings/get-settings.use-case";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
 
 export interface AiConnection {
@@ -9,17 +10,35 @@ export interface AiConnection {
   apiKey: string;
 }
 
-export async function resolveAiConnection(settingsService: SettingsService): Promise<AiConnection> {
+export interface AiConnectionOverrides {
+  provider?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
+export async function resolveAiConnection(
+  settingsService: SettingsService,
+  overrides?: AiConnectionOverrides,
+): Promise<AiConnection> {
   const [rawProvider, rawBaseURL, rawApiKey] = await Promise.all([
     settingsService.getString("AI_PROVIDER", "openai"),
     settingsService.getString("AI_BASE_URL", ""),
     settingsService.getString("AI_API_KEY", ""),
   ]);
 
-  const provider = normalizeAiProvider(rawProvider);
-  const baseURL = rawBaseURL.trim() || AI_PROVIDER_PRESETS[provider] || "";
+  const providerSource =
+    overrides?.provider && overrides.provider.trim() ? overrides.provider : rawProvider;
+  const provider = normalizeAiProvider(providerSource);
+
+  const baseURLSource = overrides?.baseURL?.trim() ?? rawBaseURL.trim();
+  const baseURL = baseURLSource || AI_PROVIDER_PRESETS[provider] || "";
+
   const isLocal = AI_LOCAL_PROVIDERS.includes(provider);
-  const apiKey = rawApiKey.trim() || (isLocal ? "local" : "");
+
+  const overrideKey = overrides?.apiKey;
+  const effectiveKey =
+    overrideKey && overrideKey !== MASKED_SENTINEL ? overrideKey : rawApiKey.trim();
+  const apiKey = isLocal ? "local" : effectiveKey;
 
   if (!baseURL) {
     throw new AiChatError(
@@ -28,7 +47,7 @@ export async function resolveAiConnection(settingsService: SettingsService): Pro
     );
   }
 
-  if (!isLocal && !rawApiKey.trim()) {
+  if (!isLocal && !effectiveKey) {
     throw new AiChatError("provider-misconfig", "AI_API_KEY must be configured in Settings");
   }
 

--- a/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { SettingsService } from "@/application/services/settings.service";
+import { listAiModels, type FetchFn } from "./list-ai-models";
+
+const makeSettings = (values: Record<string, string>) =>
+  ({
+    getString: vi.fn(async (key: string, fallback = "") => values[key] ?? fallback),
+  }) as unknown as SettingsService;
+
+const configuredSettings = makeSettings({
+  AI_PROVIDER: "openai",
+  AI_BASE_URL: "",
+  AI_API_KEY: "sk-test",
+  AI_MODEL: "gpt-4o",
+});
+
+const ollamaSettings = makeSettings({
+  AI_PROVIDER: "ollama",
+  AI_BASE_URL: "",
+  AI_API_KEY: "",
+  AI_MODEL: "llama3",
+});
+
+const misconfiguredSettings = makeSettings({
+  AI_PROVIDER: "openai",
+  AI_BASE_URL: "",
+  AI_API_KEY: "",
+  AI_MODEL: "",
+});
+
+function makeFetchMock(status: number, body: unknown): FetchFn {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response);
+}
+
+describe("listAiModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns sorted unique model ids from a successful response", async () => {
+    const fetchMock = makeFetchMock(200, {
+      data: [{ id: "gpt-4o" }, { id: "gpt-3.5-turbo" }, { id: "gpt-4o" }],
+    });
+
+    const result = await listAiModels(configuredSettings, fetchMock);
+
+    expect(result).toEqual(["gpt-3.5-turbo", "gpt-4o"]);
+  });
+
+  it("returns empty array when data is missing from response", async () => {
+    const fetchMock = makeFetchMock(200, {});
+
+    const result = await listAiModels(configuredSettings, fetchMock);
+
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when data array is empty", async () => {
+    const fetchMock = makeFetchMock(200, { data: [] });
+
+    const result = await listAiModels(configuredSettings, fetchMock);
+
+    expect(result).toEqual([]);
+  });
+
+  it("throws provider-unreachable on non-2xx response", async () => {
+    const fetchMock = makeFetchMock(401, { error: "unauthorized" });
+
+    await expect(listAiModels(configuredSettings, fetchMock)).rejects.toMatchObject({
+      code: "provider-unreachable",
+    });
+  });
+
+  it("throws provider-unreachable on network error", async () => {
+    const fetchMock: FetchFn = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+
+    await expect(listAiModels(configuredSettings, fetchMock)).rejects.toMatchObject({
+      code: "provider-unreachable",
+    });
+  });
+
+  it("throws provider-misconfig when provider is not configured", async () => {
+    const fetchMock = makeFetchMock(200, { data: [] });
+
+    await expect(listAiModels(misconfiguredSettings, fetchMock)).rejects.toMatchObject({
+      code: "provider-misconfig",
+    });
+  });
+
+  it("sends Authorization header with apiKey", async () => {
+    const fetchMock = makeFetchMock(200, { data: [{ id: "gpt-4o" }] });
+
+    await listAiModels(configuredSettings, fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/models"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-test",
+        }),
+      }),
+    );
+  });
+
+  it("calls {baseURL}/models endpoint", async () => {
+    const fetchMock = makeFetchMock(200, { data: [{ id: "llama3" }] });
+
+    await listAiModels(ollamaSettings, fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:11434/v1/models", expect.any(Object));
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.test.ts
@@ -46,7 +46,7 @@ describe("listAiModels", () => {
       data: [{ id: "gpt-4o" }, { id: "gpt-3.5-turbo" }, { id: "gpt-4o" }],
     });
 
-    const result = await listAiModels(configuredSettings, fetchMock);
+    const result = await listAiModels(configuredSettings, undefined, fetchMock);
 
     expect(result).toEqual(["gpt-3.5-turbo", "gpt-4o"]);
   });
@@ -54,7 +54,7 @@ describe("listAiModels", () => {
   it("returns empty array when data is missing from response", async () => {
     const fetchMock = makeFetchMock(200, {});
 
-    const result = await listAiModels(configuredSettings, fetchMock);
+    const result = await listAiModels(configuredSettings, undefined, fetchMock);
 
     expect(result).toEqual([]);
   });
@@ -62,7 +62,7 @@ describe("listAiModels", () => {
   it("returns empty array when data array is empty", async () => {
     const fetchMock = makeFetchMock(200, { data: [] });
 
-    const result = await listAiModels(configuredSettings, fetchMock);
+    const result = await listAiModels(configuredSettings, undefined, fetchMock);
 
     expect(result).toEqual([]);
   });
@@ -70,7 +70,7 @@ describe("listAiModels", () => {
   it("throws provider-unreachable on non-2xx response", async () => {
     const fetchMock = makeFetchMock(401, { error: "unauthorized" });
 
-    await expect(listAiModels(configuredSettings, fetchMock)).rejects.toMatchObject({
+    await expect(listAiModels(configuredSettings, undefined, fetchMock)).rejects.toMatchObject({
       code: "provider-unreachable",
     });
   });
@@ -78,7 +78,7 @@ describe("listAiModels", () => {
   it("throws provider-unreachable on network error", async () => {
     const fetchMock: FetchFn = vi.fn().mockRejectedValue(new TypeError("fetch failed"));
 
-    await expect(listAiModels(configuredSettings, fetchMock)).rejects.toMatchObject({
+    await expect(listAiModels(configuredSettings, undefined, fetchMock)).rejects.toMatchObject({
       code: "provider-unreachable",
     });
   });
@@ -86,7 +86,7 @@ describe("listAiModels", () => {
   it("throws provider-misconfig when provider is not configured", async () => {
     const fetchMock = makeFetchMock(200, { data: [] });
 
-    await expect(listAiModels(misconfiguredSettings, fetchMock)).rejects.toMatchObject({
+    await expect(listAiModels(misconfiguredSettings, undefined, fetchMock)).rejects.toMatchObject({
       code: "provider-misconfig",
     });
   });
@@ -94,7 +94,7 @@ describe("listAiModels", () => {
   it("sends Authorization header with apiKey", async () => {
     const fetchMock = makeFetchMock(200, { data: [{ id: "gpt-4o" }] });
 
-    await listAiModels(configuredSettings, fetchMock);
+    await listAiModels(configuredSettings, undefined, fetchMock);
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/models"),
@@ -109,8 +109,52 @@ describe("listAiModels", () => {
   it("calls {baseURL}/models endpoint", async () => {
     const fetchMock = makeFetchMock(200, { data: [{ id: "llama3" }] });
 
-    await listAiModels(ollamaSettings, fetchMock);
+    await listAiModels(ollamaSettings, undefined, fetchMock);
 
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:11434/v1/models", expect.any(Object));
+  });
+});
+
+describe("listAiModels — with overrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses override baseURL when provided", async () => {
+    const fetchMock = makeFetchMock(200, { data: [{ id: "gpt-4o" }] });
+
+    await listAiModels(
+      configuredSettings,
+      { baseURL: "https://override.example.com/v1" },
+      fetchMock,
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://override.example.com/v1/models",
+      expect.any(Object),
+    );
+  });
+
+  it("uses override apiKey in Authorization header", async () => {
+    const fetchMock = makeFetchMock(200, { data: [{ id: "gpt-4o" }] });
+
+    await listAiModels(configuredSettings, { apiKey: "sk-override" }, fetchMock);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-override",
+        }),
+      }),
+    );
+  });
+
+  it("undefined overrides behave identically to no overrides", async () => {
+    const fetchMock = makeFetchMock(200, { data: [{ id: "gpt-4o" }] });
+
+    const result = await listAiModels(configuredSettings, undefined, fetchMock);
+
+    expect(result).toEqual(["gpt-4o"]);
   });
 });

--- a/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.ts
@@ -1,0 +1,42 @@
+import type { SettingsService } from "@/application/services/settings.service";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
+import { resolveAiConnection } from "./ai-connection.resolver";
+
+export type FetchFn = typeof fetch;
+
+interface ModelsApiResponse {
+  data?: { id: string }[];
+}
+
+export async function listAiModels(
+  settingsService: SettingsService,
+  fetchFn: FetchFn = fetch,
+): Promise<string[]> {
+  const { baseURL, apiKey } = await resolveAiConnection(settingsService);
+
+  const url = `${baseURL.replace(/\/$/, "")}/models`;
+
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    });
+  } catch (err) {
+    throw new AiChatError("provider-unreachable", `Failed to reach ${url}: ${String(err)}`);
+  }
+
+  if (!response.ok) {
+    throw new AiChatError("provider-unreachable", `Models endpoint returned ${response.status}`);
+  }
+
+  const body = (await response.json()) as ModelsApiResponse;
+
+  if (!Array.isArray(body?.data)) {
+    return [];
+  }
+
+  return [...new Set(body.data.map((m) => m.id).filter(Boolean))].sort();
+}

--- a/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/list-ai-models.ts
@@ -1,6 +1,6 @@
 import type { SettingsService } from "@/application/services/settings.service";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
-import { resolveAiConnection } from "./ai-connection.resolver";
+import { resolveAiConnection, type AiConnectionOverrides } from "./ai-connection.resolver";
 
 export type FetchFn = typeof fetch;
 
@@ -10,9 +10,10 @@ interface ModelsApiResponse {
 
 export async function listAiModels(
   settingsService: SettingsService,
+  overrides?: AiConnectionOverrides,
   fetchFn: FetchFn = fetch,
 ): Promise<string[]> {
-  const { baseURL, apiKey } = await resolveAiConnection(settingsService);
+  const { baseURL, apiKey } = await resolveAiConnection(settingsService, overrides);
 
   const url = `${baseURL.replace(/\/$/, "")}/models`;
 

--- a/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.ts
+++ b/apps/backend/src/infrastructure/external/providers/ai/openai-compatible.adapter.ts
@@ -1,10 +1,10 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { AI_LOCAL_PROVIDERS, AI_PROVIDER_PRESETS, normalizeAiProvider } from "@spotiarr/shared";
 import { generateObject, NoObjectGeneratedError } from "ai";
 import { z } from "zod";
 import type { AiChatPort, AiTrackSuggestion } from "@/application/ports/ai-chat.port";
 import type { SettingsService } from "@/application/services/settings.service";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
+import { resolveAiConnection } from "./ai-connection.resolver";
 
 const tracksSchema = z.object({
   tracks: z
@@ -102,29 +102,9 @@ Return at most 50 tracks.`;
 export function createAiChatPort(settingsService: SettingsService): AiChatPort {
   return {
     async generateTracks(prompt: string): Promise<AiTrackSuggestion[]> {
-      const [rawProvider, rawBaseURL, rawApiKey, model] = await Promise.all([
-        settingsService.getString("AI_PROVIDER", "openai"),
-        settingsService.getString("AI_BASE_URL", ""),
-        settingsService.getString("AI_API_KEY", ""),
-        settingsService.getString("AI_MODEL", ""),
-      ]);
+      const { baseURL, apiKey } = await resolveAiConnection(settingsService);
 
-      const provider = normalizeAiProvider(rawProvider);
-      const baseURL = rawBaseURL.trim() || AI_PROVIDER_PRESETS[provider] || "";
-      const isLocal = AI_LOCAL_PROVIDERS.includes(provider);
-      const apiKey = rawApiKey.trim() || (isLocal ? "local" : "");
-
-      if (!baseURL) {
-        throw new AiChatError(
-          "provider-misconfig",
-          "AI_BASE_URL is required when using a custom provider",
-        );
-      }
-
-      if (!isLocal && !rawApiKey.trim()) {
-        throw new AiChatError("provider-misconfig", "AI_API_KEY must be configured in Settings");
-      }
-
+      const model = await settingsService.getString("AI_MODEL", "");
       if (!model) {
         throw new AiChatError("provider-misconfig", "AI_MODEL must be configured in Settings");
       }

--- a/apps/backend/src/presentation/controllers/ai.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.test.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AiChatError } from "@/domain/errors/ai-chat.error";
 import type { AiPlaylistQueueService } from "@/domain/services/ai-playlist-queue.service";
 import { AiChatController } from "./ai.controller";
 
@@ -14,6 +15,10 @@ function makeQueueService(): AiPlaylistQueueService {
   return {
     enqueueGenerate: vi.fn().mockResolvedValue(undefined),
   };
+}
+
+function makeListModelsFn(models: string[] = []) {
+  return vi.fn().mockResolvedValue(models);
 }
 
 describe("AiChatController.generate", () => {
@@ -62,5 +67,50 @@ describe("AiChatController.generate", () => {
     await controller.generate(req, res);
 
     expect(queueService.enqueueGenerate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AiChatController.listModels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with models array on success", async () => {
+    const listModelsFn = makeListModelsFn(["gpt-4o", "gpt-3.5-turbo"]);
+    const controller = new AiChatController(makeQueueService(), listModelsFn);
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.listModels(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonCall = vi.mocked(res.json).mock.calls[0][0] as { data: { models: string[] } };
+    expect(jsonCall.data.models).toEqual(["gpt-4o", "gpt-3.5-turbo"]);
+  });
+
+  it("returns 200 with empty models array", async () => {
+    const listModelsFn = makeListModelsFn([]);
+    const controller = new AiChatController(makeQueueService(), listModelsFn);
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.listModels(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const jsonCall = vi.mocked(res.json).mock.calls[0][0] as { data: { models: string[] } };
+    expect(jsonCall.data.models).toEqual([]);
+  });
+
+  it("propagates AiChatError (provider-misconfig) as thrown", async () => {
+    const listModelsFn = vi
+      .fn()
+      .mockRejectedValue(new AiChatError("provider-misconfig", "AI_API_KEY must be configured"));
+    const controller = new AiChatController(makeQueueService(), listModelsFn);
+    const req = {} as Request;
+    const res = mockRes();
+
+    await expect(controller.listModels(req, res)).rejects.toMatchObject({
+      code: "provider-misconfig",
+    });
   });
 });

--- a/apps/backend/src/presentation/controllers/ai.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.test.ts
@@ -78,7 +78,7 @@ describe("AiChatController.listModels", () => {
   it("returns 200 with models array on success", async () => {
     const listModelsFn = makeListModelsFn(["gpt-4o", "gpt-3.5-turbo"]);
     const controller = new AiChatController(makeQueueService(), listModelsFn);
-    const req = {} as Request;
+    const req = { body: {} } as Request;
     const res = mockRes();
 
     await controller.listModels(req, res);
@@ -91,7 +91,7 @@ describe("AiChatController.listModels", () => {
   it("returns 200 with empty models array", async () => {
     const listModelsFn = makeListModelsFn([]);
     const controller = new AiChatController(makeQueueService(), listModelsFn);
-    const req = {} as Request;
+    const req = { body: {} } as Request;
     const res = mockRes();
 
     await controller.listModels(req, res);
@@ -101,12 +101,40 @@ describe("AiChatController.listModels", () => {
     expect(jsonCall.data.models).toEqual([]);
   });
 
+  it("passes override fields from request body to listModelsFn", async () => {
+    const listModelsFn = makeListModelsFn(["gpt-4o"]);
+    const controller = new AiChatController(makeQueueService(), listModelsFn);
+    const req = {
+      body: { provider: "openai", baseURL: "https://api.openai.com/v1", apiKey: "sk-body" },
+    } as Request;
+    const res = mockRes();
+
+    await controller.listModels(req, res);
+
+    expect(listModelsFn).toHaveBeenCalledWith({
+      provider: "openai",
+      baseURL: "https://api.openai.com/v1",
+      apiKey: "sk-body",
+    });
+  });
+
+  it("passes empty overrides when body is empty", async () => {
+    const listModelsFn = makeListModelsFn([]);
+    const controller = new AiChatController(makeQueueService(), listModelsFn);
+    const req = { body: {} } as Request;
+    const res = mockRes();
+
+    await controller.listModels(req, res);
+
+    expect(listModelsFn).toHaveBeenCalledWith({});
+  });
+
   it("propagates AiChatError (provider-misconfig) as thrown", async () => {
     const listModelsFn = vi
       .fn()
       .mockRejectedValue(new AiChatError("provider-misconfig", "AI_API_KEY must be configured"));
     const controller = new AiChatController(makeQueueService(), listModelsFn);
-    const req = {} as Request;
+    const req = { body: {} } as Request;
     const res = mockRes();
 
     await expect(controller.listModels(req, res)).rejects.toMatchObject({

--- a/apps/backend/src/presentation/controllers/ai.controller.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.ts
@@ -1,7 +1,13 @@
 import type { Request, Response } from "express";
 import type { AiPlaylistQueueService } from "@/domain/services/ai-playlist-queue.service";
 
-type ListModelsFn = () => Promise<string[]>;
+interface ModelOverrides {
+  provider?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
+type ListModelsFn = (overrides: ModelOverrides) => Promise<string[]>;
 
 export class AiChatController {
   constructor(
@@ -19,7 +25,9 @@ export class AiChatController {
   };
 
   listModels = async (req: Request, res: Response) => {
-    const models = await this.listModelsFn!();
+    const { provider, baseURL, apiKey } = (req.body ?? {}) as ModelOverrides;
+    const overrides: ModelOverrides = { provider, baseURL, apiKey };
+    const models = await this.listModelsFn!(overrides);
     res.status(200).json({ data: { models } });
   };
 }

--- a/apps/backend/src/presentation/controllers/ai.controller.ts
+++ b/apps/backend/src/presentation/controllers/ai.controller.ts
@@ -1,8 +1,13 @@
 import type { Request, Response } from "express";
 import type { AiPlaylistQueueService } from "@/domain/services/ai-playlist-queue.service";
 
+type ListModelsFn = () => Promise<string[]>;
+
 export class AiChatController {
-  constructor(private readonly aiPlaylistQueueService: AiPlaylistQueueService) {}
+  constructor(
+    private readonly aiPlaylistQueueService: AiPlaylistQueueService,
+    private readonly listModelsFn?: ListModelsFn,
+  ) {}
 
   generate = async (req: Request, res: Response) => {
     const { prompt } = req.body as { prompt: string };
@@ -11,5 +16,10 @@ export class AiChatController {
     await this.aiPlaylistQueueService.enqueueGenerate({ jobId, prompt });
 
     res.status(202).json({ data: { jobId } });
+  };
+
+  listModels = async (req: Request, res: Response) => {
+    const models = await this.listModelsFn!();
+    res.status(200).json({ data: { models } });
   };
 }

--- a/apps/backend/src/presentation/routes/ai.routes.test.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.test.ts
@@ -3,6 +3,7 @@ import http from "node:http";
 import { afterEach, describe, it, expect, vi, beforeEach } from "vitest";
 import type { Container } from "@/container";
 import { AiChatController } from "../controllers/ai.controller";
+import { errorHandler } from "../middleware/error-handler";
 import { createAiRoutes } from "./ai.routes";
 
 const servers: http.Server[] = [];
@@ -15,6 +16,7 @@ function buildApp(container: Container): Express {
   const app = express();
   app.use(express.json());
   app.use("/api/ai", createAiRoutes(container));
+  app.use(errorHandler);
   return app;
 }
 
@@ -144,5 +146,37 @@ describe("POST /api/ai/chat/generate", () => {
 
     expect(res.status).toBe(400);
     expect(enqueueGenerate).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/ai/models", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with sorted model ids", async () => {
+    const listModelsFn = vi.fn().mockResolvedValue(["gpt-3.5-turbo", "gpt-4o"]);
+    const aiChatController = new AiChatController(makeQueueService(), listModelsFn);
+    const container = { aiChatController } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/models`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { models: string[] } };
+    expect(body.data.models).toEqual(["gpt-3.5-turbo", "gpt-4o"]);
+  });
+
+  it("returns 200 with empty array when no models", async () => {
+    const listModelsFn = vi.fn().mockResolvedValue([]);
+    const aiChatController = new AiChatController(makeQueueService(), listModelsFn);
+    const container = { aiChatController } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/models`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { models: string[] } };
+    expect(body.data.models).toEqual([]);
   });
 });

--- a/apps/backend/src/presentation/routes/ai.routes.test.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.test.ts
@@ -149,7 +149,7 @@ describe("POST /api/ai/chat/generate", () => {
   });
 });
 
-describe("GET /api/ai/models", () => {
+describe("POST /api/ai/models", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -160,7 +160,11 @@ describe("GET /api/ai/models", () => {
     const container = { aiChatController } as unknown as Container;
     const baseUrl = await startServer(buildApp(container));
 
-    const res = await fetch(`${baseUrl}/api/ai/models`);
+    const res = await fetch(`${baseUrl}/api/ai/models`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: { models: string[] } };
@@ -173,10 +177,47 @@ describe("GET /api/ai/models", () => {
     const container = { aiChatController } as unknown as Container;
     const baseUrl = await startServer(buildApp(container));
 
-    const res = await fetch(`${baseUrl}/api/ai/models`);
+    const res = await fetch(`${baseUrl}/api/ai/models`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
 
     expect(res.status).toBe(200);
     const body = (await res.json()) as { data: { models: string[] } };
     expect(body.data.models).toEqual([]);
+  });
+
+  it("passes override body fields to listModelsFn", async () => {
+    const listModelsFn = vi.fn().mockResolvedValue(["gpt-4o"]);
+    const aiChatController = new AiChatController(makeQueueService(), listModelsFn);
+    const container = { aiChatController } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/models`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openai", apiKey: "sk-body" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(listModelsFn).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", apiKey: "sk-body" }),
+    );
+  });
+
+  it("accepts empty body", async () => {
+    const listModelsFn = vi.fn().mockResolvedValue([]);
+    const aiChatController = new AiChatController(makeQueueService(), listModelsFn);
+    const container = { aiChatController } as unknown as Container;
+    const baseUrl = await startServer(buildApp(container));
+
+    const res = await fetch(`${baseUrl}/api/ai/models`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/backend/src/presentation/routes/ai.routes.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.ts
@@ -14,5 +14,7 @@ export function createAiRoutes(container: Container): ExpressRouter {
     asyncHandler(aiChatController.generate),
   );
 
+  router.get("/models", asyncHandler(aiChatController.listModels));
+
   return router;
 }

--- a/apps/backend/src/presentation/routes/ai.routes.ts
+++ b/apps/backend/src/presentation/routes/ai.routes.ts
@@ -2,7 +2,7 @@ import { Router, type Router as ExpressRouter } from "express";
 import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 import { validate } from "../middleware/validate";
-import { generateAiPlaylistSchema } from "./schemas/ai.schema";
+import { generateAiPlaylistSchema, listModelsSchema } from "./schemas/ai.schema";
 
 export function createAiRoutes(container: Container): ExpressRouter {
   const router: ExpressRouter = Router();
@@ -14,7 +14,7 @@ export function createAiRoutes(container: Container): ExpressRouter {
     asyncHandler(aiChatController.generate),
   );
 
-  router.get("/models", asyncHandler(aiChatController.listModels));
+  router.post("/models", validate(listModelsSchema), asyncHandler(aiChatController.listModels));
 
   return router;
 }

--- a/apps/backend/src/presentation/routes/schemas/ai.schema.test.ts
+++ b/apps/backend/src/presentation/routes/schemas/ai.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { generateAiPlaylistSchema } from "./ai.schema";
+import { generateAiPlaylistSchema, listModelsSchema } from "./ai.schema";
 
 describe("generateAiPlaylistSchema", () => {
   it("accepts a valid prompt", () => {
@@ -38,5 +38,34 @@ describe("generateAiPlaylistSchema", () => {
   it("rejects missing prompt field", () => {
     const result = generateAiPlaylistSchema.safeParse({ body: {} });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("listModelsSchema", () => {
+  it("accepts empty body", () => {
+    const result = listModelsSchema.safeParse({ body: {} });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts body with all optional fields", () => {
+    const result = listModelsSchema.safeParse({
+      body: { provider: "openai", baseURL: "https://api.openai.com/v1", apiKey: "sk-test" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts body with only provider", () => {
+    const result = listModelsSchema.safeParse({ body: { provider: "ollama" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts body with only apiKey", () => {
+    const result = listModelsSchema.safeParse({ body: { apiKey: "sk-test" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts missing body (all fields optional)", () => {
+    const result = listModelsSchema.safeParse({ body: undefined });
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/backend/src/presentation/routes/schemas/ai.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/ai.schema.ts
@@ -9,3 +9,13 @@ export const generateAiPlaylistSchema = z.object({
       .max(500, "Prompt must not exceed 500 characters"),
   }),
 });
+
+export const listModelsSchema = z.object({
+  body: z
+    .object({
+      provider: z.string().optional(),
+      baseURL: z.string().optional(),
+      apiKey: z.string().optional(),
+    })
+    .optional(),
+});

--- a/apps/frontend/src/components/molecules/AiModelField.test.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.test.tsx
@@ -54,15 +54,16 @@ describe("AiModelField", () => {
     expect(input.disabled).toBe(false);
   });
 
-  it("clicking Load models triggers getModels and fills datalist", async () => {
+  it("shows a dropdown listing all models even when the input already has a value, and selecting one calls onChange", async () => {
+    const onChange = vi.fn();
     vi.mocked(aiChatService.getModels).mockResolvedValueOnce(["gpt-4o", "gpt-3.5-turbo"]);
 
     render(
       <AiModelField
         id="AI_MODEL"
         label="AI Model"
-        value=""
-        onChange={vi.fn()}
+        value="already-typed-model"
+        onChange={onChange}
         description=""
         provider="openai"
         baseURL=""
@@ -76,12 +77,13 @@ describe("AiModelField", () => {
       expect(screen.getByText("2 models loaded")).toBeTruthy();
     });
 
-    const datalist = document.getElementById("AI_MODEL-models-list");
-    expect(datalist).not.toBeNull();
-    const options = datalist?.querySelectorAll("option");
-    expect(options?.length).toBe(2);
-    expect(options?.[0].value).toBe("gpt-4o");
-    expect(options?.[1].value).toBe("gpt-3.5-turbo");
+    const options = screen.getAllByRole("option");
+    expect(options.length).toBe(2);
+    expect(options[0].textContent).toBe("gpt-4o");
+    expect(options[1].textContent).toBe("gpt-3.5-turbo");
+
+    fireEvent.click(options[0]);
+    expect(onChange).toHaveBeenCalledWith({ target: { value: "gpt-4o" } });
   });
 
   it("shows loading state while fetching", async () => {

--- a/apps/frontend/src/components/molecules/AiModelField.test.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { aiChatService } from "@/services/aiChat.service";
+
+vi.mock("@/services/aiChat.service", () => ({
+  aiChatService: {
+    getModels: vi.fn(),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number; defaultValue?: string }) => {
+      if (key === "settings.items.AI_MODEL.loadModels") return "Load models";
+      if (key === "settings.items.AI_MODEL.loadingModels") return "Loading...";
+      if (key === "settings.items.AI_MODEL.modelsLoaded") return `${opts?.count} models loaded`;
+      if (key === "settings.items.AI_MODEL.modelsEmpty")
+        return "No models returned. Type a model name manually.";
+      if (key === "settings.items.AI_MODEL.modelsError")
+        return "Could not load models. Check your provider settings.";
+      return opts?.defaultValue ?? key;
+    },
+  }),
+}));
+
+const { AiModelField } = await import("./AiModelField");
+
+describe("AiModelField", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the text input and Load models button", () => {
+    render(
+      <AiModelField
+        id="AI_MODEL"
+        label="AI Model"
+        value="gpt-4o"
+        onChange={vi.fn()}
+        description="Model description"
+      />,
+    );
+
+    expect(screen.getByLabelText("AI Model")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Load models" })).toBeTruthy();
+  });
+
+  it("input is free-text (not disabled by default)", () => {
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    const input = screen.getByLabelText("AI Model") as HTMLInputElement;
+    expect(input.disabled).toBe(false);
+  });
+
+  it("clicking Load models triggers getModels and fills datalist", async () => {
+    vi.mocked(aiChatService.getModels).mockResolvedValueOnce(["gpt-4o", "gpt-3.5-turbo"]);
+
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("2 models loaded")).toBeTruthy();
+    });
+
+    const datalist = document.getElementById("AI_MODEL-models-list");
+    expect(datalist).not.toBeNull();
+    const options = datalist?.querySelectorAll("option");
+    expect(options?.length).toBe(2);
+    expect(options?.[0].value).toBe("gpt-4o");
+    expect(options?.[1].value).toBe("gpt-3.5-turbo");
+  });
+
+  it("shows loading state while fetching", async () => {
+    let resolve: (v: string[]) => void;
+    vi.mocked(aiChatService.getModels).mockReturnValueOnce(
+      new Promise<string[]>((r) => {
+        resolve = r;
+      }),
+    );
+
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    expect(screen.getByText("Loading...")).toBeTruthy();
+    const btn = screen.getByRole("button", { name: "Loading..." }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    resolve!(["gpt-4o"]);
+    await waitFor(() => {
+      expect(screen.getByText("1 models loaded")).toBeTruthy();
+    });
+  });
+
+  it("shows error message when getModels fails", async () => {
+    vi.mocked(aiChatService.getModels).mockRejectedValueOnce(new Error("Provider unreachable"));
+
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Could not load models. Check your provider settings.")).toBeTruthy();
+    });
+
+    const input = screen.getByLabelText("AI Model") as HTMLInputElement;
+    expect(input.disabled).toBe(false);
+  });
+
+  it("shows empty message when getModels returns no models", async () => {
+    vi.mocked(aiChatService.getModels).mockResolvedValueOnce([]);
+
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No models returned. Type a model name manually.")).toBeTruthy();
+    });
+  });
+
+  it("does not auto-fetch on mount", () => {
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    expect(aiChatService.getModels).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/molecules/AiModelField.test.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.test.tsx
@@ -58,7 +58,16 @@ describe("AiModelField", () => {
     vi.mocked(aiChatService.getModels).mockResolvedValueOnce(["gpt-4o", "gpt-3.5-turbo"]);
 
     render(
-      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+      <AiModelField
+        id="AI_MODEL"
+        label="AI Model"
+        value=""
+        onChange={vi.fn()}
+        description=""
+        provider="openai"
+        baseURL=""
+        apiKey="sk-test"
+      />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Load models" }));
@@ -136,5 +145,50 @@ describe("AiModelField", () => {
     );
 
     expect(aiChatService.getModels).not.toHaveBeenCalled();
+  });
+
+  it("passes provider, baseURL, apiKey overrides to getModels", async () => {
+    vi.mocked(aiChatService.getModels).mockResolvedValueOnce(["gpt-4o"]);
+
+    render(
+      <AiModelField
+        id="AI_MODEL"
+        label="AI Model"
+        value=""
+        onChange={vi.fn()}
+        description=""
+        provider="openai"
+        baseURL="https://api.openai.com/v1"
+        apiKey="sk-form-key"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    await waitFor(() => {
+      expect(aiChatService.getModels).toHaveBeenCalledWith({
+        provider: "openai",
+        baseURL: "https://api.openai.com/v1",
+        apiKey: "sk-form-key",
+      });
+    });
+  });
+
+  it("calls getModels with empty overrides when no override props provided", async () => {
+    vi.mocked(aiChatService.getModels).mockResolvedValueOnce(["gpt-4o"]);
+
+    render(
+      <AiModelField id="AI_MODEL" label="AI Model" value="" onChange={vi.fn()} description="" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Load models" }));
+
+    await waitFor(() => {
+      expect(aiChatService.getModels).toHaveBeenCalledWith({
+        provider: undefined,
+        baseURL: undefined,
+        apiKey: undefined,
+      });
+    });
   });
 });

--- a/apps/frontend/src/components/molecules/AiModelField.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import type { ChangeEvent, FC } from "react";
+import { useTranslation } from "react-i18next";
+import { aiChatService } from "@/services/aiChat.service";
+
+interface AiModelFieldProps {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  description: string;
+  disabled?: boolean;
+}
+
+type LoadState = "idle" | "loading" | "success" | "empty" | "error";
+
+export const AiModelField: FC<AiModelFieldProps> = ({
+  id,
+  label,
+  value,
+  onChange,
+  description,
+  disabled,
+}) => {
+  const { t } = useTranslation();
+  const [loadState, setLoadState] = useState<LoadState>("idle");
+  const [models, setModels] = useState<string[]>([]);
+  const datalistId = `${id}-models-list`;
+
+  const handleLoadModels = async () => {
+    setLoadState("loading");
+    try {
+      const result = await aiChatService.getModels();
+      if (result.length === 0) {
+        setLoadState("empty");
+      } else {
+        setModels(result);
+        setLoadState("success");
+      }
+    } catch {
+      setLoadState("error");
+    }
+  };
+
+  const buttonLabel =
+    loadState === "loading"
+      ? t("settings.items.AI_MODEL.loadingModels")
+      : t("settings.items.AI_MODEL.loadModels");
+
+  return (
+    <div>
+      <label className="mb-2 block text-sm font-semibold" htmlFor={id}>
+        {label}
+      </label>
+      <div className="flex gap-2">
+        <input
+          id={id}
+          type="text"
+          list={loadState === "success" ? datalistId : undefined}
+          className={[
+            "bg-background-input text-text-primary focus:ring-text-primary/20 w-full rounded-md border-none px-4 py-2 focus:ring-2 focus:outline-none",
+            disabled ? "cursor-not-allowed opacity-50" : "",
+          ]
+            .filter(Boolean)
+            .join(" ")}
+          value={value}
+          onChange={onChange}
+          disabled={disabled}
+        />
+        {loadState === "success" && (
+          <datalist id={datalistId}>
+            {models.map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        )}
+        <button
+          type="button"
+          onClick={handleLoadModels}
+          disabled={loadState === "loading" || disabled}
+          className="bg-background-input text-text-secondary hover:text-text-primary shrink-0 rounded-md px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {buttonLabel}
+        </button>
+      </div>
+      {loadState === "success" && (
+        <p className="text-text-secondary mt-1 text-xs">
+          {t("settings.items.AI_MODEL.modelsLoaded", { count: models.length })}
+        </p>
+      )}
+      {loadState === "empty" && (
+        <p className="text-text-secondary mt-1 text-xs">
+          {t("settings.items.AI_MODEL.modelsEmpty")}
+        </p>
+      )}
+      {loadState === "error" && (
+        <p className="mt-1 text-xs text-red-400">{t("settings.items.AI_MODEL.modelsError")}</p>
+      )}
+      {loadState === "idle" && <p className="text-text-secondary mt-1 text-xs">{description}</p>}
+    </div>
+  );
+};

--- a/apps/frontend/src/components/molecules/AiModelField.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.tsx
@@ -1,3 +1,5 @@
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 import type { ChangeEvent, FC } from "react";
 import { useTranslation } from "react-i18next";
@@ -31,23 +33,32 @@ export const AiModelField: FC<AiModelFieldProps> = ({
   const { t } = useTranslation();
   const [loadState, setLoadState] = useState<LoadState>("idle");
   const [models, setModels] = useState<string[]>([]);
-  const datalistId = `${id}-models-list`;
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleLoadModels = async () => {
     setLoadState("loading");
+    setIsOpen(false);
     try {
       const result = await aiChatService.getModels({ provider, baseURL, apiKey });
       if (result.length === 0) {
+        setModels([]);
         setLoadState("empty");
       } else {
         setModels(result);
         setLoadState("success");
+        setIsOpen(true);
       }
     } catch {
       setLoadState("error");
     }
   };
 
+  const selectModel = (model: string) => {
+    onChange({ target: { value: model } } as ChangeEvent<HTMLInputElement>);
+    setIsOpen(false);
+  };
+
+  const hasModels = models.length > 0;
   const buttonLabel =
     loadState === "loading"
       ? t("settings.items.AI_MODEL.loadingModels")
@@ -59,27 +70,66 @@ export const AiModelField: FC<AiModelFieldProps> = ({
         {label}
       </label>
       <div className="flex gap-2">
-        <input
-          id={id}
-          type="text"
-          list={loadState === "success" ? datalistId : undefined}
-          className={[
-            "bg-background-input text-text-primary focus:ring-text-primary/20 w-full rounded-md border-none px-4 py-2 focus:ring-2 focus:outline-none",
-            disabled ? "cursor-not-allowed opacity-50" : "",
-          ]
-            .filter(Boolean)
-            .join(" ")}
-          value={value}
-          onChange={onChange}
-          disabled={disabled}
-        />
-        {loadState === "success" && (
-          <datalist id={datalistId}>
-            {models.map((m) => (
-              <option key={m} value={m} />
-            ))}
-          </datalist>
-        )}
+        <div className="relative w-full">
+          <input
+            id={id}
+            type="text"
+            autoComplete="off"
+            className={[
+              "bg-background-input text-text-primary focus:ring-text-primary/20 w-full rounded-md border-none px-4 py-2 focus:ring-2 focus:outline-none",
+              hasModels ? "pr-10" : "",
+              disabled ? "cursor-not-allowed opacity-50" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            value={value}
+            onChange={onChange}
+            disabled={disabled}
+          />
+          {hasModels && (
+            <button
+              type="button"
+              aria-label={t("settings.items.AI_MODEL.toggleModels")}
+              onClick={() => setIsOpen((open) => !open)}
+              disabled={disabled}
+              className="text-text-secondary hover:text-text-primary absolute inset-y-0 right-0 flex items-center px-3"
+            >
+              <FontAwesomeIcon icon={faChevronDown} className="text-sm" />
+            </button>
+          )}
+          {isOpen && hasModels && (
+            <>
+              <button
+                type="button"
+                aria-hidden="true"
+                tabIndex={-1}
+                onClick={() => setIsOpen(false)}
+                className="fixed inset-0 z-10 cursor-default"
+              />
+              <ul
+                role="listbox"
+                className="bg-background-input absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-md border border-white/10 py-1 shadow-lg"
+              >
+                {models.map((model) => (
+                  <li key={model}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={model === value}
+                      onClick={() => selectModel(model)}
+                      className={[
+                        "block w-full px-4 py-2 text-left text-sm hover:bg-white/10",
+                        model === value ? "text-primary" : "text-text-primary",
+                      ].join(" ")}
+                    >
+                      {model}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
         <button
           type="button"
           onClick={handleLoadModels}

--- a/apps/frontend/src/components/molecules/AiModelField.tsx
+++ b/apps/frontend/src/components/molecules/AiModelField.tsx
@@ -10,6 +10,9 @@ interface AiModelFieldProps {
   onChange: (event: ChangeEvent<HTMLInputElement>) => void;
   description: string;
   disabled?: boolean;
+  provider?: string;
+  baseURL?: string;
+  apiKey?: string;
 }
 
 type LoadState = "idle" | "loading" | "success" | "empty" | "error";
@@ -21,6 +24,9 @@ export const AiModelField: FC<AiModelFieldProps> = ({
   onChange,
   description,
   disabled,
+  provider,
+  baseURL,
+  apiKey,
 }) => {
   const { t } = useTranslation();
   const [loadState, setLoadState] = useState<LoadState>("idle");
@@ -30,7 +36,7 @@ export const AiModelField: FC<AiModelFieldProps> = ({
   const handleLoadModels = async () => {
     setLoadState("loading");
     try {
-      const result = await aiChatService.getModels();
+      const result = await aiChatService.getModels({ provider, baseURL, apiKey });
       if (result.length === 0) {
         setLoadState("empty");
       } else {

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -302,7 +302,8 @@
         "loadingModels": "Loading...",
         "modelsLoaded": "{{count}} models loaded",
         "modelsEmpty": "No models returned. Type a model name manually.",
-        "modelsError": "Could not load models. Check your provider settings."
+        "modelsError": "Could not load models. Check your provider settings.",
+        "toggleModels": "Show models"
       },
       "UI_LANGUAGE": {
         "label": "Interface Language",

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -297,7 +297,12 @@
       },
       "AI_MODEL": {
         "label": "AI Model",
-        "description": "The model name to use for playlist generation (e.g. gpt-4o, llama-3.1)."
+        "description": "The model name to use for playlist generation (e.g. gpt-4o, llama-3.1).",
+        "loadModels": "Load models",
+        "loadingModels": "Loading...",
+        "modelsLoaded": "{{count}} models loaded",
+        "modelsEmpty": "No models returned. Type a model name manually.",
+        "modelsError": "Could not load models. Check your provider settings."
       },
       "UI_LANGUAGE": {
         "label": "Interface Language",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -297,7 +297,12 @@
       },
       "AI_MODEL": {
         "label": "Modelo de IA",
-        "description": "El nombre del modelo a usar para la generación de listas (p. ej. gpt-4o, llama-3.1)."
+        "description": "El nombre del modelo a usar para la generación de listas (p. ej. gpt-4o, llama-3.1).",
+        "loadModels": "Cargar modelos",
+        "loadingModels": "Cargando...",
+        "modelsLoaded": "{{count}} modelos cargados",
+        "modelsEmpty": "No se devolvieron modelos. Escribe el nombre del modelo manualmente.",
+        "modelsError": "No se pudieron cargar los modelos. Comprueba la configuración del proveedor."
       },
       "UI_LANGUAGE": {
         "label": "Idioma de la interfaz",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -302,7 +302,8 @@
         "loadingModels": "Cargando...",
         "modelsLoaded": "{{count}} modelos cargados",
         "modelsEmpty": "No se devolvieron modelos. Escribe el nombre del modelo manualmente.",
-        "modelsError": "No se pudieron cargar los modelos. Comprueba la configuración del proveedor."
+        "modelsError": "No se pudieron cargar los modelos. Comprueba la configuración del proveedor.",
+        "toggleModels": "Mostrar modelos"
       },
       "UI_LANGUAGE": {
         "label": "Idioma de la interfaz",

--- a/apps/frontend/src/services/aiChat.service.test.ts
+++ b/apps/frontend/src/services/aiChat.service.test.ts
@@ -38,19 +38,31 @@ describe("aiChatService", () => {
 });
 
 describe("aiChatService.getModels", () => {
-  it("calls GET /ai/models and returns the models array", async () => {
-    vi.mocked(httpClient.get).mockResolvedValueOnce({
+  it("calls POST /ai/models with overrides and returns the models array", async () => {
+    vi.mocked(httpClient.post).mockResolvedValueOnce({
       data: { models: ["gpt-4o", "gpt-3.5-turbo"] },
+    });
+
+    const overrides = { provider: "openai", baseURL: "https://api.openai.com/v1", apiKey: "sk-x" };
+    const result = await aiChatService.getModels(overrides);
+
+    expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.AI}/models`, overrides);
+    expect(result).toEqual(["gpt-4o", "gpt-3.5-turbo"]);
+  });
+
+  it("calls POST /ai/models with empty overrides when none provided", async () => {
+    vi.mocked(httpClient.post).mockResolvedValueOnce({
+      data: { models: [] },
     });
 
     const result = await aiChatService.getModels();
 
-    expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.AI}/models`);
-    expect(result).toEqual(["gpt-4o", "gpt-3.5-turbo"]);
+    expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.AI}/models`, {});
+    expect(result).toEqual([]);
   });
 
   it("returns empty array when models is empty", async () => {
-    vi.mocked(httpClient.get).mockResolvedValueOnce({ data: { models: [] } });
+    vi.mocked(httpClient.post).mockResolvedValueOnce({ data: { models: [] } });
 
     const result = await aiChatService.getModels();
 
@@ -58,7 +70,7 @@ describe("aiChatService.getModels", () => {
   });
 
   it("propagates errors thrown by httpClient", async () => {
-    vi.mocked(httpClient.get).mockRejectedValueOnce(new Error("Provider unreachable"));
+    vi.mocked(httpClient.post).mockRejectedValueOnce(new Error("Provider unreachable"));
 
     await expect(aiChatService.getModels()).rejects.toThrow("Provider unreachable");
   });

--- a/apps/frontend/src/services/aiChat.service.test.ts
+++ b/apps/frontend/src/services/aiChat.service.test.ts
@@ -6,6 +6,7 @@ import { aiChatService } from "./aiChat.service";
 vi.mock("@/services/httpClient", () => ({
   httpClient: {
     post: vi.fn(),
+    get: vi.fn(),
   },
 }));
 
@@ -33,5 +34,32 @@ describe("aiChatService", () => {
     vi.mocked(httpClient.post).mockRejectedValueOnce(new Error("Network error"));
 
     await expect(aiChatService.generate("test")).rejects.toThrow("Network error");
+  });
+});
+
+describe("aiChatService.getModels", () => {
+  it("calls GET /ai/models and returns the models array", async () => {
+    vi.mocked(httpClient.get).mockResolvedValueOnce({
+      data: { models: ["gpt-4o", "gpt-3.5-turbo"] },
+    });
+
+    const result = await aiChatService.getModels();
+
+    expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.AI}/models`);
+    expect(result).toEqual(["gpt-4o", "gpt-3.5-turbo"]);
+  });
+
+  it("returns empty array when models is empty", async () => {
+    vi.mocked(httpClient.get).mockResolvedValueOnce({ data: { models: [] } });
+
+    const result = await aiChatService.getModels();
+
+    expect(result).toEqual([]);
+  });
+
+  it("propagates errors thrown by httpClient", async () => {
+    vi.mocked(httpClient.get).mockRejectedValueOnce(new Error("Provider unreachable"));
+
+    await expect(aiChatService.getModels()).rejects.toThrow("Provider unreachable");
   });
 });

--- a/apps/frontend/src/services/aiChat.service.ts
+++ b/apps/frontend/src/services/aiChat.service.ts
@@ -9,4 +9,9 @@ export const aiChatService = {
     );
     return response.data;
   },
+
+  getModels: async (): Promise<string[]> => {
+    const response = await httpClient.get<{ data: { models: string[] } }>(`${ApiRoutes.AI}/models`);
+    return response.data.models;
+  },
 };

--- a/apps/frontend/src/services/aiChat.service.ts
+++ b/apps/frontend/src/services/aiChat.service.ts
@@ -1,6 +1,12 @@
 import { ApiRoutes, type GenerateAiPlaylistResponse } from "@spotiarr/shared";
 import { httpClient } from "./httpClient";
 
+export interface ModelOverrides {
+  provider?: string;
+  baseURL?: string;
+  apiKey?: string;
+}
+
 export const aiChatService = {
   generate: async (prompt: string): Promise<GenerateAiPlaylistResponse> => {
     const response = await httpClient.post<{ data: GenerateAiPlaylistResponse }>(
@@ -10,8 +16,11 @@ export const aiChatService = {
     return response.data;
   },
 
-  getModels: async (): Promise<string[]> => {
-    const response = await httpClient.get<{ data: { models: string[] } }>(`${ApiRoutes.AI}/models`);
+  getModels: async (overrides: ModelOverrides = {}): Promise<string[]> => {
+    const response = await httpClient.post<{ data: { models: string[] } }>(
+      `${ApiRoutes.AI}/models`,
+      overrides,
+    );
     return response.data.models;
   },
 };

--- a/apps/frontend/src/views/Settings.test.tsx
+++ b/apps/frontend/src/views/Settings.test.tsx
@@ -7,6 +7,12 @@ vi.mock("@/hooks/controllers/useSettingsController", () => ({
   useSettingsController: () => mockUseSettingsController(),
 }));
 
+vi.mock("@/services/aiChat.service", () => ({
+  aiChatService: {
+    getModels: vi.fn().mockResolvedValue([]),
+  },
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
@@ -37,6 +43,15 @@ const aiSettings = {
       defaultValue: "",
       type: "string",
     },
+    {
+      key: "AI_MODEL",
+      component: "input",
+      section: "AI",
+      label: "AI Model",
+      description: "The model name.",
+      defaultValue: "",
+      type: "string",
+    },
   ],
 };
 
@@ -56,6 +71,15 @@ beforeEach(() => {
 });
 
 const { Settings } = await import("./Settings");
+
+describe("Settings — AI model field", () => {
+  it("renders AI Model field with Load models button", () => {
+    render(<Settings />);
+
+    expect(screen.getByLabelText("AI Model")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "settings.items.AI_MODEL.loadModels" })).toBeTruthy();
+  });
+});
 
 describe("Settings — AI base URL field", () => {
   it("disables base URL and shows the default provider preset as placeholder when nothing is saved", () => {

--- a/apps/frontend/src/views/Settings.tsx
+++ b/apps/frontend/src/views/Settings.tsx
@@ -57,6 +57,9 @@ export const Settings: FC = () => {
                                 defaultValue: setting.description,
                               })}
                               disabled={isSaving}
+                              provider={values["AI_PROVIDER"]}
+                              baseURL={values["AI_BASE_URL"]}
+                              apiKey={values["AI_API_KEY"]}
                             />
                           );
                         }

--- a/apps/frontend/src/views/Settings.tsx
+++ b/apps/frontend/src/views/Settings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/atoms/Button";
 import { Loading } from "@/components/atoms/Loading";
 import { AppFooter } from "@/components/layouts/AppFooter";
+import { AiModelField } from "@/components/molecules/AiModelField";
 import { PageHeader } from "@/components/molecules/PageHeader";
 import { SettingItem } from "@/components/molecules/SettingItem";
 import { SpotifyAuthCard } from "@/components/organisms/SpotifyAuthCard";
@@ -38,8 +39,28 @@ export const Settings: FC = () => {
                     <div className="space-y-6">
                       {sectionSettings.map((setting) => {
                         const isBaseUrl = setting.key === "AI_BASE_URL";
+                        const isModel = setting.key === "AI_MODEL";
                         const provider = normalizeAiProvider(values["AI_PROVIDER"]);
                         const isCustomProvider = provider === "custom";
+
+                        if (isModel) {
+                          return (
+                            <AiModelField
+                              key={setting.key}
+                              id={setting.key}
+                              label={t(`settings.items.${setting.key}.label`, {
+                                defaultValue: setting.label,
+                              })}
+                              value={values[setting.key] ?? ""}
+                              onChange={handleChange(setting.key)}
+                              description={t(`settings.items.${setting.key}.description`, {
+                                defaultValue: setting.description,
+                              })}
+                              disabled={isSaving}
+                            />
+                          );
+                        }
+
                         return (
                           <SettingItem
                             key={setting.key}


### PR DESCRIPTION
Lets users discover available models from their configured OpenAI-compatible provider instead of guessing the model id. Builds on the AI provider presets (#164).

## Backend
- **`GET /api/ai/models`**: resolves the configured connection and calls `{baseURL}/models` with `Authorization: Bearer {key}`, returns `{ models: string[] }` (deduped, sorted, ids only).
- **`resolveAiConnection(settingsService)`**: extracted shared resolver (provider normalize + preset base URL + local-provider keyless handling) — now reused by BOTH `createAiChatPort` and `listAiModels` (DRY).
- **`listAiModels(settingsService, fetchFn)`**: fetch-injected (unit-testable, no network). Errors map to the AiChatError taxonomy: not configured → `provider-misconfig`, network/non-2xx → `provider-unreachable`; missing `data` array → `[]`.
- Controller handler + route + container wiring.

## Frontend
- **`AiModelField`**: the AI Model setting stays a FREE-TEXT input but gains a "Load models" button (lazy — only fetches on click, since it needs a configured provider + key). Results populate an HTML `<datalist>` so the input offers autocomplete suggestions while still accepting any id. Loading / error / empty states handled; input remains editable on failure.
- `aiChat.service.getModels()` + Settings special-cases AI_MODEL (mirrors the AI_BASE_URL special-casing).
- i18n keys (en + es).

## Tests (strict TDD)
- Backend: 644 passing — resolver (7), listAiModels (8: parse/sort/dedupe, empty data, non-2xx, unreachable, misconfig).
- Frontend: 628 passing — service parse, field renders Load-models button, fetch fills datalist, error path, free-text preserved.
- tsc clean both. Locales valid JSON.

Pre-existing `release-feed` 30-day-window test is a date-sensitive flake on main, unrelated.