### PR TITLE
fix(backend): idempotent terminal writes + download dedup (recovery redesign 2/5)

### DIFF
--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
@@ -211,33 +211,22 @@ describe("DownloadTrackUseCase", () => {
 
   // T2.3 — CAS guard: early return when markDownloadingIfNotAlready returns false
   describe("R2-S1 / R3-S1: idempotent guard via CAS claim", () => {
-    beforeEach(() => {
-      // Add markDownloadingIfNotAlready to the mock repository
-      (
-        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
-      ).markDownloadingIfNotAlready = vi.fn();
-    });
-
     it("returns early without writing Completed when CAS claim fails (track already Downloading)", async () => {
       const track = new Track(makeTrack());
       trackRepository.findOne.mockResolvedValue(track);
-      (
-        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
-      ).markDownloadingIfNotAlready.mockResolvedValue(false);
+      trackRepository.markDownloadingIfNotAlready.mockResolvedValue(false);
 
       await useCase.execute(makeTrack());
 
       // No download attempted and no terminal status written
       expect(youtubeDownloadService.downloadAndFormat).not.toHaveBeenCalled();
-      expect(trackRepository.update).not.toHaveBeenCalled();
+      expect(trackRepository.updateStatusIf).not.toHaveBeenCalled();
     });
 
     it("returns early without enqueueing a second download when track is already Downloading", async () => {
       const track = new Track(makeTrack({ status: TrackStatusEnum.Downloading }));
       trackRepository.findOne.mockResolvedValue(track);
-      (
-        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
-      ).markDownloadingIfNotAlready.mockResolvedValue(false);
+      trackRepository.markDownloadingIfNotAlready.mockResolvedValue(false);
 
       await useCase.execute(makeTrack({ status: TrackStatusEnum.Downloading }));
 
@@ -248,22 +237,28 @@ describe("DownloadTrackUseCase", () => {
       const track = new Track(makeTrack());
       trackRepository.findOne.mockResolvedValue(track);
       trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
-      (
-        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
-      ).markDownloadingIfNotAlready.mockResolvedValue(true);
-      (trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>).updateStatusIf = vi
-        .fn()
-        .mockResolvedValue(true);
 
       await useCase.execute(makeTrack());
 
-      expect(
-        (trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>).updateStatusIf,
-      ).toHaveBeenCalledWith(
+      expect(trackRepository.updateStatusIf).toHaveBeenCalledWith(
         "track-1",
         TrackStatusEnum.Downloading,
         expect.objectContaining({ status: TrackStatusEnum.Completed }),
       );
+    });
+
+    it("skips history and M3U when the completed write was clobbered (updateStatusIf returns false)", async () => {
+      const track = new Track(makeTrack());
+      trackRepository.findOne.mockResolvedValue(track);
+      trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+      // Download succeeds, but the conditional terminal write loses the race
+      // (the row was flipped to Error mid-download by recovery).
+      trackRepository.updateStatusIf.mockResolvedValue(false);
+
+      await useCase.execute(makeTrack());
+
+      expect(downloadHistoryRepository.createFromTrack).not.toHaveBeenCalled();
+      expect(trackPostProcessingService.updatePlaylistM3u).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
@@ -19,6 +19,8 @@ describe("DownloadTrackUseCase", () => {
     findOne: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     findOneWithPlaylist: ReturnType<typeof vi.fn>;
+    markDownloadingIfNotAlready: ReturnType<typeof vi.fn>;
+    updateStatusIf: ReturnType<typeof vi.fn>;
   };
   let youtubeDownloadService: { downloadAndFormat: ReturnType<typeof vi.fn> };
   let trackFileHelper: {
@@ -41,6 +43,8 @@ describe("DownloadTrackUseCase", () => {
       findOne: vi.fn(),
       update: vi.fn().mockResolvedValue(undefined),
       findOneWithPlaylist: vi.fn(),
+      markDownloadingIfNotAlready: vi.fn().mockResolvedValue(true),
+      updateStatusIf: vi.fn().mockResolvedValue(true),
     };
     youtubeDownloadService = { downloadAndFormat: vi.fn().mockResolvedValue({}) };
     trackFileHelper = {
@@ -91,17 +95,18 @@ describe("DownloadTrackUseCase", () => {
     trackRepository.findOne.mockResolvedValue(track);
     trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
 
-    // The same entity instance is mutated in place, so snapshot the status at
-    // each persist call instead of reading the shared reference afterwards.
-    const persistedStatuses: (string | undefined)[] = [];
-    trackRepository.update.mockImplementation((_id, entity: Track) => {
-      persistedStatuses.push(entity.status);
-      return Promise.resolve(undefined);
-    });
-
     await useCase.execute(makeTrack());
 
-    expect(persistedStatuses).toEqual([TrackStatusEnum.Downloading, TrackStatusEnum.Completed]);
+    // Downloading is claimed via the CAS guard, then the terminal write goes
+    // through updateStatusIf (expecting the Downloading state) with Completed.
+    expect(trackRepository.markDownloadingIfNotAlready).toHaveBeenCalledWith(track.id);
+    const [, expectedStatus, patch] = trackRepository.updateStatusIf.mock.calls.at(-1) as [
+      string,
+      TrackStatusEnum,
+      { status?: string },
+    ];
+    expect(expectedStatus).toBe(TrackStatusEnum.Downloading);
+    expect(patch.status).toBe(TrackStatusEnum.Completed);
   });
 
   it("writes history and updates the M3U only after the track is marked completed", async () => {
@@ -112,7 +117,7 @@ describe("DownloadTrackUseCase", () => {
     await useCase.execute(makeTrack());
 
     // Final DB persist (Completed) must happen before M3U generation.
-    const completedUpdateOrder = trackRepository.update.mock.invocationCallOrder[1];
+    const completedUpdateOrder = trackRepository.updateStatusIf.mock.invocationCallOrder[0];
     const m3uOrder = trackPostProcessingService.updatePlaylistM3u.mock.invocationCallOrder[0];
     const historyOrder = downloadHistoryRepository.createFromTrack.mock.invocationCallOrder[0];
 
@@ -138,11 +143,12 @@ describe("DownloadTrackUseCase", () => {
     youtubeDownloadService.downloadAndFormat.mockRejectedValue(new Error("boom"));
 
     const persisted: { status?: string; error?: string }[] = [];
-    trackRepository.update.mockImplementation((_id, entity: Track) => {
-      const { status, error } = entity.toPrimitive();
-      persisted.push({ status, error });
-      return Promise.resolve(undefined);
-    });
+    trackRepository.updateStatusIf.mockImplementation(
+      (_id, _expected, patch: { status?: string; error?: string }) => {
+        persisted.push({ status: patch.status, error: patch.error });
+        return Promise.resolve(true);
+      },
+    );
 
     await useCase.execute(makeTrack());
 
@@ -180,10 +186,12 @@ describe("DownloadTrackUseCase", () => {
     youtubeDownloadService.downloadAndFormat.mockResolvedValue({ durationMs: 215000 });
 
     const persisted: (number | undefined)[] = [];
-    trackRepository.update.mockImplementation((_id, entity: Track) => {
-      persisted.push(entity.toPrimitive().durationMs);
-      return Promise.resolve(undefined);
-    });
+    trackRepository.updateStatusIf.mockImplementation(
+      (_id, _expected, patch: { durationMs?: number }) => {
+        persisted.push(patch.durationMs);
+        return Promise.resolve(true);
+      },
+    );
 
     await useCase.execute(makeTrack());
 
@@ -199,5 +207,63 @@ describe("DownloadTrackUseCase", () => {
     await useCase.execute(makeTrack());
 
     expect(trackFileHelper.getFolderName).toHaveBeenCalledWith(expect.anything(), undefined);
+  });
+
+  // T2.3 — CAS guard: early return when markDownloadingIfNotAlready returns false
+  describe("R2-S1 / R3-S1: idempotent guard via CAS claim", () => {
+    beforeEach(() => {
+      // Add markDownloadingIfNotAlready to the mock repository
+      (
+        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
+      ).markDownloadingIfNotAlready = vi.fn();
+    });
+
+    it("returns early without writing Completed when CAS claim fails (track already Downloading)", async () => {
+      const track = new Track(makeTrack());
+      trackRepository.findOne.mockResolvedValue(track);
+      (
+        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
+      ).markDownloadingIfNotAlready.mockResolvedValue(false);
+
+      await useCase.execute(makeTrack());
+
+      // No download attempted and no terminal status written
+      expect(youtubeDownloadService.downloadAndFormat).not.toHaveBeenCalled();
+      expect(trackRepository.update).not.toHaveBeenCalled();
+    });
+
+    it("returns early without enqueueing a second download when track is already Downloading", async () => {
+      const track = new Track(makeTrack({ status: TrackStatusEnum.Downloading }));
+      trackRepository.findOne.mockResolvedValue(track);
+      (
+        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
+      ).markDownloadingIfNotAlready.mockResolvedValue(false);
+
+      await useCase.execute(makeTrack({ status: TrackStatusEnum.Downloading }));
+
+      expect(youtubeDownloadService.downloadAndFormat).not.toHaveBeenCalled();
+    });
+
+    it("uses updateStatusIf for the terminal write so a stale writer cannot clobber a newer state", async () => {
+      const track = new Track(makeTrack());
+      trackRepository.findOne.mockResolvedValue(track);
+      trackRepository.findOneWithPlaylist.mockResolvedValue(new Track(makeTrack()));
+      (
+        trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>
+      ).markDownloadingIfNotAlready.mockResolvedValue(true);
+      (trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>).updateStatusIf = vi
+        .fn()
+        .mockResolvedValue(true);
+
+      await useCase.execute(makeTrack());
+
+      expect(
+        (trackRepository as unknown as Record<string, ReturnType<typeof vi.fn>>).updateStatusIf,
+      ).toHaveBeenCalledWith(
+        "track-1",
+        TrackStatusEnum.Downloading,
+        expect.objectContaining({ status: TrackStatusEnum.Completed }),
+      );
+    });
   });
 });

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
@@ -1,4 +1,4 @@
-import { type ITrack, PlaylistTypeEnum } from "@spotiarr/shared";
+import { TrackStatusEnum, type ITrack, PlaylistTypeEnum } from "@spotiarr/shared";
 import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
 import type { YoutubeDownloadPort } from "@/application/ports/youtube.port";
 import { AppError } from "@/domain/errors/app-error";
@@ -32,9 +32,11 @@ export class DownloadTrackUseCase {
     // Validate required fields
     this.validateTrack(track.toPrimitive());
 
-    // Update status to Downloading
-    track.markAsDownloading();
-    await this.trackRepository.update(track.id, track);
+    // CAS claim: only proceed if the track is not already Downloading
+    const claimed = await this.trackRepository.markDownloadingIfNotAlready(track.id);
+    if (!claimed) {
+      return;
+    }
     this.eventBus.emit("playlists-updated");
 
     let error: string | undefined;
@@ -50,7 +52,7 @@ export class DownloadTrackUseCase {
       error = getErrorMessage(err);
     }
 
-    // Update final status
+    // Terminal write via CAS so a stale writer cannot clobber a newer state
     if (error) {
       track.markAsError(error);
     } else {
@@ -60,7 +62,11 @@ export class DownloadTrackUseCase {
       track.markAsCompleted();
     }
 
-    await this.trackRepository.update(track.id, track);
+    await this.trackRepository.updateStatusIf(
+      track.id,
+      TrackStatusEnum.Downloading,
+      track.toPrimitive(),
+    );
 
     // Persist in download history when successful
     if (!error) {
@@ -109,7 +115,10 @@ export class DownloadTrackUseCase {
     await this.trackFileHelper.ensureParentDirectory(trackFilePath);
 
     // 1. Download Content
-    const { durationMs } = await this.youtubeDownloadService.downloadAndFormat(track, trackFilePath);
+    const { durationMs } = await this.youtubeDownloadService.downloadAndFormat(
+      track,
+      trackFilePath,
+    );
 
     // 2. Post-Processing (Metadata, Covers, M3U)
     // Delegated to dedicated service to keep Use Case clean

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
@@ -62,14 +62,17 @@ export class DownloadTrackUseCase {
       track.markAsCompleted();
     }
 
-    await this.trackRepository.updateStatusIf(
+    const written = await this.trackRepository.updateStatusIf(
       track.id,
       TrackStatusEnum.Downloading,
       track.toPrimitive(),
     );
 
-    // Persist in download history when successful
-    if (!error) {
+    // Persist in download history only when the completed write actually
+    // landed. If `written` is false the row was clobbered mid-download (e.g.
+    // recovery flipped it to Error), so we must not record history/M3U for a
+    // state that no longer exists in the DB.
+    if (!error && written) {
       // We need playlist info; reload with relations so playlist is present
       // Note: findOneWithPlaylist returns Track entity now
       const persistedTrack = await this.trackRepository.findOneWithPlaylist(track.id);

--- a/apps/backend/src/domain/repositories/track.repository.ts
+++ b/apps/backend/src/domain/repositories/track.repository.ts
@@ -21,4 +21,12 @@ export interface TrackRepository {
   findStuckTracks(statuses: TrackStatusEnum[], activeBefore: number): Promise<Track[]>;
 
   findAllByStatuses(statuses: TrackStatusEnum[]): Promise<Track[]>;
+
+  markDownloadingIfNotAlready(id: string): Promise<boolean>;
+
+  updateStatusIf(
+    id: string,
+    expectedStatus: TrackStatusEnum,
+    patch: Partial<ITrack>,
+  ): Promise<boolean>;
 }

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.test.ts
@@ -145,3 +145,99 @@ describe("PrismaTrackRepository.update", () => {
     expect(Number(stamped)).toBeGreaterThanOrEqual(before);
   });
 });
+
+// T2.1 — markDownloadingIfNotAlready CAS claim
+describe("PrismaTrackRepository.markDownloadingIfNotAlready", () => {
+  describe("R3-S1: returns false when track is already Downloading", () => {
+    it("returns false and does not mutate when count === 0 (already Downloading)", async () => {
+      const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      const result = await repo.markDownloadingIfNotAlready("track-1");
+
+      expect(result).toBe(false);
+      expect(updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "track-1",
+            status: { not: TrackStatusEnum.Downloading },
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("R3-S1 (complement): returns true when track transitions to Downloading", () => {
+    it("returns true when count === 1 (claim succeeded)", async () => {
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      const result = await repo.markDownloadingIfNotAlready("track-1");
+
+      expect(result).toBe(true);
+    });
+
+    it("stamps lastActivityAt on a successful claim", async () => {
+      const before = Date.now();
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      await repo.markDownloadingIfNotAlready("track-1");
+
+      const arg = updateMany.mock.calls[0][0];
+      expect(typeof arg.data.lastActivityAt).toBe("bigint");
+      expect(Number(arg.data.lastActivityAt)).toBeGreaterThanOrEqual(before);
+    });
+  });
+});
+
+// T2.2 — updateStatusIf conditional terminal write
+describe("PrismaTrackRepository.updateStatusIf", () => {
+  describe("R2-S1: applies update when expected status matches", () => {
+    it("returns true when the row is updated (count === 1)", async () => {
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      const result = await repo.updateStatusIf("track-1", TrackStatusEnum.Downloading, {
+        status: TrackStatusEnum.Completed,
+      });
+
+      expect(result).toBe(true);
+      expect(updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: "track-1",
+            status: TrackStatusEnum.Downloading,
+          }),
+        }),
+      );
+    });
+
+    it("stamps lastActivityAt on a successful conditional update", async () => {
+      const before = Date.now();
+      const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      await repo.updateStatusIf("track-1", TrackStatusEnum.Downloading, {
+        status: TrackStatusEnum.Completed,
+      });
+
+      const arg = updateMany.mock.calls[0][0];
+      expect(typeof arg.data.lastActivityAt).toBe("bigint");
+      expect(Number(arg.data.lastActivityAt)).toBeGreaterThanOrEqual(before);
+    });
+  });
+
+  describe("R2-S2: is a no-op when status does not match (stale writer)", () => {
+    it("returns false when count === 0 (status mismatch)", async () => {
+      const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+      const repo = new PrismaTrackRepository(makePrisma({ updateMany }));
+
+      const result = await repo.updateStatusIf("track-1", TrackStatusEnum.Downloading, {
+        status: TrackStatusEnum.Completed,
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient, Prisma, Track as DbTrack } from "@prisma/client";
-import type { ITrack, TrackStatusEnum } from "@spotiarr/shared";
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { Track } from "@/domain/entities/track.entity";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
 import { prisma as defaultPrisma } from "../setup/prisma";
@@ -128,6 +128,33 @@ export class PrismaTrackRepository implements TrackRepository {
       include: { playlist: true },
     });
     return tracks.map((t) => this.mapToTrack(t));
+  }
+
+  async markDownloadingIfNotAlready(id: string): Promise<boolean> {
+    const result = await this.prisma.track.updateMany({
+      where: { id, status: { not: TrackStatusEnum.Downloading } },
+      data: { status: TrackStatusEnum.Downloading, lastActivityAt: BigInt(Date.now()) },
+    });
+    return result.count === 1;
+  }
+
+  async updateStatusIf(
+    id: string,
+    expectedStatus: TrackStatusEnum,
+    patch: Partial<ITrack>,
+  ): Promise<boolean> {
+    const result = await this.prisma.track.updateMany({
+      where: { id, status: expectedStatus },
+      data: {
+        status: patch.status,
+        error: patch.error,
+        completedAt: patch.completedAt ? BigInt(patch.completedAt) : undefined,
+        durationMs: patch.durationMs,
+        youtubeUrl: patch.youtubeUrl,
+        lastActivityAt: BigInt(Date.now()),
+      },
+    });
+    return result.count === 1;
   }
 
   private mapToTrack(track: DbTrack): Track {

--- a/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.ts
@@ -11,7 +11,7 @@ export class BullMqTrackQueueService implements TrackQueueService {
 
   async enqueueDownloadTrack(track: ITrack, options?: { maxRetries?: number }): Promise<void> {
     const attempts = options?.maxRetries ?? 3;
-    const jobId = `download-${track.id}-${Date.now()}`;
+    const jobId = `download-${track.id}`;
 
     await getTrackDownloadQueue().add("download-track", track, {
       jobId,

--- a/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.ts
@@ -21,7 +21,11 @@ export class BullMqTrackQueueService implements TrackQueueService {
         delay: 5000,
       },
       removeOnComplete: true,
-      removeOnFail: false,
+      // Remove failed jobs too: with a deterministic jobId, a lingering
+      // failed job would block any re-enqueue (queue.add with the same id
+      // is a no-op), permanently stranding retries. The failed handler
+      // still fires before removal.
+      removeOnFail: true,
     });
   }
 }

--- a/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
@@ -1,0 +1,109 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const workerListeners: Record<string, (...args: unknown[]) => unknown> = {};
+
+const workerOn = vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
+  workerListeners[event] = cb;
+});
+
+const WorkerMock = vi.fn((..._args: unknown[]) => ({ on: workerOn }));
+
+const trackService = {
+  findOnYoutube: vi.fn(),
+  update: vi.fn(),
+};
+const settingsService = { getNumber: vi.fn() };
+const eventsController = { emit: vi.fn() };
+
+vi.mock("bullmq", () => ({ Worker: WorkerMock }));
+
+vi.mock("../../container", () => ({
+  getContainer: () => ({ trackService, settingsService, eventsController }),
+}));
+
+vi.mock("../setup/environment", () => ({
+  getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
+}));
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return { id: "track-1", name: "Song", artist: "Artist", ...overrides };
+}
+
+describe("createTrackSearchWorker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(workerListeners).forEach((key) => delete workerListeners[key]);
+    settingsService.getNumber.mockResolvedValue(3);
+    trackService.update.mockResolvedValue(undefined);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("configures the BullMQ worker with the search concurrency setting", async () => {
+    const { createTrackSearchWorker } = await import("./track-search.worker");
+    settingsService.getNumber.mockResolvedValue(5);
+
+    await createTrackSearchWorker();
+
+    const options = WorkerMock.mock.calls[0][2] as unknown as { concurrency: number };
+    expect(options.concurrency).toBe(5);
+  });
+
+  // T2.4 — R6-S1: failed handler sets track status to Error
+  describe("R6-S1: failed handler writes Error when a search job fails", () => {
+    it("marks the track as Error and stores the exception message", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      await workerListeners.failed?.(
+        { id: "job-1", data: makeTrack() },
+        new Error("unhandled search failure"),
+      );
+
+      expect(trackService.update).toHaveBeenCalledWith(
+        "track-1",
+        expect.objectContaining({
+          status: TrackStatusEnum.Error,
+          error: "unhandled search failure",
+        }),
+      );
+    });
+
+    it("emits playlists-updated after writing Error", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      await workerListeners.failed?.(
+        { id: "job-1", data: makeTrack() },
+        new Error("search failed"),
+      );
+
+      expect(eventsController.emit).toHaveBeenCalledWith("playlists-updated");
+    });
+
+    it("does nothing when the failed job has no track id", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      await workerListeners.failed?.({ id: "job-2", data: {} }, new Error("search failed"));
+
+      expect(trackService.update).not.toHaveBeenCalled();
+    });
+
+    // R1-S3 (non-regression): failed handler triggers a write that stamps lastActivityAt
+    // We verify this indirectly — trackService.update is called (which calls repo.update,
+    // which stamps lastActivityAt per the existing contract from Slice 1).
+    it("calls trackService.update so that lastActivityAt is stamped via the repo", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      await workerListeners.failed?.(
+        { id: "job-3", data: makeTrack({ id: "track-99" }) },
+        new Error("boom"),
+      );
+
+      expect(trackService.update).toHaveBeenCalledWith("track-99", expect.anything());
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/workers/track-search.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.ts
@@ -1,10 +1,10 @@
-import { type ITrack } from "@spotiarr/shared";
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { Worker } from "bullmq";
 import { getContainer } from "../../container";
 import { getEnv } from "../setup/environment";
 
 export async function createTrackSearchWorker() {
-  const { trackService, settingsService } = getContainer();
+  const { trackService, settingsService, eventsController } = getContainer();
   const concurrency = await settingsService.getNumber("YT_SEARCH_CONCURRENCY");
 
   const worker = new Worker(
@@ -26,8 +26,29 @@ export async function createTrackSearchWorker() {
     console.log(`[TrackSearchWorker] Job ${job.id} completed`);
   });
 
-  worker.on("failed", (job, err) => {
+  worker.on("failed", async (job, err) => {
     console.error(`[TrackSearchWorker] Job ${job?.id} failed:`, err);
+
+    if (job?.data?.id) {
+      const track: ITrack = job.data;
+      const trackId = track.id;
+
+      if (!trackId) {
+        console.error("Cannot update track status: track.id is undefined");
+        return;
+      }
+
+      try {
+        await trackService.update(trackId, {
+          ...track,
+          status: TrackStatusEnum.Error,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        eventsController.emit("playlists-updated");
+      } catch (updateError) {
+        console.error(`Failed to update track ${trackId} status after job failure:`, updateError);
+      }
+    }
   });
 
   console.log(`✅ Track search worker initialized (Concurrency: ${concurrency || 3})`);


### PR DESCRIPTION
## What

Slice 2/5 of the track-recovery redesign. Makes track terminal writes idempotent and deduplicates downloads.

- **CAS repo methods** (`track.repository.ts` + Prisma impl): `markDownloadingIfNotAlready(id)` claims a track via `updateMany` where `status != Downloading` (atomic claim, returns `count === 1`); `updateStatusIf(id, expectedStatus, patch)` writes only when the current status still matches, so a stale writer cannot clobber a newer state.
- **`DownloadTrackUseCase`**: claims via CAS (early-return if the claim fails → no duplicate concurrent download); terminal write goes through `updateStatusIf`; download-history + M3U are written **only when the terminal write actually landed**.
- **Deterministic download jobId** `download-${id}` so BullMQ dedupes concurrent enqueues; paired with `removeOnFail: true` so a failed job can't permanently block re-enqueue.
- **Search worker `failed` handler** now writes Error (previously silent — finding R6).
- Uses `TrackStatusEnum.Downloading` (lowercase) in the CAS query; a capitalized literal would never match stored values and silently defeat the guard.

## Why

The recovery audit found: the stuck-tracks job could mark a track Error while its download job was still live (last-writer-wins clobber → Completed↔Error flip, duplicate downloads), and the download enqueue used a non-deterministic jobId so multiple paths could spawn concurrent downloads to the same path. This slice closes both via a single terminal-write owner (CAS) + deterministic jobId.

## Verification

- `pnpm --filter backend run test:run` → **725 passed** (TDD red-first).
- `tsc --noEmit` → no errors.
- Fresh adversarial review: 3 blockers found and fixed (history/M3U on dropped write; failed-job blocking retries; status casing), plus a new test for the clobbered-write path.

## Reviewer notes (deliberate decisions)

- **CAS uses `not: Downloading` (not `notIn: [Downloading, Completed]`)**: re-claiming a Completed track is not a regression (pre-slice code re-downloaded unconditionally), and excluding Completed here would break slice 5's reconciliation, which intentionally re-downloads Completed-but-missing files. Kept as-is.
- **Search/download worker `failed` handlers use unconditional `update`** (not CAS): mirrors the pre-existing download worker; a search-failed track being concurrently moved to Downloading is not a real path. Left for consistency.

## Roadmap (chained, stacked-to-main)

1. ✅ lastActivityAt + re-key detection (#176, merged)
2. **this PR** — CAS + dedup + search-worker failed handler
3. searchAttempts + attempt cap + terminal-error classification
4. global Error drainer + remove subscribed-sync re-enqueue
5. Completed↔file reconciliation