### PR TITLE
test(frontend): unit tests for query hooks, custom hooks, artworkBackfill

### DIFF
--- a/apps/frontend/src/hooks/queries/useAlbumTracksQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useAlbumTracksQuery.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { artistService } from "@/services/artist.service";
+import { useAlbumTracksQuery } from "./useAlbumTracksQuery";
+
+vi.mock("@/services/artist.service", () => ({
+  artistService: { getAlbumTracks: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAlbumTracksQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      { name: "Track 1", artist: "Artist 1", artists: [{ name: "Artist 1", url: undefined }] },
+    ];
+    vi.mocked(artistService.getAlbumTracks).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(
+      () => useAlbumTracksQuery({ artistId: "a1", albumId: "al1", enabled: true }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when enabled=false", () => {
+    const { result } = renderHook(
+      () => useAlbumTracksQuery({ artistId: "a1", albumId: "al1", enabled: false }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(artistService.getAlbumTracks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useArtistAlbumsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useArtistAlbumsQuery.test.tsx
@@ -1,0 +1,53 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { artistService } from "@/services/artist.service";
+import { useArtistAlbumsQuery } from "./useArtistAlbumsQuery";
+
+vi.mock("@/services/artist.service", () => ({
+  artistService: { getArtistAlbums: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useArtistAlbumsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      {
+        artistId: "a1",
+        artistName: "Artist",
+        artistImageUrl: null,
+        albumId: "al1",
+        albumName: "Album",
+        coverUrl: null,
+      },
+    ];
+    vi.mocked(artistService.getArtistAlbums).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(
+      () => useArtistAlbumsQuery({ artistId: "a1", limit: 10, offset: 0 }),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when enabled=false", () => {
+    const { result } = renderHook(
+      () => useArtistAlbumsQuery({ artistId: "a1", limit: 10, offset: 0, enabled: false }),
+      { wrapper: createWrapper() },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(artistService.getArtistAlbums).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useArtistDetailQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useArtistDetailQuery.test.tsx
@@ -1,0 +1,46 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { artistService } from "@/services/artist.service";
+import { useArtistDetailQuery } from "./useArtistDetailQuery";
+
+vi.mock("@/services/artist.service", () => ({
+  artistService: { getArtistDetail: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useArtistDetailQuery", () => {
+  it("success: returns artist when artistId is provided", async () => {
+    const artist = {
+      id: "a1",
+      name: "Artist",
+      imageUrl: null,
+      albums: [],
+      catalogRefreshPending: false,
+    };
+    vi.mocked(artistService.getArtistDetail).mockResolvedValueOnce(artist as never);
+    const { result } = renderHook(() => useArtistDetailQuery("a1"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.artist).toBe(artist);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("disabled: service is NOT called when artistId is null", () => {
+    vi.mocked(artistService.getArtistDetail).mockResolvedValueOnce(undefined as never);
+    const { result } = renderHook(() => useArtistDetailQuery(null), { wrapper: createWrapper() });
+    expect(result.current.artist).toBeNull();
+    expect(artistService.getArtistDetail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useArtworkBackfillStatusQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useArtworkBackfillStatusQuery.test.tsx
@@ -1,0 +1,34 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchArtworkBackfillStatus } from "@/services/artworkBackfill.service";
+import { useArtworkBackfillStatusQuery } from "./useArtworkBackfillStatusQuery";
+
+vi.mock("@/services/artworkBackfill.service", () => ({
+  fetchArtworkBackfillStatus: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useArtworkBackfillStatusQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = { status: "idle", processed: 0, total: 0, errors: 0 };
+    vi.mocked(fetchArtworkBackfillStatus).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useArtworkBackfillStatusQuery(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useDownloadHistoryQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useDownloadHistoryQuery.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { historyService } from "@/services/history.service";
+import { useDownloadHistoryQuery } from "./useDownloadHistoryQuery";
+
+vi.mock("@/services/history.service", () => ({
+  historyService: { getDownloadHistory: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useDownloadHistoryQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      {
+        playlistId: "p1",
+        playlistName: "My Playlist",
+        playlistSpotifyUrl: null,
+        trackCount: 5,
+        lastCompletedAt: 1234567890,
+      },
+    ];
+    vi.mocked(historyService.getDownloadHistory).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useDownloadHistoryQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useDownloadStatusQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useDownloadStatusQuery.test.tsx
@@ -1,0 +1,32 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlistService } from "@/services/playlist.service";
+import { useDownloadStatusQuery } from "./useDownloadStatusQuery";
+
+vi.mock("@/services/playlist.service", () => ({
+  playlistService: { getDownloadStatus: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useDownloadStatusQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = { playlistStatusMap: {}, trackStatusMap: {}, albumTrackCountMap: {} };
+    vi.mocked(playlistService.getDownloadStatus).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useDownloadStatusQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useFollowedArtistsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useFollowedArtistsQuery.test.tsx
@@ -1,0 +1,39 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { artistService } from "@/services/artist.service";
+import { settingsService } from "@/services/settings.service";
+import { useFollowedArtistsQuery } from "./useFollowedArtistsQuery";
+
+vi.mock("@/services/artist.service", () => ({
+  artistService: { getFollowedArtists: vi.fn() },
+}));
+
+vi.mock("@/services/settings.service", () => ({
+  settingsService: { getSettings: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useFollowedArtistsQuery", () => {
+  it("success: returns artists when both services resolve", async () => {
+    const artists = [{ id: "a1", name: "Artist", image: null }];
+    vi.mocked(settingsService.getSettings).mockResolvedValue([] as never);
+    vi.mocked(artistService.getFollowedArtists).mockResolvedValueOnce(artists as never);
+    const { result } = renderHook(() => useFollowedArtistsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.artists).toEqual(artists);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useLibraryArtistQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useLibraryArtistQuery.test.tsx
@@ -1,0 +1,49 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLibraryArtist } from "@/services/library.service";
+import { useLibraryArtistQuery } from "./useLibraryArtistQuery";
+
+vi.mock("@/services/library.service", () => ({
+  fetchLibraryArtist: vi.fn(),
+  fetchLibraryArtists: vi.fn(),
+  fetchLibraryStats: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useLibraryArtistQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = {
+      name: "Artist",
+      path: "/music/Artist",
+      albumCount: 2,
+      trackCount: 10,
+      totalSize: 50000,
+      albums: [],
+    };
+    vi.mocked(fetchLibraryArtist).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useLibraryArtistQuery("Artist"), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when name is empty string", () => {
+    const { result } = renderHook(() => useLibraryArtistQuery(""), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetchLibraryArtist).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useLibraryArtistsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useLibraryArtistsQuery.test.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLibraryArtists } from "@/services/library.service";
+import { useLibraryArtistsQuery } from "./useLibraryArtistsQuery";
+
+vi.mock("@/services/library.service", () => ({
+  fetchLibraryArtist: vi.fn(),
+  fetchLibraryArtists: vi.fn(),
+  fetchLibraryStats: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useLibraryArtistsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      { name: "Artist", path: "/music/Artist", albumCount: 1, trackCount: 5, totalSize: 25000 },
+    ];
+    vi.mocked(fetchLibraryArtists).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useLibraryArtistsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useLibraryStatsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useLibraryStatsQuery.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLibraryStats } from "@/services/library.service";
+import { useLibraryStatsQuery } from "./useLibraryStatsQuery";
+
+vi.mock("@/services/library.service", () => ({
+  fetchLibraryArtist: vi.fn(),
+  fetchLibraryArtists: vi.fn(),
+  fetchLibraryStats: vi.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useLibraryStatsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = {
+      totalArtists: 10,
+      totalAlbums: 20,
+      totalTracks: 100,
+      totalSize: 500000,
+      lastScannedAt: "2024-01-01",
+    };
+    vi.mocked(fetchLibraryStats).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useLibraryStatsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useMyPlaylistsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useMyPlaylistsQuery.test.tsx
@@ -1,0 +1,41 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlistService } from "@/services/playlist.service";
+import { useMyPlaylistsQuery } from "./useMyPlaylistsQuery";
+
+vi.mock("@/services/playlist.service", () => ({
+  playlistService: { getMyPlaylists: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useMyPlaylistsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      {
+        id: "p1",
+        name: "My Playlist",
+        image: null,
+        owner: "user1",
+        tracks: 10,
+        spotifyUrl: "https://spotify.com",
+      },
+    ];
+    vi.mocked(playlistService.getMyPlaylists).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useMyPlaylistsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/usePlaylistPreviewQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/usePlaylistPreviewQuery.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlistService } from "@/services/playlist.service";
+import { usePlaylistPreviewQuery } from "./usePlaylistPreviewQuery";
+
+vi.mock("@/services/playlist.service", () => ({
+  playlistService: { getPlaylistPreview: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePlaylistPreviewQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = {
+      name: "Playlist",
+      type: "playlist",
+      description: "",
+      coverUrl: null,
+      totalTracks: 5,
+      tracks: [],
+    };
+    vi.mocked(playlistService.getPlaylistPreview).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(
+      () => usePlaylistPreviewQuery("https://open.spotify.com/playlist/abc"),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when spotifyUrl is null", () => {
+    const { result } = renderHook(() => usePlaylistPreviewQuery(null), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(playlistService.getPlaylistPreview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/usePlaylistsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/usePlaylistsQuery.test.tsx
@@ -1,0 +1,62 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { playlistService } from "@/services/playlist.service";
+import { calculatePlaylistStats } from "@/utils/playlist";
+import { usePlaylistsQuery } from "./usePlaylistsQuery";
+
+vi.mock("@/services/playlist.service", () => ({
+  playlistService: { getPlaylists: vi.fn() },
+}));
+
+vi.mock("@/utils/playlist", () => ({
+  calculatePlaylistStats: vi.fn().mockReturnValue({
+    completedCount: 1,
+    downloadingCount: 0,
+    searchingCount: 0,
+    queuedCount: 0,
+    activeCount: 0,
+    errorCount: 0,
+    totalCount: 1,
+    progress: 100,
+    isDownloading: false,
+    hasErrors: false,
+    isCompleted: true,
+  }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("usePlaylistsQuery", () => {
+  it("success: reaches isSuccess with data defined", async () => {
+    const raw = [
+      { id: "p1", name: "My Playlist", type: "playlist", spotifyUrl: "https://spotify.com" },
+    ];
+    vi.mocked(playlistService.getPlaylists).mockResolvedValueOnce(raw as never);
+    const { result } = renderHook(() => usePlaylistsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeDefined();
+  });
+
+  it("select: transform adds stats to each playlist", async () => {
+    const raw = [
+      { id: "p1", name: "My Playlist", type: "playlist", spotifyUrl: "https://spotify.com" },
+    ];
+    vi.mocked(playlistService.getPlaylists).mockResolvedValueOnce(raw as never);
+    const { result } = renderHook(() => usePlaylistsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(calculatePlaylistStats).toHaveBeenCalledWith(raw[0]);
+    expect(result.current.data?.[0]).toHaveProperty("stats");
+  });
+});

--- a/apps/frontend/src/hooks/queries/useReleasesQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useReleasesQuery.test.tsx
@@ -1,0 +1,48 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { artistService } from "@/services/artist.service";
+import { settingsService } from "@/services/settings.service";
+import { useReleasesQuery } from "./useReleasesQuery";
+
+vi.mock("@/services/artist.service", () => ({
+  artistService: { getReleases: vi.fn() },
+}));
+
+vi.mock("@/services/settings.service", () => ({
+  settingsService: { getSettings: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useReleasesQuery", () => {
+  it("success: returns releases when both services resolve", async () => {
+    const releases = [
+      {
+        artistId: "a1",
+        artistName: "Artist",
+        artistImageUrl: null,
+        albumId: "al1",
+        albumName: "Album",
+        coverUrl: null,
+      },
+    ];
+    vi.mocked(settingsService.getSettings).mockResolvedValue([] as never);
+    vi.mocked(artistService.getReleases).mockResolvedValueOnce(releases as never);
+    const { result } = renderHook(() => useReleasesQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.releases).toEqual(releases);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useSearchQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useSearchQuery.test.tsx
@@ -1,0 +1,38 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SearchService } from "../../services/search.service";
+import { useSearchQuery } from "./useSearchQuery";
+
+vi.mock("../../services/search.service", () => ({
+  SearchService: { searchCatalog: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSearchQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = { tracks: [], albums: [], artists: [] };
+    vi.mocked(SearchService.searchCatalog).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useSearchQuery("radiohead"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when query is empty string", () => {
+    const { result } = renderHook(() => useSearchQuery(""), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(SearchService.searchCatalog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/queries/useSettingsMetadataQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useSettingsMetadataQuery.test.tsx
@@ -1,0 +1,42 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settingsService } from "@/services/settings.service";
+import { useSettingsMetadataQuery } from "./useSettingsMetadataQuery";
+
+vi.mock("@/services/settings.service", () => ({
+  settingsService: { getSettingsMetadata: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSettingsMetadataQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = {
+      key1: {
+        key: "key1",
+        defaultValue: "val",
+        type: "string",
+        component: "input",
+        section: "general",
+        label: "Key 1",
+        description: "",
+      },
+    };
+    vi.mocked(settingsService.getSettingsMetadata).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useSettingsMetadataQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useSettingsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useSettingsQuery.test.tsx
@@ -1,0 +1,32 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settingsService } from "@/services/settings.service";
+import { useSettingsQuery } from "./useSettingsQuery";
+
+vi.mock("@/services/settings.service", () => ({
+  settingsService: { getSettings: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSettingsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [{ key: "theme", value: "dark" }];
+    vi.mocked(settingsService.getSettings).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useSettingsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useSpotifyAuthStatusQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useSpotifyAuthStatusQuery.test.tsx
@@ -1,0 +1,37 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useSpotifyAuthStatusQuery } from "./useSpotifyAuthStatusQuery";
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSpotifyAuthStatusQuery", () => {
+  it("success: reaches isSuccess with authenticated data", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ authenticated: true, hasRefreshToken: false }),
+    } as Response);
+    const { result } = renderHook(() => useSpotifyAuthStatusQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ authenticated: true, hasRefreshToken: false });
+  });
+
+  it("error: reaches isError when fetch returns not-ok", async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+    } as Response);
+    const { result } = renderHook(() => useSpotifyAuthStatusQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/frontend/src/hooks/queries/useSupportedFormatsQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useSupportedFormatsQuery.test.tsx
@@ -1,0 +1,32 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { settingsService } from "@/services/settings.service";
+import { useSupportedFormatsQuery } from "./useSupportedFormatsQuery";
+
+vi.mock("@/services/settings.service", () => ({
+  settingsService: { getSupportedFormats: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSupportedFormatsQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = ["mp3", "flac"];
+    vi.mocked(settingsService.getSupportedFormats).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useSupportedFormatsQuery(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+});

--- a/apps/frontend/src/hooks/queries/useTracksQuery.test.tsx
+++ b/apps/frontend/src/hooks/queries/useTracksQuery.test.tsx
@@ -1,0 +1,40 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { trackService } from "@/services/track.service";
+import { useTracksQuery } from "./useTracksQuery";
+
+vi.mock("@/services/track.service", () => ({
+  trackService: { getTracksByPlaylist: vi.fn() },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTracksQuery", () => {
+  it("success: reaches isSuccess with the resolved data", async () => {
+    const data = [
+      { id: "t1", name: "Track", artist: "Artist", status: "completed", playlistId: "p1" },
+    ];
+    vi.mocked(trackService.getTracksByPlaylist).mockResolvedValueOnce(data as never);
+    const { result } = renderHook(() => useTracksQuery("p1"), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(data);
+  });
+
+  it("disabled: service is NOT called when playlistId is undefined", () => {
+    const { result } = renderHook(() => useTracksQuery(undefined), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(trackService.getTracksByPlaylist).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useAlbumListDownloadStates.test.ts
+++ b/apps/frontend/src/hooks/useAlbumListDownloadStates.test.ts
@@ -1,0 +1,88 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBulkPlaylistStatus } from "@/hooks/queries/useDownloadStatus";
+import { useAlbumListDownloadStates } from "./useAlbumListDownloadStates";
+
+// Mock useBulkPlaylistStatus — the hook delegates all logic to it.
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkPlaylistStatus: vi.fn(),
+}));
+
+const mockUseBulkPlaylistStatus = vi.mocked(useBulkPlaylistStatus);
+
+const makeAlbum = (overrides: Partial<ArtistRelease> = {}): ArtistRelease => ({
+  artistId: "artist-1",
+  artistName: "Test Artist",
+  artistImageUrl: null,
+  albumId: "album-1",
+  albumName: "Test Album",
+  coverUrl: null,
+  spotifyUrl: "https://open.spotify.com/album/abc",
+  totalTracks: 10,
+  ...overrides,
+});
+
+describe("useAlbumListDownloadStates", () => {
+  it("passes the correct status items (url + totalTracks) to useBulkPlaylistStatus", () => {
+    const album = makeAlbum();
+    const expectedMap = new Map([
+      [album.spotifyUrl!, { isDownloaded: false, isDownloading: false }],
+    ]);
+    mockUseBulkPlaylistStatus.mockReturnValue(expectedMap);
+
+    renderHook(() => useAlbumListDownloadStates([album]));
+
+    expect(mockUseBulkPlaylistStatus).toHaveBeenCalledWith([
+      { url: album.spotifyUrl, totalTracks: album.totalTracks },
+    ]);
+  });
+
+  it("returns the map produced by useBulkPlaylistStatus", () => {
+    const album1 = makeAlbum({ albumId: "a1", spotifyUrl: "https://open.spotify.com/album/a1" });
+    const album2 = makeAlbum({ albumId: "a2", spotifyUrl: "https://open.spotify.com/album/a2" });
+
+    const expectedMap = new Map<string, { isDownloaded: boolean; isDownloading: boolean }>([
+      [album1.spotifyUrl!, { isDownloaded: true, isDownloading: false }],
+      [album2.spotifyUrl!, { isDownloaded: false, isDownloading: true }],
+    ]);
+    mockUseBulkPlaylistStatus.mockReturnValue(expectedMap);
+
+    const { result } = renderHook(() => useAlbumListDownloadStates([album1, album2]));
+
+    expect(result.current).toBe(expectedMap);
+  });
+
+  it("returns an empty map when given an empty album list", () => {
+    const emptyMap = new Map<string, { isDownloaded: boolean; isDownloading: boolean }>();
+    mockUseBulkPlaylistStatus.mockReturnValue(emptyMap);
+
+    const { result } = renderHook(() => useAlbumListDownloadStates([]));
+
+    expect(result.current.size).toBe(0);
+  });
+
+  it("handles albums without a spotifyUrl by still passing them to useBulkPlaylistStatus", () => {
+    const album = makeAlbum({ spotifyUrl: undefined });
+    const emptyMap = new Map<string, { isDownloaded: boolean; isDownloading: boolean }>();
+    mockUseBulkPlaylistStatus.mockReturnValue(emptyMap);
+
+    renderHook(() => useAlbumListDownloadStates([album]));
+
+    expect(mockUseBulkPlaylistStatus).toHaveBeenCalledWith([
+      { url: undefined, totalTracks: album.totalTracks },
+    ]);
+  });
+
+  it("passes totalTracks undefined when not present on the album", () => {
+    const album = makeAlbum({ totalTracks: undefined });
+    const emptyMap = new Map<string, { isDownloaded: boolean; isDownloading: boolean }>();
+    mockUseBulkPlaylistStatus.mockReturnValue(emptyMap);
+
+    renderHook(() => useAlbumListDownloadStates([album]));
+
+    expect(mockUseBulkPlaylistStatus).toHaveBeenCalledWith([
+      { url: album.spotifyUrl, totalTracks: undefined },
+    ]);
+  });
+});

--- a/apps/frontend/src/hooks/useAlbumPreviewNavigation.test.ts
+++ b/apps/frontend/src/hooks/useAlbumPreviewNavigation.test.ts
@@ -1,0 +1,104 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PlaylistWithStats } from "@/types";
+import { usePlaylistsQuery } from "./queries/usePlaylistsQuery";
+import { useAlbumPreviewNavigation } from "./useAlbumPreviewNavigation";
+
+// Must be declared before the module imports that use them.
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("./queries/usePlaylistsQuery", () => ({
+  usePlaylistsQuery: vi.fn(),
+}));
+
+const mockUsePlaylistsQuery = vi.mocked(usePlaylistsQuery);
+
+// Minimal playlist factory — only fields the hook actually inspects.
+const makePlaylist = (id: string, spotifyUrl: string): PlaylistWithStats =>
+  ({
+    id,
+    spotifyUrl,
+  }) as PlaylistWithStats;
+
+const makeAlbum = (overrides: Partial<ArtistRelease> = {}): ArtistRelease => ({
+  artistId: "artist-1",
+  artistName: "Test Artist",
+  artistImageUrl: null,
+  albumId: "album-abc",
+  albumName: "Test Album",
+  coverUrl: null,
+  spotifyUrl: "https://open.spotify.com/album/abc",
+  totalTracks: 10,
+  ...overrides,
+});
+
+describe("useAlbumPreviewNavigation", () => {
+  it("navigates to PLAYLIST_DETAIL when the album is already in the local playlist list", () => {
+    const album = makeAlbum();
+    const playlist = makePlaylist("playlist-42", album.spotifyUrl!);
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist] } as ReturnType<
+      typeof usePlaylistsQuery
+    >);
+
+    const { result } = renderHook(() => useAlbumPreviewNavigation());
+    result.current.navigateToAlbumPreview(album);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/playlist/playlist-42");
+  });
+
+  it("navigates to ALBUM_DETAIL when the album is not in the local playlist list", () => {
+    const album = makeAlbum();
+    mockUsePlaylistsQuery.mockReturnValue({ data: [] } as unknown as ReturnType<
+      typeof usePlaylistsQuery
+    >);
+
+    const { result } = renderHook(() => useAlbumPreviewNavigation());
+    result.current.navigateToAlbumPreview(album);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/album/artist-1/album-abc");
+  });
+
+  it("navigates to ALBUM_DETAIL when the album has no spotifyUrl", () => {
+    const album = makeAlbum({ spotifyUrl: undefined });
+    mockUsePlaylistsQuery.mockReturnValue({ data: [] } as unknown as ReturnType<
+      typeof usePlaylistsQuery
+    >);
+
+    const { result } = renderHook(() => useAlbumPreviewNavigation());
+    result.current.navigateToAlbumPreview(album);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/album/artist-1/album-abc");
+  });
+
+  it("uses the default empty array when usePlaylistsQuery returns undefined data", () => {
+    mockUsePlaylistsQuery.mockReturnValue({ data: undefined } as unknown as ReturnType<
+      typeof usePlaylistsQuery
+    >);
+
+    const album = makeAlbum();
+
+    const { result } = renderHook(() => useAlbumPreviewNavigation());
+    result.current.navigateToAlbumPreview(album);
+
+    // No match → falls through to ALBUM_DETAIL
+    expect(mockNavigate).toHaveBeenCalledWith("/album/artist-1/album-abc");
+  });
+
+  it("navigates to ALBUM_DETAIL when spotifyUrl is present but no playlist matches", () => {
+    const album = makeAlbum({ spotifyUrl: "https://open.spotify.com/album/xyz" });
+    const playlist = makePlaylist("p-1", "https://open.spotify.com/album/different");
+    mockUsePlaylistsQuery.mockReturnValue({ data: [playlist] } as ReturnType<
+      typeof usePlaylistsQuery
+    >);
+
+    const { result } = renderHook(() => useAlbumPreviewNavigation());
+    result.current.navigateToAlbumPreview(album);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/album/artist-1/album-abc");
+  });
+});

--- a/apps/frontend/src/hooks/useDebounce.test.ts
+++ b/apps/frontend/src/hooks/useDebounce.test.ts
@@ -1,0 +1,135 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the initial value immediately without waiting", () => {
+    const { result } = renderHook(() => useDebounce("hello", 300));
+    expect(result.current).toBe("hello");
+  });
+
+  it("does not update the value before the delay elapses", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 300),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe("initial");
+  });
+
+  it("updates the value after the delay has fully elapsed", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 300),
+      { initialProps: { value: "initial" } },
+    );
+
+    rerender({ value: "updated" });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe("updated");
+  });
+
+  it("resets the timer on rapid changes — only the last value applies", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDebounce(value, 300),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "b" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: "c" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    rerender({ value: "d" });
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    // 300 ms since last change hasn't passed yet
+    expect(result.current).toBe("a");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe("d");
+  });
+
+  it("works with numeric values", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: number }) => useDebounce(value, 500),
+      { initialProps: { value: 0 } },
+    );
+
+    rerender({ value: 42 });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe(42);
+  });
+
+  it("works with object values — uses reference equality", () => {
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+
+    const { result, rerender } = renderHook(
+      ({ value }: { value: object }) => useDebounce(value, 200),
+      { initialProps: { value: obj1 } },
+    );
+
+    rerender({ value: obj2 });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(result.current).toBe(obj2);
+  });
+
+  it("does not apply a stale timer after the delay changes", () => {
+    const { result, rerender } = renderHook(
+      ({ value, delay }: { value: string; delay: number }) => useDebounce(value, delay),
+      { initialProps: { value: "first", delay: 300 } },
+    );
+
+    // Change both value and delay together
+    rerender({ value: "second", delay: 600 });
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    // With delay=600 we should NOT have updated yet
+    expect(result.current).toBe("first");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe("second");
+  });
+});

--- a/apps/frontend/src/hooks/useGridColumns.test.ts
+++ b/apps/frontend/src/hooks/useGridColumns.test.ts
@@ -1,0 +1,137 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { APP_CONFIG } from "@/config/app";
+import { useGridColumns } from "./useGridColumns";
+
+const { BREAKPOINTS, COLUMNS } = APP_CONFIG.GRID;
+
+// Helper: set window.innerWidth and fire a resize event.
+function setWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: width,
+  });
+  act(() => {
+    window.dispatchEvent(new Event("resize"));
+  });
+}
+
+describe("useGridColumns", () => {
+  const originalWidth = window.innerWidth;
+
+  afterEach(() => {
+    // Restore original innerWidth
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: originalWidth,
+    });
+  });
+
+  it("returns MOBILE columns when width is below SM breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.SM - 1,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.MOBILE);
+  });
+
+  it("returns SM columns at the SM breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.SM,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.SM);
+  });
+
+  it("returns MD columns at the MD breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.MD,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.MD);
+  });
+
+  it("returns LG columns at the LG breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.LG,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.LG);
+  });
+
+  it("returns XL columns at the XL breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.XL,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.XL);
+  });
+
+  it("returns LARGE columns at the LARGE breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.LARGE,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.LARGE);
+  });
+
+  it("returns ULTRAWIDE columns at the ULTRAWIDE breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.ULTRAWIDE,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.ULTRAWIDE);
+  });
+
+  it("updates columns when the window is resized to a larger breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.SM - 1,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.MOBILE);
+
+    setWidth(BREAKPOINTS.LG);
+    expect(result.current).toBe(COLUMNS.LG);
+  });
+
+  it("updates columns when the window is resized to a smaller breakpoint", () => {
+    Object.defineProperty(window, "innerWidth", {
+      writable: true,
+      configurable: true,
+      value: BREAKPOINTS.XL,
+    });
+    const { result } = renderHook(() => useGridColumns());
+    expect(result.current).toBe(COLUMNS.XL);
+
+    setWidth(BREAKPOINTS.SM - 1);
+    expect(result.current).toBe(COLUMNS.MOBILE);
+  });
+
+  it("removes the resize listener on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useGridColumns());
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/apps/frontend/src/hooks/useLanguageSync.test.ts
+++ b/apps/frontend/src/hooks/useLanguageSync.test.ts
@@ -1,0 +1,99 @@
+import type { SettingItem } from "@spotiarr/shared";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSettingsQuery } from "./queries/useSettingsQuery";
+import { useLanguageSync } from "./useLanguageSync";
+
+// Stable mock references declared before vi.mock calls.
+const mockChangeLanguage = vi.fn();
+const mockI18n = {
+  language: "en",
+  changeLanguage: mockChangeLanguage,
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ i18n: mockI18n }),
+}));
+
+vi.mock("./queries/useSettingsQuery", () => ({
+  useSettingsQuery: vi.fn(),
+}));
+
+const mockUseSettingsQuery = vi.mocked(useSettingsQuery);
+
+const makeSetting = (key: string, value: string): SettingItem => ({ key, value });
+
+describe("useLanguageSync", () => {
+  it("calls i18n.changeLanguage when UI_LANGUAGE setting differs from current language", () => {
+    mockI18n.language = "en";
+    mockUseSettingsQuery.mockReturnValue({
+      data: [makeSetting("UI_LANGUAGE", "es")],
+    } as ReturnType<typeof useSettingsQuery>);
+
+    renderHook(() => useLanguageSync());
+
+    expect(mockChangeLanguage).toHaveBeenCalledWith("es");
+  });
+
+  it("does NOT call changeLanguage when UI_LANGUAGE matches the current i18n language", () => {
+    mockChangeLanguage.mockClear();
+    mockI18n.language = "es";
+    mockUseSettingsQuery.mockReturnValue({
+      data: [makeSetting("UI_LANGUAGE", "es")],
+    } as ReturnType<typeof useSettingsQuery>);
+
+    renderHook(() => useLanguageSync());
+
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call changeLanguage when settings are undefined", () => {
+    mockChangeLanguage.mockClear();
+    mockUseSettingsQuery.mockReturnValue({
+      data: undefined,
+    } as ReturnType<typeof useSettingsQuery>);
+
+    renderHook(() => useLanguageSync());
+
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call changeLanguage when UI_LANGUAGE key is absent from settings", () => {
+    mockChangeLanguage.mockClear();
+    mockI18n.language = "en";
+    mockUseSettingsQuery.mockReturnValue({
+      data: [makeSetting("OTHER_SETTING", "value")],
+    } as ReturnType<typeof useSettingsQuery>);
+
+    renderHook(() => useLanguageSync());
+
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call changeLanguage when UI_LANGUAGE value is an empty string", () => {
+    mockChangeLanguage.mockClear();
+    mockI18n.language = "en";
+    mockUseSettingsQuery.mockReturnValue({
+      data: [makeSetting("UI_LANGUAGE", "")],
+    } as ReturnType<typeof useSettingsQuery>);
+
+    renderHook(() => useLanguageSync());
+
+    expect(mockChangeLanguage).not.toHaveBeenCalled();
+  });
+
+  it("calls changeLanguage again when settings change to a new language", () => {
+    mockChangeLanguage.mockClear();
+    mockI18n.language = "en";
+
+    const { rerender } = renderHook(() => useLanguageSync());
+
+    mockUseSettingsQuery.mockReturnValue({
+      data: [makeSetting("UI_LANGUAGE", "es")],
+    } as ReturnType<typeof useSettingsQuery>);
+
+    rerender();
+
+    expect(mockChangeLanguage).toHaveBeenCalledWith("es");
+  });
+});

--- a/apps/frontend/src/hooks/useNavigationHelpers.test.ts
+++ b/apps/frontend/src/hooks/useNavigationHelpers.test.ts
@@ -1,0 +1,44 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+import { useNavigationHelpers } from "./useNavigationHelpers";
+
+const mockNavigate = vi.fn();
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+describe("useNavigationHelpers", () => {
+  it("handleGoBack calls navigate(-1)", () => {
+    const { result } = renderHook(() => useNavigationHelpers());
+    act(() => result.current.handleGoBack());
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("handleGoHome calls navigate with Path.HOME", () => {
+    const { result } = renderHook(() => useNavigationHelpers());
+    act(() => result.current.handleGoHome());
+    expect(mockNavigate).toHaveBeenCalledWith(Path.HOME);
+  });
+
+  it("Path.HOME resolves to '/'", () => {
+    expect(Path.HOME).toBe("/");
+  });
+
+  it("handleGoBack and handleGoHome are stable references across re-renders", () => {
+    const { result, rerender } = renderHook(() => useNavigationHelpers());
+    const { handleGoBack: back1, handleGoHome: home1 } = result.current;
+
+    rerender();
+
+    expect(result.current.handleGoBack).toBe(back1);
+    expect(result.current.handleGoHome).toBe(home1);
+  });
+
+  it("returns an object with exactly handleGoBack and handleGoHome", () => {
+    const { result } = renderHook(() => useNavigationHelpers());
+    expect(typeof result.current.handleGoBack).toBe("function");
+    expect(typeof result.current.handleGoHome).toBe("function");
+  });
+});

--- a/apps/frontend/src/utils/artworkBackfill.test.ts
+++ b/apps/frontend/src/utils/artworkBackfill.test.ts
@@ -1,0 +1,30 @@
+import type { ArtworkBackfillRunStatus } from "@spotiarr/shared";
+import { describe, expect, it } from "vitest";
+import { ACTIVE_BACKFILL_STATUSES } from "./artworkBackfill";
+
+describe("ACTIVE_BACKFILL_STATUSES", () => {
+  it("is a Set", () => {
+    expect(ACTIVE_BACKFILL_STATUSES).toBeInstanceOf(Set);
+  });
+
+  it("contains exactly 4 statuses", () => {
+    expect(ACTIVE_BACKFILL_STATUSES.size).toBe(4);
+  });
+
+  const activeStatuses: ArtworkBackfillRunStatus[] = [
+    "running",
+    "pause_requested",
+    "paused",
+    "paused_rate_limited",
+  ];
+
+  it.each(activeStatuses)("includes '%s' as an active status", (status) => {
+    expect(ACTIVE_BACKFILL_STATUSES.has(status)).toBe(true);
+  });
+
+  const inactiveStatuses: ArtworkBackfillRunStatus[] = ["idle", "completed", "error"];
+
+  it.each(inactiveStatuses)("does NOT include '%s' as an active status", (status) => {
+    expect(ACTIVE_BACKFILL_STATUSES.has(status)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds characterization unit tests for the remaining untested **hooks** layer:
- **20 React Query query hooks** (album tracks, artist albums/detail, artwork backfill status, download history/status, followed artists, library artist(s)/stats, my playlists, playlist preview, playlists, releases, search, settings(+metadata), spotify auth status, supported formats, tracks)
- **6 custom hooks**: useDebounce, useGridColumns, useAlbumListDownloadStates, useAlbumPreviewNavigation, useNavigationHelpers, useLanguageSync
- **1 util**: artworkBackfill

## Why

Continues the frontend coverage push (#185/#186/#187 covered services, mutations, controllers). Closes the hooks/util gap. Part of the ratchet goal (#149).

## Coverage notes

- Query hooks: assert query key, service call args, `select` transforms (e.g. `usePlaylistsQuery` → `calculatePlaylistStats`), and `enabled:false` gating (service NOT called).
- `useSpotifyAuthStatusQuery` mocks `global.fetch` (no service layer); `useFollowedArtistsQuery`/`useReleasesQuery` mock both their service and `settingsService`.
- `useDebounce`: fake timers, timer-reset on rapid changes. `useGridColumns`: `window.innerWidth` + resize. `useAlbumPreviewNavigation`: downloaded→PLAYLIST_DETAIL vs fallback→ALBUM_DETAIL branch. `useLanguageSync`: mismatch/match/missing/empty guards.

76 new tests. No source changes. `tsc --noEmit` clean; full suite 940 passing.