### PR TITLE
fix(frontend): translate recovery settings labels (i18n)

### DIFF
--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -361,6 +361,14 @@
         "label": "Maximum download retries",
         "description": "How many times to retry a failed download before giving up."
       },
+      "SEARCH_MAX_ATTEMPTS": {
+        "label": "Maximum search attempts",
+        "description": "How many times to retry finding a track on YouTube before marking it permanently failed."
+      },
+      "RECOVERY_JOB_INTERVAL_MINUTES": {
+        "label": "Error recovery interval (minutes)",
+        "description": "How often to re-drive errored tracks across all playlists."
+      },
       "STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES": {
         "label": "Stuck tracks cleanup interval (minutes)",
         "description": "How often to check for and clean up stuck tracks."

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -361,6 +361,14 @@
         "label": "Intentos máximos de descarga",
         "description": "Cuántas veces reintentar una descarga fallida antes de rendirse."
       },
+      "SEARCH_MAX_ATTEMPTS": {
+        "label": "Intentos máximos de búsqueda",
+        "description": "Cuántas veces reintentar encontrar una pista en YouTube antes de marcarla como fallida permanentemente."
+      },
+      "RECOVERY_JOB_INTERVAL_MINUTES": {
+        "label": "Intervalo de recuperación de errores (minutos)",
+        "description": "Con qué frecuencia reintentar las pistas con error en todas las listas."
+      },
       "STUCK_TRACKS_CLEANUP_INTERVAL_MINUTES": {
         "label": "Intervalo de limpieza de pistas atascadas (minutos)",
         "description": "¿Con qué frecuencia comprobar y limpiar pistas atascadas?"


### PR DESCRIPTION
## What

Adds i18n `label`/`description` entries for `SEARCH_MAX_ATTEMPTS` and `RECOVERY_JOB_INTERVAL_MINUTES` to `en.json` and `es.json`.

## Why

Both keys were registered in `SETTINGS_METADATA` (PR #181) but had no translation entries, so the settings UI fell back to the raw English metadata labels — visible as untranslated "Maximum search attempts" / "Error recovery interval (minutes)" in a Spanish UI.

## Verification

- JSON validated (both files parse).
- Vite hot-reloaded the locales in the running dev app; labels now render translated.