### PR TITLE
test(frontend): unit tests for controllers, queryKeys, preferences store, toast context

### DIFF
--- a/apps/frontend/src/contexts/ToastContext.test.tsx
+++ b/apps/frontend/src/contexts/ToastContext.test.tsx
@@ -1,0 +1,299 @@
+import { act, renderHook } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToastProvider, useToast } from "./ToastContext";
+
+// ---------------------------------------------------------------------------
+// Wrapper helper
+// ---------------------------------------------------------------------------
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ToastProvider>{children}</ToastProvider>
+);
+
+// ---------------------------------------------------------------------------
+// useToast — outside provider guard
+// ---------------------------------------------------------------------------
+
+describe("useToast outside provider", () => {
+  it("throws when consumed outside ToastProvider", () => {
+    // Suppress the React error boundary noise in test output
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(() => renderHook(() => useToast())).toThrow(
+      "useToast must be used within a ToastProvider",
+    );
+    consoleError.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addToast
+// ---------------------------------------------------------------------------
+
+describe("addToast", () => {
+  it("appends a toast with the correct message and type", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("Hello world", "success");
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]!.message).toBe("Hello world");
+    expect(result.current.toasts[0]!.type).toBe("success");
+  });
+
+  it("assigns a non-empty string id to the new toast", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("id check", "info");
+    });
+
+    expect(typeof result.current.toasts[0]!.id).toBe("string");
+    expect(result.current.toasts[0]!.id.length).toBeGreaterThan(0);
+  });
+
+  it("stores the provided duration on the toast", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("with duration", "warning", 5000);
+    });
+
+    expect(result.current.toasts[0]!.duration).toBe(5000);
+  });
+
+  it("defaults duration to 3000 when not provided", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("default duration", "error");
+    });
+
+    expect(result.current.toasts[0]!.duration).toBe(3000);
+  });
+
+  it("multiple toasts get distinct ids", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("first", "success");
+      result.current.addToast("second", "error");
+      result.current.addToast("third", "info");
+    });
+
+    const ids = result.current.toasts.map((t) => t.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(3);
+  });
+
+  it("appends in insertion order", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("first", "success");
+      result.current.addToast("second", "error");
+    });
+
+    expect(result.current.toasts[0]!.message).toBe("first");
+    expect(result.current.toasts[1]!.message).toBe("second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeToast
+// ---------------------------------------------------------------------------
+
+describe("removeToast", () => {
+  it("removes the toast with the matching id", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("to remove", "info");
+    });
+    const id = result.current.toasts[0]!.id;
+
+    act(() => {
+      result.current.removeToast(id);
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("leaves other toasts intact when removing one by id", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("keep me", "success");
+      result.current.addToast("remove me", "error");
+    });
+
+    const removeId = result.current.toasts[1]!.id;
+    act(() => {
+      result.current.removeToast(removeId);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]!.message).toBe("keep me");
+  });
+
+  it("is a no-op when the id does not exist", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("still here", "info");
+    });
+
+    act(() => {
+      result.current.removeToast("non-existent-id");
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auto-dismiss (fake timers)
+// ---------------------------------------------------------------------------
+
+describe("auto-dismiss scheduling", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("removes the toast after the configured duration", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("will vanish", "success", 2000);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("does not remove the toast before the duration elapses", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("still visible", "info", 3000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2999);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it("does NOT schedule auto-removal when duration is 0", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("sticky toast", "warning", 0);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+  });
+
+  it("auto-dismisses each toast independently according to its own duration", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast("short", "success", 1000);
+      result.current.addToast("long", "error", 5000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]!.message).toBe("long");
+
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Convenience helpers: success / error / info / warning
+// ---------------------------------------------------------------------------
+
+describe("convenience helpers", () => {
+  it("success() adds a toast with type 'success'", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.success("Operation done");
+    });
+
+    expect(result.current.toasts[0]!.type).toBe("success");
+    expect(result.current.toasts[0]!.message).toBe("Operation done");
+  });
+
+  it("error() adds a toast with type 'error'", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.error("Something went wrong");
+    });
+
+    expect(result.current.toasts[0]!.type).toBe("error");
+  });
+
+  it("info() adds a toast with type 'info'", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.info("FYI");
+    });
+
+    expect(result.current.toasts[0]!.type).toBe("info");
+  });
+
+  it("warning() adds a toast with type 'warning'", () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.warning("Heads up");
+    });
+
+    expect(result.current.toasts[0]!.type).toBe("warning");
+  });
+
+  it("convenience helpers forward duration to addToast", () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.success("custom duration", 1500);
+    });
+
+    expect(result.current.toasts[0]!.duration).toBe(1500);
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(result.current.toasts).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useAlbumDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useAlbumDetailController.test.ts
@@ -1,0 +1,174 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseAlbumTracksQuery = vi.fn();
+const mockUseArtistAlbumsQuery = vi.fn();
+const mockUseBulkTrackStatus = vi.fn();
+const mockUsePlaylistController = vi.fn();
+const mockHandleGoBack = vi.fn();
+const mockHandleGoHome = vi.fn();
+const mockCreatePlaylistMutate = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ artistId: "artist-1", albumId: "album-1" }),
+  };
+});
+
+vi.mock("@/hooks/queries/useAlbumTracksQuery", () => ({
+  useAlbumTracksQuery: () => mockUseAlbumTracksQuery(),
+}));
+
+vi.mock("@/hooks/queries/useArtistAlbumsQuery", () => ({
+  useArtistAlbumsQuery: () => mockUseArtistAlbumsQuery(),
+}));
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkTrackStatus: (urls: (string | null)[]) => mockUseBulkTrackStatus(urls),
+}));
+
+vi.mock("./usePlaylistController", () => ({
+  usePlaylistController: () => mockUsePlaylistController(),
+}));
+
+vi.mock("@/hooks/useNavigationHelpers", () => ({
+  useNavigationHelpers: () => ({
+    handleGoBack: mockHandleGoBack,
+    handleGoHome: mockHandleGoHome,
+  }),
+}));
+
+const { useAlbumDetailController } = await import("./useAlbumDetailController");
+
+const makeRawTrack = (name: string, trackUrl: string | null = null, album = "OK Computer") => ({
+  name,
+  artist: "Radiohead",
+  album,
+  durationMs: 240000,
+  trackUrl,
+  albumUrl: "https://open.spotify.com/album/abc",
+  albumCoverUrl: null,
+  previewUrl: null,
+  artists: [{ name: "Radiohead", url: "https://open.spotify.com/artist/xyz" }],
+  primaryArtist: "Radiohead",
+  primaryArtistImage: null,
+  unavailable: false,
+  albumId: "album-1",
+});
+
+const stubPlaylistController = () => ({
+  isDownloaded: false,
+  isButtonLoading: false,
+  hasFailed: false,
+  completedCount: 0,
+  displayTitle: "OK Computer",
+  handleToggleSubscription: vi.fn(),
+  handleDelete: vi.fn(),
+  handleRetryFailed: vi.fn(),
+  handleRetryTrack: vi.fn(),
+  mutations: {
+    createPlaylist: {
+      mutate: mockCreatePlaylistMutate,
+      isPending: false,
+      isSuccess: false,
+    },
+  },
+});
+
+describe("useAlbumDetailController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAlbumTracksQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockUseArtistAlbumsQuery.mockReturnValue({ data: [] });
+    mockUseBulkTrackStatus.mockReturnValue(new Map());
+    mockUsePlaylistController.mockReturnValue(stubPlaylistController());
+  });
+
+  it("tracks is empty when no rawTracks", () => {
+    mockUseAlbumTracksQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    expect(result.current.tracks).toHaveLength(0);
+  });
+
+  it("tracks maps NormalizedTrack to Track with proper id format 'album-{albumId}-{index}'", () => {
+    const rawTracks = [makeRawTrack("Paranoid Android"), makeRawTrack("Karma Police")];
+    mockUseAlbumTracksQuery.mockReturnValue({ data: rawTracks, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    expect(result.current.tracks[0]!.id).toBe("album-album-1-0");
+    expect(result.current.tracks[1]!.id).toBe("album-album-1-1");
+    expect(result.current.tracks[0]!.name).toBe("Paranoid Android");
+  });
+
+  it("isSaved is false when no completed tracks", () => {
+    const rawTracks = [makeRawTrack("Paranoid Android", "https://track.url/1")];
+    mockUseAlbumTracksQuery.mockReturnValue({ data: rawTracks, isLoading: false, error: null });
+    mockUseBulkTrackStatus.mockReturnValue(new Map([["https://track.url/1", TrackStatusEnum.New]]));
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    expect(result.current.isSaved).toBe(false);
+  });
+
+  it("isSaved is true when at least one track has status Completed", () => {
+    const rawTracks = [makeRawTrack("Paranoid Android", "https://track.url/1")];
+    mockUseAlbumTracksQuery.mockReturnValue({ data: rawTracks, isLoading: false, error: null });
+    mockUseBulkTrackStatus.mockReturnValue(
+      new Map([["https://track.url/1", TrackStatusEnum.Completed]]),
+    );
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    expect(result.current.isSaved).toBe(true);
+  });
+
+  it("handleDownload calls createPlaylist.mutate with kind 'album'", () => {
+    const rawTracks = [makeRawTrack("Paranoid Android")];
+    mockUseAlbumTracksQuery.mockReturnValue({ data: rawTracks, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    act(() => {
+      result.current.handleDownload();
+    });
+
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "album",
+      artistId: "artist-1",
+      albumId: "album-1",
+    });
+  });
+
+  it("handleDownloadTrack extracts track index from track.id and calls mutate with kind 'albumTrack'", () => {
+    const rawTracks = [makeRawTrack("Paranoid Android"), makeRawTrack("Karma Police")];
+    mockUseAlbumTracksQuery.mockReturnValue({ data: rawTracks, isLoading: false, error: null });
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    act(() => {
+      result.current.handleDownloadTrack(result.current.tracks[1]!);
+    });
+
+    expect(mockCreatePlaylistMutate).toHaveBeenCalledWith({
+      kind: "albumTrack",
+      artistId: "artist-1",
+      albumId: "album-1",
+      trackIndex: 1,
+    });
+  });
+
+  it("playlist is undefined when both album and tracks are empty", () => {
+    mockUseAlbumTracksQuery.mockReturnValue({ data: [], isLoading: false, error: null });
+    mockUseArtistAlbumsQuery.mockReturnValue({ data: [] });
+
+    const { result } = renderHook(() => useAlbumDetailController());
+
+    expect(result.current.playlist).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useArtistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useArtistDetailController.test.ts
@@ -1,0 +1,149 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+
+const mockNavigate = vi.fn();
+const mockNavigateToAlbumPreview = vi.fn();
+const mockUseArtistDetailQuery = vi.fn();
+const mockUsePlaylistDownloaded = vi.fn();
+const mockUseCreatePlaylistMutation = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: "artist-current" }),
+  };
+});
+
+vi.mock("@/hooks/queries/useArtistDetailQuery", () => ({
+  useArtistDetailQuery: () => mockUseArtistDetailQuery(),
+}));
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  usePlaylistDownloaded: (url: string | undefined) => mockUsePlaylistDownloaded(url),
+}));
+
+vi.mock("@/hooks/mutations/useCreatePlaylistMutation", () => ({
+  useCreatePlaylistMutation: () => mockUseCreatePlaylistMutation(),
+}));
+
+vi.mock("@/hooks/useAlbumPreviewNavigation", () => ({
+  useAlbumPreviewNavigation: () => ({
+    navigateToAlbumPreview: mockNavigateToAlbumPreview,
+  }),
+}));
+
+vi.mock("./useArtistDiscographyController", () => ({
+  useArtistDiscographyController: () => ({
+    filter: "all",
+    setFilter: vi.fn(),
+    filteredAlbums: [],
+    visibleItems: 8,
+    isLoadingMore: false,
+    handleShowMore: vi.fn(),
+    canShowMore: false,
+  }),
+}));
+
+vi.mock("@/hooks/useGridColumns", () => ({
+  useGridColumns: () => 4,
+}));
+
+const { useArtistDetailController } = await import("./useArtistDetailController");
+
+const makeArtist = (overrides = {}) => ({
+  id: "artist-current",
+  name: "Radiohead",
+  image: "https://image.url",
+  spotifyUrl: "https://open.spotify.com/artist/abc",
+  followers: 1000000,
+  genres: ["alternative rock"],
+  albums: [],
+  isFollowed: true,
+  catalogRefreshPending: false,
+  ...overrides,
+});
+
+describe("useArtistDetailController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseArtistDetailQuery.mockReturnValue({
+      artist: makeArtist(),
+      isLoading: false,
+      error: null,
+    });
+    mockUsePlaylistDownloaded.mockReturnValue(false);
+    mockUseCreatePlaylistMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+    });
+  });
+
+  it("hasArtist is true when artist exists, id exists, and no error", () => {
+    const { result } = renderHook(() => useArtistDetailController());
+
+    expect(result.current.hasArtist).toBe(true);
+  });
+
+  it("hasArtist is false when artist is null", () => {
+    mockUseArtistDetailQuery.mockReturnValue({
+      artist: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useArtistDetailController());
+
+    expect(result.current.hasArtist).toBe(false);
+  });
+
+  it("handleArtistClick navigates to ARTIST_DETAIL for a different artist id", () => {
+    const { result } = renderHook(() => useArtistDetailController());
+
+    act(() => {
+      result.current.handleArtistClick("artist-other");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Path.ARTIST_DETAIL.replace(":id", "artist-other"));
+  });
+
+  it("handleArtistClick does nothing for the same artist id", () => {
+    const { result } = renderHook(() => useArtistDetailController());
+
+    act(() => {
+      result.current.handleArtistClick("artist-current");
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("handleNavigate calls navigateToAlbumPreview with the album", () => {
+    const { result } = renderHook(() => useArtistDetailController());
+    const album = {
+      artistId: "artist-current",
+      artistName: "Radiohead",
+      artistImageUrl: null,
+      albumId: "album-1",
+      albumName: "OK Computer",
+      releaseDate: "1997-06-21",
+      coverUrl: null,
+    };
+
+    act(() => {
+      result.current.handleNavigate(album as any);
+    });
+
+    expect(mockNavigateToAlbumPreview).toHaveBeenCalledWith(album);
+  });
+
+  it("isArtistDownloaded reflects usePlaylistDownloaded", () => {
+    mockUsePlaylistDownloaded.mockReturnValue(true);
+
+    const { result } = renderHook(() => useArtistDetailController());
+
+    expect(result.current.isArtistDownloaded).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useArtistDiscographyController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useArtistDiscographyController.test.ts
@@ -1,0 +1,114 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/queries/useArtistAlbumsQuery", () => ({
+  useArtistAlbumsQuery: () => ({ data: [], isFetching: false }),
+}));
+
+const { useArtistDiscographyController } = await import("./useArtistDiscographyController");
+
+const makeRelease = (albumId: string, albumType: string, releaseDate: string) => ({
+  artistId: "artist-1",
+  artistName: "Radiohead",
+  artistImageUrl: null,
+  albumId,
+  albumName: `Album ${albumId}`,
+  albumType: albumType as any,
+  releaseDate,
+  coverUrl: null,
+  spotifyUrl: undefined,
+  totalTracks: 10,
+});
+
+const albums = [
+  makeRelease("a1", "album", "2020-01-01"),
+  makeRelease("a2", "single", "2021-06-15"),
+  makeRelease("a3", "ep", "2019-03-10"),
+  makeRelease("a4", "album", "2022-11-20"),
+  makeRelease("a5", "compilation", "2018-07-05"),
+];
+
+describe("useArtistDiscographyController", () => {
+  const defaultProps = {
+    artistId: "artist-1",
+    initialAlbums: albums,
+    pageSize: 3,
+    hasMore: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns all albums sorted by releaseDate descending when filter is 'all'", () => {
+    const { result } = renderHook(() => useArtistDiscographyController(defaultProps));
+
+    const dates = result.current.filteredAlbums.map((a) => a.releaseDate);
+    expect(dates).toEqual(["2022-11-20", "2021-06-15", "2020-01-01", "2019-03-10", "2018-07-05"]);
+  });
+
+  it("filters singles and eps when filter is 'single'", () => {
+    const { result } = renderHook(() => useArtistDiscographyController(defaultProps));
+
+    act(() => {
+      result.current.setFilter("single");
+    });
+
+    const types = result.current.filteredAlbums.map((a) => a.albumType);
+    expect(types.every((t) => t === "single" || t === "ep")).toBe(true);
+    expect(result.current.filteredAlbums).toHaveLength(2);
+  });
+
+  it("filters only albums when filter is 'album'", () => {
+    const { result } = renderHook(() => useArtistDiscographyController(defaultProps));
+
+    act(() => {
+      result.current.setFilter("album");
+    });
+
+    const types = result.current.filteredAlbums.map((a) => a.albumType);
+    expect(types.every((t) => t === "album")).toBe(true);
+    expect(result.current.filteredAlbums).toHaveLength(2);
+  });
+
+  it("visibleItems starts at pageSize", () => {
+    const { result } = renderHook(() => useArtistDiscographyController(defaultProps));
+
+    expect(result.current.visibleItems).toBe(3);
+  });
+
+  it("handleShowMore increments visibleItems by pageSize", () => {
+    const { result } = renderHook(() => useArtistDiscographyController(defaultProps));
+
+    act(() => {
+      result.current.handleShowMore();
+    });
+
+    expect(result.current.visibleItems).toBe(6);
+  });
+
+  it("canShowMore is true when more items exist beyond visibleItems", () => {
+    const { result } = renderHook(() =>
+      useArtistDiscographyController({ ...defaultProps, pageSize: 2 }),
+    );
+
+    // 5 albums, pageSize 2, visibleItems starts at 2 → 3 more remain
+    expect(result.current.canShowMore).toBe(true);
+  });
+
+  it("canShowMore is false when all items are visible and hasFetchedAll", () => {
+    const smallAlbums = [makeRelease("b1", "album", "2020-01-01")];
+
+    const { result } = renderHook(() =>
+      useArtistDiscographyController({
+        artistId: "artist-1",
+        initialAlbums: smallAlbums,
+        pageSize: 5,
+        hasMore: false,
+      }),
+    );
+
+    // 1 album, pageSize 5 → visibleItems = 5, filteredAlbums.length = 1 → canShowMore false
+    expect(result.current.canShowMore).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useArtistsController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useArtistsController.test.ts
@@ -1,0 +1,104 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+
+const mockNavigate = vi.fn();
+const mockUseFollowedArtistsQuery = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/queries/useFollowedArtistsQuery", () => ({
+  useFollowedArtistsQuery: () => mockUseFollowedArtistsQuery(),
+}));
+
+vi.mock("../useDebounce", () => ({
+  useDebounce: (value: string) => value,
+}));
+
+const { useArtistsController } = await import("./useArtistsController");
+
+const makeArtist = (id: string, name: string) => ({
+  id,
+  name,
+  image: null,
+  spotifyUrl: `https://open.spotify.com/artist/${id}`,
+});
+
+describe("useArtistsController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFollowedArtistsQuery.mockReturnValue({
+      artists: [makeArtist("1", "Radiohead"), makeArtist("2", "Arcade Fire")],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("returns all artists when search is empty", () => {
+    const { result } = renderHook(() => useArtistsController());
+
+    expect(result.current.filteredArtists).toHaveLength(2);
+  });
+
+  it("filters by name case-insensitively", () => {
+    const { result } = renderHook(() => useArtistsController());
+
+    act(() => {
+      result.current.handleSearchChange("radio");
+    });
+
+    expect(result.current.filteredArtists).toHaveLength(1);
+    expect(result.current.filteredArtists[0]!.name).toBe("Radiohead");
+  });
+
+  it("returns empty array when no artist matches the search", () => {
+    const { result } = renderHook(() => useArtistsController());
+
+    act(() => {
+      result.current.handleSearchChange("zzznomatch");
+    });
+
+    expect(result.current.filteredArtists).toHaveLength(0);
+  });
+
+  it("handleArtistClick navigates to ARTIST_DETAIL with id replaced", () => {
+    const { result } = renderHook(() => useArtistsController());
+
+    act(() => {
+      result.current.handleArtistClick("42");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Path.ARTIST_DETAIL.replace(":id", "42"));
+  });
+
+  it("returns empty array when artists is null", () => {
+    mockUseFollowedArtistsQuery.mockReturnValue({
+      artists: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useArtistsController());
+
+    expect(result.current.filteredArtists).toHaveLength(0);
+  });
+
+  it("passes isLoading and error through from query", () => {
+    mockUseFollowedArtistsQuery.mockReturnValue({
+      artists: [],
+      isLoading: true,
+      error: "NOT_FOUND",
+    });
+
+    const { result } = renderHook(() => useArtistsController());
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("NOT_FOUND");
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useHeaderController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useHeaderController.test.ts
@@ -1,0 +1,160 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+const mockMutate = vi.fn();
+const mockUseCreatePlaylistMutation = vi.fn();
+const mockNormalizeSpotifyUrl = vi.fn();
+
+let mockPathname = "/";
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useLocation: () => ({ pathname: mockPathname }),
+    useSearchParams: () => [new URLSearchParams(), vi.fn()],
+  };
+});
+
+vi.mock("@/hooks/mutations/useCreatePlaylistMutation", () => ({
+  useCreatePlaylistMutation: () => mockUseCreatePlaylistMutation(),
+}));
+
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: (value: string) => value,
+}));
+
+vi.mock("@/utils/spotify", () => ({
+  normalizeSpotifyUrl: (url: string) => mockNormalizeSpotifyUrl(url),
+}));
+
+const { useHeaderController } = await import("./useHeaderController");
+
+describe("useHeaderController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPathname = "/";
+    mockNormalizeSpotifyUrl.mockReturnValue(null);
+    mockUseCreatePlaylistMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isSuccess: false,
+    });
+  });
+
+  it("isValidUrl is false when url is empty or not a Spotify URL", () => {
+    const { result } = renderHook(() => useHeaderController());
+
+    expect(result.current.isValidUrl).toBe(false);
+  });
+
+  it("isValidUrl is true when normalizeSpotifyUrl returns a non-null value", () => {
+    mockNormalizeSpotifyUrl.mockReturnValue("https://open.spotify.com/album/abc");
+
+    const { result } = renderHook(() => useHeaderController());
+
+    act(() => {
+      result.current.handleChangeUrl({
+        target: { value: "https://open.spotify.com/album/abc" },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(result.current.isValidUrl).toBe(true);
+  });
+
+  it("handleSubmit calls createPlaylist.mutate when isValidUrl is true", () => {
+    const normalizedUrl = "https://open.spotify.com/album/abc";
+    mockNormalizeSpotifyUrl.mockReturnValue(normalizedUrl);
+
+    const { result } = renderHook(() => useHeaderController());
+
+    act(() => {
+      result.current.handleChangeUrl({
+        target: { value: normalizedUrl },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.handleSubmit();
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      kind: "spotifyUrl",
+      spotifyUrl: normalizedUrl,
+    });
+  });
+
+  it("handleSubmit navigates to search when url is not a Spotify URL", () => {
+    mockNormalizeSpotifyUrl.mockReturnValue(null);
+
+    const { result } = renderHook(() => useHeaderController());
+
+    act(() => {
+      result.current.handleChangeUrl({
+        target: { value: "some artist name" },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.handleSubmit();
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.stringContaining("/search?q="),
+      expect.any(Object),
+    );
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("handleChangeUrl updates url", () => {
+    // On the search page the clearing effect does not fire for non-Spotify urls
+    mockPathname = "/search";
+    const { result } = renderHook(() => useHeaderController());
+
+    act(() => {
+      result.current.handleChangeUrl({
+        target: { value: "new value" },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    expect(result.current.url).toBe("new value");
+  });
+
+  it("handleKeyUp calls handleSubmit on Enter key", () => {
+    const normalizedUrl = "https://open.spotify.com/album/xyz";
+    mockNormalizeSpotifyUrl.mockReturnValue(normalizedUrl);
+
+    const { result } = renderHook(() => useHeaderController());
+
+    act(() => {
+      result.current.handleChangeUrl({
+        target: { value: normalizedUrl },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+
+    act(() => {
+      result.current.handleKeyUp({
+        key: "Enter",
+      } as React.KeyboardEvent<HTMLInputElement>);
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith({
+      kind: "spotifyUrl",
+      spotifyUrl: normalizedUrl,
+    });
+  });
+
+  it("isPending comes from createPlaylist.isPending", () => {
+    mockUseCreatePlaylistMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+      isSuccess: false,
+    });
+
+    const { result } = renderHook(() => useHeaderController());
+
+    expect(result.current.isPending).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useHistoryController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useHistoryController.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+
+const mockNavigate = vi.fn();
+const mockUseDownloadHistoryQuery = vi.fn();
+const mockUsePlaylistsQuery = vi.fn();
+const mockUseRecreatePlaylistMutation = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/queries/useDownloadHistoryQuery", () => ({
+  useDownloadHistoryQuery: () => mockUseDownloadHistoryQuery(),
+}));
+
+vi.mock("@/hooks/queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: () => mockUsePlaylistsQuery(),
+}));
+
+vi.mock("@/hooks/mutations/useRecreatePlaylistMutation", () => ({
+  useRecreatePlaylistMutation: () => mockUseRecreatePlaylistMutation(),
+}));
+
+const { useHistoryController } = await import("./useHistoryController");
+
+const makeHistoryItem = (overrides = {}) => ({
+  playlistId: "pl-1",
+  playlistName: "My Playlist",
+  playlistSpotifyUrl: "https://open.spotify.com/playlist/abc",
+  trackCount: 10,
+  lastCompletedAt: Date.now(),
+  ...overrides,
+});
+
+const makeActivePlaylist = (overrides = {}) => ({
+  id: "pl-1",
+  name: "My Playlist",
+  spotifyUrl: "https://open.spotify.com/playlist/abc",
+  type: "playlist" as any,
+  subscribed: true,
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+const mockMutate = vi.fn();
+
+describe("useHistoryController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDownloadHistoryQuery.mockReturnValue({ data: [], isLoading: false });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [] });
+    mockUseRecreatePlaylistMutation.mockReturnValue({ mutate: mockMutate, isPending: false });
+  });
+
+  it("handleHistoryItemClick navigates to PLAYLIST_DETAIL when activePlaylist is provided", () => {
+    const { result } = renderHook(() => useHistoryController());
+    const item = makeHistoryItem();
+    const activePlaylist = makeActivePlaylist({ id: "pl-1" });
+
+    act(() => {
+      result.current.handleHistoryItemClick(item, activePlaylist as any);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      Path.PLAYLIST_DETAIL.replace(":id", activePlaylist.id),
+    );
+  });
+
+  it("handleHistoryItemClick navigates to PLAYLIST_PREVIEW when no activePlaylist and has spotifyUrl", () => {
+    const { result } = renderHook(() => useHistoryController());
+    const item = makeHistoryItem({ playlistSpotifyUrl: "https://open.spotify.com/playlist/xyz" });
+
+    act(() => {
+      result.current.handleHistoryItemClick(item, undefined);
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(item.playlistSpotifyUrl!)}`,
+    );
+  });
+
+  it("handleHistoryItemClick does nothing when no activePlaylist and no spotifyUrl", () => {
+    const { result } = renderHook(() => useHistoryController());
+    const item = makeHistoryItem({ playlistSpotifyUrl: null });
+
+    act(() => {
+      result.current.handleHistoryItemClick(item, undefined);
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("handleRecreatePlaylistClick calls recreatePlaylist.mutate with playlistSpotifyUrl", () => {
+    const { result } = renderHook(() => useHistoryController());
+    const spotifyUrl = "https://open.spotify.com/playlist/abc";
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent<HTMLButtonElement>;
+
+    act(() => {
+      result.current.handleRecreatePlaylistClick(event, spotifyUrl);
+    });
+
+    expect(mockMutate).toHaveBeenCalledWith(spotifyUrl);
+  });
+
+  it("handleRecreatePlaylistClick does nothing when playlistSpotifyUrl is null", () => {
+    const { result } = renderHook(() => useHistoryController());
+    const event = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as React.MouseEvent<HTMLButtonElement>;
+
+    act(() => {
+      result.current.handleRecreatePlaylistClick(event, null);
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  it("history and isLoading come from query", () => {
+    const historyItem = makeHistoryItem();
+    mockUseDownloadHistoryQuery.mockReturnValue({
+      data: [historyItem],
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useHistoryController());
+
+    expect(result.current.history).toEqual([historyItem]);
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useReleasesController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useReleasesController.test.ts
@@ -1,0 +1,88 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+
+const mockNavigate = vi.fn();
+const mockNavigateToAlbumPreview = vi.fn();
+const mockUseReleasesQuery = vi.fn();
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@/hooks/queries/useReleasesQuery", () => ({
+  useReleasesQuery: () => mockUseReleasesQuery(),
+}));
+
+vi.mock("@/hooks/useAlbumPreviewNavigation", () => ({
+  useAlbumPreviewNavigation: () => ({
+    navigateToAlbumPreview: mockNavigateToAlbumPreview,
+  }),
+}));
+
+const { useReleasesController } = await import("./useReleasesController");
+
+const makeRelease = (overrides = {}) => ({
+  artistId: "artist-1",
+  artistName: "Radiohead",
+  artistImageUrl: null,
+  albumId: "album-1",
+  albumName: "OK Computer",
+  albumType: "album" as const,
+  releaseDate: "1997-06-21",
+  coverUrl: null,
+  spotifyUrl: "https://open.spotify.com/album/abc",
+  totalTracks: 12,
+  ...overrides,
+});
+
+describe("useReleasesController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReleasesQuery.mockReturnValue({
+      releases: [makeRelease()],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it("handleReleaseClick calls navigateToAlbumPreview with the release", () => {
+    const { result } = renderHook(() => useReleasesController());
+    const release = makeRelease();
+
+    act(() => {
+      result.current.handleReleaseClick(release);
+    });
+
+    expect(mockNavigateToAlbumPreview).toHaveBeenCalledWith(release);
+  });
+
+  it("handleArtistClick navigates to ARTIST_DETAIL with id replaced", () => {
+    const { result } = renderHook(() => useReleasesController());
+
+    act(() => {
+      result.current.handleArtistClick("artist-42");
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(Path.ARTIST_DETAIL.replace(":id", "artist-42"));
+  });
+
+  it("passes releases, isLoading, and error through from query", () => {
+    const releases = [makeRelease()];
+    mockUseReleasesQuery.mockReturnValue({
+      releases,
+      isLoading: true,
+      error: "SERVER_ERROR",
+    });
+
+    const { result } = renderHook(() => useReleasesController());
+
+    expect(result.current.releases).toEqual(releases);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe("SERVER_ERROR");
+  });
+});

--- a/apps/frontend/src/hooks/controllers/useSpotifyAuthController.test.ts
+++ b/apps/frontend/src/hooks/controllers/useSpotifyAuthController.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSpotifyAuthStatusQuery = vi.fn();
+const mockMutate = vi.fn();
+const mockUseSpotifyLogoutMutation = vi.fn();
+
+vi.mock("@/hooks/queries/useSpotifyAuthStatusQuery", () => ({
+  useSpotifyAuthStatusQuery: () => mockUseSpotifyAuthStatusQuery(),
+}));
+
+vi.mock("@/hooks/mutations/useSpotifyLogoutMutation", () => ({
+  useSpotifyLogoutMutation: () => mockUseSpotifyLogoutMutation(),
+}));
+
+const { useSpotifyAuthController } = await import("./useSpotifyAuthController");
+
+describe("useSpotifyAuthController", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSpotifyAuthStatusQuery.mockReturnValue({
+      data: { authenticated: false, hasRefreshToken: false },
+      isLoading: false,
+    });
+    mockUseSpotifyLogoutMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    });
+    Object.defineProperty(window, "location", {
+      value: { href: "" },
+      writable: true,
+    });
+  });
+
+  it("isAuthenticated is false when data is undefined", () => {
+    mockUseSpotifyAuthStatusQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("isAuthenticated reflects data.authenticated", () => {
+    mockUseSpotifyAuthStatusQuery.mockReturnValue({
+      data: { authenticated: true, hasRefreshToken: true },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it("hasRefreshToken reflects data.hasRefreshToken", () => {
+    mockUseSpotifyAuthStatusQuery.mockReturnValue({
+      data: { authenticated: true, hasRefreshToken: true },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    expect(result.current.hasRefreshToken).toBe(true);
+  });
+
+  it("isLoading aggregates query isLoading OR mutation isPending", () => {
+    mockUseSpotifyAuthStatusQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseSpotifyLogoutMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+    });
+
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("login() sets window.location.href to the login URL", () => {
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    act(() => {
+      result.current.login();
+    });
+
+    expect(window.location.href).toBe("/api/auth/spotify/login");
+  });
+
+  it("logout() calls logoutMutation.mutate()", () => {
+    const { result } = renderHook(() => useSpotifyAuthController());
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/hooks/queryKeys.test.ts
+++ b/apps/frontend/src/hooks/queryKeys.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+
+describe("queryKeys — static keys", () => {
+  it("playlists returns the expected tuple", () => {
+    expect(queryKeys.playlists).toEqual(["playlists"]);
+  });
+
+  it("myPlaylists returns the expected tuple", () => {
+    expect(queryKeys.myPlaylists).toEqual(["my-playlists"]);
+  });
+
+  it("downloadHistory returns the expected tuple", () => {
+    expect(queryKeys.downloadHistory).toEqual(["download-history"]);
+  });
+
+  it("downloadStatus returns the expected tuple", () => {
+    expect(queryKeys.downloadStatus).toEqual(["download-status"]);
+  });
+
+  it("settings returns the expected tuple", () => {
+    expect(queryKeys.settings).toEqual(["settings"]);
+  });
+
+  it("settingsMetadata returns the expected tuple", () => {
+    expect(queryKeys.settingsMetadata).toEqual(["settingsMetadata"]);
+  });
+
+  it("supportedFormats returns the expected tuple", () => {
+    expect(queryKeys.supportedFormats).toEqual(["supportedFormats"]);
+  });
+
+  it("releases returns the expected tuple", () => {
+    expect(queryKeys.releases).toEqual(["releases"]);
+  });
+
+  it("followedArtists returns the expected tuple", () => {
+    expect(queryKeys.followedArtists).toEqual(["followed-artists"]);
+  });
+
+  it("spotifyAuthStatus returns the expected tuple", () => {
+    expect(queryKeys.spotifyAuthStatus).toEqual(["spotify-auth-status"]);
+  });
+
+  it("library returns the expected tuple", () => {
+    expect(queryKeys.library).toEqual(["library"]);
+  });
+
+  it("artworkBackfillStatus returns the expected tuple", () => {
+    expect(queryKeys.artworkBackfillStatus).toEqual(["library", "artwork-backfill", "status"]);
+  });
+
+  it("libraryStats returns the expected tuple", () => {
+    expect(queryKeys.libraryStats).toEqual(["library", "stats"]);
+  });
+
+  it("libraryArtists returns the expected tuple", () => {
+    expect(queryKeys.libraryArtists).toEqual(["library", "artists"]);
+  });
+
+  it("authSession returns the expected tuple", () => {
+    expect(queryKeys.authSession).toEqual(["auth", "session"]);
+  });
+
+  it("aiChatMessages returns the expected tuple", () => {
+    expect(queryKeys.aiChatMessages).toEqual(["ai", "chat", "messages"]);
+  });
+});
+
+describe("queryKeys — parameterized keys", () => {
+  describe("tracks", () => {
+    it("places playlistId at position [1]", () => {
+      const key = queryKeys.tracks("pl-123");
+      expect(key[0]).toBe("tracks");
+      expect(key[1]).toBe("pl-123");
+      expect(key).toEqual(["tracks", "pl-123"]);
+    });
+
+    it("returns distinct keys for distinct playlistIds", () => {
+      expect(queryKeys.tracks("a")).not.toEqual(queryKeys.tracks("b"));
+    });
+  });
+
+  describe("playlistPreview", () => {
+    it("places spotifyUrl at position [1]", () => {
+      const url = "https://open.spotify.com/playlist/abc";
+      const key = queryKeys.playlistPreview(url);
+      expect(key[0]).toBe("playlist-preview");
+      expect(key[1]).toBe(url);
+    });
+  });
+
+  describe("playlistPreviewTracksPage", () => {
+    it("places spotifyUrl, offset, limit at positions [1], [2], [3]", () => {
+      const url = "https://open.spotify.com/playlist/xyz";
+      const key = queryKeys.playlistPreviewTracksPage(url, 20, 10);
+      expect(key[0]).toBe("playlist-preview-tracks-page");
+      expect(key[1]).toBe(url);
+      expect(key[2]).toBe(20);
+      expect(key[3]).toBe(10);
+      expect(key).toHaveLength(4);
+    });
+
+    it("returns distinct keys for different offsets", () => {
+      const url = "https://open.spotify.com/playlist/xyz";
+      expect(queryKeys.playlistPreviewTracksPage(url, 0, 10)).not.toEqual(
+        queryKeys.playlistPreviewTracksPage(url, 10, 10),
+      );
+    });
+  });
+
+  describe("playlistPreviewTracks", () => {
+    it("places spotifyUrl at position [1]", () => {
+      const url = "https://open.spotify.com/playlist/def";
+      const key = queryKeys.playlistPreviewTracks(url);
+      expect(key[0]).toBe("playlist-preview-tracks");
+      expect(key[1]).toBe(url);
+    });
+  });
+
+  describe("artistDetail", () => {
+    it("places artistId at position [1]", () => {
+      const key = queryKeys.artistDetail("artist-99");
+      expect(key[0]).toBe("artist-detail");
+      expect(key[1]).toBe("artist-99");
+    });
+  });
+
+  describe("artistAlbums", () => {
+    it("places artistId, limit, offset at positions [1], [2], [3]", () => {
+      const key = queryKeys.artistAlbums("art-1", 50, 0);
+      expect(key[0]).toBe("artist-albums");
+      expect(key[1]).toBe("art-1");
+      expect(key[2]).toBe(50);
+      expect(key[3]).toBe(0);
+      expect(key).toHaveLength(4);
+    });
+
+    it("returns distinct keys for different offsets", () => {
+      expect(queryKeys.artistAlbums("art-1", 50, 0)).not.toEqual(
+        queryKeys.artistAlbums("art-1", 50, 50),
+      );
+    });
+  });
+
+  describe("artistAlbumTracks", () => {
+    it("places artistId at [1] and albumId at [2]", () => {
+      const key = queryKeys.artistAlbumTracks("art-1", "alb-2");
+      expect(key[0]).toBe("artist-album-tracks");
+      expect(key[1]).toBe("art-1");
+      expect(key[2]).toBe("alb-2");
+      expect(key).toHaveLength(3);
+    });
+  });
+
+  describe("libraryArtistDetail", () => {
+    it("places name at position [2] with fixed prefix", () => {
+      const key = queryKeys.libraryArtistDetail("Radiohead");
+      expect(key[0]).toBe("library");
+      expect(key[1]).toBe("artist");
+      expect(key[2]).toBe("Radiohead");
+    });
+
+    it("returns distinct keys for distinct names", () => {
+      expect(queryKeys.libraryArtistDetail("A")).not.toEqual(queryKeys.libraryArtistDetail("B"));
+    });
+  });
+
+  describe("search", () => {
+    it("places query at [1], types at [2], limit at [3]", () => {
+      const key = queryKeys.search("radiohead", ["track", "artist"], 20);
+      expect(key[0]).toBe("search");
+      expect(key[1]).toBe("radiohead");
+      expect(key[2]).toEqual(["track", "artist"]);
+      expect(key[3]).toBe(20);
+      expect(key).toHaveLength(4);
+    });
+
+    it("returns distinct keys for different queries", () => {
+      expect(queryKeys.search("foo", ["track"], 10)).not.toEqual(
+        queryKeys.search("bar", ["track"], 10),
+      );
+    });
+  });
+});

--- a/apps/frontend/src/store/usePreferencesStore.test.ts
+++ b/apps/frontend/src/store/usePreferencesStore.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Zustand stores with `persist` are module-level singletons. We use
+// vi.resetModules() + dynamic import in beforeEach so every test starts from a
+// clean slate — same pattern as usePlayerStore.test.ts.
+
+let usePreferencesStore: typeof import("./usePreferencesStore").usePreferencesStore;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import("./usePreferencesStore");
+  usePreferencesStore = mod.usePreferencesStore;
+  // Reset to initial state defined in the store factory
+  usePreferencesStore.setState({ isSidebarCollapsed: false });
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("initial state", () => {
+  it("isSidebarCollapsed is false by default", () => {
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toggleSidebar
+// ---------------------------------------------------------------------------
+
+describe("toggleSidebar", () => {
+  it("flips isSidebarCollapsed from false to true", () => {
+    usePreferencesStore.getState().toggleSidebar();
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it("flips isSidebarCollapsed from true to false", () => {
+    usePreferencesStore.setState({ isSidebarCollapsed: true });
+    usePreferencesStore.getState().toggleSidebar();
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(false);
+  });
+
+  it("toggles twice — returns to original value", () => {
+    usePreferencesStore.getState().toggleSidebar();
+    usePreferencesStore.getState().toggleSidebar();
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setSidebarCollapsed
+// ---------------------------------------------------------------------------
+
+describe("setSidebarCollapsed", () => {
+  it("sets isSidebarCollapsed to true when called with true", () => {
+    usePreferencesStore.getState().setSidebarCollapsed(true);
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it("sets isSidebarCollapsed to false when called with false", () => {
+    usePreferencesStore.setState({ isSidebarCollapsed: true });
+    usePreferencesStore.getState().setSidebarCollapsed(false);
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(false);
+  });
+
+  it("is idempotent — calling true twice remains true", () => {
+    usePreferencesStore.getState().setSidebarCollapsed(true);
+    usePreferencesStore.getState().setSidebarCollapsed(true);
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it("is idempotent — calling false twice remains false", () => {
+    usePreferencesStore.getState().setSidebarCollapsed(false);
+    usePreferencesStore.getState().setSidebarCollapsed(false);
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persist middleware: state changes survive setState round-trip
+// ---------------------------------------------------------------------------
+
+describe("persist — state updates are reflected after setState", () => {
+  it("setSidebarCollapsed change is visible via getState()", () => {
+    usePreferencesStore.getState().setSidebarCollapsed(true);
+    // Verify the store reports the updated value (no async flush needed for
+    // in-memory access; localStorage side-effects are not asserted here)
+    expect(usePreferencesStore.getState().isSidebarCollapsed).toBe(true);
+  });
+
+  it("persist storage key is spotiarr-preferences", async () => {
+    // Access the Zustand persist API to confirm the storage key is stable
+    const persistApi = usePreferencesStore.persist;
+    expect(persistApi.getOptions().name).toBe("spotiarr-preferences");
+  });
+});


### PR DESCRIPTION
## What

Adds characterization unit tests for the remaining high-value untested logic:
- **8 controller hooks**: album detail, artist detail, artist discography, artists, header, history, releases, spotify auth
- **queryKeys** factory (`src/hooks/queryKeys.ts`)
- **usePreferencesStore** (Zustand)
- **ToastContext** provider + hook

## Why

Closes out the high-value frontend coverage gap (services + mutations landed in #185 / #186). Controllers carry derived-state and navigation logic; queryKeys underpins all cache invalidation; ToastContext owns timer-based lifecycle. Pinning these guards the riskiest client behavior. Part of the ratchet goal (#149).

## Coverage notes

- Controllers mock their query/mutation/router dependencies and assert derived state, filtering/search, and navigation handler calls.
- `queryKeys`: exact tuple equality for static keys + argument placement for parameterized factories.
- `usePreferencesStore`: initial state, toggle/set actions, persist storage key — isolated via `vi.resetModules()` per test.
- `ToastContext`: add/remove lifecycle, unique id generation, fake-timer auto-dismiss boundaries, `duration=0` sticky behavior, all four convenience helpers.

107 new tests. No source changes. `tsc --noEmit` clean; full suite 774 passing.