### PR TITLE
fix(frontend): AI Chat UI polish before release

### DIFF
--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -454,12 +454,12 @@
     "assistantDone": "Created playlist with {{count}} tracks.",
     "assistantError": "Generation failed: {{code}}",
     "clearConversation": "Clear conversation",
-    "clearConfirm": "This will permanently delete your chat history. Continue?",
+    "clearConfirm": "This will permanently delete your chat history.",
     "playlistGone": "Playlist no longer exists"
   },
   "ai": {
     "title": "AI Chat",
-    "subtitle": "Describe a playlist in your own words and let AI build it from your library.",
+    "subtitle": "Describe a playlist in your own words and AI will find and download the tracks.",
     "empty": {
       "title": "Create a playlist with AI",
       "hint": "Describe a mood, genre, activity or era — for example \"upbeat 90s rock for running\"."

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -454,12 +454,12 @@
     "assistantDone": "Lista creada con {{count}} pistas.",
     "assistantError": "Generación fallida: {{code}}",
     "clearConversation": "Borrar conversación",
-    "clearConfirm": "Esto eliminará permanentemente el historial. ¿Continuar?",
+    "clearConfirm": "Esto eliminará permanentemente el historial.",
     "playlistGone": "Lista ya no existe"
   },
   "ai": {
     "title": "Chat con IA",
-    "subtitle": "Describe una lista con tus palabras y deja que la IA la genere desde tu biblioteca.",
+    "subtitle": "Describe una lista con tus palabras y la IA buscará y descargará las pistas.",
     "empty": {
       "title": "Crea una lista con IA",
       "hint": "Describe un estado de ánimo, género, actividad o época — por ejemplo «rock noventero animado para correr»."

--- a/apps/frontend/src/views/Chat.test.tsx
+++ b/apps/frontend/src/views/Chat.test.tsx
@@ -65,7 +65,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockUseChatController.mockReturnValue(defaultController);
   mockUsePlaylistsQuery.mockReturnValue({ data: [], isLoading: false });
-  vi.spyOn(window, "confirm").mockReturnValue(false);
 });
 
 const { Chat } = await import("./Chat");
@@ -251,9 +250,8 @@ describe("Chat view", () => {
     expect(link.getAttribute("href")).toContain("pid-loading");
   });
 
-  // S-F-14: clear button triggers confirmation before mutating
-  it("clear button does NOT call clearMessages when confirm returns false", () => {
-    vi.spyOn(window, "confirm").mockReturnValue(false);
+  // S-F-14: clear button opens the confirm modal without mutating (no native confirm)
+  it("clear button opens the confirm modal and does NOT call clearMessages yet", () => {
     mockUseChatController.mockReturnValue({
       ...defaultController,
       displayMessages: [
@@ -268,14 +266,16 @@ describe("Chat view", () => {
       ],
     });
     render(<Chat />);
-    const clearBtn = screen.getByText("aiChat.clearConversation");
-    fireEvent.click(clearBtn);
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(screen.getByText("aiChat.clearConversation"));
+
+    expect(screen.getByRole("dialog")).toBeDefined();
     expect(mockClearMessages).not.toHaveBeenCalled();
   });
 
-  // S-F-15: clear button calls clearMessages when confirmed
-  it("clear button calls clearMessages when confirm returns true", () => {
-    vi.spyOn(window, "confirm").mockReturnValue(true);
+  // S-F-14b: cancelling the modal closes it without mutating
+  it("clear modal cancel button closes the modal without calling clearMessages", () => {
     mockUseChatController.mockReturnValue({
       ...defaultController,
       displayMessages: [
@@ -290,9 +290,34 @@ describe("Chat view", () => {
       ],
     });
     render(<Chat />);
-    const clearBtn = screen.getByText("aiChat.clearConversation");
-    fireEvent.click(clearBtn);
+    fireEvent.click(screen.getByText("aiChat.clearConversation"));
+    fireEvent.click(screen.getByRole("button", { name: "common.cancel" }));
+
+    expect(mockClearMessages).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  // S-F-15: confirming the modal calls clearMessages and closes the modal
+  it("clear modal confirm button calls clearMessages once and closes the modal", () => {
+    mockUseChatController.mockReturnValue({
+      ...defaultController,
+      displayMessages: [
+        {
+          id: "m1",
+          role: "user" as const,
+          content: { key: "aiChat.userPrompt", params: { prompt: "jazz" } },
+          playlistId: null,
+          errorCode: null,
+          createdAt: 1000,
+        },
+      ],
+    });
+    render(<Chat />);
+    fireEvent.click(screen.getByText("aiChat.clearConversation"));
+    fireEvent.click(screen.getByRole("button", { name: "common.delete" }));
+
     expect(mockClearMessages).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 
   // S-F-16: clear button disabled while isClearPending

--- a/apps/frontend/src/views/Chat.tsx
+++ b/apps/frontend/src/views/Chat.tsx
@@ -1,7 +1,7 @@
 import { faRobot, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type AiChatMessageDto } from "@spotiarr/shared";
-import { FC, KeyboardEvent, useState } from "react";
+import { FC, KeyboardEvent, memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/atoms/Button";
@@ -20,7 +20,7 @@ interface MessageBubbleProps {
   isPlaylistsLoading: boolean;
 }
 
-const MessageBubble: FC<MessageBubbleProps> = ({ msg, playlists, isPlaylistsLoading }) => {
+const MessageBubble: FC<MessageBubbleProps> = memo(({ msg, playlists, isPlaylistsLoading }) => {
   const { t } = useTranslation();
 
   const params = (msg.content.params ?? {}) as Record<string, unknown>;
@@ -69,7 +69,8 @@ const MessageBubble: FC<MessageBubbleProps> = ({ msg, playlists, isPlaylistsLoad
       {playlistLink}
     </div>
   );
-};
+});
+MessageBubble.displayName = "MessageBubble";
 
 export const Chat: FC = () => {
   const { t } = useTranslation();

--- a/apps/frontend/src/views/Chat.tsx
+++ b/apps/frontend/src/views/Chat.tsx
@@ -1,11 +1,12 @@
 import { faRobot, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { type AiChatMessageDto } from "@spotiarr/shared";
-import { FC, KeyboardEvent } from "react";
+import { FC, KeyboardEvent, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/atoms/Button";
 import { PageHeader } from "@/components/molecules/PageHeader";
+import { ConfirmModal } from "@/components/organisms/ConfirmModal";
 import { useChatController } from "@/hooks/controllers/useChatController";
 import { usePlaylistsQuery } from "@/hooks/queries/usePlaylistsQuery";
 import { Path } from "@/routes/routes";
@@ -64,7 +65,7 @@ const MessageBubble: FC<MessageBubbleProps> = ({ msg, playlists, isPlaylistsLoad
           : "bg-background-elevated text-text-primary self-start",
       )}
     >
-      <span>{text}</span>
+      <p>{text}</p>
       {playlistLink}
     </div>
   );
@@ -88,6 +89,7 @@ export const Chat: FC = () => {
     isClearPending,
   } = useChatController();
   const { data: playlists, isLoading: isPlaylistsLoading } = usePlaylistsQuery();
+  const [isClearConfirmOpen, setIsClearConfirmOpen] = useState(false);
 
   const canSubmit = prompt.trim().length > 0 && !isGenerating;
   const showEmptyState = displayMessages.length === 0 && !isGenerating && !stage;
@@ -113,11 +115,9 @@ export const Chat: FC = () => {
     }
   };
 
-  const handleClearClick = () => {
-    const confirmed = window.confirm(t("aiChat.clearConfirm"));
-    if (confirmed) {
-      clearMessages();
-    }
+  const handleClearConfirm = () => {
+    setIsClearConfirmOpen(false);
+    clearMessages();
   };
 
   return (
@@ -127,7 +127,7 @@ export const Chat: FC = () => {
           <PageHeader title={t("ai.title")} description={t("ai.subtitle")} />
           {displayMessages.length > 0 && (
             <button
-              onClick={handleClearClick}
+              onClick={() => setIsClearConfirmOpen(true)}
               disabled={isClearPending}
               className="text-text-secondary hover:text-text-primary mt-1 flex items-center gap-1.5 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
             >
@@ -233,6 +233,17 @@ export const Chat: FC = () => {
           </div>
         </div>
       </div>
+
+      <ConfirmModal
+        isOpen={isClearConfirmOpen}
+        title={t("aiChat.clearConversation")}
+        description={t("aiChat.clearConfirm")}
+        confirmLabel={t("common.delete")}
+        cancelLabel={t("common.cancel")}
+        onConfirm={handleClearConfirm}
+        onCancel={() => setIsClearConfirmOpen(false)}
+        isDestructive
+      />
     </section>
   );
 };

--- a/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
@@ -34,6 +34,50 @@ function buildAiErrorEvents(jobId: string): string {
   );
 }
 
+interface MockChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: { key: string; params?: Record<string, unknown> };
+  playlistId: string | null;
+  errorCode: string | null;
+  createdAt: number;
+}
+
+function userMessage(id: string, prompt: string, createdAt: number): MockChatMessage {
+  return {
+    id,
+    role: "user",
+    content: { key: "aiChat.userPrompt", params: { prompt } },
+    playlistId: null,
+    errorCode: null,
+    createdAt,
+  };
+}
+
+function assistantDoneMessage(
+  id: string,
+  count: number,
+  playlistId: string,
+  createdAt: number,
+): MockChatMessage {
+  return {
+    id,
+    role: "assistant",
+    content: { key: "aiChat.assistantDone", params: { count } },
+    playlistId,
+    errorCode: null,
+    createdAt,
+  };
+}
+
+function fulfillJson(route: import("@playwright/test").Route, data: unknown) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(data),
+  });
+}
+
 test.describe("Mocked AI Chat flows", () => {
   test("happy path: prompt submit triggers progress stages and shows playlist created", async ({
     page,
@@ -141,5 +185,155 @@ test.describe("Mocked AI Chat flows", () => {
 
     await textarea.fill("actual content");
     await expect(sendBtn).toBeEnabled();
+  });
+
+  test("history persistence: loads the saved transcript with an active playlist link on mount", async ({
+    page,
+  }) => {
+    const PLAYLIST_ID = "pl-history-1";
+
+    await page.route("**/api/ai/chat/messages", async (route) => {
+      if (route.request().method() === "DELETE") {
+        await fulfillJson(route, { data: { deleted: 2 } });
+        return;
+      }
+      await fulfillJson(route, {
+        data: {
+          messages: [
+            userMessage("u1", "jazz for studying", 1),
+            assistantDoneMessage("a1", 5, PLAYLIST_ID, 2),
+          ],
+        },
+      });
+    });
+
+    await page.route("**/api/playlist", async (route) => {
+      await fulfillJson(route, { data: [{ id: PLAYLIST_ID, name: "AI mix" }] });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("jazz for studying")).toBeVisible();
+    await expect(page.getByText(/Created playlist with 5 tracks/i)).toBeVisible();
+
+    const link = page.getByRole("link", { name: /View playlist/i });
+    await expect(link).toBeVisible();
+    const href = await link.getAttribute("href");
+    expect(href).toContain(PLAYLIST_ID);
+    expect(href).toContain("mode=library");
+  });
+
+  test("conversation threading: renders multiple prompt/response pairs in order", async ({
+    page,
+  }) => {
+    await page.route("**/api/ai/chat/messages", async (route) => {
+      if (route.request().method() === "DELETE") {
+        await fulfillJson(route, { data: { deleted: 4 } });
+        return;
+      }
+      await fulfillJson(route, {
+        data: {
+          messages: [
+            userMessage("u1", "first prompt", 1),
+            assistantDoneMessage("a1", 3, "pl-1", 2),
+            userMessage("u2", "second prompt", 3),
+            assistantDoneMessage("a2", 7, "pl-2", 4),
+          ],
+        },
+      });
+    });
+
+    await page.route("**/api/playlist", async (route) => {
+      await fulfillJson(route, { data: [{ id: "pl-1" }, { id: "pl-2" }] });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("first prompt")).toBeVisible();
+    await expect(page.getByText("second prompt")).toBeVisible();
+    await expect(page.getByText(/Created playlist with 3 tracks/i)).toBeVisible();
+    await expect(page.getByText(/Created playlist with 7 tracks/i)).toBeVisible();
+
+    // User bubbles must render in chronological order (oldest first).
+    const promptTexts = await page.getByText(/prompt$/).allTextContents();
+    expect(promptTexts).toEqual(["first prompt", "second prompt"]);
+  });
+
+  test("clear conversation: confirm modal deletes the transcript and shows the empty state", async ({
+    page,
+  }) => {
+    let cleared = false;
+
+    await page.route("**/api/ai/chat/messages", async (route) => {
+      if (route.request().method() === "DELETE") {
+        cleared = true;
+        await fulfillJson(route, { data: { deleted: 1 } });
+        return;
+      }
+      await fulfillJson(route, {
+        data: { messages: cleared ? [] : [userMessage("u1", "drum and bass set", 1)] },
+      });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("drum and bass set")).toBeVisible();
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+
+    // Opening the modal must NOT mutate anything yet.
+    await page.getByRole("button", { name: /Clear conversation/i }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Cancel closes the modal and keeps the transcript.
+    await dialog.getByRole("button", { name: /^Cancel$/ }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText("drum and bass set")).toBeVisible();
+
+    // Confirming the destructive action clears the transcript.
+    await page.getByRole("button", { name: /Clear conversation/i }).click();
+    await page.getByRole("dialog").getByRole("button", { name: /^Delete$/ }).click();
+
+    await expect(page.getByText("drum and bass set")).toBeHidden();
+    await expect(page.getByText(/No conversation yet/i)).toBeVisible();
+  });
+});
+
+test.describe("Mocked AI Chat playlist link navigation", () => {
+  // Clicking the link mounts the playlist detail view, which fires its own
+  // (here unmocked) requests; allow them so the navigation assertion can run.
+  test.use({ allowUnhandledRequests: true });
+
+  test("clicking 'View playlist' navigates to the playlist detail in library mode", async ({
+    page,
+  }) => {
+    const PLAYLIST_ID = "pl-nav-9";
+
+    await page.route("**/api/ai/chat/messages", async (route) => {
+      if (route.request().method() === "DELETE") {
+        await fulfillJson(route, { data: { deleted: 2 } });
+        return;
+      }
+      await fulfillJson(route, {
+        data: {
+          messages: [
+            userMessage("u1", "lofi beats", 1),
+            assistantDoneMessage("a1", 4, PLAYLIST_ID, 2),
+          ],
+        },
+      });
+    });
+
+    await page.route("**/api/playlist", async (route) => {
+      await fulfillJson(route, { data: [{ id: PLAYLIST_ID, name: "AI mix" }] });
+    });
+
+    await page.goto("/chat", { waitUntil: "domcontentloaded" });
+
+    const link = page.getByRole("link", { name: /View playlist/i });
+    await expect(link).toBeVisible();
+    await link.click();
+
+    await expect(page).toHaveURL(/pl-nav-9\?mode=library/);
   });
 });


### PR DESCRIPTION
Closes #172

## Type
- [x] Bug fix

## Summary
- Fix missing space between `Lista creada con N pistas.` and the `Ver lista` link in the AI Chat assistant bubble.
- Reword `ai.subtitle` (es/en) so it no longer claims the AI generates "from your library" — it actually suggests, resolves on Spotify and downloads.
- Replace the native `window.confirm` for *Borrar conversación* with the existing `ConfirmModal` (focus trap, destructive variant, a11y).

## Changes
| File | Change |
|------|--------|
| `apps/frontend/src/views/Chat.tsx` | `<span>`→`<p>` in `MessageBubble`; `window.confirm` → `ConfirmModal` with local open state |
| `apps/frontend/src/locales/es.json` | Reworded `ai.subtitle`; trimmed `aiChat.clearConfirm` |
| `apps/frontend/src/locales/en.json` | Reworded `ai.subtitle`; trimmed `aiChat.clearConfirm` |
| `apps/frontend/src/views/Chat.test.tsx` | Updated clear-flow tests for the modal (open/cancel/confirm); removed stale `window.confirm` spies |

## Test Plan
- [x] `tsc --noEmit` — no errors
- [x] `oxlint` — clean
- [x] `vitest run src/views/Chat.test.tsx` — 25/25 pass
- [x] Fresh-context diff review — no CRITICAL/WARNING

## Notes
- Backend behavior unchanged. Docs already describe the real flow correctly — no doc fix needed.
- "Top N" yielding fewer tracks (unresolved on Spotify get filtered) is expected behavior, out of scope.
