### PR TITLE
test(frontend): unit tests for 9 service modules

### DIFF
--- a/apps/frontend/src/services/artist.service.test.ts
+++ b/apps/frontend/src/services/artist.service.test.ts
@@ -1,0 +1,98 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { artistService } from "./artist.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("artistService", () => {
+  describe("getReleases", () => {
+    it("calls httpClient.get with FEED/releases and returns the result", async () => {
+      const payload = [{ id: "r1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getReleases();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.FEED}/releases`);
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getFollowedArtists", () => {
+    it("calls httpClient.get with FEED/artists and returns the result", async () => {
+      const payload = [{ id: "a1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getFollowedArtists();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.FEED}/artists`);
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getArtistDetail", () => {
+    it("calls httpClient.get with ARTIST/{id}?limit=<default> when limit is omitted", async () => {
+      const payload = { id: "a1", name: "Artist" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getArtistDetail("a1");
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.ARTIST}/a1?limit=12`);
+      expect(result).toBe(payload);
+    });
+
+    it("calls httpClient.get with ARTIST/{id}?limit=<custom> when limit is provided", async () => {
+      const payload = { id: "a1", name: "Artist" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getArtistDetail("a1", 5);
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.ARTIST}/a1?limit=5`);
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getArtistAlbums", () => {
+    it("calls httpClient.get with default limit and offset when not provided", async () => {
+      const payload = [{ id: "album1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getArtistAlbums("a1");
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.ARTIST}/a1/albums?limit=50&offset=0`,
+      );
+      expect(result).toBe(payload);
+    });
+
+    it("calls httpClient.get with custom limit and offset when provided", async () => {
+      const payload = [{ id: "album1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getArtistAlbums("a1", 20, 40);
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.ARTIST}/a1/albums?limit=20&offset=40`,
+      );
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getAlbumTracks", () => {
+    it("calls httpClient.get with ARTIST/{artistId}/albums/{albumId}/tracks and returns the result", async () => {
+      const payload = [{ id: "t1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await artistService.getAlbumTracks("a1", "alb1");
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.ARTIST}/a1/albums/alb1/tracks`);
+      expect(result).toBe(payload);
+    });
+  });
+});

--- a/apps/frontend/src/services/artworkBackfill.service.test.ts
+++ b/apps/frontend/src/services/artworkBackfill.service.test.ts
@@ -1,0 +1,39 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { fetchArtworkBackfillStatus, startArtworkBackfill } from "./artworkBackfill.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("artworkBackfill service", () => {
+  describe("fetchArtworkBackfillStatus", () => {
+    it("calls httpClient.get with LIBRARY/artwork-backfill/status and returns result.data", async () => {
+      const data = { total: 10, processed: 5 };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await fetchArtworkBackfillStatus();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.LIBRARY}/artwork-backfill/status`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("startArtworkBackfill", () => {
+    it("calls httpClient.post with LIBRARY/artwork-backfill/start and returns result.data", async () => {
+      const data = { jobId: "job-1" };
+      vi.mocked(httpClient.post).mockResolvedValueOnce({ data });
+
+      const result = await startArtworkBackfill();
+
+      expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.LIBRARY}/artwork-backfill/start`);
+      expect(result).toBe(data);
+    });
+  });
+});

--- a/apps/frontend/src/services/external-url.service.test.ts
+++ b/apps/frontend/src/services/external-url.service.test.ts
@@ -1,0 +1,82 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { externalUrlService } from "./external-url.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("externalUrlService", () => {
+  describe("resolve", () => {
+    it("builds the query with required params only when name and artistName are omitted", async () => {
+      const payload = { url: "https://example.com" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await externalUrlService.resolve({
+        provider: "spotify",
+        type: "artist",
+        id: "abc123",
+      });
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.EXTERNAL_URL}?provider=spotify&type=artist&id=abc123`,
+      );
+      expect(result).toBe(payload);
+    });
+
+    it("appends name to query when provided", async () => {
+      const payload = { url: "https://example.com" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      await externalUrlService.resolve({
+        provider: "deezer",
+        type: "track",
+        id: "t1",
+        name: "My Track",
+      });
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      expect(callArg).toContain("name=My+Track");
+      expect(callArg).toContain("provider=deezer");
+      expect(callArg).not.toContain("artist=");
+    });
+
+    it("appends artist to query when artistName is provided", async () => {
+      const payload = { url: "https://example.com" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      await externalUrlService.resolve({
+        provider: "spotify",
+        type: "album",
+        id: "alb1",
+        artistName: "Some Artist",
+      });
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      expect(callArg).toContain("artist=Some+Artist");
+      expect(callArg).not.toContain("name=");
+    });
+
+    it("appends both name and artist when both are provided", async () => {
+      const payload = { url: "https://example.com" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      await externalUrlService.resolve({
+        provider: "deezer",
+        type: "track",
+        id: "t2",
+        name: "Track Name",
+        artistName: "Artist Name",
+      });
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      expect(callArg).toContain("name=Track+Name");
+      expect(callArg).toContain("artist=Artist+Name");
+    });
+  });
+});

--- a/apps/frontend/src/services/history.service.test.ts
+++ b/apps/frontend/src/services/history.service.test.ts
@@ -1,0 +1,38 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { historyService } from "./history.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("historyService", () => {
+  describe("getDownloadHistory", () => {
+    it("calls httpClient.get with HISTORY/downloads and returns response.data", async () => {
+      const data = [{ id: "p1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await historyService.getDownloadHistory();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.HISTORY}/downloads`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("getDownloadTracks", () => {
+    it("calls httpClient.get with HISTORY/tracks and returns response.data", async () => {
+      const data = [{ id: "t1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await historyService.getDownloadTracks();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.HISTORY}/tracks`);
+      expect(result).toBe(data);
+    });
+  });
+});

--- a/apps/frontend/src/services/library.service.test.ts
+++ b/apps/frontend/src/services/library.service.test.ts
@@ -1,0 +1,81 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import {
+  fetchLibraryArtist,
+  fetchLibraryArtists,
+  fetchLibraryStats,
+  scanLibrary,
+} from "./library.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("library service", () => {
+  describe("fetchLibraryStats", () => {
+    it("calls httpClient.get with LIBRARY/stats and returns result.data", async () => {
+      const data = { total: 100 };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await fetchLibraryStats();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.LIBRARY}/stats`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("fetchLibraryArtists", () => {
+    it("calls httpClient.get with LIBRARY/artists and returns result.data", async () => {
+      const data = [{ name: "Artist A" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await fetchLibraryArtists();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.LIBRARY}/artists`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("fetchLibraryArtist", () => {
+    it("encodes the artist name and calls httpClient.get with LIBRARY/artists/{encodedName}", async () => {
+      const data = { name: "AC/DC", path: "/music/ac-dc" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await fetchLibraryArtist({ name: "AC/DC", path: "/music/ac-dc" });
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.LIBRARY}/artists/${encodeURIComponent("AC/DC")}`,
+      );
+      expect(result).toBe(data);
+    });
+
+    it("encodes names with spaces correctly", async () => {
+      const data = { name: "The Beatles", path: "/music/the-beatles" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      await fetchLibraryArtist({ name: "The Beatles", path: "/music/the-beatles" });
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.LIBRARY}/artists/${encodeURIComponent("The Beatles")}`,
+      );
+    });
+  });
+
+  describe("scanLibrary", () => {
+    it("calls httpClient.post with LIBRARY/scan and returns result.data", async () => {
+      const data = { scanned: 42 };
+      vi.mocked(httpClient.post).mockResolvedValueOnce({ data });
+
+      const result = await scanLibrary();
+
+      expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.LIBRARY}/scan`);
+      expect(result).toBe(data);
+    });
+  });
+});

--- a/apps/frontend/src/services/playlist.service.test.ts
+++ b/apps/frontend/src/services/playlist.service.test.ts
@@ -1,0 +1,185 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiError, httpClient } from "@/services/httpClient";
+import { playlistService } from "./playlist.service";
+
+vi.mock("@/services/httpClient", () => ({
+  ApiError: class ApiError extends Error {
+    code?: string;
+    status?: number;
+    constructor(message: string, code?: string, status?: number) {
+      super(message);
+      this.name = "ApiError";
+      this.code = code;
+      this.status = status;
+    }
+  },
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("playlistService", () => {
+  describe("getPlaylists", () => {
+    it("calls httpClient.get with PLAYLIST and returns response.data", async () => {
+      const data = [{ id: "p1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await playlistService.getPlaylists();
+
+      expect(httpClient.get).toHaveBeenCalledWith(ApiRoutes.PLAYLIST);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("getMyPlaylists", () => {
+    it("calls httpClient.get with PLAYLIST/me and returns the result", async () => {
+      const payload = [{ id: "sp1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await playlistService.getMyPlaylists();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.PLAYLIST}/me`);
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getDownloadStatus", () => {
+    it("calls httpClient.get with PLAYLIST/status and returns the result", async () => {
+      const payload = { status: "idle" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const result = await playlistService.getDownloadStatus();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.PLAYLIST}/status`);
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getPlaylistPreview", () => {
+    it("calls httpClient.get with PLAYLIST/preview?url=<encoded> and returns the result", async () => {
+      const payload = { name: "My Playlist" };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const spotifyUrl = "https://open.spotify.com/playlist/abc";
+      const result = await playlistService.getPlaylistPreview(spotifyUrl);
+
+      const expectedParams = new URLSearchParams({ url: spotifyUrl });
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.PLAYLIST}/preview?${expectedParams.toString()}`,
+      );
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("getPlaylistPreviewTracksPage", () => {
+    it("calls httpClient.get with PLAYLIST/preview/tracks?url=...&offset=...&limit=... and returns the result", async () => {
+      const payload = { tracks: [], total: 0 };
+      vi.mocked(httpClient.get).mockResolvedValueOnce(payload);
+
+      const spotifyUrl = "https://open.spotify.com/playlist/abc";
+      const result = await playlistService.getPlaylistPreviewTracksPage(spotifyUrl, 20, 10);
+
+      const expectedParams = new URLSearchParams({
+        url: spotifyUrl,
+        offset: "20",
+        limit: "10",
+      });
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.PLAYLIST}/preview/tracks?${expectedParams.toString()}`,
+      );
+      expect(result).toBe(payload);
+    });
+  });
+
+  describe("createPlaylist", () => {
+    it("calls httpClient.post with PLAYLIST and input, then returns the result", async () => {
+      const input = {
+        kind: "spotifyUrl" as const,
+        spotifyUrl: "https://open.spotify.com/playlist/abc",
+      };
+      const payload = { id: "p1", ...input };
+      vi.mocked(httpClient.post).mockResolvedValueOnce(payload);
+
+      const result = await playlistService.createPlaylist(input);
+
+      expect(httpClient.post).toHaveBeenCalledWith(ApiRoutes.PLAYLIST, input);
+      expect(result).toBe(payload);
+    });
+
+    it("re-throws ApiError with invalid_playlist_payload code when httpClient throws that error", async () => {
+      const original = new ApiError("some message", "invalid_playlist_payload", 422);
+      vi.mocked(httpClient.post).mockRejectedValueOnce(original);
+
+      await expect(
+        playlistService.createPlaylist({
+          kind: "spotifyUrl",
+          spotifyUrl: "https://open.spotify.com/playlist/abc",
+        }),
+      ).rejects.toMatchObject({ code: "invalid_playlist_payload" });
+    });
+
+    it("re-throws other errors without remapping", async () => {
+      const other = new Error("network failure");
+      vi.mocked(httpClient.post).mockRejectedValueOnce(other);
+
+      await expect(
+        playlistService.createPlaylist({
+          kind: "spotifyUrl",
+          spotifyUrl: "https://open.spotify.com/playlist/abc",
+        }),
+      ).rejects.toBe(other);
+    });
+  });
+
+  describe("updatePlaylist", () => {
+    it("calls httpClient.put with PLAYLIST/{id} and data", async () => {
+      vi.mocked(httpClient.put).mockResolvedValueOnce(undefined);
+
+      await playlistService.updatePlaylist("p1", { name: "Updated" });
+
+      expect(httpClient.put).toHaveBeenCalledWith(`${ApiRoutes.PLAYLIST}/p1`, { name: "Updated" });
+    });
+
+    it("re-throws ApiError with invalid_playlist_payload code when httpClient throws that error", async () => {
+      const original = new ApiError("some message", "invalid_playlist_payload", 422);
+      vi.mocked(httpClient.put).mockRejectedValueOnce(original);
+
+      await expect(playlistService.updatePlaylist("p1", { name: "Bad" })).rejects.toMatchObject({
+        code: "invalid_playlist_payload",
+      });
+    });
+
+    it("re-throws other errors without remapping", async () => {
+      const other = new Error("network failure");
+      vi.mocked(httpClient.put).mockRejectedValueOnce(other);
+
+      await expect(playlistService.updatePlaylist("p1", { name: "Bad" })).rejects.toBe(other);
+    });
+  });
+
+  describe("retryFailedTracks", () => {
+    it("calls httpClient.post with PLAYLIST/{id}/retry and returns the result", async () => {
+      vi.mocked(httpClient.post).mockResolvedValueOnce(undefined);
+
+      await playlistService.retryFailedTracks("p1");
+
+      expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.PLAYLIST}/p1/retry`);
+    });
+  });
+
+  describe("deletePlaylist", () => {
+    it("calls httpClient.delete with PLAYLIST/{id} and returns the result", async () => {
+      vi.mocked(httpClient.delete).mockResolvedValueOnce(undefined);
+
+      await playlistService.deletePlaylist("p1");
+
+      expect(httpClient.delete).toHaveBeenCalledWith(`${ApiRoutes.PLAYLIST}/p1`);
+    });
+  });
+});

--- a/apps/frontend/src/services/search.service.test.ts
+++ b/apps/frontend/src/services/search.service.test.ts
@@ -1,0 +1,70 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { SearchService } from "./search.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("SearchService", () => {
+  describe("searchCatalog", () => {
+    it("builds URL with encoded query and default limit when types is omitted", async () => {
+      const data = { artists: [] };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await SearchService.searchCatalog("hello world");
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.SEARCH}?q=${encodeURIComponent("hello world")}&limit=10`,
+      );
+      expect(result).toBe(data);
+    });
+
+    it("builds URL with custom limit when provided", async () => {
+      const data = { artists: [] };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      await SearchService.searchCatalog("test", undefined, 5);
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        `${ApiRoutes.SEARCH}?q=${encodeURIComponent("test")}&limit=5`,
+      );
+    });
+
+    it("appends types param as comma-separated list when types is provided", async () => {
+      const data = { artists: [], tracks: [] };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      await SearchService.searchCatalog("test", ["artist", "track"]);
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      // The service builds types via Array.join(",") — not URLSearchParams — so commas are literal
+      expect(callArg).toContain("types=artist,track");
+    });
+
+    it("does not append types param when types array is empty", async () => {
+      const data = {};
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      await SearchService.searchCatalog("test", []);
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      expect(callArg).not.toContain("types=");
+    });
+
+    it("encodes special characters in query", async () => {
+      const data = {};
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      await SearchService.searchCatalog("AC/DC & more");
+
+      const callArg = vi.mocked(httpClient.get).mock.calls[0][0] as string;
+      expect(callArg).toContain(`q=${encodeURIComponent("AC/DC & more")}`);
+    });
+  });
+});

--- a/apps/frontend/src/services/settings.service.test.ts
+++ b/apps/frontend/src/services/settings.service.test.ts
@@ -1,0 +1,62 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { settingsService } from "./settings.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("settingsService", () => {
+  describe("getSettings", () => {
+    it("calls httpClient.get with SETTINGS and returns response.data", async () => {
+      const data = [{ key: "theme", value: "dark" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await settingsService.getSettings();
+
+      expect(httpClient.get).toHaveBeenCalledWith(ApiRoutes.SETTINGS);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("updateSettings", () => {
+    it("calls httpClient.put with SETTINGS and wrapped settings array", async () => {
+      vi.mocked(httpClient.put).mockResolvedValueOnce(undefined);
+
+      const settings = [{ key: "theme", value: "light" }];
+      await settingsService.updateSettings(settings);
+
+      expect(httpClient.put).toHaveBeenCalledWith(ApiRoutes.SETTINGS, { settings });
+    });
+  });
+
+  describe("getSupportedFormats", () => {
+    it("calls httpClient.get with SETTINGS/formats and returns response.data", async () => {
+      const data = [{ format: "mp3" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await settingsService.getSupportedFormats();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.SETTINGS}/formats`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("getSettingsMetadata", () => {
+    it("calls httpClient.get with SETTINGS/metadata and returns response.data", async () => {
+      const data = { theme: { label: "Theme", type: "select" } };
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await settingsService.getSettingsMetadata();
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.SETTINGS}/metadata`);
+      expect(result).toBe(data);
+    });
+  });
+});

--- a/apps/frontend/src/services/track.service.test.ts
+++ b/apps/frontend/src/services/track.service.test.ts
@@ -1,0 +1,48 @@
+import { ApiRoutes } from "@spotiarr/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { httpClient } from "@/services/httpClient";
+import { trackService } from "./track.service";
+
+vi.mock("@/services/httpClient", () => ({
+  httpClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+afterEach(() => vi.clearAllMocks());
+
+describe("trackService", () => {
+  describe("getTracksByPlaylist", () => {
+    it("calls httpClient.get with TRACK/playlist/{playlistId} and returns response.data", async () => {
+      const data = [{ id: "t1" }];
+      vi.mocked(httpClient.get).mockResolvedValueOnce({ data });
+
+      const result = await trackService.getTracksByPlaylist("p1");
+
+      expect(httpClient.get).toHaveBeenCalledWith(`${ApiRoutes.TRACK}/playlist/p1`);
+      expect(result).toBe(data);
+    });
+  });
+
+  describe("retryTrack", () => {
+    it("calls httpClient.post with TRACK/{id}/retry and returns the result", async () => {
+      vi.mocked(httpClient.post).mockResolvedValueOnce(undefined);
+
+      await trackService.retryTrack("t1");
+
+      expect(httpClient.post).toHaveBeenCalledWith(`${ApiRoutes.TRACK}/t1/retry`);
+    });
+  });
+
+  describe("deleteTrack", () => {
+    it("calls httpClient.delete with TRACK/{id} and returns the result", async () => {
+      vi.mocked(httpClient.delete).mockResolvedValueOnce(undefined);
+
+      await trackService.deleteTrack("t1");
+
+      expect(httpClient.delete).toHaveBeenCalledWith(`${ApiRoutes.TRACK}/t1`);
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds characterization unit tests for the 9 previously-untested frontend service modules: `artist`, `artworkBackfill`, `external-url`, `history`, `library`, `playlist`, `search`, `settings`, `track`.

## Why

Frontend service layer had no direct unit coverage. These tests pin current behavior of the `httpClient` contract (verb, route, payload) so regressions in URL building or error mapping surface immediately. Part of raising frontend coverage toward the ratchet goal (#149).

## Coverage notes

- `playlist.service`: covers `invalid_playlist_payload` error remap path **and** passthrough of other errors for `createPlaylist`/`updatePlaylist`.
- `library.service`: `encodeURIComponent` on artist names (e.g. `AC/DC`).
- `external-url.service`: all 4 combinations of optional `name`/`artistName`.
- `search.service`: no-types vs has-types branch, literal comma in `types` query param.
- `artworkBackfill`/`library`: assert unwrapped `.data`, not the raw `ApiSuccess<T>` wrapper.

45 new tests. No source files changed. Full suite: 712 passing.