### PR TITLE
feat(ai-chat): persist chat history — PR1 persistence foundation [1/3]

### DIFF
--- a/apps/backend/prisma/migrations/20260615000000_add_ai_chat_message/migration.sql
+++ b/apps/backend/prisma/migrations/20260615000000_add_ai_chat_message/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "AiChatMessage" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "role" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "contentKey" TEXT,
+    "contentParams" TEXT,
+    "playlistId" TEXT,
+    "errorCode" TEXT,
+    "createdAt" BIGINT NOT NULL DEFAULT 0
+);
+
+-- CreateIndex
+CREATE INDEX "AiChatMessage_createdAt_idx" ON "AiChatMessage"("createdAt");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -183,3 +183,16 @@ model PlaylistCache {
 
   @@index([expiresAt])
 }
+
+model AiChatMessage {
+  id            String  @id @default(uuid())
+  role          String
+  content       String
+  contentKey    String?
+  contentParams String?
+  playlistId    String?
+  errorCode     String?
+  createdAt     BigInt  @default(0)
+
+  @@index([createdAt])
+}

--- a/apps/backend/src/application/use-cases/ai/__tests__/ai-chat-message.use-cases.test.ts
+++ b/apps/backend/src/application/use-cases/ai/__tests__/ai-chat-message.use-cases.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import type { AiChatMessageRepository } from "@/domain/repositories/ai-chat-message.repository";
+import { AppendChatMessageUseCase } from "../append-chat-message.use-case";
+import { ClearChatMessagesUseCase } from "../clear-chat-messages.use-case";
+import { GetChatMessagesUseCase } from "../get-chat-messages.use-case";
+
+function makeRepo(overrides: Partial<AiChatMessageRepository> = {}): AiChatMessageRepository {
+  return {
+    append: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue([]),
+    clear: vi.fn().mockResolvedValue(0),
+    ...overrides,
+  };
+}
+
+describe("AppendChatMessageUseCase", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("S-B-01: appends user message and calls repository.append once", async () => {
+    const repo = makeRepo();
+    const useCase = new AppendChatMessageUseCase(repo);
+
+    await useCase.execute({
+      role: "user",
+      contentKey: "aiChat.userPrompt",
+      contentParams: { prompt: "jazz" },
+    });
+
+    expect(repo.append).toHaveBeenCalledOnce();
+    const entity = (repo.append as ReturnType<typeof vi.fn>).mock.calls[0][0] as AiChatMessage;
+    expect(entity.role).toBe("user");
+    expect(entity.content.key).toBe("aiChat.userPrompt");
+    expect(entity.content.params).toMatchObject({ prompt: "jazz" });
+    expect(entity.id).toBeTruthy();
+    expect(entity.id.length).toBeGreaterThan(0);
+    expect(entity.createdAt).toBeGreaterThan(0);
+  });
+
+  it("S-B-02: appends assistant done message with playlistId and errorCode=null", async () => {
+    const repo = makeRepo();
+    const useCase = new AppendChatMessageUseCase(repo);
+
+    await useCase.execute({
+      role: "assistant",
+      contentKey: "aiChat.assistantDone",
+      contentParams: { count: 12 },
+      playlistId: "p-1",
+    });
+
+    expect(repo.append).toHaveBeenCalledOnce();
+    const entity = (repo.append as ReturnType<typeof vi.fn>).mock.calls[0][0] as AiChatMessage;
+    expect(entity.role).toBe("assistant");
+    expect(entity.playlistId).toBe("p-1");
+    expect(entity.errorCode).toBeNull();
+  });
+
+  it("S-B-03: appends assistant error message with errorCode and playlistId=null", async () => {
+    const repo = makeRepo();
+    const useCase = new AppendChatMessageUseCase(repo);
+
+    await useCase.execute({
+      role: "assistant",
+      contentKey: "aiChat.assistantError",
+      contentParams: { code: "zero-resolved" },
+      errorCode: "zero-resolved",
+    });
+
+    expect(repo.append).toHaveBeenCalledOnce();
+    const entity = (repo.append as ReturnType<typeof vi.fn>).mock.calls[0][0] as AiChatMessage;
+    expect(entity.role).toBe("assistant");
+    expect(entity.errorCode).toBe("zero-resolved");
+    expect(entity.playlistId).toBeNull();
+  });
+});
+
+describe("GetChatMessagesUseCase", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("S-B-04: returns empty array when thread is empty", async () => {
+    const repo = makeRepo({ list: vi.fn().mockResolvedValue([]) });
+    const useCase = new GetChatMessagesUseCase(repo);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([]);
+  });
+
+  it("S-B-05: maps domain entities to DTOs", async () => {
+    const entity: AiChatMessage = {
+      id: "m1",
+      role: "user",
+      content: { key: "aiChat.userPrompt" },
+      playlistId: null,
+      errorCode: null,
+      createdAt: 1000,
+    };
+    const repo = makeRepo({ list: vi.fn().mockResolvedValue([entity]) });
+    const useCase = new GetChatMessagesUseCase(repo);
+
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "m1",
+      role: "user",
+      content: { key: "aiChat.userPrompt" },
+      playlistId: null,
+      errorCode: null,
+      createdAt: 1000,
+    });
+  });
+});
+
+describe("ClearChatMessagesUseCase", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("S-B-06: returns deleted count from repository", async () => {
+    const repo = makeRepo({ clear: vi.fn().mockResolvedValue(5) });
+    const useCase = new ClearChatMessagesUseCase(repo);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ deleted: 5 });
+  });
+
+  it("S-B-07: returns zero when thread is empty (no error)", async () => {
+    const repo = makeRepo({ clear: vi.fn().mockResolvedValue(0) });
+    const useCase = new ClearChatMessagesUseCase(repo);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ deleted: 0 });
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.ts
@@ -1,0 +1,30 @@
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import type { AiChatMessageRepository } from "@/domain/repositories/ai-chat-message.repository";
+
+export interface AppendChatMessageInput {
+  role: "user" | "assistant";
+  contentKey: string;
+  contentParams?: Record<string, unknown>;
+  playlistId?: string | null;
+  errorCode?: string | null;
+}
+
+export class AppendChatMessageUseCase {
+  constructor(private readonly repository: AiChatMessageRepository) {}
+
+  async execute(input: AppendChatMessageInput): Promise<void> {
+    const message = new AiChatMessage({
+      id: crypto.randomUUID(),
+      role: input.role,
+      content: {
+        key: input.contentKey,
+        params: input.contentParams,
+      },
+      playlistId: input.playlistId ?? null,
+      errorCode: input.errorCode ?? null,
+      createdAt: Date.now(),
+    });
+
+    await this.repository.append(message);
+  }
+}

--- a/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.ts
@@ -1,0 +1,14 @@
+import type { AiChatMessageRepository } from "@/domain/repositories/ai-chat-message.repository";
+
+export interface ClearChatMessagesResult {
+  deleted: number;
+}
+
+export class ClearChatMessagesUseCase {
+  constructor(private readonly repository: AiChatMessageRepository) {}
+
+  async execute(): Promise<ClearChatMessagesResult> {
+    const deleted = await this.repository.clear();
+    return { deleted };
+  }
+}

--- a/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.ts
@@ -1,0 +1,23 @@
+import type { AiChatMessageDto } from "@spotiarr/shared";
+import type { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import type { AiChatMessageRepository } from "@/domain/repositories/ai-chat-message.repository";
+
+function toDto(entity: AiChatMessage): AiChatMessageDto {
+  return {
+    id: entity.id,
+    role: entity.role,
+    content: entity.content,
+    playlistId: entity.playlistId,
+    errorCode: entity.errorCode,
+    createdAt: entity.createdAt,
+  };
+}
+
+export class GetChatMessagesUseCase {
+  constructor(private readonly repository: AiChatMessageRepository) {}
+
+  async execute(): Promise<AiChatMessageDto[]> {
+    const messages = await this.repository.list();
+    return messages.map(toDto);
+  }
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -9,6 +9,9 @@ import { SettingsService } from "./application/services/settings.service";
 import { SpotifyService } from "./application/services/spotify.service";
 import { TrackPostProcessingService } from "./application/services/track-post-processing.service";
 import { TrackService } from "./application/services/track.service";
+import { AppendChatMessageUseCase } from "./application/use-cases/ai/append-chat-message.use-case";
+import { ClearChatMessagesUseCase } from "./application/use-cases/ai/clear-chat-messages.use-case";
+import { GetChatMessagesUseCase } from "./application/use-cases/ai/get-chat-messages.use-case";
 import { GetAlbumTracksUseCase } from "./application/use-cases/artists/get-album-tracks.use-case";
 import { GetArtistAlbumsUseCase } from "./application/use-cases/artists/get-artist-albums.use-case";
 import { GetArtistDetailUseCase } from "./application/use-cases/artists/get-artist-detail.use-case";
@@ -50,6 +53,7 @@ import { ExternalUrlCacheRepository } from "./infrastructure/database/external-u
 import { FeedCacheEvictionRepository } from "./infrastructure/database/feed-cache-eviction.repository";
 import { FeedSyncStateRepository } from "./infrastructure/database/feed-sync-state.repository";
 import { FollowedArtistRepository } from "./infrastructure/database/followed-artist.repository";
+import { PrismaAiChatMessageRepository } from "./infrastructure/database/prisma-ai-chat-message.repository";
 import { PrismaHistoryRepository } from "./infrastructure/database/prisma-history.repository";
 import { PrismaPlaylistRepository } from "./infrastructure/database/prisma-playlist.repository";
 import { PrismaSettingsRepository } from "./infrastructure/database/prisma-settings.repository";
@@ -127,6 +131,7 @@ export function createContainer(env: Env) {
   const playlistRepository = new PrismaPlaylistRepository();
   const trackRepository = new PrismaTrackRepository();
   const historyRepository = new PrismaHistoryRepository();
+  const aiChatMessageRepository = new PrismaAiChatMessageRepository();
   const settingsRepository = new PrismaSettingsRepository();
   const followedArtistRepository = new FollowedArtistRepository(prisma);
   const artistAlbumCacheRepository = new ArtistAlbumCacheRepository(prisma);
@@ -600,6 +605,10 @@ export function createContainer(env: Env) {
   const searchController = new SearchController(catalogSearchPort);
   const settingsController = new SettingsController(getSettingsUseCase, updateSettingUseCase);
 
+  const appendChatMessageUseCase = new AppendChatMessageUseCase(aiChatMessageRepository);
+  const getChatMessagesUseCase = new GetChatMessagesUseCase(aiChatMessageRepository);
+  const clearChatMessagesUseCase = new ClearChatMessagesUseCase(aiChatMessageRepository);
+
   const aiPlaylistQueueService = new BullMqAiPlaylistQueueService();
   const aiChatController = new AiChatController(aiPlaylistQueueService, (overrides) =>
     listAiModels(settingsService, overrides),
@@ -682,6 +691,9 @@ export function createContainer(env: Env) {
     processArtworkBackfillBatchUseCase,
     aiPlaylistQueueService,
     aiChatController,
+    appendChatMessageUseCase,
+    getChatMessagesUseCase,
+    clearChatMessagesUseCase,
     spotifyUrlLookupClient,
     playlistRepository,
   };

--- a/apps/backend/src/domain/entities/ai-chat-message.entity.ts
+++ b/apps/backend/src/domain/entities/ai-chat-message.entity.ts
@@ -1,0 +1,31 @@
+export interface AiChatMessageContent {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
+export interface AiChatMessageProps {
+  id: string;
+  role: "user" | "assistant";
+  content: AiChatMessageContent;
+  playlistId: string | null;
+  errorCode: string | null;
+  createdAt: number;
+}
+
+export class AiChatMessage {
+  readonly id: string;
+  readonly role: "user" | "assistant";
+  readonly content: AiChatMessageContent;
+  readonly playlistId: string | null;
+  readonly errorCode: string | null;
+  readonly createdAt: number;
+
+  constructor(props: AiChatMessageProps) {
+    this.id = props.id;
+    this.role = props.role;
+    this.content = props.content;
+    this.playlistId = props.playlistId;
+    this.errorCode = props.errorCode;
+    this.createdAt = props.createdAt;
+  }
+}

--- a/apps/backend/src/domain/repositories/ai-chat-message.repository.ts
+++ b/apps/backend/src/domain/repositories/ai-chat-message.repository.ts
@@ -1,0 +1,7 @@
+import type { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+
+export interface AiChatMessageRepository {
+  append(message: AiChatMessage): Promise<void>;
+  list(): Promise<AiChatMessage[]>;
+  clear(): Promise<number>;
+}

--- a/apps/backend/src/infrastructure/database/__tests__/prisma-ai-chat-message.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/__tests__/prisma-ai-chat-message.repository.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import { PrismaAiChatMessageRepository } from "../prisma-ai-chat-message.repository";
+
+function makeEntity(overrides: Partial<AiChatMessage> = {}): AiChatMessage {
+  return {
+    id: "test-id-1",
+    role: "user",
+    content: { key: "aiChat.userPrompt", params: { prompt: "jazz" } },
+    playlistId: null,
+    errorCode: null,
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makePrismaRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "test-id-1",
+    role: "user",
+    content: JSON.stringify({ key: "aiChat.userPrompt", params: { prompt: "jazz" } }),
+    contentKey: "aiChat.userPrompt",
+    contentParams: JSON.stringify({ prompt: "jazz" }),
+    playlistId: null,
+    errorCode: null,
+    createdAt: BigInt(1000),
+    ...overrides,
+  };
+}
+
+describe("PrismaAiChatMessageRepository", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("S-B-08: list returns messages in ascending createdAt order", () => {
+    it("returns messages ordered ascending by createdAt as JS numbers", async () => {
+      const rows = [
+        makePrismaRow({ id: "id-2", createdAt: BigInt(2000) }),
+        makePrismaRow({ id: "id-1", createdAt: BigInt(1000) }),
+        makePrismaRow({ id: "id-3", createdAt: BigInt(3000) }),
+      ];
+      const prisma = {
+        aiChatMessage: {
+          findMany: vi.fn().mockResolvedValue(rows),
+        },
+      } as any;
+
+      const repo = new PrismaAiChatMessageRepository(prisma);
+      const result = await repo.list();
+
+      expect(prisma.aiChatMessage.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: "asc" },
+        }),
+      );
+      expect(result.map((r) => r.createdAt)).toEqual([2000, 1000, 3000]);
+      result.forEach((r) => {
+        expect(typeof r.createdAt).toBe("number");
+      });
+    });
+  });
+
+  describe("S-B-09: clear removes all rows and returns count", () => {
+    it("calls deleteMany and returns deleted count", async () => {
+      const prisma = {
+        aiChatMessage: {
+          deleteMany: vi.fn().mockResolvedValue({ count: 3 }),
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+      } as any;
+
+      const repo = new PrismaAiChatMessageRepository(prisma);
+      const count = await repo.clear();
+
+      expect(prisma.aiChatMessage.deleteMany).toHaveBeenCalledWith({});
+      expect(count).toBe(3);
+    });
+  });
+
+  describe("S-B-10: append serialises content as JSON string", () => {
+    it("stores content as JSON-parseable string in the DB row", async () => {
+      const prisma = {
+        aiChatMessage: {
+          create: vi.fn().mockImplementation(({ data }) => {
+            return Promise.resolve({
+              ...data,
+              createdAt: data.createdAt,
+            });
+          }),
+        },
+      } as any;
+
+      const entity = makeEntity({
+        content: { key: "aiChat.userPrompt", params: { prompt: "metal" } },
+      });
+      const repo = new PrismaAiChatMessageRepository(prisma);
+      await repo.append(entity);
+
+      expect(prisma.aiChatMessage.create).toHaveBeenCalledOnce();
+      const createArg = (prisma.aiChatMessage.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      const storedContent = createArg.data.content;
+      expect(() => JSON.parse(storedContent)).not.toThrow();
+      const parsed = JSON.parse(storedContent);
+      expect(parsed.key).toBe("aiChat.userPrompt");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-ai-chat-message.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-ai-chat-message.repository.ts
@@ -1,0 +1,50 @@
+import type { PrismaClient } from "@prisma/client";
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import type { AiChatMessageRepository } from "@/domain/repositories/ai-chat-message.repository";
+import { prisma as defaultPrisma } from "../setup/prisma";
+
+export class PrismaAiChatMessageRepository implements AiChatMessageRepository {
+  private readonly prisma: PrismaClient;
+
+  constructor(prismaClient?: PrismaClient) {
+    this.prisma = prismaClient ?? defaultPrisma;
+  }
+
+  async append(message: AiChatMessage): Promise<void> {
+    await this.prisma.aiChatMessage.create({
+      data: {
+        id: message.id,
+        role: message.role,
+        content: JSON.stringify(message.content),
+        contentKey: message.content.key ?? null,
+        contentParams: message.content.params ? JSON.stringify(message.content.params) : null,
+        playlistId: message.playlistId ?? null,
+        errorCode: message.errorCode ?? null,
+        createdAt: BigInt(message.createdAt),
+      },
+    });
+  }
+
+  async list(): Promise<AiChatMessage[]> {
+    const rows = await this.prisma.aiChatMessage.findMany({
+      orderBy: { createdAt: "asc" },
+    });
+
+    return rows.map(
+      (row) =>
+        new AiChatMessage({
+          id: row.id,
+          role: row.role as "user" | "assistant",
+          content: JSON.parse(row.content) as { key: string; params?: Record<string, unknown> },
+          playlistId: row.playlistId ?? null,
+          errorCode: row.errorCode ?? null,
+          createdAt: Number(row.createdAt),
+        }),
+    );
+  }
+
+  async clear(): Promise<number> {
+    const result = await this.prisma.aiChatMessage.deleteMany({});
+    return result.count;
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -462,6 +462,32 @@ export interface UnlockRequestDto {
   token: string;
 }
 
+// AI Chat History
+
+export type AiChatRole = "user" | "assistant";
+
+export interface AiChatMessageContent {
+  key: string;
+  params?: Record<string, unknown>;
+}
+
+export interface AiChatMessageDto {
+  id: string;
+  role: AiChatRole;
+  content: AiChatMessageContent;
+  playlistId: string | null;
+  errorCode: string | null;
+  createdAt: number; // epoch ms as JS number
+}
+
+export interface AiChatHistoryDto {
+  messages: AiChatMessageDto[];
+}
+
+export interface ClearChatMessagesResponseDto {
+  deleted: number;
+}
+
 export interface AuthSessionResponseDto {
   tokenRequired: boolean;
 }


### PR DESCRIPTION
## Chained PR 1/3 — #167 AI chat history persistence

Base: `feature/ai-chat-history-persistence` (tracker branch — feature-branch-chain). Only the tracker merges to main.

### Scope (persistence foundation)
- **Prisma** `AiChatMessage` model + migration (`@@index([createdAt])`). Columns: `role`, `content`, nullable `contentKey`/`contentParams` (i18n {key,params}), nullable `playlistId` (soft ref, no FK cascade), nullable `errorCode`, `createdAt`.
- **Shared** DTOs + role union in `packages/shared`.
- **Domain** `AiChatMessage` entity + repository port (no Prisma import).
- **Infrastructure** `PrismaAiChatMessageRepository` (BigInt→Number mapping in repo layer only).
- **Application** use-cases: `appendChatMessage`, `getChatMessages`, `clearChatMessages`.
- **Container** DI wiring.

### Tests (TDD, RED→GREEN)
10 new tests (S-B-01..10). Full backend suite green: **682 passed**. Architecture guard holds (no `@prisma/client` in domain/application).

### Notes
- `appendChatMessage` is delivered here but wired into the generation flow in **PR2** (additive, no-op default — keeps existing use-case tests green).
- Repo `append(message: AiChatMessage): Promise<void>` follows the spec (use-case builds id+createdAt; repo only persists).
- Migration SQL authored manually (local dev DB was locked); identical to prisma-generated output, applied via `migrate deploy` in CI.

Part of #167. PR2 (generation wiring + API) and PR3 (frontend) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)