### PR TITLE
fix(backend): stuck-tracks killer uses CAS (close recovery WARNING-1)

### DIFF
--- a/apps/backend/src/application/services/track.service.ts
+++ b/apps/backend/src/application/services/track.service.ts
@@ -61,6 +61,14 @@ export class TrackService {
     await this.updateTrackUseCase.execute(id, track);
   }
 
+  async updateStatusIf(
+    id: string,
+    expectedStatus: TrackStatusEnum,
+    patch: Partial<ITrack>,
+  ): Promise<boolean> {
+    return this.updateTrackUseCase.executeIfStatus(id, expectedStatus, patch);
+  }
+
   async retry(id: string): Promise<void> {
     return this.retryTrackDownloadUseCase.execute(id);
   }

--- a/apps/backend/src/application/use-cases/tracks/update-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/update-track.use-case.test.ts
@@ -1,0 +1,54 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UpdateTrackUseCase } from "./update-track.use-case";
+
+describe("UpdateTrackUseCase", () => {
+  const trackRepository = {
+    update: vi.fn().mockResolvedValue(undefined),
+    updateStatusIf: vi.fn(),
+  };
+
+  let useCase: UpdateTrackUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new UpdateTrackUseCase(trackRepository as never);
+  });
+
+  it("execute delegates an unconditional update to the repository", async () => {
+    await useCase.execute("track-1", { status: TrackStatusEnum.Completed });
+
+    expect(trackRepository.update).toHaveBeenCalledWith("track-1", {
+      status: TrackStatusEnum.Completed,
+    });
+  });
+
+  describe("executeIfStatus (CAS)", () => {
+    it("delegates to repository.updateStatusIf with the expected status and patch", async () => {
+      trackRepository.updateStatusIf.mockResolvedValue(true);
+
+      const applied = await useCase.executeIfStatus("track-1", TrackStatusEnum.Searching, {
+        status: TrackStatusEnum.Error,
+        error: "stuck",
+      });
+
+      expect(applied).toBe(true);
+      expect(trackRepository.updateStatusIf).toHaveBeenCalledWith(
+        "track-1",
+        TrackStatusEnum.Searching,
+        { status: TrackStatusEnum.Error, error: "stuck" },
+      );
+    });
+
+    it("returns false when the row moved out of the expected status (no clobber)", async () => {
+      trackRepository.updateStatusIf.mockResolvedValue(false);
+
+      const applied = await useCase.executeIfStatus("track-1", TrackStatusEnum.Downloading, {
+        status: TrackStatusEnum.Error,
+        error: "stuck",
+      });
+
+      expect(applied).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/update-track.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/update-track.use-case.ts
@@ -1,4 +1,4 @@
-import type { ITrack } from "@spotiarr/shared";
+import type { ITrack, TrackStatusEnum } from "@spotiarr/shared";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
 
 export class UpdateTrackUseCase {
@@ -6,5 +6,19 @@ export class UpdateTrackUseCase {
 
   async execute(id: string, track: Partial<ITrack>): Promise<void> {
     await this.trackRepository.update(id, track);
+  }
+
+  /**
+   * Conditional (CAS) update: applies the patch only if the track is still in
+   * `expectedStatus`. Returns false if the row moved on in the meantime, so a
+   * background writer (e.g. the stuck-tracks killer) cannot clobber a track
+   * that legitimately progressed between the read and the write.
+   */
+  async executeIfStatus(
+    id: string,
+    expectedStatus: TrackStatusEnum,
+    patch: Partial<ITrack>,
+  ): Promise<boolean> {
+    return this.trackRepository.updateStatusIf(id, expectedStatus, patch);
   }
 }

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -82,9 +82,12 @@ export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
     if (stuckTracks.length > 0) {
       console.log(`[ScheduledJob] Found ${stuckTracks.length} stuck tracks, marking as error`);
       for (const track of stuckTracks) {
-        if (track.id) {
-          await trackService.update(track.id, {
-            ...track,
+        if (track.id && track.status) {
+          // CAS: only mark Error if the track is STILL in the stuck status we
+          // observed. If it progressed (e.g. download completed) between the
+          // query and now, the write is a no-op — the killer must not clobber
+          // a track that legitimately moved on.
+          await trackService.updateStatusIf(track.id, track.status, {
             status: TrackStatusEnum.Error,
             error:
               track.error ||


### PR DESCRIPTION
## What

`cleanStuckTracksJob` now marks stuck tracks Error via a conditional CAS write instead of an unconditional `update()`.

- `UpdateTrackUseCase.executeIfStatus(id, expectedStatus, patch)` → delegates to the repository's `updateStatusIf` (added in slice 2).
- `TrackService.updateStatusIf` passthrough (keeps the job within service→use-case→repository layering).
- The job passes the track's observed stuck status as the expected status.

## Why

Verify WARNING-1 (track-recovery redesign): the stuck-tracks killer used `update()` unconditionally, so it could clobber a track that legitimately progressed (e.g. a download that completed) between the stuck query and the write — flipping a now-Completed row to Error and triggering a needless re-download. The download-side CAS (slice 2) already made "Error vs Completed" deterministic in one direction; this closes the symmetric direction.

## Verification

- `pnpm --filter backend run test:run` → **771 passed** (3 new UpdateTrackUseCase CAS tests).
- `tsc --noEmit` → no errors.

This was the only open follow-up from the track-recovery redesign verify report. The remaining SUGGESTION (`markAsDownloading()` dead code) is cosmetic and left as-is.