### PR TITLE
fix(backend): recover tracks stranded in New status

### DIFF
--- a/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
@@ -1,0 +1,79 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { RescueStuckTracksUseCase } from "./rescue-stuck-tracks.use-case";
+
+function makeTrack(input: Partial<ITrack> = {}): Track {
+  return new Track({
+    id: "track-1",
+    name: "Track 01",
+    artist: "Artist",
+    trackUrl: "https://open.spotify.com/track/1",
+    status: TrackStatusEnum.New,
+    playlistId: "playlist-1",
+    playlistIndex: 1,
+    ...input,
+  });
+}
+
+describe("RescueStuckTracksUseCase", () => {
+  const trackRepository = {
+    findAll: vi.fn(),
+    findAllByPlaylist: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+    save: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    deleteAll: vi.fn(),
+    findStuckTracks: vi.fn(),
+    findAllByStatuses: vi.fn(),
+  };
+
+  const retryTrackDownloadUseCase = {
+    execute: vi.fn(),
+  };
+
+  let useCase: RescueStuckTracksUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new RescueStuckTracksUseCase(
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+    );
+  });
+
+  it("includes New in the rescued statuses so never-searched tracks are not stranded", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([]);
+
+    await useCase.execute();
+
+    expect(trackRepository.findAllByStatuses).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        TrackStatusEnum.New,
+        TrackStatusEnum.Searching,
+        TrackStatusEnum.Queued,
+        TrackStatusEnum.Downloading,
+      ]),
+    );
+  });
+
+  it("re-enqueues a track stranded in New", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      makeTrack({ id: "track-new", status: TrackStatusEnum.New }),
+    ]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-new");
+  });
+
+  it("does nothing when there are no stuck tracks", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
@@ -69,6 +69,21 @@ describe("RescueStuckTracksUseCase", () => {
     expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-new");
   });
 
+  it("re-enqueues every stuck track across mixed statuses", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      makeTrack({ id: "track-new", status: TrackStatusEnum.New }),
+      makeTrack({ id: "track-searching", status: TrackStatusEnum.Searching }),
+      makeTrack({ id: "track-queued", status: TrackStatusEnum.Queued }),
+    ]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledTimes(3);
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-new");
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-searching");
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-queued");
+  });
+
   it("does nothing when there are no stuck tracks", async () => {
     trackRepository.findAllByStatuses.mockResolvedValue([]);
 

--- a/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.ts
@@ -12,6 +12,7 @@ export class RescueStuckTracksUseCase {
     console.log("🚑 Checking for stuck tracks...");
 
     const stuckStatuses = [
+      TrackStatusEnum.New,
       TrackStatusEnum.Downloading,
       TrackStatusEnum.Searching,
       TrackStatusEnum.Queued,

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -44,7 +44,12 @@ export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
     }
 
     const stuckTracks = await trackService.findStuckTracks(
-      [TrackStatusEnum.Queued, TrackStatusEnum.Downloading, TrackStatusEnum.Searching],
+      [
+        TrackStatusEnum.New,
+        TrackStatusEnum.Queued,
+        TrackStatusEnum.Downloading,
+        TrackStatusEnum.Searching,
+      ],
       now - safeTimeout * 60 * 1000,
     );
 


### PR DESCRIPTION
## What

Adds `New` to both stuck-track recovery sets so tracks that never started their YouTube search are re-driven instead of stuck forever.

- `apps/backend/src/infrastructure/jobs/index.ts` — periodic `cleanStuckTracksJob` (marks stranded → `Error`; the playlist sync then re-enqueues `Error` tracks). Guarded by the existing `createdAt` staleness filter (default 10 min).
- `apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.ts` — startup rescue (directly re-enqueues).
- New unit tests in `rescue-stuck-tracks.use-case.test.ts`.

## Why

Songs added to an already-subscribed Spotify playlist were detected (count updated, e.g. `30 / 33`) but never downloaded.

Root cause: a track stranded in `New` (search job never enqueued/processed — worker down, backend killed right after the row was saved, or a failed enqueue) had **no recovery path**. `cleanStuckTracksJob` and `RescueStuckTracksUseCase` both excluded `New`, and the playlist sync only re-enqueues `Error` tracks. So a `New` track on a long-running server stayed stuck indefinitely.

Closes #174.

## Verification

- `pnpm --filter backend run test:run` → **704 passed / 0 failed** (4 new rescue tests).
- `tsc --noEmit` → no errors.
- `oxlint` on changed files → ok.

Re-enqueue safety: `enqueueSearchTrack` uses a stable `jobId: id-${track.id}`, so BullMQ deduplicates a re-enqueue of an in-flight track (no duplicate downloads). This matches the pre-existing rescue behavior for `Searching`/`Queued`/`Downloading`.

## Known limitation (out of scope)

Non-subscribed playlists still don't auto-retry `Error` tracks (pre-existing). Tracked separately if it surfaces.