### PR TITLE
fix(backend): bounded search attempts + terminal-error classification (recovery redesign 3/5)

### DIFF
--- a/apps/backend/prisma/migrations/20260616160000_add_track_search_attempts/migration.sql
+++ b/apps/backend/prisma/migrations/20260616160000_add_track_search_attempts/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Track" ADD COLUMN "searchAttempts" INTEGER NOT NULL DEFAULT 0;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Track {
   createdAt             BigInt  @default(0)
   completedAt           BigInt?
   lastActivityAt        BigInt  @default(0)
+  searchAttempts        Int     @default(0)
   playlistIndex         Int?
 
   playlistId            String?

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
@@ -126,4 +126,115 @@ describe("SearchTrackOnYoutubeUseCase", () => {
       maxRetries: expected,
     });
   });
+
+  // T3.1 — R4-S2: searchAttempts increments on youtube_not_found
+  describe("R4-S2: searchAttempts increments on each failed search attempt", () => {
+    it("increments searchAttempts by 1 when youtube_not_found is returned", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(makeTrack({ searchAttempts: 2 })),
+      );
+      youtubeSearchService.findOnYoutubeOne.mockResolvedValue("");
+
+      const persisted: ITrack[] = [];
+      trackRepository.update.mockImplementation((_id: string, entity: Track) => {
+        persisted.push(entity.toPrimitive());
+        return Promise.resolve(undefined);
+      });
+
+      await useCase.execute(makeTrack({ searchAttempts: 2 }));
+
+      const finalWrite = persisted.at(-1);
+      expect(finalWrite?.searchAttempts).toBe(3);
+    });
+
+    it("increments searchAttempts when the search throws an exception", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(makeTrack({ searchAttempts: 1 })),
+      );
+      youtubeSearchService.findOnYoutubeOne.mockRejectedValue(new Error("yt down"));
+
+      const persisted: ITrack[] = [];
+      trackRepository.update.mockImplementation((_id: string, entity: Track) => {
+        persisted.push(entity.toPrimitive());
+        return Promise.resolve(undefined);
+      });
+
+      await useCase.execute(makeTrack({ searchAttempts: 1 }));
+
+      const finalWrite = persisted.at(-1);
+      expect(finalWrite?.searchAttempts).toBe(2);
+    });
+  });
+
+  // T3.1 — R4-S4: successful search resets searchAttempts to 0 on Queued transition
+  describe("R4-S4: successful search resets searchAttempts to 0", () => {
+    it("resets searchAttempts to 0 when a YouTube URL is found", async () => {
+      // Set SEARCH_MAX_ATTEMPTS high so cap guard doesn't fire on a track with 3 attempts
+      settingsService.getNumber.mockImplementation((key: string) => {
+        if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+        return Promise.resolve(3);
+      });
+
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(makeTrack({ searchAttempts: 3 })),
+      );
+      youtubeSearchService.findOnYoutubeOne.mockResolvedValue("https://youtu.be/abc");
+
+      const persisted: ITrack[] = [];
+      trackRepository.update.mockImplementation((_id: string, entity: Track) => {
+        persisted.push(entity.toPrimitive());
+        return Promise.resolve(undefined);
+      });
+
+      await useCase.execute(makeTrack({ searchAttempts: 3 }));
+
+      const finalWrite = persisted.at(-1);
+      expect(finalWrite?.searchAttempts).toBe(0);
+      expect(finalWrite?.status).toBe(TrackStatusEnum.Queued);
+    });
+  });
+
+  // T3.1 — R4-S1: track at cap is NOT re-enqueued; terminal error is written
+  describe("R4-S1: track at attempt cap stops being re-enqueued", () => {
+    it("writes terminal Error and does not enqueue when searchAttempts >= SEARCH_MAX_ATTEMPTS", async () => {
+      // SEARCH_MAX_ATTEMPTS default is 5; settingsService.getNumber returns 5 for it
+      settingsService.getNumber.mockImplementation((key: string) => {
+        if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+        return Promise.resolve(3);
+      });
+
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(makeTrack({ searchAttempts: 5, status: TrackStatusEnum.Error })),
+      );
+
+      const persisted: ITrack[] = [];
+      trackRepository.update.mockImplementation((_id: string, entity: Track) => {
+        persisted.push(entity.toPrimitive());
+        return Promise.resolve(undefined);
+      });
+
+      await useCase.execute(makeTrack({ searchAttempts: 5, status: TrackStatusEnum.Error }));
+
+      expect(youtubeSearchService.findOnYoutubeOne).not.toHaveBeenCalled();
+      expect(queueService.enqueueDownloadTrack).not.toHaveBeenCalled();
+      const finalWrite = persisted.at(-1);
+      expect(finalWrite?.status).toBe(TrackStatusEnum.Error);
+    });
+
+    it("still searches when searchAttempts is below cap", async () => {
+      settingsService.getNumber.mockImplementation((key: string) => {
+        if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+        return Promise.resolve(3);
+      });
+
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(makeTrack({ searchAttempts: 4 })),
+      );
+      youtubeSearchService.findOnYoutubeOne.mockResolvedValue("https://youtu.be/abc");
+
+      await useCase.execute(makeTrack({ searchAttempts: 4 }));
+
+      expect(youtubeSearchService.findOnYoutubeOne).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
@@ -237,4 +237,52 @@ describe("SearchTrackOnYoutubeUseCase", () => {
       expect(youtubeSearchService.findOnYoutubeOne).toHaveBeenCalledTimes(1);
     });
   });
+
+  // R4 — terminal error codes short-circuit before the cap is reached
+  describe("terminal error classification short-circuits the search", () => {
+    it("does NOT re-search a track with a terminal error code even when below the cap", async () => {
+      settingsService.getNumber.mockImplementation((key: string) => {
+        if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+        return Promise.resolve(3);
+      });
+
+      // youtube_not_found is terminal; attempts (1) are well below the cap (5)
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(
+          makeTrack({
+            searchAttempts: 1,
+            status: TrackStatusEnum.Error,
+            error: "youtube_not_found",
+          }),
+        ),
+      );
+
+      await useCase.execute(
+        makeTrack({ searchAttempts: 1, status: TrackStatusEnum.Error, error: "youtube_not_found" }),
+      );
+
+      expect(youtubeSearchService.findOnYoutubeOne).not.toHaveBeenCalled();
+      expect(queueService.enqueueDownloadTrack).not.toHaveBeenCalled();
+    });
+
+    it("DOES re-search a track with a non-terminal (transient) error below the cap", async () => {
+      settingsService.getNumber.mockImplementation((key: string) => {
+        if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+        return Promise.resolve(3);
+      });
+
+      trackRepository.findOneWithPlaylist.mockResolvedValue(
+        new Track(
+          makeTrack({ searchAttempts: 2, status: TrackStatusEnum.Error, error: "network timeout" }),
+        ),
+      );
+      youtubeSearchService.findOnYoutubeOne.mockResolvedValue("https://youtu.be/abc");
+
+      await useCase.execute(
+        makeTrack({ searchAttempts: 2, status: TrackStatusEnum.Error, error: "network timeout" }),
+      );
+
+      expect(youtubeSearchService.findOnYoutubeOne).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
@@ -29,8 +29,17 @@ export class SearchTrackOnYoutubeUseCase {
     const maxAttempts = await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS");
     const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
 
-    if (existingTrack.searchAttempts >= safeMaxAttempts) {
-      existingTrack.markAsError(existingTrack.toPrimitive().error || "search_attempts_exceeded");
+    // Stop re-driving when the failure is permanent: a known-terminal error
+    // code (e.g. youtube_not_found) is deterministic, so don't burn the
+    // attempt budget re-searching for it; transient errors get re-tried up to
+    // the cap and then settle into a stable terminal Error.
+    const capReached = existingTrack.searchAttempts >= safeMaxAttempts;
+    if (existingTrack.isTerminalError() || capReached) {
+      existingTrack.markAsError(
+        capReached
+          ? "search_attempts_exceeded"
+          : existingTrack.toPrimitive().error || "search_attempts_exceeded",
+      );
       await this.trackRepository.update(track.id, existingTrack);
       this.eventBus.emit("playlists-updated");
       return;

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
@@ -5,6 +5,8 @@ import { EventBus } from "@/domain/events/event-bus";
 import { TrackRepository } from "@/domain/repositories/track.repository";
 import type { TrackQueueService } from "@/domain/services/track-queue.service";
 
+const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
+
 export class SearchTrackOnYoutubeUseCase {
   constructor(
     private readonly trackRepository: TrackRepository,
@@ -21,6 +23,16 @@ export class SearchTrackOnYoutubeUseCase {
 
     const existingTrack = await this.trackRepository.findOneWithPlaylist(track.id);
     if (!existingTrack) {
+      return;
+    }
+
+    const maxAttempts = await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS");
+    const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
+
+    if (existingTrack.searchAttempts >= safeMaxAttempts) {
+      existingTrack.markAsError(existingTrack.toPrimitive().error || "search_attempts_exceeded");
+      await this.trackRepository.update(track.id, existingTrack);
+      this.eventBus.emit("playlists-updated");
       return;
     }
 

--- a/apps/backend/src/domain/entities/track.entity.test.ts
+++ b/apps/backend/src/domain/entities/track.entity.test.ts
@@ -1,0 +1,54 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { describe, expect, it } from "vitest";
+import { Track } from "./track.entity";
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Song",
+    artist: "Artist",
+    status: TrackStatusEnum.New,
+    ...overrides,
+  };
+}
+
+// T3.2 — R4 + R9: Track.isTerminalError() domain method
+describe("Track.isTerminalError()", () => {
+  it("returns true when error is youtube_not_found", () => {
+    const track = new Track(makeTrack({ error: "youtube_not_found" }));
+    expect(track.isTerminalError()).toBe(true);
+  });
+
+  it("returns false for a retryable error message", () => {
+    const track = new Track(makeTrack({ error: "network_error" }));
+    expect(track.isTerminalError()).toBe(false);
+  });
+
+  it("returns false for an arbitrary exception message", () => {
+    const track = new Track(makeTrack({ error: "yt-dlp crashed unexpectedly" }));
+    expect(track.isTerminalError()).toBe(false);
+  });
+
+  it("returns false when error is undefined", () => {
+    const track = new Track(makeTrack({ error: undefined }));
+    expect(track.isTerminalError()).toBe(false);
+  });
+
+  it("returns false when error is null/empty string", () => {
+    const track = new Track(makeTrack({ error: "" }));
+    expect(track.isTerminalError()).toBe(false);
+  });
+});
+
+// T3.2 — searchAttempts getter
+describe("Track.searchAttempts", () => {
+  it("defaults to 0 when not set", () => {
+    const track = new Track(makeTrack());
+    expect(track.searchAttempts).toBe(0);
+  });
+
+  it("exposes the value passed in props", () => {
+    const track = new Track(makeTrack({ searchAttempts: 3 }));
+    expect(track.searchAttempts).toBe(3);
+  });
+});

--- a/apps/backend/src/domain/entities/track.entity.ts
+++ b/apps/backend/src/domain/entities/track.entity.ts
@@ -1,5 +1,7 @@
 import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 
+export const TERMINAL_TRACK_ERROR_CODES = new Set(["youtube_not_found"]);
+
 export class Track {
   constructor(private readonly props: ITrack) {}
 
@@ -27,6 +29,13 @@ export class Track {
   get trackUrl() {
     return this.props.trackUrl;
   }
+  get searchAttempts(): number {
+    return this.props.searchAttempts ?? 0;
+  }
+
+  isTerminalError(): boolean {
+    return !!this.props.error && TERMINAL_TRACK_ERROR_CODES.has(this.props.error);
+  }
 
   markAsDownloading() {
     if (this.props.status === TrackStatusEnum.Completed) {
@@ -53,10 +62,12 @@ export class Track {
   markAsQueued(youtubeUrl: string) {
     this.props.youtubeUrl = youtubeUrl;
     this.props.status = TrackStatusEnum.Queued;
+    this.props.searchAttempts = 0;
   }
 
   markAsSearching() {
     this.props.status = TrackStatusEnum.Searching;
+    this.props.searchAttempts = (this.props.searchAttempts ?? 0) + 1;
   }
 
   markAsNew() {

--- a/apps/backend/src/infrastructure/database/prisma-track.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-track.repository.ts
@@ -97,6 +97,7 @@ export class PrismaTrackRepository implements TrackRepository {
         completedAt: data.completedAt ? BigInt(data.completedAt) : undefined,
         lastActivityAt: BigInt(Date.now()),
         playlistIndex: data.playlistIndex ?? undefined,
+        searchAttempts: data.searchAttempts !== undefined ? data.searchAttempts : undefined,
       },
     });
   }
@@ -179,6 +180,7 @@ export class PrismaTrackRepository implements TrackRepository {
       completedAt: track.completedAt ? Number(track.completedAt) : undefined,
       playlistId: track.playlistId ?? undefined,
       playlistIndex: track.playlistIndex ?? undefined,
+      searchAttempts: track.searchAttempts,
     };
     return new Track(iTrack);
   }

--- a/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
@@ -106,4 +106,39 @@ describe("createTrackSearchWorker", () => {
       expect(trackService.update).toHaveBeenCalledWith("track-99", expect.anything());
     });
   });
+
+  // T3.3 — R6-S2: failed handler increments searchAttempts
+  describe("R6-S2: failed handler increments searchAttempts", () => {
+    it("increments searchAttempts by 1 in the failed handler update payload", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      const trackWithAttempts = makeTrack({ searchAttempts: 2 });
+      await workerListeners.failed?.(
+        { id: "job-4", data: trackWithAttempts },
+        new Error("worker crash"),
+      );
+
+      expect(trackService.update).toHaveBeenCalledWith(
+        "track-1",
+        expect.objectContaining({
+          searchAttempts: 3,
+        }),
+      );
+    });
+
+    it("starts searchAttempts at 1 when the track has no prior attempts", async () => {
+      const { createTrackSearchWorker } = await import("./track-search.worker");
+      await createTrackSearchWorker();
+
+      await workerListeners.failed?.({ id: "job-5", data: makeTrack() }, new Error("crash"));
+
+      expect(trackService.update).toHaveBeenCalledWith(
+        "track-1",
+        expect.objectContaining({
+          searchAttempts: 1,
+        }),
+      );
+    });
+  });
 });

--- a/apps/backend/src/infrastructure/workers/track-search.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.ts
@@ -43,6 +43,7 @@ export async function createTrackSearchWorker() {
           ...track,
           status: TrackStatusEnum.Error,
           error: err instanceof Error ? err.message : String(err),
+          searchAttempts: (track.searchAttempts ?? 0) + 1,
         });
         eventsController.emit("playlists-updated");
       } catch (updateError) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -170,6 +170,7 @@ export interface ITrack {
   completedAt?: number;
   playlistId?: string;
   playlistIndex?: number;
+  searchAttempts?: number;
 }
 
 export interface IPlaylist {


### PR DESCRIPTION
## What

Slice 3/5 of the track-recovery redesign. Bounds search retries so a track can no longer be re-searched forever.

- `searchAttempts Int @default(0)` column on Track + migration (safe `ADD COLUMN`, default 0 for existing rows — no backfill).
- `TERMINAL_TRACK_ERROR_CODES` set (`youtube_not_found`) + `Track.isTerminalError()`.
- `markAsSearching()` increments `searchAttempts`; `markAsQueued()` (success) resets it to 0; `markAsNew()` preserves it (a download failure is not a search failure).
- `SearchTrackOnYoutubeUseCase` cap guard: a **terminal** error code short-circuits immediately (no point re-searching a deterministically-absent track); a **transient** error retries up to `SEARCH_MAX_ATTEMPTS` (default 5) and then settles into a canonical `search_attempts_exceeded` terminal Error.
- Search worker `failed` handler increments `searchAttempts`.

## Why

Audit finding: `youtube_not_found` (and any error) was re-searched on every sync cycle forever — unbounded, never-converging YouTube load. The download path had `attempts`/backoff; the search path had no cap at all. This adds the missing bound and distinguishes deterministic failures (stop fast) from transient ones (retry then stop).

## Verification

- `pnpm --filter backend run test:run` → **741 passed** (TDD red-first; includes terminal-vs-transient short-circuit tests).
- `tsc --noEmit` → no errors.
- Fresh adversarial review: no blockers. Its main finding — `isTerminalError()` was dead code (cap was a pure count check, permanently capping transient errors too) — is fixed in this PR by wiring terminal classification into the guard, with tests.

## Known gap — deferred to slice 4 (documented per review)

`SyncSubscribedPlaylistsUseCase` still re-enqueues every Error track each cycle **without** checking `searchAttempts`/terminal state. The cap stops the *search from executing* (the guard writes Error and returns), but not the *re-enqueue*: a cap-reached track still costs one wasted job + DB writes per sync tick. **Slice 4** removes the sync-side Error re-enqueue and replaces it with a global drainer that skips cap-reached/terminal tracks. Until then the cap is enforced at the search use-case, not at the enqueue site.

## Roadmap (chained, stacked-to-main)

1. ✅ lastActivityAt + re-key detection (#176)
2. ✅ CAS + dedup + search-worker failed handler (#177)
3. **this PR** — searchAttempts + attempt cap + terminal-error classification
4. global Error drainer (skips cap-reached) + remove subscribed-sync re-enqueue
5. Completed↔file reconciliation