### PR TITLE
fix(backend): reconcile Completed tracks with missing files (recovery redesign 5/5)

### DIFF
--- a/apps/backend/src/application/ports/file-system.port.ts
+++ b/apps/backend/src/application/ports/file-system.port.ts
@@ -24,6 +24,7 @@ export interface FileSystemTrackPathPort {
 
 export interface FileSystemScannerPort {
   scanMusicLibrary(libraryPath: string): Promise<LibraryArtist[]>;
+  fileExists(filePath: string): Promise<boolean>;
 }
 
 export interface MetadataPort {

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
@@ -18,6 +18,7 @@ function makeCompletedTrack(overrides: Partial<ITrack> = {}): Track {
 describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () => {
   const scannerService = {
     scanMusicLibrary: vi.fn(),
+    fileExists: vi.fn(),
   };
 
   const pathService = {
@@ -50,6 +51,9 @@ describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () =>
   beforeEach(() => {
     vi.clearAllMocks();
     scannerService.scanMusicLibrary.mockResolvedValue([]);
+    // Default: file absent on disk (reconciliation triggers). Present-file
+    // tests override fileExists to true.
+    scannerService.fileExists.mockResolvedValue(false);
     settingsService.getNumber.mockImplementation(async (key: string) => {
       if (key === "SEARCH_MAX_ATTEMPTS") return 5;
       return 0;
@@ -60,9 +64,7 @@ describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () =>
     const track = makeCompletedTrack({ id: "track-missing" });
     trackRepository.findAllByStatuses.mockResolvedValue([track]);
     pathService.getFolderName.mockResolvedValue("/music/Artist/Song.mp3");
-
-    // scanMusicLibrary returns no files → the expected path is absent
-    scannerService.scanMusicLibrary.mockResolvedValue([]);
+    scannerService.fileExists.mockResolvedValue(false);
 
     const useCase = new ScanLibraryUseCase(
       scannerService as never,
@@ -83,22 +85,8 @@ describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () =>
 
     const presentFilePath = "/music/Artist/Song.mp3";
     pathService.getFolderName.mockResolvedValue(presentFilePath);
-
-    // scanMusicLibrary returns a structure whose flat file list includes the path
-    scannerService.scanMusicLibrary.mockResolvedValue([
-      {
-        name: "Artist",
-        albumCount: 1,
-        trackCount: 1,
-        totalSize: 1000,
-        albums: [
-          {
-            name: "Album",
-            tracks: [{ name: "Song", filePath: presentFilePath, duration: 180 }],
-          },
-        ],
-      },
-    ]);
+    // File is present on disk → no re-drive.
+    scannerService.fileExists.mockResolvedValue(true);
 
     const useCase = new ScanLibraryUseCase(
       scannerService as never,
@@ -110,6 +98,7 @@ describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () =>
 
     await useCase.execute();
 
+    expect(scannerService.fileExists).toHaveBeenCalledWith(presentFilePath);
     expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
   });
 
@@ -206,6 +195,7 @@ describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () =>
 describe("ScanLibraryUseCase — T5.2 path-parity: reconciliation uses same getFolderName as DownloadTrackUseCase", () => {
   const scannerService = {
     scanMusicLibrary: vi.fn(),
+    fileExists: vi.fn(),
   };
 
   const pathService = {
@@ -238,6 +228,7 @@ describe("ScanLibraryUseCase — T5.2 path-parity: reconciliation uses same getF
   beforeEach(() => {
     vi.clearAllMocks();
     scannerService.scanMusicLibrary.mockResolvedValue([]);
+    scannerService.fileExists.mockResolvedValue(true);
   });
 
   const playlistRepository = {

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
@@ -1,0 +1,412 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { ScanLibraryUseCase } from "./scan-library.use-case";
+
+function makeCompletedTrack(overrides: Partial<ITrack> = {}): Track {
+  return new Track({
+    id: "track-completed-1",
+    name: "Song",
+    artist: "Artist",
+    status: TrackStatusEnum.Completed,
+    searchAttempts: 0,
+    playlistId: "playlist-1",
+    ...overrides,
+  });
+}
+
+describe("ScanLibraryUseCase — Completed file reconciliation (Slice 5)", () => {
+  const scannerService = {
+    scanMusicLibrary: vi.fn(),
+  };
+
+  const pathService = {
+    getMusicLibraryPath: vi.fn(() => "/music"),
+    getFolderName: vi.fn(),
+    getTrackFileName: vi.fn(),
+    getPlaylistFolderPath: vi.fn(),
+    getArtistFolderPath: vi.fn(),
+    getAlbumFolderPath: vi.fn(),
+    ensureParentDirectory: vi.fn(),
+  };
+
+  const trackRepository = {
+    findAllByStatuses: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+  };
+
+  const retryTrackDownloadUseCase = {
+    execute: vi.fn(),
+  };
+
+  const settingsService = {
+    getNumber: vi.fn(async (key: string) => {
+      if (key === "SEARCH_MAX_ATTEMPTS") return 5;
+      return 0;
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+    settingsService.getNumber.mockImplementation(async (key: string) => {
+      if (key === "SEARCH_MAX_ATTEMPTS") return 5;
+      return 0;
+    });
+  });
+
+  it("R7-S1: Completed track with missing file is re-driven via retryTrackDownloadUseCase", async () => {
+    const track = makeCompletedTrack({ id: "track-missing" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+    pathService.getFolderName.mockResolvedValue("/music/Artist/Song.mp3");
+
+    // scanMusicLibrary returns no files → the expected path is absent
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-missing");
+  });
+
+  it("R7-S2 / R10-S1: Completed track with present file remains Completed and is NOT re-enqueued", async () => {
+    const track = makeCompletedTrack({ id: "track-present" });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    const presentFilePath = "/music/Artist/Song.mp3";
+    pathService.getFolderName.mockResolvedValue(presentFilePath);
+
+    // scanMusicLibrary returns a structure whose flat file list includes the path
+    scannerService.scanMusicLibrary.mockResolvedValue([
+      {
+        name: "Artist",
+        albumCount: 1,
+        trackCount: 1,
+        totalSize: 1000,
+        albums: [
+          {
+            name: "Album",
+            tracks: [{ name: "Song", filePath: presentFilePath, duration: 180 }],
+          },
+        ],
+      },
+    ]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("R7-S3: file-missing re-drive does NOT increment searchAttempts on the track", async () => {
+    const track = makeCompletedTrack({ id: "track-missing-2", searchAttempts: 0 });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+    pathService.getFolderName.mockResolvedValue("/music/Artist/Song.mp3");
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    // retryTrackDownloadUseCase is called, not a direct searchAttempts mutation
+    // The reconciliation path must NOT touch searchAttempts (it delegates to retryTrackDownloadUseCase)
+    // Track entity still at 0 — no increment happened
+    expect(track.searchAttempts).toBe(0);
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-missing-2");
+  });
+
+  it("cap-reached track (searchAttempts >= max) is skipped even if file is missing", async () => {
+    const track = makeCompletedTrack({ id: "track-capped", searchAttempts: 5 });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+    pathService.getFolderName.mockResolvedValue("/music/Artist/Song.mp3");
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("terminal-error track is skipped even if file is missing", async () => {
+    const track = makeCompletedTrack({
+      id: "track-terminal",
+      searchAttempts: 3,
+      error: "youtube_not_found",
+    });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+    pathService.getFolderName.mockResolvedValue("/music/Artist/Song.mp3");
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("a failure in per-track reconciliation does NOT abort the overall scan", async () => {
+    const failingTrack = makeCompletedTrack({ id: "track-fail" });
+    const goodTrack = makeCompletedTrack({ id: "track-ok" });
+    trackRepository.findAllByStatuses.mockResolvedValue([failingTrack, goodTrack]);
+
+    pathService.getFolderName
+      .mockRejectedValueOnce(new Error("path resolution failed"))
+      .mockResolvedValueOnce("/music/Artist/Song2.mp3");
+
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await expect(useCase.execute()).resolves.not.toThrow();
+    // good track's file is also absent → retried
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-ok");
+  });
+});
+
+describe("ScanLibraryUseCase — T5.2 path-parity: reconciliation uses same getFolderName as DownloadTrackUseCase", () => {
+  const scannerService = {
+    scanMusicLibrary: vi.fn(),
+  };
+
+  const pathService = {
+    getMusicLibraryPath: vi.fn(() => "/music"),
+    getFolderName: vi.fn(),
+    getTrackFileName: vi.fn(),
+    getPlaylistFolderPath: vi.fn(),
+    getArtistFolderPath: vi.fn(),
+    getAlbumFolderPath: vi.fn(),
+    ensureParentDirectory: vi.fn(),
+  };
+
+  const trackRepository = {
+    findAllByStatuses: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+  };
+
+  const retryTrackDownloadUseCase = {
+    execute: vi.fn(),
+  };
+
+  const settingsService = {
+    getNumber: vi.fn(async (key: string) => {
+      if (key === "SEARCH_MAX_ATTEMPTS") return 5;
+      return 0;
+    }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+  });
+
+  it("T5.2: reconciliation calls pathService.getFolderName with the same (track, playlistName) args as DownloadTrackUseCase would — playlist-type track", async () => {
+    const track = makeCompletedTrack({
+      id: "track-playlist",
+      playlistId: "playlist-1",
+      // playlistType is not on ITrack directly; the reconciliation uses track.toPrimitive()
+    });
+    trackRepository.findAllByStatuses.mockResolvedValue([track]);
+
+    const expectedPath = "/music/Playlists/My Playlist/Artist - Song.mp3";
+    pathService.getFolderName.mockResolvedValue(expectedPath);
+
+    // File is present — no re-drive expected. Purpose of this test is to
+    // assert getFolderName is called with the track primitives.
+    scannerService.scanMusicLibrary.mockResolvedValue([
+      {
+        name: "Artist",
+        albumCount: 1,
+        trackCount: 1,
+        totalSize: 1000,
+        albums: [
+          {
+            name: "Album",
+            tracks: [{ name: "Song", filePath: expectedPath, duration: 180 }],
+          },
+        ],
+      },
+    ]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    // The reconciliation MUST call getFolderName with (trackPrimitive, undefined)
+    // because the scan use-case has no playlist names — it uses the same
+    // getFolderName path derivation that DownloadTrackUseCase uses for
+    // Artist/Album type tracks (no playlistName → album folder).
+    expect(pathService.getFolderName).toHaveBeenCalledWith(track.toPrimitive(), undefined);
+  });
+
+  it("T5.2: when a non-Playlist/non-AI track path is used, getFolderName is called without playlistName — produces the same path as DownloadTrackUseCase for Album/Artist type", async () => {
+    const albumTrack = makeCompletedTrack({
+      id: "track-album",
+      playlistId: undefined,
+    });
+    trackRepository.findAllByStatuses.mockResolvedValue([albumTrack]);
+
+    const albumPath = "/music/Artist/Album/Song.mp3";
+    pathService.getFolderName.mockResolvedValue(albumPath);
+
+    scannerService.scanMusicLibrary.mockResolvedValue([
+      {
+        name: "Artist",
+        albumCount: 1,
+        trackCount: 1,
+        totalSize: 1000,
+        albums: [
+          {
+            name: "Album",
+            tracks: [{ name: "Song", filePath: albumPath, duration: 180 }],
+          },
+        ],
+      },
+    ]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    expect(pathService.getFolderName).toHaveBeenCalledWith(albumTrack.toPrimitive(), undefined);
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("T5.2: path parity — track with Playlist type gets playlistName passed if playlist is resolved (design note: scan-use-case passes undefined; parity test for Album)", async () => {
+    // This test validates that for Album-type tracks (no playlistName needed),
+    // the path produced by getFolderName(track, undefined) matches what
+    // DownloadTrackUseCase produces for Album/Artist tracks.
+    // For Playlist/AI types, DownloadTrackUseCase passes the playlist name;
+    // the reconciliation cannot resolve playlist names efficiently at scan time
+    // so it passes undefined — this is a known minor divergence, documented here.
+    // The critical invariant: for Album/Artist tracks the paths ARE identical.
+    const albumTrack = makeCompletedTrack({ id: "track-album-parity", playlistId: undefined });
+    trackRepository.findAllByStatuses.mockResolvedValue([albumTrack]);
+
+    pathService.getFolderName.mockImplementation(async (track: ITrack, playlistName?: string) => {
+      if (playlistName) {
+        return `/music/Playlists/${playlistName}/${track.artist} - ${track.name}.mp3`;
+      }
+      return `/music/${track.artist}/${track.name}.mp3`;
+    });
+
+    const expectedPath = "/music/Artist/Song.mp3";
+    scannerService.scanMusicLibrary.mockResolvedValue([
+      {
+        name: "Artist",
+        albumCount: 1,
+        trackCount: 1,
+        totalSize: 1000,
+        albums: [
+          {
+            name: "Album",
+            tracks: [{ name: "Song", filePath: expectedPath, duration: 180 }],
+          },
+        ],
+      },
+    ]);
+
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+      retryTrackDownloadUseCase as never,
+      settingsService as never,
+    );
+
+    await useCase.execute();
+
+    // File IS present → no re-drive
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+});
+
+describe("ScanLibraryUseCase — works without retryTrackDownloadUseCase (backward compat)", () => {
+  const scannerService = {
+    scanMusicLibrary: vi.fn(),
+  };
+
+  const pathService = {
+    getMusicLibraryPath: vi.fn(() => "/music"),
+    getFolderName: vi.fn(),
+    getTrackFileName: vi.fn(),
+    getPlaylistFolderPath: vi.fn(),
+    getArtistFolderPath: vi.fn(),
+    getAlbumFolderPath: vi.fn(),
+    ensureParentDirectory: vi.fn(),
+  };
+
+  const trackRepository = {
+    findAllByStatuses: vi.fn(),
+    findOne: vi.fn(),
+    findOneWithPlaylist: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    scannerService.scanMusicLibrary.mockResolvedValue([]);
+    trackRepository.findAllByStatuses.mockResolvedValue([]);
+  });
+
+  it("executes without error when retryTrackDownloadUseCase is not injected", async () => {
+    const useCase = new ScanLibraryUseCase(
+      scannerService as never,
+      pathService as never,
+      trackRepository as never,
+    );
+
+    await expect(useCase.execute()).resolves.not.toThrow();
+  });
+});

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.test.ts
@@ -1,4 +1,4 @@
-import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { PlaylistTypeEnum, TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Track } from "@/domain/entities/track.entity";
 import { ScanLibraryUseCase } from "./scan-library.use-case";
@@ -240,19 +240,28 @@ describe("ScanLibraryUseCase — T5.2 path-parity: reconciliation uses same getF
     scannerService.scanMusicLibrary.mockResolvedValue([]);
   });
 
-  it("T5.2: reconciliation calls pathService.getFolderName with the same (track, playlistName) args as DownloadTrackUseCase would — playlist-type track", async () => {
+  const playlistRepository = {
+    findOne: vi.fn(),
+  };
+
+  it("T5.2: resolves the playlist name and calls getFolderName with the SAME (track, playlistName) args as DownloadTrackUseCase — playlist-type track", async () => {
     const track = makeCompletedTrack({
       id: "track-playlist",
       playlistId: "playlist-1",
-      // playlistType is not on ITrack directly; the reconciliation uses track.toPrimitive()
     });
     trackRepository.findAllByStatuses.mockResolvedValue([track]);
+    // A Playlist-type playlist contributes its name to the path, exactly as
+    // DownloadTrackUseCase does — so the reconciliation must look it up too.
+    playlistRepository.findOne.mockResolvedValue({
+      type: PlaylistTypeEnum.Playlist,
+      name: "My Playlist",
+    });
 
     const expectedPath = "/music/Playlists/My Playlist/Artist - Song.mp3";
     pathService.getFolderName.mockResolvedValue(expectedPath);
 
-    // File is present — no re-drive expected. Purpose of this test is to
-    // assert getFolderName is called with the track primitives.
+    // File is present — no re-drive expected. Purpose is to assert the path
+    // derivation uses the resolved playlist name.
     scannerService.scanMusicLibrary.mockResolvedValue([
       {
         name: "Artist",
@@ -274,15 +283,14 @@ describe("ScanLibraryUseCase — T5.2 path-parity: reconciliation uses same getF
       trackRepository as never,
       retryTrackDownloadUseCase as never,
       settingsService as never,
+      playlistRepository as never,
     );
 
     await useCase.execute();
 
-    // The reconciliation MUST call getFolderName with (trackPrimitive, undefined)
-    // because the scan use-case has no playlist names — it uses the same
-    // getFolderName path derivation that DownloadTrackUseCase uses for
-    // Artist/Album type tracks (no playlistName → album folder).
-    expect(pathService.getFolderName).toHaveBeenCalledWith(track.toPrimitive(), undefined);
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("playlist-1");
+    expect(pathService.getFolderName).toHaveBeenCalledWith(track.toPrimitive(), "My Playlist");
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
   });
 
   it("T5.2: when a non-Playlist/non-AI track path is used, getFolderName is called without playlistName — produces the same path as DownloadTrackUseCase for Album/Artist type", async () => {

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
@@ -1,9 +1,10 @@
-import { TrackStatusEnum, type LibraryScanResult } from "@spotiarr/shared";
+import { PlaylistTypeEnum, TrackStatusEnum, type LibraryScanResult } from "@spotiarr/shared";
 import type {
   FileSystemScannerPort,
   FileSystemTrackPathPort,
 } from "@/application/ports/file-system.port";
 import type { SettingsPort } from "@/application/ports/settings.port";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
 import type { RetryTrackDownloadUseCase } from "../tracks/retry-track-download.use-case";
 
@@ -16,6 +17,7 @@ export class ScanLibraryUseCase {
     private readonly trackRepository?: TrackRepository,
     private readonly retryTrackDownloadUseCase?: RetryTrackDownloadUseCase,
     private readonly settingsService?: SettingsPort,
+    private readonly playlistRepository?: PlaylistRepository,
   ) {}
 
   async execute(): Promise<LibraryScanResult> {
@@ -71,6 +73,24 @@ export class ScanLibraryUseCase {
             : DEFAULT_SEARCH_MAX_ATTEMPTS;
           const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
 
+          // Resolve playlist names the SAME way DownloadTrackUseCase does, so
+          // the reconciliation path matches what the download actually wrote.
+          // Only Playlist/AI tracks live under the playlist folder; album and
+          // artist downloads do not. Cache per playlistId to avoid N queries.
+          const playlistNameCache = new Map<string, string | undefined>();
+          const resolvePlaylistName = async (playlistId?: string): Promise<string | undefined> => {
+            if (!playlistId || !this.playlistRepository) return undefined;
+            if (playlistNameCache.has(playlistId)) return playlistNameCache.get(playlistId);
+            const playlist = await this.playlistRepository.findOne(playlistId);
+            const name =
+              playlist &&
+              (playlist.type === PlaylistTypeEnum.Playlist || playlist.type === PlaylistTypeEnum.Ai)
+                ? playlist.name
+                : undefined;
+            playlistNameCache.set(playlistId, name);
+            return name;
+          };
+
           for (const track of completedTracks) {
             if (!track.id) continue;
 
@@ -80,18 +100,9 @@ export class ScanLibraryUseCase {
             }
 
             try {
-              // Resolve the expected on-disk path using the SAME derivation as
-              // DownloadTrackUseCase: getFolderName(track, playlistName).
-              // The scan use-case does not have playlist names in scope, so it
-              // passes undefined. This is correct for Album/Artist tracks; for
-              // Playlist/AI tracks the path will differ from what the download
-              // wrote (which included the playlist name). This is a documented
-              // minor divergence — a false-negative (missing detection skipped)
-              // for Playlist/AI tracks rather than a false-positive (spurious re-download).
-              const expectedPath = await this.pathService.getFolderName(
-                track.toPrimitive(),
-                undefined,
-              );
+              const trackData = track.toPrimitive();
+              const playlistName = await resolvePlaylistName(trackData.playlistId);
+              const expectedPath = await this.pathService.getFolderName(trackData, playlistName);
 
               if (!scannedPaths.has(expectedPath)) {
                 await this.retryTrackDownloadUseCase.execute(track.id);

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
@@ -3,13 +3,19 @@ import type {
   FileSystemScannerPort,
   FileSystemTrackPathPort,
 } from "@/application/ports/file-system.port";
+import type { SettingsPort } from "@/application/ports/settings.port";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
+import type { RetryTrackDownloadUseCase } from "../tracks/retry-track-download.use-case";
+
+const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
 
 export class ScanLibraryUseCase {
   constructor(
     private readonly scannerService: FileSystemScannerPort,
     private readonly pathService: FileSystemTrackPathPort,
     private readonly trackRepository?: TrackRepository,
+    private readonly retryTrackDownloadUseCase?: RetryTrackDownloadUseCase,
+    private readonly settingsService?: SettingsPort,
   ) {}
 
   async execute(): Promise<LibraryScanResult> {
@@ -20,19 +26,27 @@ export class ScanLibraryUseCase {
 
     const artists = await this.scannerService.scanMusicLibrary(libraryPath);
 
-    // Try to attach duration from DB if available
     if (this.trackRepository) {
+      // Build the set of scanned file paths once for O(1) membership checks
+      const scannedPaths = new Set<string>();
+      for (const artist of artists) {
+        for (const album of artist.albums) {
+          for (const track of album.tracks) {
+            scannedPaths.add(track.filePath);
+          }
+        }
+      }
+
       try {
         const completedTracks = await this.trackRepository.findAllByStatuses([
           TrackStatusEnum.Completed,
         ]);
 
-        // Build map for quick lookup. A precise match requires matching title and artist.
+        // Attach durations from DB
         const dbTrackMap = new Map<string, number>();
         for (const t of completedTracks) {
           const trackData = t.toPrimitive();
           if (trackData.durationMs) {
-            // Simplified key: lowercase artist + name to maximize matches
             const key = `${trackData.artist.toLowerCase()} - ${trackData.name.toLowerCase()}`;
             dbTrackMap.set(key, trackData.durationMs);
           }
@@ -44,9 +58,46 @@ export class ScanLibraryUseCase {
               const key = `${artist.name.toLowerCase()} - ${track.name.toLowerCase()}`;
               const durationMs = dbTrackMap.get(key);
               if (!track.duration && durationMs) {
-                // frontend expects duration in seconds (based on frontend's * 1000)
                 track.duration = Math.round(durationMs / 1000);
               }
+            }
+          }
+        }
+
+        // Completed-file reconciliation pass
+        if (this.retryTrackDownloadUseCase) {
+          const maxAttempts = this.settingsService
+            ? await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS")
+            : DEFAULT_SEARCH_MAX_ATTEMPTS;
+          const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
+
+          for (const track of completedTracks) {
+            if (!track.id) continue;
+
+            // Skip permanently-unfindable tracks — re-driving them would loop forever
+            if (track.isTerminalError() || track.searchAttempts >= safeMaxAttempts) {
+              continue;
+            }
+
+            try {
+              // Resolve the expected on-disk path using the SAME derivation as
+              // DownloadTrackUseCase: getFolderName(track, playlistName).
+              // The scan use-case does not have playlist names in scope, so it
+              // passes undefined. This is correct for Album/Artist tracks; for
+              // Playlist/AI tracks the path will differ from what the download
+              // wrote (which included the playlist name). This is a documented
+              // minor divergence — a false-negative (missing detection skipped)
+              // for Playlist/AI tracks rather than a false-positive (spurious re-download).
+              const expectedPath = await this.pathService.getFolderName(
+                track.toPrimitive(),
+                undefined,
+              );
+
+              if (!scannedPaths.has(expectedPath)) {
+                await this.retryTrackDownloadUseCase.execute(track.id);
+              }
+            } catch (err) {
+              console.warn(`[ScanLibrary] Reconciliation failed for track ${track.id}:`, err);
             }
           }
         }

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
@@ -29,16 +29,6 @@ export class ScanLibraryUseCase {
     const artists = await this.scannerService.scanMusicLibrary(libraryPath);
 
     if (this.trackRepository) {
-      // Build the set of scanned file paths once for O(1) membership checks
-      const scannedPaths = new Set<string>();
-      for (const artist of artists) {
-        for (const album of artist.albums) {
-          for (const track of album.tracks) {
-            scannedPaths.add(track.filePath);
-          }
-        }
-      }
-
       try {
         const completedTracks = await this.trackRepository.findAllByStatuses([
           TrackStatusEnum.Completed,
@@ -102,9 +92,13 @@ export class ScanLibraryUseCase {
             try {
               const trackData = track.toPrimitive();
               const playlistName = await resolvePlaylistName(trackData.playlistId);
+              // Check the file directly at the path the download wrote (same
+              // getFolderName derivation), so parity is guaranteed and the
+              // check also covers the Playlists/ zone that the library scan
+              // intentionally skips.
               const expectedPath = await this.pathService.getFolderName(trackData, playlistName);
 
-              if (!scannedPaths.has(expectedPath)) {
+              if (!(await this.scannerService.fileExists(expectedPath))) {
                 await this.retryTrackDownloadUseCase.execute(track.id);
               }
             } catch (err) {

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -539,6 +539,8 @@ export function createContainer(env: Env) {
     fileSystemScannerService,
     trackFileHelper,
     trackRepository,
+    retryTrackDownloadUseCase,
+    settingsService,
   );
   const libraryService = new LibraryService(scanLibraryUseCase);
   const libraryAudioService = new FileSystemLibraryAudioService(() => env.DOWNLOADS);

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -541,6 +541,7 @@ export function createContainer(env: Env) {
     trackRepository,
     retryTrackDownloadUseCase,
     settingsService,
+    playlistRepository,
   );
   const libraryService = new LibraryService(scanLibraryUseCase);
   const libraryAudioService = new FileSystemLibraryAudioService(() => env.DOWNLOADS);


### PR DESCRIPTION
## What

Final slice (5/5) of the track-recovery redesign. Detects Completed tracks whose audio file is gone from disk and re-downloads them.

- `ScanLibraryUseCase` gains a reconciliation pass: for each Completed track, derive its expected path with the SAME `getFolderName(track, playlistName)` the download used, and if `fileExists` is false, re-drive via `retryTrackDownloadUseCase`.
- Playlist name resolved exactly like `DownloadTrackUseCase` (Playlist/AI types only, cached per playlistId) via an injected `PlaylistRepository`.
- Skips terminal/cap-reached tracks; per-track work wrapped in try/catch so one failure never aborts the scan.
- Runs on the existing library scan (triggered by the download worker's queue-drain).

## Why

Audit finding #1 (CRITICAL): a Completed track whose file is deleted (manual cleanup, volume remount, permission change, partial write) was never detected or re-downloaded — `scan-library` read Completed tracks read-only and never reconciled. This closes the last open gap in the redesign.

## Verification

- `pnpm --filter backend run test:run` → **765 passed** (TDD red-first: missing→redrive, present→untouched, terminal/cap skipped, playlist-name parity, per-track failure isolation).
- `tsc --noEmit` → no errors.
- Fresh adversarial review found **2 CRITICAL blockers**, both fixed before this PR:
  - The reconciliation first built a present-file set from the library scan tree — but the scanner **intentionally skips the `Playlists/` directory**, while playlist tracks are stored under `Music/Playlists/`. So every Completed playlist track looked missing → library-wide re-download storm. **Fixed** by checking existence directly with `scannerService.fileExists(getFolderName(...))`, which covers the Playlists/ zone and guarantees path parity with what the download wrote.
  - An earlier shortcut passed `undefined` playlist name (would never match playlist paths). **Fixed** by resolving the playlist name the same way the download does.
- Reviewer's `searchAttempts`-increment warning does not apply: a Completed track retains its `youtubeUrl`, so the re-drive skips search (`markAsQueued` resets `searchAttempts` to 0) rather than incrementing.

## Roadmap — redesign COMPLETE after this merge

1. ✅ lastActivityAt + re-key detection (#176)
2. ✅ CAS + dedup + search-worker failed handler (#177)
3. ✅ searchAttempts + attempt cap + terminal-error classification (#178)
4. ✅ global Error drainer + remove subscribed-sync re-enqueue (#179)
5. **this PR** — Completed↔file reconciliation