### PR TITLE
fix(backend): re-key stuck-track detection on last activity (recovery redesign 1/5)

### DIFF
--- a/apps/backend/prisma/migrations/20260616111929_add_track_last_activity_at/migration.sql
+++ b/apps/backend/prisma/migrations/20260616111929_add_track_last_activity_at/migration.sql
@@ -1,0 +1,35 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Track" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "artist" TEXT NOT NULL,
+    "albumArtist" TEXT,
+    "name" TEXT NOT NULL,
+    "album" TEXT,
+    "albumYear" INTEGER,
+    "trackNumber" INTEGER,
+    "durationMs" INTEGER,
+    "spotifyUrl" TEXT,
+    "trackUrl" TEXT,
+    "albumUrl" TEXT,
+    "albumCoverUrl" TEXT,
+    "primaryArtistImageUrl" TEXT,
+    "artists" TEXT,
+    "youtubeUrl" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'New',
+    "error" TEXT,
+    "createdAt" BIGINT NOT NULL DEFAULT 0,
+    "completedAt" BIGINT,
+    "lastActivityAt" BIGINT NOT NULL DEFAULT 0,
+    "playlistIndex" INTEGER,
+    "playlistId" TEXT,
+    CONSTRAINT "Track_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "Playlist" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Track" ("album", "albumArtist", "albumCoverUrl", "albumUrl", "albumYear", "artist", "artists", "completedAt", "createdAt", "durationMs", "error", "id", "name", "playlistId", "playlistIndex", "primaryArtistImageUrl", "spotifyUrl", "status", "trackNumber", "trackUrl", "youtubeUrl") SELECT "album", "albumArtist", "albumCoverUrl", "albumUrl", "albumYear", "artist", "artists", "completedAt", "createdAt", "durationMs", "error", "id", "name", "playlistId", "playlistIndex", "primaryArtistImageUrl", "spotifyUrl", "status", "trackNumber", "trackUrl", "youtubeUrl" FROM "Track";
+-- Backfill: seed lastActivityAt from createdAt so pre-existing rows are not treated as instantly stale
+UPDATE "new_Track" SET "lastActivityAt" = "createdAt" WHERE "lastActivityAt" = 0;
+DROP TABLE "Track";
+ALTER TABLE "new_Track" RENAME TO "Track";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Track {
   error                 String?
   createdAt             BigInt  @default(0)
   completedAt           BigInt?
+  lastActivityAt        BigInt  @default(0)
   playlistIndex         Int?
 
   playlistId            String?

--- a/apps/backend/src/application/services/track.service.ts
+++ b/apps/backend/src/application/services/track.service.ts
@@ -73,7 +73,7 @@ export class TrackService {
     return this.downloadTrackUseCase.execute(track);
   }
 
-  async findStuckTracks(statuses: TrackStatusEnum[], createdBefore: number): Promise<ITrack[]> {
-    return this.getTracksUseCase.findStuckTracks(statuses, createdBefore);
+  async findStuckTracks(statuses: TrackStatusEnum[], activeBefore: number): Promise<ITrack[]> {
+    return this.getTracksUseCase.findStuckTracks(statuses, activeBefore);
   }
 }

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.ts
@@ -52,8 +52,8 @@ export class GetTracksUseCase {
     return track ? track.toPrimitive() : null;
   }
 
-  async findStuckTracks(statuses: TrackStatusEnum[], createdBefore: number): Promise<ITrack[]> {
-    const tracks = await this.trackRepository.findStuckTracks(statuses, createdBefore);
+  async findStuckTracks(statuses: TrackStatusEnum[], activeBefore: number): Promise<ITrack[]> {
+    const tracks = await this.trackRepository.findStuckTracks(statuses, activeBefore);
     return tracks.map((t) => t.toPrimitive());
   }
 }

--- a/apps/backend/src/domain/repositories/track.repository.ts
+++ b/apps/backend/src/domain/repositories/track.repository.ts
@@ -18,7 +18,7 @@ export interface TrackRepository {
 
   deleteAll(ids: string[]): Promise<void>;
 
-  findStuckTracks(statuses: TrackStatusEnum[], createdBefore: number): Promise<Track[]>;
+  findStuckTracks(statuses: TrackStatusEnum[], activeBefore: number): Promise<Track[]>;
 
   findAllByStatuses(statuses: TrackStatusEnum[]): Promise<Track[]>;
 }

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
@@ -1,3 +1,4 @@
+import type { PrismaClient } from "@prisma/client";
 import { TrackStatusEnum } from "@spotiarr/shared";
 import { describe, expect, it, vi } from "vitest";
 import { PrismaTrackRepository } from "./prisma-track.repository";
@@ -31,22 +32,21 @@ function makeDbTrack(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makePrisma(track: Record<string, ReturnType<typeof vi.fn>>): PrismaClient {
+  return { track } as unknown as PrismaClient;
+}
+
 describe("PrismaTrackRepository.findStuckTracks", () => {
   describe("R1-S1: recently-active row is NOT returned even if createdAt is old", () => {
     it("excludes a track whose lastActivityAt is within the timeout window", async () => {
       const now = Date.now();
       const threshold = now - 10 * 60 * 1000;
 
-      const prisma = {
-        track: {
-          findMany: vi.fn().mockResolvedValue([]),
-        },
-      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
-
-      const repo = new PrismaTrackRepository(prisma);
+      const findMany = vi.fn().mockResolvedValue([]);
+      const repo = new PrismaTrackRepository(makePrisma({ findMany }));
       await repo.findStuckTracks([TrackStatusEnum.Downloading], threshold);
 
-      expect(prisma.track.findMany).toHaveBeenCalledWith(
+      expect(findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             lastActivityAt: expect.objectContaining({ lt: BigInt(threshold) }),
@@ -54,7 +54,7 @@ describe("PrismaTrackRepository.findStuckTracks", () => {
         }),
       );
 
-      expect(prisma.track.findMany).toHaveBeenCalledWith(
+      expect(findMany).toHaveBeenCalledWith(
         expect.not.objectContaining({
           where: expect.objectContaining({
             createdAt: expect.anything(),
@@ -76,13 +76,8 @@ describe("PrismaTrackRepository.findStuckTracks", () => {
         lastActivityAt: BigInt(now - 20 * 60 * 1000),
       });
 
-      const prisma = {
-        track: {
-          findMany: vi.fn().mockResolvedValue([staleTrack]),
-        },
-      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
-
-      const repo = new PrismaTrackRepository(prisma);
+      const findMany = vi.fn().mockResolvedValue([staleTrack]);
+      const repo = new PrismaTrackRepository(makePrisma({ findMany }));
       const result = await repo.findStuckTracks([TrackStatusEnum.Searching], threshold);
 
       expect(result).toHaveLength(1);
@@ -95,16 +90,11 @@ describe("PrismaTrackRepository.findStuckTracks", () => {
       const now = Date.now();
       const threshold = now - 10 * 60 * 1000;
 
-      const prisma = {
-        track: {
-          findMany: vi.fn().mockResolvedValue([]),
-        },
-      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
-
-      const repo = new PrismaTrackRepository(prisma);
+      const findMany = vi.fn().mockResolvedValue([]);
+      const repo = new PrismaTrackRepository(makePrisma({ findMany }));
       const result = await repo.findStuckTracks([TrackStatusEnum.New], threshold);
 
-      expect(prisma.track.findMany).toHaveBeenCalledWith(
+      expect(findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             lastActivityAt: { lt: BigInt(threshold) },
@@ -120,26 +110,21 @@ describe("PrismaTrackRepository.save", () => {
   it("stamps lastActivityAt with current epoch-ms on create", async () => {
     const before = Date.now();
 
-    const prisma = {
-      track: {
-        create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) =>
-          Promise.resolve({
-            ...makeDbTrack(),
-            ...data,
-            playlist: null,
-          }),
-        ),
-      },
-    } as unknown as { track: { create: ReturnType<typeof vi.fn> } };
-
-    const repo = new PrismaTrackRepository(prisma);
+    const create = vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+      Promise.resolve({
+        ...makeDbTrack(),
+        ...data,
+        playlist: null,
+      }),
+    );
+    const repo = new PrismaTrackRepository(makePrisma({ create }));
     await repo.save({
       name: "Song",
       artist: "Artist",
       status: TrackStatusEnum.New,
     });
 
-    const createArg = (prisma.track.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const createArg = create.mock.calls[0][0];
     const stamped = createArg.data.lastActivityAt;
     expect(typeof stamped).toBe("bigint");
     expect(Number(stamped)).toBeGreaterThanOrEqual(before);
@@ -150,16 +135,11 @@ describe("PrismaTrackRepository.update", () => {
   it("stamps lastActivityAt with current epoch-ms on update", async () => {
     const before = Date.now();
 
-    const prisma = {
-      track: {
-        update: vi.fn().mockResolvedValue(undefined),
-      },
-    } as unknown as { track: { update: ReturnType<typeof vi.fn> } };
-
-    const repo = new PrismaTrackRepository(prisma);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const repo = new PrismaTrackRepository(makePrisma({ update }));
     await repo.update("track-1", { status: TrackStatusEnum.Downloading });
 
-    const updateArg = (prisma.track.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const updateArg = update.mock.calls[0][0];
     const stamped = updateArg.data.lastActivityAt;
     expect(typeof stamped).toBe("bigint");
     expect(Number(stamped)).toBeGreaterThanOrEqual(before);

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
@@ -1,0 +1,167 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { PrismaTrackRepository } from "./prisma-track.repository";
+
+function makeDbTrack(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "track-1",
+    name: "Song",
+    artist: "Artist",
+    albumArtist: null,
+    album: null,
+    albumUrl: null,
+    albumCoverUrl: null,
+    primaryArtistImageUrl: null,
+    albumYear: null,
+    trackNumber: null,
+    durationMs: null,
+    spotifyUrl: null,
+    trackUrl: null,
+    artists: null,
+    youtubeUrl: null,
+    status: "New",
+    error: null,
+    createdAt: BigInt(1000),
+    completedAt: null,
+    playlistId: null,
+    playlistIndex: null,
+    lastActivityAt: BigInt(1000),
+    playlist: null,
+    ...overrides,
+  };
+}
+
+describe("PrismaTrackRepository.findStuckTracks", () => {
+  describe("R1-S1: recently-active row is NOT returned even if createdAt is old", () => {
+    it("excludes a track whose lastActivityAt is within the timeout window", async () => {
+      const now = Date.now();
+      const threshold = now - 10 * 60 * 1000;
+
+      const prisma = {
+        track: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
+
+      const repo = new PrismaTrackRepository(prisma);
+      await repo.findStuckTracks([TrackStatusEnum.Downloading], threshold);
+
+      expect(prisma.track.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            lastActivityAt: expect.objectContaining({ lt: BigInt(threshold) }),
+          }),
+        }),
+      );
+
+      expect(prisma.track.findMany).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          where: expect.objectContaining({
+            createdAt: expect.anything(),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("R1-S2: genuinely stale track IS returned", () => {
+    it("includes a track whose lastActivityAt is older than the timeout threshold", async () => {
+      const now = Date.now();
+      const threshold = now - 10 * 60 * 1000;
+
+      const staleTrack = makeDbTrack({
+        id: "stale-track",
+        status: TrackStatusEnum.Searching,
+        createdAt: BigInt(now - 30 * 60 * 1000),
+        lastActivityAt: BigInt(now - 20 * 60 * 1000),
+      });
+
+      const prisma = {
+        track: {
+          findMany: vi.fn().mockResolvedValue([staleTrack]),
+        },
+      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
+
+      const repo = new PrismaTrackRepository(prisma);
+      const result = await repo.findStuckTracks([TrackStatusEnum.Searching], threshold);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("stale-track");
+    });
+  });
+
+  describe("R1-S3: recently re-activated track is NOT re-marked as stuck", () => {
+    it("excludes a track whose lastActivityAt was refreshed (markAsNew stamps it to now)", async () => {
+      const now = Date.now();
+      const threshold = now - 10 * 60 * 1000;
+
+      const prisma = {
+        track: {
+          findMany: vi.fn().mockResolvedValue([]),
+        },
+      } as unknown as { track: { findMany: ReturnType<typeof vi.fn> } };
+
+      const repo = new PrismaTrackRepository(prisma);
+      const result = await repo.findStuckTracks([TrackStatusEnum.New], threshold);
+
+      expect(prisma.track.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            lastActivityAt: { lt: BigInt(threshold) },
+          }),
+        }),
+      );
+      expect(result).toHaveLength(0);
+    });
+  });
+});
+
+describe("PrismaTrackRepository.save", () => {
+  it("stamps lastActivityAt with current epoch-ms on create", async () => {
+    const before = Date.now();
+
+    const prisma = {
+      track: {
+        create: vi.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve({
+            ...makeDbTrack(),
+            ...data,
+            playlist: null,
+          }),
+        ),
+      },
+    } as unknown as { track: { create: ReturnType<typeof vi.fn> } };
+
+    const repo = new PrismaTrackRepository(prisma);
+    await repo.save({
+      name: "Song",
+      artist: "Artist",
+      status: TrackStatusEnum.New,
+    });
+
+    const createArg = (prisma.track.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const stamped = createArg.data.lastActivityAt;
+    expect(typeof stamped).toBe("bigint");
+    expect(Number(stamped)).toBeGreaterThanOrEqual(before);
+  });
+});
+
+describe("PrismaTrackRepository.update", () => {
+  it("stamps lastActivityAt with current epoch-ms on update", async () => {
+    const before = Date.now();
+
+    const prisma = {
+      track: {
+        update: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as { track: { update: ReturnType<typeof vi.fn> } };
+
+    const repo = new PrismaTrackRepository(prisma);
+    await repo.update("track-1", { status: TrackStatusEnum.Downloading });
+
+    const updateArg = (prisma.track.update as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const stamped = updateArg.data.lastActivityAt;
+    expect(typeof stamped).toBe("bigint");
+    expect(Number(stamped)).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.ts
@@ -1,13 +1,19 @@
-import type { Prisma, Track as DbTrack } from "@prisma/client";
+import type { PrismaClient, Prisma, Track as DbTrack } from "@prisma/client";
 import type { ITrack, TrackStatusEnum } from "@spotiarr/shared";
 import { Track } from "@/domain/entities/track.entity";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
-import { prisma } from "../setup/prisma";
+import { prisma as defaultPrisma } from "../setup/prisma";
 import { jsonToTrackArtists, toTrackStatus, trackArtistsToJson } from "./types";
 
 export class PrismaTrackRepository implements TrackRepository {
+  private readonly prisma: PrismaClient;
+
+  constructor(prismaClient?: PrismaClient) {
+    this.prisma = prismaClient ?? defaultPrisma;
+  }
+
   async findAll(where?: Partial<ITrack>): Promise<Track[]> {
-    const tracks = await prisma.track.findMany({
+    const tracks = await this.prisma.track.findMany({
       where: where as Prisma.TrackWhereInput | undefined,
       include: { playlist: true },
     });
@@ -15,7 +21,7 @@ export class PrismaTrackRepository implements TrackRepository {
   }
 
   async findAllByPlaylist(playlistId: string): Promise<Track[]> {
-    const tracks = await prisma.track.findMany({
+    const tracks = await this.prisma.track.findMany({
       where: { playlistId },
       include: { playlist: true },
       orderBy: { playlistIndex: "asc" },
@@ -24,12 +30,12 @@ export class PrismaTrackRepository implements TrackRepository {
   }
 
   async findOne(id: string): Promise<Track | null> {
-    const track = await prisma.track.findUnique({ where: { id } });
+    const track = await this.prisma.track.findUnique({ where: { id } });
     return track ? this.mapToTrack(track) : null;
   }
 
   async findOneWithPlaylist(id: string): Promise<Track | null> {
-    const track = await prisma.track.findUnique({
+    const track = await this.prisma.track.findUnique({
       where: { id },
       include: { playlist: true },
     });
@@ -39,7 +45,7 @@ export class PrismaTrackRepository implements TrackRepository {
   async save(track: ITrack | Track): Promise<Track> {
     const data = track instanceof Track ? track.toPrimitive() : track;
 
-    const created = await prisma.track.create({
+    const created = await this.prisma.track.create({
       data: {
         id: data.id,
         name: data.name,
@@ -59,6 +65,7 @@ export class PrismaTrackRepository implements TrackRepository {
         error: data.error,
         createdAt: data.createdAt ? BigInt(data.createdAt) : BigInt(Date.now()),
         completedAt: data.completedAt ? BigInt(data.completedAt) : null,
+        lastActivityAt: BigInt(Date.now()),
         playlistId: data.playlistId,
         playlistIndex: data.playlistIndex,
       },
@@ -69,7 +76,7 @@ export class PrismaTrackRepository implements TrackRepository {
   async update(id: string, track: Partial<ITrack> | Track): Promise<void> {
     const data = track instanceof Track ? track.toPrimitive() : track;
 
-    await prisma.track.update({
+    await this.prisma.track.update({
       where: { id },
       data: {
         name: data.name,
@@ -88,24 +95,25 @@ export class PrismaTrackRepository implements TrackRepository {
         status: data.status,
         error: data.error,
         completedAt: data.completedAt ? BigInt(data.completedAt) : undefined,
+        lastActivityAt: BigInt(Date.now()),
         playlistIndex: data.playlistIndex ?? undefined,
       },
     });
   }
 
   async delete(id: string): Promise<void> {
-    await prisma.track.delete({ where: { id } });
+    await this.prisma.track.delete({ where: { id } });
   }
 
   async deleteAll(ids: string[]): Promise<void> {
-    await prisma.track.deleteMany({ where: { id: { in: ids } } });
+    await this.prisma.track.deleteMany({ where: { id: { in: ids } } });
   }
 
-  async findStuckTracks(statuses: TrackStatusEnum[], createdBefore: number): Promise<Track[]> {
-    const tracks = await prisma.track.findMany({
+  async findStuckTracks(statuses: TrackStatusEnum[], activeBefore: number): Promise<Track[]> {
+    const tracks = await this.prisma.track.findMany({
       where: {
         status: { in: statuses },
-        createdAt: { lt: BigInt(createdBefore) },
+        lastActivityAt: { lt: BigInt(activeBefore) },
       },
       include: { playlist: true },
     });
@@ -113,7 +121,7 @@ export class PrismaTrackRepository implements TrackRepository {
   }
 
   async findAllByStatuses(statuses: TrackStatusEnum[]): Promise<Track[]> {
-    const tracks = await prisma.track.findMany({
+    const tracks = await this.prisma.track.findMany({
       where: {
         status: { in: statuses },
       },


### PR DESCRIPTION
## What

Slice 1/5 of the track-recovery subsystem redesign (see audit in engram `architecture/track-recovery-gaps`). Adds a `lastActivityAt` timestamp and re-keys stuck-track detection off it instead of `createdAt`.

- `schema.prisma`: new `lastActivityAt BigInt @default(0)` on Track (BigInt epoch-ms to match the codebase's existing `createdAt`/`completedAt` — Prisma `@updatedAt` is `DateTime` and would break `findStuckTracks`' BigInt comparison).
- Migration: SQLite table-rebuild + **manually-appended backfill** `UPDATE ... SET lastActivityAt = createdAt` (Prisma does not author this; without it every existing row would be `0` and get mass-marked Error on the first cleanup tick).
- `PrismaTrackRepository`: stamps `BigInt(Date.now())` on every `save()` and `update()` (behaves like `@updatedAt`); `findStuckTracks` now filters on `lastActivityAt`.
- Renamed the `findStuckTracks` param `createdBefore → activeBefore` across the domain interface + service so the contract is honest.

## Why

The periodic stuck-track cleanup measured "stuck" by **row age** (`createdAt`), not by inactivity. On a large/slow playlist a track that legitimately starts downloading 30 min after its row was created got marked Error immediately; a retried track kept its old `createdAt` and was re-killed every tick (New⇄Error oscillation, the killer fighting the rescuers). Keying on last activity fixes the false positives and the oscillation — the highest-leverage fix in the redesign, shipped first.

## Verification

- `pnpm --filter backend run test:run` → **710 passed** (5 new repo tests, red-first TDD).
- `tsc --noEmit` → no errors.
- `oxlint` on changed files → ok.
- Fresh adversarial review: 0 blockers; migration statement order verified (backfill runs after INSERT, before DROP, targets the staging table).

## Known follow-up (out of scope here)

Pre-`createdAt`-stamping rows with `createdAt = 0` backfill to `lastActivityAt = 0` and look stale once; the rescue is idempotent/safe (re-enqueue, search jobId dedups). Tracked in the redesign.

## Redesign roadmap (chained, stacked-to-main)

1. **this PR** — lastActivityAt + re-key detection
2. CAS terminal writes + deterministic download jobId + search-worker failed-handler
3. searchAttempts + attempt cap + terminal-error classification
4. global Error drainer (all origins) + remove subscribed-sync re-enqueue
5. Completed↔file reconciliation