### PR TITLE
fix(backend): global Error drainer for all playlist origins (recovery redesign 4/5)

### DIFF
--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -8,10 +8,6 @@ const spotifyCircuitBreaker = {
   isOpen: vi.fn(() => false),
 };
 
-const retryTrackDownloadUseCase = {
-  execute: vi.fn(),
-};
-
 describe("SyncSubscribedPlaylistsUseCase", () => {
   const playlist = new Playlist({
     id: "playlist-1",
@@ -68,6 +64,16 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
     trackService.create.mockResolvedValue(undefined);
   });
 
+  function makeUseCase() {
+    return new SyncSubscribedPlaylistsUseCase(
+      playlistRepository as never,
+      spotifyService as never,
+      trackService as never,
+      eventBus as never,
+      spotifyCircuitBreaker as never,
+    );
+  }
+
   it("dedupes using trackUrl instead of legacy spotifyUrl semantics", async () => {
     const existingTrack: ITrack = {
       name: "Song",
@@ -76,21 +82,12 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
     };
     trackService.getAllByPlaylist.mockResolvedValue([existingTrack]);
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
-
-    await useCase.execute();
+    await makeUseCase().execute();
 
     expect(trackService.create).not.toHaveBeenCalled();
   });
 
-  it("re-enqueues previously errored tracks on subscribed playlists", async () => {
+  it("R5-S5: does NOT re-enqueue Error tracks — responsibility moved to global recovery drainer", async () => {
     const erroredTrack: ITrack = {
       id: "track-err",
       name: "Song",
@@ -100,19 +97,10 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
     };
     trackService.getAllByPlaylist.mockResolvedValue([erroredTrack]);
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
-
-    await useCase.execute();
+    await makeUseCase().execute();
 
     expect(trackService.create).not.toHaveBeenCalled();
-    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-err");
+    expect(eventBus.emit).not.toHaveBeenCalled();
   });
 
   it("does not re-enqueue completed tracks", async () => {
@@ -125,33 +113,15 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
     };
     trackService.getAllByPlaylist.mockResolvedValue([completedTrack]);
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
+    await makeUseCase().execute();
 
-    await useCase.execute();
-
-    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
   });
 
   it("skips the run entirely when the Spotify circuit breaker is open", async () => {
     spotifyCircuitBreaker.isOpen.mockReturnValue(true);
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
-
-    await useCase.execute();
+    await makeUseCase().execute();
 
     expect(playlistRepository.findAll).not.toHaveBeenCalled();
     expect(spotifyService.getPlaylistDetail).not.toHaveBeenCalled();
@@ -170,16 +140,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       new AppError(403, "playlist_not_accessible", "belongs to another user"),
     );
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
-
-    await useCase.execute();
+    await makeUseCase().execute();
 
     expect(thirdParty.subscribed).toBe(false);
     expect(thirdParty.error).toBe("belongs to another user");
@@ -199,16 +160,7 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
       new AppError(503, "circuit_open", "Spotify rate limit circuit breaker is open"),
     );
 
-    const useCase = new SyncSubscribedPlaylistsUseCase(
-      playlistRepository as never,
-      spotifyService as never,
-      trackService as never,
-      eventBus as never,
-      spotifyCircuitBreaker as never,
-      retryTrackDownloadUseCase as never,
-    );
-
-    await useCase.execute();
+    await makeUseCase().execute();
 
     expect(spotifyService.getPlaylistDetail).toHaveBeenCalledTimes(1);
     expect(playlistRepository.update).not.toHaveBeenCalled();

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -1,4 +1,4 @@
-import { PlaylistTypeEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { PlaylistTypeEnum } from "@spotiarr/shared";
 import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
 import { SpotifyService, type PlaylistTrack } from "@/application/services/spotify.service";
 import { AppError } from "@/domain/errors/app-error";
@@ -6,7 +6,6 @@ import { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackService } from "../../services/track.service";
-import type { RetryTrackDownloadUseCase } from "../tracks/retry-track-download.use-case";
 
 const PERMANENTLY_UNAVAILABLE_ERROR_CODES = new Set([
   "playlist_not_accessible",
@@ -24,7 +23,6 @@ export class SyncSubscribedPlaylistsUseCase {
     private readonly trackService: TrackService,
     private readonly eventBus: EventBus,
     private readonly spotifyCircuitBreaker: SpotifyCircuitBreakerPort,
-    private readonly retryTrackDownloadUseCase: RetryTrackDownloadUseCase,
   ) {}
 
   async execute(): Promise<void> {
@@ -148,16 +146,6 @@ export class SyncSubscribedPlaylistsUseCase {
               });
             }),
           );
-        }
-        this.eventBus.emit("playlists-updated");
-      }
-
-      // Error is terminal with no auto-recovery (startup rescue skips it), so re-enqueue stranded tracks each sync.
-      const erroredTracks = existingTracks.filter((t) => t.status === TrackStatusEnum.Error);
-      if (erroredTracks.length > 0) {
-        for (const track of erroredTracks) {
-          if (!track.id) continue;
-          await this.retryTrackDownloadUseCase.execute(track.id);
         }
         this.eventBus.emit("playlists-updated");
       }

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
@@ -1,0 +1,162 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { RecoverErroredTracksUseCase } from "./recover-errored-tracks.use-case";
+
+function makeErrorTrack(overrides: Partial<ITrack> = {}): Track {
+  return new Track({
+    id: "track-err-1",
+    name: "Song",
+    artist: "Artist",
+    status: TrackStatusEnum.Error,
+    searchAttempts: 0,
+    playlistId: "playlist-1",
+    ...overrides,
+  });
+}
+
+describe("RecoverErroredTracksUseCase", () => {
+  const trackRepository = {
+    findAllByStatuses: vi.fn(),
+  };
+
+  const retryTrackDownloadUseCase = {
+    execute: vi.fn(),
+  };
+
+  const spotifyCircuitBreaker = {
+    isOpen: vi.fn(() => false),
+  };
+
+  const settingsService = {
+    getNumber: vi.fn((key: string) => {
+      if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+      return Promise.resolve(0);
+    }),
+  };
+
+  const eventBus = {
+    emit: vi.fn(),
+  };
+
+  let useCase: RecoverErroredTracksUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spotifyCircuitBreaker.isOpen.mockReturnValue(false);
+    settingsService.getNumber.mockImplementation((key: string) => {
+      if (key === "SEARCH_MAX_ATTEMPTS") return Promise.resolve(5);
+      return Promise.resolve(0);
+    });
+    useCase = new RecoverErroredTracksUseCase(
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      spotifyCircuitBreaker as never,
+      settingsService as never,
+      eventBus as never,
+    );
+  });
+
+  it("R5-S1: re-enqueues a track from a spotiarr:// synthetic playlist", async () => {
+    const track = makeErrorTrack({ id: "track-synthetic", playlistId: "playlist-synthetic" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-synthetic");
+  });
+
+  it("R5-S2: re-enqueues a track from an Album-type playlist", async () => {
+    const track = makeErrorTrack({ id: "track-album", playlistId: "playlist-album" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-album");
+  });
+
+  it("R5-S3: re-enqueues a track from a non-subscribed playlist", async () => {
+    const track = makeErrorTrack({ id: "track-nosub", playlistId: "playlist-nosub" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-nosub");
+  });
+
+  it("R5-S4: when circuit breaker is open, returns early without enqueuing any track", async () => {
+    spotifyCircuitBreaker.isOpen.mockReturnValue(true);
+    const track = makeErrorTrack({ id: "track-deferred" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("R5-S4: circuit breaker open does NOT increment searchAttempts", async () => {
+    spotifyCircuitBreaker.isOpen.mockReturnValue(true);
+    const track = makeErrorTrack({ id: "track-deferred", searchAttempts: 4 });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+    expect(track.searchAttempts).toBe(4);
+  });
+
+  it("R4-S1 cross-check: skips a track that has reached the attempt cap", async () => {
+    const track = makeErrorTrack({ id: "track-capped", searchAttempts: 5 });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("R4-S1 cross-check: skips a track with a terminal error code (isTerminalError)", async () => {
+    const track = makeErrorTrack({ id: "track-terminal", error: "youtube_not_found" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("skips terminal tracks but still enqueues eligible tracks in the same batch", async () => {
+    const terminalTrack = makeErrorTrack({ id: "track-terminal", error: "youtube_not_found" });
+    const eligibleTrack = makeErrorTrack({ id: "track-eligible", searchAttempts: 2 });
+    trackRepository.findAllByStatuses.mockResolvedValue([terminalTrack, eligibleTrack]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledTimes(1);
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-eligible");
+  });
+
+  it("emits playlists-updated when at least one track is recovered", async () => {
+    const track = makeErrorTrack({ id: "track-ok" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    await useCase.execute();
+
+    expect(eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("does not emit playlists-updated when no tracks are recovered", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([]);
+
+    await useCase.execute();
+
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("queries the repository for Error-status tracks", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([]);
+
+    await useCase.execute();
+
+    expect(trackRepository.findAllByStatuses).toHaveBeenCalledWith([TrackStatusEnum.Error]);
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
@@ -64,6 +64,9 @@ describe("RecoverErroredTracksUseCase", () => {
     await useCase.execute();
 
     expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-synthetic");
+    // Contract guard: the drain query must be by Error status only, with no
+    // playlist-type/subscription filter — that is what makes recovery global.
+    expect(trackRepository.findAllByStatuses).toHaveBeenCalledWith([TrackStatusEnum.Error]);
   });
 
   it("R5-S2: re-enqueues a track from an Album-type playlist", async () => {

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
@@ -1,0 +1,48 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
+import { EventBus } from "@/domain/events/event-bus";
+import type { TrackRepository } from "@/domain/repositories/track.repository";
+import type { RetryTrackDownloadUseCase } from "./retry-track-download.use-case";
+
+const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
+
+export class RecoverErroredTracksUseCase {
+  constructor(
+    private readonly trackRepository: TrackRepository,
+    private readonly retryTrackDownloadUseCase: RetryTrackDownloadUseCase,
+    private readonly spotifyCircuitBreaker: SpotifyCircuitBreakerPort,
+    private readonly settingsService: SettingsPort,
+    private readonly eventBus: EventBus,
+  ) {}
+
+  async execute(): Promise<void> {
+    if (this.spotifyCircuitBreaker.isOpen()) {
+      console.warn(
+        "[RecoverErroredTracks] Skipping run — Spotify circuit breaker is open. Tracks remain in Error and will be retried on next tick.",
+      );
+      return;
+    }
+
+    const erroredTracks = await this.trackRepository.findAllByStatuses([TrackStatusEnum.Error]);
+
+    const maxAttempts = await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS");
+    const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
+
+    let recovered = 0;
+    for (const track of erroredTracks) {
+      if (!track.id) continue;
+
+      if (track.isTerminalError() || track.searchAttempts >= safeMaxAttempts) {
+        continue;
+      }
+
+      await this.retryTrackDownloadUseCase.execute(track.id);
+      recovered++;
+    }
+
+    if (recovered > 0) {
+      this.eventBus.emit("playlists-updated");
+    }
+  }
+}

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -40,6 +40,7 @@ import { CreateTrackUseCase } from "./application/use-cases/tracks/create-track.
 import { DeleteTrackUseCase } from "./application/use-cases/tracks/delete-track.use-case";
 import { DownloadTrackUseCase } from "./application/use-cases/tracks/download-track.use-case";
 import { GetTracksUseCase } from "./application/use-cases/tracks/get-tracks.use-case";
+import { RecoverErroredTracksUseCase } from "./application/use-cases/tracks/recover-errored-tracks.use-case";
 import { RescueStuckTracksUseCase } from "./application/use-cases/tracks/rescue-stuck-tracks.use-case";
 import { RetryTrackDownloadUseCase } from "./application/use-cases/tracks/retry-track-download.use-case";
 import { SearchTrackOnYoutubeUseCase } from "./application/use-cases/tracks/search-track-on-youtube.use-case";
@@ -480,13 +481,19 @@ export function createContainer(env: Env) {
   const updatePlaylistUseCase = new UpdatePlaylistUseCase(playlistRepository, eventBus);
 
   const spotifyCircuitBreakerAdapter = new SpotifyCircuitBreakerAdapter(appTokenCircuitBreaker);
+  const recoverErroredTracksUseCase = new RecoverErroredTracksUseCase(
+    trackRepository,
+    retryTrackDownloadUseCase,
+    spotifyCircuitBreakerAdapter,
+    settingsService,
+    eventBus,
+  );
   const syncSubscribedPlaylistsUseCase = new SyncSubscribedPlaylistsUseCase(
     playlistRepository,
     spotifyServiceSync,
     trackService,
     eventBus,
     spotifyCircuitBreakerAdapter,
-    retryTrackDownloadUseCase,
   );
   const retryPlaylistDownloadsUseCase = new RetryPlaylistDownloadsUseCase(
     playlistRepository,
@@ -688,6 +695,7 @@ export function createContainer(env: Env) {
     eventBus,
     trackPostProcessingService,
     rescueStuckTracksUseCase,
+    recoverErroredTracksUseCase,
     libraryService,
     feedRepository,
     artworkBackfillRepository,

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -6,6 +6,27 @@ import { startFeedSyncJob } from "./feed-sync.job";
 
 let lastPlaylistCheckTimestamp = 0;
 let lastStuckTracksCleanupTimestamp = 0;
+let lastRecoveryTimestamp = 0;
+
+export const recoverErroredTracksJob = cron.createTask("* * * * *", async () => {
+  try {
+    const { recoverErroredTracksUseCase, settingsService } = getContainer();
+    const intervalMinutes = await settingsService.getNumber("RECOVERY_JOB_INTERVAL_MINUTES");
+    const safeIntervalMinutes = intervalMinutes > 0 ? intervalMinutes : 5;
+    const now = Date.now();
+
+    if (now - lastRecoveryTimestamp < safeIntervalMinutes * 60_000) {
+      return;
+    }
+
+    lastRecoveryTimestamp = now;
+    console.log("[ScheduledJob] Running errored-tracks recovery...");
+    await recoverErroredTracksUseCase.execute();
+    console.log("[ScheduledJob] Errored-tracks recovery completed");
+  } catch (error) {
+    console.error("[ScheduledJob] Error recovering errored tracks:", error);
+  }
+});
 
 export const checkPlaylistsJob = cron.createTask("* * * * *", async () => {
   try {
@@ -76,6 +97,7 @@ export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
 });
 
 export function startScheduledJobs(): void {
+  recoverErroredTracksJob.start();
   checkPlaylistsJob.start();
   cleanStuckTracksJob.start();
   startFeedSyncJob();

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -8,6 +8,11 @@ let lastPlaylistCheckTimestamp = 0;
 let lastStuckTracksCleanupTimestamp = 0;
 let lastRecoveryTimestamp = 0;
 
+// Global Error-recovery: re-drives Error tracks for ALL playlist origins
+// (subscribed, non-subscribed, synthetic spotiarr://, album, AI). This
+// replaces the subscribed-only re-enqueue that used to live in the playlist
+// sync, so subscribed tracks now recover on this interval (default 5 min)
+// instead of waiting for the 60-min playlist sync.
 export const recoverErroredTracksJob = cron.createTask("* * * * *", async () => {
   try {
     const { recoverErroredTracksUseCase, settingsService } = getContainer();

--- a/apps/backend/src/infrastructure/jobs/recover-errored-tracks.job.test.ts
+++ b/apps/backend/src/infrastructure/jobs/recover-errored-tracks.job.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("recoverErroredTracksJob interval guard", () => {
+  const recoverErroredTracksUseCase = {
+    execute: vi.fn(),
+  };
+
+  const settingsService = {
+    getNumber: vi.fn((key: string) => {
+      if (key === "RECOVERY_JOB_INTERVAL_MINUTES") return Promise.resolve(5);
+      return Promise.resolve(0);
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.doMock("../../container", () => ({
+      getContainer: vi.fn(() => ({ recoverErroredTracksUseCase, settingsService })),
+    }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("../../container");
+  });
+
+  it("delegates to RecoverErroredTracksUseCase on first run", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const { recoverErroredTracksJob } = await import("./index");
+
+    await recoverErroredTracksJob.execute();
+
+    expect(recoverErroredTracksUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("interval guard prevents a second run within the configured interval", async () => {
+    vi.setSystemTime(new Date("2026-01-01T01:00:00Z"));
+    const { recoverErroredTracksJob } = await import("./index");
+
+    await recoverErroredTracksJob.execute();
+    expect(recoverErroredTracksUseCase.execute).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(60_000);
+
+    await recoverErroredTracksJob.execute();
+    expect(recoverErroredTracksUseCase.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("interval guard allows a run after the configured interval has elapsed", async () => {
+    vi.setSystemTime(new Date("2026-01-01T02:00:00Z"));
+    const { recoverErroredTracksJob } = await import("./index");
+
+    await recoverErroredTracksJob.execute();
+    expect(recoverErroredTracksUseCase.execute).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(6 * 60_000);
+
+    await recoverErroredTracksJob.execute();
+    expect(recoverErroredTracksUseCase.execute).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## What

Slice 4/5 of the track-recovery redesign. Replaces the subscribed-only Error re-enqueue with a global recovery drainer.

- New `RecoverErroredTracksUseCase`: `findAllByStatuses([Error])` (no playlist filter), defers entirely when the Spotify circuit breaker is open, skips terminal (`isTerminalError()`) and cap-reached (`searchAttempts >= SEARCH_MAX_ATTEMPTS`) tracks, otherwise re-drives each via `retryTrackDownloadUseCase`.
- New `recoverErroredTracksJob` cron (interval guard, `RECOVERY_JOB_INTERVAL_MINUTES`, default 5 min), wired into `startScheduledJobs()`.
- **Removed** the Error re-enqueue block from `SyncSubscribedPlaylistsUseCase` (and dropped `retryTrackDownloadUseCase` from its constructor) — recovery is no longer the sync's responsibility.
- DI wiring in `container.ts`.

## Why

Audit gap #2: `cleanStuckTracksJob` marks tracks Error globally, but only the subscribed-playlist sync ever drained Error — so Error tracks on non-subscribed / synthetic `spotiarr://` / album / AI playlists never auto-recovered (manual retry only). And it closes the slice-3 enforcement gap: the drainer skips cap-reached/terminal tracks, so the attempt cap is now enforced at the enqueue site, not just inside the search use-case.

Net behavior change: subscribed tracks now recover on the 5-min drainer interval instead of waiting for the 60-min playlist sync — faster, and uniform across all origins.

## Verification

- `pnpm --filter backend run test:run` → **755 passed** (TDD red-first; covers all-origin coverage, breaker-defer-without-budget, skip terminal/cap, mixed batch, sync regression).
- `tsc --noEmit` → no errors.
- Fresh adversarial review: no blockers. The 3 correctness invariants (global query, breaker early-return before any per-track work, skip-check reads persisted Error state before `markAsNew` clears it) verified sound. Addressed: added a contract-guard assertion that the drain query has no playlist filter; documented the recovery-interval change. (Reviewer's "1min→5min slowdown" warning was based on a wrong premise — the old sync recovery ran on the 60-min throttle, so this is faster, not slower.)

## Roadmap (chained, stacked-to-main)

1. ✅ lastActivityAt + re-key detection (#176)
2. ✅ CAS + dedup + search-worker failed handler (#177)
3. ✅ searchAttempts + attempt cap + terminal-error classification (#178)
4. **this PR** — global Error drainer + remove subscribed-sync re-enqueue
5. Completed↔file reconciliation (final slice)