### PR TITLE
test(frontend): unit tests for atoms, errors, layouts, skeletons

### DIFF
--- a/apps/frontend/src/components/atoms/Button.test.tsx
+++ b/apps/frontend/src/components/atoms/Button.test.tsx
@@ -1,0 +1,99 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./Button";
+
+describe("Button", () => {
+  it("renders children", () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole("button", { name: "Click me" })).toBeTruthy();
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click me</Button>);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClick when disabled", () => {
+    const onClick = vi.fn();
+    render(
+      <Button onClick={onClick} disabled>
+        Click me
+      </Button>,
+    );
+    const btn = screen.getByRole("button");
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when loading is true", () => {
+    render(<Button loading>Click me</Button>);
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("applies primary variant styles", () => {
+    render(<Button variant="primary">Primary</Button>);
+    expect(screen.getByRole("button").className).toContain("bg-primary");
+  });
+
+  it("applies danger variant styles", () => {
+    render(<Button variant="danger">Danger</Button>);
+    expect(screen.getByRole("button").className).toContain("bg-white/10");
+  });
+
+  it("applies ghost variant styles", () => {
+    render(<Button variant="ghost">Ghost</Button>);
+    expect(screen.getByRole("button").className).toContain("bg-transparent");
+  });
+
+  it("applies sm size styles", () => {
+    render(<Button size="sm">Small</Button>);
+    expect(screen.getByRole("button").className).toContain("px-3");
+  });
+
+  it("applies lg size styles", () => {
+    render(<Button size="lg">Large</Button>);
+    expect(screen.getByRole("button").className).toContain("px-6");
+  });
+
+  it("sets aria-label from ariaLabel prop", () => {
+    render(<Button ariaLabel="accessible label">Click me</Button>);
+    expect(screen.getByRole("button", { name: "accessible label" })).toBeTruthy();
+  });
+
+  it("sets title attribute", () => {
+    render(<Button title="tooltip">Click me</Button>);
+    expect(screen.getByTitle("tooltip")).toBeTruthy();
+  });
+
+  it("renders icon when provided", () => {
+    render(<Button icon={faMusic}>With icon</Button>);
+    // FontAwesomeIcon renders an svg
+    const btn = screen.getByRole("button");
+    expect(btn.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders spinner svg when loading", () => {
+    render(<Button loading>Click me</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn.querySelector("svg")).toBeTruthy();
+  });
+
+  it("applies disabled opacity class when disabled", () => {
+    render(<Button disabled>Click me</Button>);
+    expect(screen.getByRole("button").className).toContain("opacity-50");
+  });
+
+  it("sets type=submit when specified", () => {
+    render(<Button type="submit">Submit</Button>);
+    expect((screen.getByRole("button") as HTMLButtonElement).type).toBe("submit");
+  });
+
+  it("defaults to type=button", () => {
+    render(<Button>Click me</Button>);
+    expect((screen.getByRole("button") as HTMLButtonElement).type).toBe("button");
+  });
+});

--- a/apps/frontend/src/components/atoms/Image.test.tsx
+++ b/apps/frontend/src/components/atoms/Image.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Image } from "./Image";
+
+describe("Image", () => {
+  it("renders an img element when src is provided", () => {
+    render(<Image src="https://example.com/photo.jpg" alt="Test image" />);
+    expect(screen.getByRole("img", { name: "Test image" })).toBeTruthy();
+  });
+
+  it("renders fallback icon when src is empty string", () => {
+    const { container } = render(<Image src="" alt="No image" />);
+    // No img element — renders a div with a FontAwesome svg icon
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders fallback icon when src is undefined", () => {
+    const { container } = render(<Image alt="No image" />);
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("renders fallback icon after image load error", () => {
+    const { container } = render(<Image src="https://example.com/broken.jpg" alt="Broken image" />);
+    const img = screen.getByRole("img");
+    fireEvent.error(img);
+    // After error the img is replaced by the fallback div
+    expect(screen.queryByRole("img")).toBeNull();
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+
+  it("image starts with opacity-0 and becomes opacity-100 after load", () => {
+    render(<Image src="https://example.com/photo.jpg" alt="Photo" />);
+    const img = screen.getByRole("img");
+    expect(img.className).toContain("opacity-0");
+    fireEvent.load(img);
+    expect(img.className).toContain("opacity-100");
+  });
+
+  it("applies className to the img element", () => {
+    render(<Image src="https://example.com/photo.jpg" alt="Photo" className="rounded-full" />);
+    expect(screen.getByRole("img").className).toContain("rounded-full");
+  });
+
+  it("applies wrapperClassName to the wrapper div", () => {
+    const { container } = render(
+      <Image src="https://example.com/photo.jpg" alt="Photo" wrapperClassName="my-wrapper" />,
+    );
+    expect(container.firstChild).toBeTruthy();
+    expect((container.firstChild as HTMLElement).className).toContain("my-wrapper");
+  });
+});

--- a/apps/frontend/src/components/atoms/Loading.test.tsx
+++ b/apps/frontend/src/components/atoms/Loading.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Loading } from "./Loading";
+
+describe("Loading", () => {
+  it("renders with role=status", () => {
+    render(<Loading />);
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
+
+  it("has default aria-label of 'Loading' when no message is provided", () => {
+    render(<Loading />);
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Loading");
+  });
+
+  it("renders screen-reader-only 'Loading' text when no message", () => {
+    render(<Loading />);
+    expect(screen.getByText("Loading")).toBeTruthy();
+  });
+
+  it("sets aria-label to the provided message", () => {
+    render(<Loading message="Fetching data..." />);
+    expect(screen.getByRole("status").getAttribute("aria-label")).toBe("Fetching data...");
+  });
+
+  it("renders the message text visibly when provided", () => {
+    render(<Loading message="Please wait" />);
+    expect(screen.getByText("Please wait")).toBeTruthy();
+  });
+
+  it("does not render a visible message paragraph when message is absent", () => {
+    render(<Loading />);
+    // Only the sr-only span should exist, no <p> element
+    const status = screen.getByRole("status");
+    expect(status.querySelector("p")).toBeNull();
+  });
+
+  it("applies additional className to the container", () => {
+    render(<Loading className="custom-class" />);
+    expect(screen.getByRole("status").className).toContain("custom-class");
+  });
+
+  it("renders a spinning icon (svg)", () => {
+    const { container } = render(<Loading />);
+    expect(container.querySelector("svg")).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/components/atoms/Skeleton.test.tsx
+++ b/apps/frontend/src/components/atoms/Skeleton.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+describe("Skeleton", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders a div element", () => {
+    const { container } = render(<Skeleton />);
+    expect((container.firstChild as HTMLElement).tagName).toBe("DIV");
+  });
+
+  it("includes animate-pulse class by default", () => {
+    const { container } = render(<Skeleton />);
+    expect((container.firstChild as HTMLElement).className).toContain("animate-pulse");
+  });
+
+  it("includes rounded-md class by default", () => {
+    const { container } = render(<Skeleton />);
+    expect((container.firstChild as HTMLElement).className).toContain("rounded-md");
+  });
+
+  it("merges additional className with base classes", () => {
+    const { container } = render(<Skeleton className="h-4 w-32" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.className).toContain("animate-pulse");
+    expect(el.className).toContain("h-4");
+    expect(el.className).toContain("w-32");
+  });
+
+  it("forwards extra HTML attributes to the div", () => {
+    const { container } = render(<Skeleton data-testid="skel" aria-hidden="true" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.getAttribute("data-testid")).toBe("skel");
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+  });
+});

--- a/apps/frontend/src/components/errors/ErrorBoundary.test.tsx
+++ b/apps/frontend/src/components/errors/ErrorBoundary.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+// Silence the expected console.error from ErrorBoundary.componentDidCatch
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleErrorSpy.mockClear();
+});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+const ThrowingChild = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error("Test error message");
+  }
+  return <span>Safe child</span>;
+};
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error is thrown", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Safe child")).toBeTruthy();
+  });
+
+  it("renders default fallback when child throws and no fallback prop is provided", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(screen.getByText("Test error message")).toBeTruthy();
+  });
+
+  it("renders a 'Try again' button in the default fallback", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+  });
+
+  it("resets error state when 'Try again' is clicked — hides the fallback", () => {
+    // After reset the boundary clears its error state.
+    // Re-render with a non-throwing child to confirm children render.
+    let shouldThrow = true;
+    const ControlledChild = () => {
+      if (shouldThrow) throw new Error("Boom");
+      return <span>Safe child</span>;
+    };
+
+    const { rerender } = render(
+      <ErrorBoundary>
+        <ControlledChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+
+    // Click reset, then re-render without throwing
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    rerender(
+      <ErrorBoundary>
+        <ControlledChild />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Safe child")).toBeTruthy();
+  });
+
+  it("calls custom fallback prop with error and reset function", () => {
+    const fallback = vi.fn().mockReturnValue(<span>Custom fallback</span>);
+    render(
+      <ErrorBoundary fallback={fallback}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Custom fallback")).toBeTruthy();
+    expect(fallback).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Test error message" }),
+      expect.any(Function),
+    );
+  });
+});

--- a/apps/frontend/src/components/errors/ErrorFallback.test.tsx
+++ b/apps/frontend/src/components/errors/ErrorFallback.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ErrorFallback } from "./ErrorFallback";
+
+// ErrorFallback delegates to GenericErrorState which uses onGoHome to set window.location.href
+// We just need the error and resetError contract tested.
+
+describe("ErrorFallback", () => {
+  it("renders without crashing", () => {
+    const { container } = render(
+      <ErrorFallback error={new Error("Something failed")} resetError={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders a retry button", () => {
+    render(<ErrorFallback error={new Error("fail")} resetError={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeTruthy();
+  });
+
+  it("calls resetError when Try Again is clicked", () => {
+    const resetError = vi.fn();
+    render(<ErrorFallback error={new Error("fail")} resetError={resetError} />);
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(resetError).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a Go Home button", () => {
+    render(<ErrorFallback error={new Error("fail")} resetError={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Go Home" })).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/components/errors/GenericErrorState.test.tsx
+++ b/apps/frontend/src/components/errors/GenericErrorState.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { GenericErrorState } from "./GenericErrorState";
+
+describe("GenericErrorState", () => {
+  it("renders with default title and description", () => {
+    render(<GenericErrorState />);
+    expect(screen.getByText("Oops! Something went wrong")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Don't worry, this happens sometimes. Try refreshing the page or going back home.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("renders custom title and description when provided", () => {
+    render(<GenericErrorState title="Custom Title" description="Custom description." />);
+    expect(screen.getByText("Custom Title")).toBeTruthy();
+    expect(screen.getByText("Custom description.")).toBeTruthy();
+  });
+
+  it("renders Try Again button when onRetry is provided", () => {
+    render(<GenericErrorState onRetry={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeTruthy();
+  });
+
+  it("does not render Try Again button when onRetry is absent", () => {
+    render(<GenericErrorState />);
+    expect(screen.queryByRole("button", { name: "Try Again" })).toBeNull();
+  });
+
+  it("calls onRetry when Try Again is clicked", () => {
+    const onRetry = vi.fn();
+    render(<GenericErrorState onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders Go Home button when onGoHome is provided", () => {
+    render(<GenericErrorState onGoHome={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Go Home" })).toBeTruthy();
+  });
+
+  it("does not render Go Home button when onGoHome is absent", () => {
+    render(<GenericErrorState />);
+    expect(screen.queryByRole("button", { name: "Go Home" })).toBeNull();
+  });
+
+  it("calls onGoHome when Go Home is clicked", () => {
+    const onGoHome = vi.fn();
+    render(<GenericErrorState onGoHome={onGoHome} />);
+    fireEvent.click(screen.getByRole("button", { name: "Go Home" }));
+    expect(onGoHome).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders both buttons when both handlers are provided", () => {
+    render(<GenericErrorState onRetry={vi.fn()} onGoHome={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Go Home" })).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/components/errors/RouteErrorBoundary.test.tsx
+++ b/apps/frontend/src/components/errors/RouteErrorBoundary.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { RouteErrorBoundary } from "./RouteErrorBoundary";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Suppress expected React error boundary console.error noise
+const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+afterEach(() => {
+  consoleErrorSpy.mockClear();
+});
+
+afterAll(() => {
+  consoleErrorSpy.mockRestore();
+});
+
+const ThrowingChild = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error("Route error");
+  }
+  return <span>Child content</span>;
+};
+
+const renderInRouter = (ui: React.ReactNode) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe("RouteErrorBoundary", () => {
+  it("renders children when no error is thrown", () => {
+    renderInRouter(
+      <RouteErrorBoundary>
+        <ThrowingChild shouldThrow={false} />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText("Child content")).toBeTruthy();
+  });
+
+  it("renders fallback with i18n title when a child throws", () => {
+    renderInRouter(
+      <RouteErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByText("common.errors.pageError")).toBeTruthy();
+  });
+
+  it("renders a retry button in the fallback", () => {
+    renderInRouter(
+      <RouteErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: "Try Again" })).toBeTruthy();
+  });
+
+  it("renders a go home button in the fallback", () => {
+    renderInRouter(
+      <RouteErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </RouteErrorBoundary>,
+    );
+    expect(screen.getByRole("button", { name: "Go Home" })).toBeTruthy();
+  });
+
+  it("resets and renders children again after clicking Try Again", () => {
+    // Provide a stable ref so we can flip shouldThrow without remounting
+    // the boundary. We rerender BEFORE the reset click so the boundary
+    // receives safe children by the time it re-renders after reset.
+    const { rerender } = renderInRouter(
+      <RouteErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </RouteErrorBoundary>,
+    );
+
+    expect(screen.getByText("common.errors.pageError")).toBeTruthy();
+
+    // Swap children to non-throwing FIRST, then click reset.
+    // This prevents the boundary from immediately re-catching after reset.
+    rerender(
+      <MemoryRouter>
+        <RouteErrorBoundary>
+          <ThrowingChild shouldThrow={false} />
+        </RouteErrorBoundary>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Try Again" }));
+
+    expect(screen.getByText("Child content")).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/components/layouts/AppFooter.test.tsx
+++ b/apps/frontend/src/components/layouts/AppFooter.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppFooter } from "./AppFooter";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/config/version", () => ({ APP_VERSION: "1.2.3" }));
+vi.mock("@/config/links", () => ({
+  BUY_ME_A_COFFEE_URL: "https://buymeacoffee.com/test",
+  GITHUB_RELEASE_URL: "https://github.com/test/releases/tag/v1.2.3",
+}));
+
+describe("AppFooter (expanded)", () => {
+  it("renders version text", () => {
+    render(<AppFooter />);
+    expect(screen.getByText(/1\.2\.3/)).toBeTruthy();
+  });
+
+  it("renders buy-me-a-coffee link with i18n label", () => {
+    render(<AppFooter />);
+    expect(screen.getByText("navigation.buyMeCoffee")).toBeTruthy();
+  });
+
+  it("buy-me-a-coffee link opens in a new tab", () => {
+    render(<AppFooter />);
+    const link = screen.getByText("navigation.buyMeCoffee").closest("a");
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toContain("noopener");
+  });
+});
+
+describe("AppFooter (collapsed)", () => {
+  it("renders icon-only coffee link with title when collapsed", () => {
+    render(<AppFooter collapsed />);
+    const coffeeLink = screen.getByTitle("navigation.buyMeCoffee");
+    expect(coffeeLink).toBeTruthy();
+  });
+
+  it("renders version anchor with title when collapsed", () => {
+    render(<AppFooter collapsed />);
+    expect(screen.getByTitle("SpotiArr v1.2.3")).toBeTruthy();
+  });
+
+  it("does not render the full 'navigation.buyMeCoffee' text when collapsed", () => {
+    render(<AppFooter collapsed />);
+    // Text node inside the link should not exist in collapsed state
+    expect(screen.queryByText("navigation.buyMeCoffee")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/layouts/AppHeader.test.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppHeader } from "./AppHeader";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const mockController = {
+  url: "",
+  handleSubmit: vi.fn(),
+  isPending: false,
+  isValidUrl: false,
+  handleChangeUrl: vi.fn(),
+  handleKeyUp: vi.fn(),
+};
+
+vi.mock("@/hooks/controllers/useHeaderController", () => ({
+  useHeaderController: () => mockController,
+}));
+
+const renderHeader = () =>
+  render(
+    <MemoryRouter>
+      <AppHeader />
+    </MemoryRouter>,
+  );
+
+describe("AppHeader", () => {
+  beforeEach(() => {
+    mockController.url = "";
+    mockController.isValidUrl = false;
+    mockController.isPending = false;
+  });
+
+  it("renders the search input", () => {
+    renderHeader();
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("renders the SpotiArr logo image", () => {
+    renderHeader();
+    expect(screen.getByAltText("SpotiArr Logo")).toBeTruthy();
+  });
+
+  it("does not render the submit button when url is empty", () => {
+    renderHeader();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders submit button when url is non-empty", () => {
+    mockController.url = "https://open.spotify.com/playlist/123";
+    renderHeader();
+    expect(screen.getByRole("button")).toBeTruthy();
+  });
+
+  it("submit button is disabled when isPending is true", () => {
+    mockController.url = "https://open.spotify.com/playlist/123";
+    mockController.isPending = true;
+    renderHeader();
+    expect((screen.getByRole("button") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders at least one navigation link", () => {
+    renderHeader();
+    expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/frontend/src/components/layouts/AppLayout.test.tsx
+++ b/apps/frontend/src/components/layouts/AppLayout.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
+import { AppLayout } from "./AppLayout";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("@/config/version", () => ({ APP_VERSION: "1.0.0" }));
+vi.mock("@/config/links", () => ({
+  BUY_ME_A_COFFEE_URL: "https://buymeacoffee.com/test",
+  GITHUB_RELEASE_URL: "https://github.com/test/releases",
+}));
+
+const mockUsePreferencesStore = vi.fn(() => ({
+  isSidebarCollapsed: false,
+  toggleSidebar: vi.fn(),
+  setSidebarCollapsed: vi.fn(),
+}));
+
+vi.mock("@/store/usePreferencesStore", () => ({
+  usePreferencesStore: () => mockUsePreferencesStore(),
+}));
+
+vi.mock("@/hooks/controllers/useHeaderController", () => ({
+  useHeaderController: () => ({
+    url: "",
+    handleSubmit: vi.fn(),
+    isPending: false,
+    isValidUrl: false,
+    handleChangeUrl: vi.fn(),
+    handleKeyUp: vi.fn(),
+  }),
+}));
+
+// Stub the GlobalPlayerBar — it has heavy store/audio dependencies
+vi.mock("../organisms/GlobalPlayerBar", () => ({
+  GlobalPlayerBar: () => <div data-testid="global-player-bar" />,
+}));
+
+// react-router-dom Outlet renders matched child routes; stub it for unit tests
+vi.mock("react-router-dom", async (importActual) => {
+  const actual = await importActual<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    Outlet: () => <div data-testid="outlet" />,
+  };
+});
+
+const renderLayout = (pathname: Path = Path.HOME) =>
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <AppLayout pathname={pathname} version="1.0.0" />
+    </MemoryRouter>,
+  );
+
+describe("AppLayout", () => {
+  it("renders without crashing", () => {
+    const { container } = renderLayout();
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders the Outlet placeholder", () => {
+    renderLayout();
+    expect(screen.getByTestId("outlet")).toBeTruthy();
+  });
+
+  it("renders the GlobalPlayerBar", () => {
+    renderLayout();
+    expect(screen.getByTestId("global-player-bar")).toBeTruthy();
+  });
+
+  it("renders a main element for the page content area", () => {
+    renderLayout();
+    expect(screen.getByRole("main")).toBeTruthy();
+  });
+
+  it("renders the navigation (Sidebar)", () => {
+    renderLayout();
+    // Sidebar renders an <aside> — check via complementary role or just landmark
+    const { container } = renderLayout();
+    expect(container.querySelector("aside")).toBeTruthy();
+  });
+
+  it("applies collapsed margin class when sidebar is collapsed", () => {
+    mockUsePreferencesStore.mockReturnValueOnce({
+      isSidebarCollapsed: true,
+      toggleSidebar: vi.fn(),
+      setSidebarCollapsed: vi.fn(),
+    });
+    const { getByRole } = renderLayout();
+    expect(getByRole("main").className).toContain("md:ml-20");
+  });
+});

--- a/apps/frontend/src/components/layouts/BottomNavigation.test.tsx
+++ b/apps/frontend/src/components/layouts/BottomNavigation.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { MOBILE_NAV_ITEMS } from "@/config/navigation";
+import { Path } from "@/routes/routes";
+import { BottomNavigation } from "./BottomNavigation";
+
+const renderNav = (pathname: string) =>
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <BottomNavigation pathname={pathname} />
+    </MemoryRouter>,
+  );
+
+describe("BottomNavigation", () => {
+  it("renders a nav element", () => {
+    renderNav(Path.HOME);
+    expect(screen.getByRole("navigation")).toBeTruthy();
+  });
+
+  it("renders a link for each mobile nav item", () => {
+    renderNav(Path.HOME);
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(MOBILE_NAV_ITEMS.length);
+  });
+
+  it("renders each nav item label", () => {
+    renderNav(Path.HOME);
+    for (const item of MOBILE_NAV_ITEMS) {
+      expect(screen.getByText(item.label)).toBeTruthy();
+    }
+  });
+
+  it("applies active text-white class to the current route link", () => {
+    renderNav(Path.HOME);
+    const homeItem = MOBILE_NAV_ITEMS.find((i) => i.to === Path.HOME)!;
+    const homeLink = screen.getByText(homeItem.label).closest("a")!;
+    expect(homeLink.className).toContain("text-white");
+  });
+
+  it("does not apply text-white to inactive route links", () => {
+    renderNav(Path.HOME);
+    const historyItem = MOBILE_NAV_ITEMS.find((i) => i.to === Path.HISTORY)!;
+    const historyLink = screen.getByText(historyItem.label).closest("a")!;
+    expect(historyLink.className).not.toContain("text-white");
+  });
+
+  it("each link points to the correct path", () => {
+    renderNav(Path.HOME);
+    for (const item of MOBILE_NAV_ITEMS) {
+      const link = screen.getByText(item.label).closest("a")!;
+      expect(link.getAttribute("href")).toBe(item.to);
+    }
+  });
+});

--- a/apps/frontend/src/components/layouts/Sidebar.test.tsx
+++ b/apps/frontend/src/components/layouts/Sidebar.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NAV_ITEMS } from "@/config/navigation";
+import { Path } from "@/routes/routes";
+import { Sidebar } from "./Sidebar";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/config/version", () => ({ APP_VERSION: "1.0.0" }));
+vi.mock("@/config/links", () => ({
+  BUY_ME_A_COFFEE_URL: "https://buymeacoffee.com/test",
+  GITHUB_RELEASE_URL: "https://github.com/test/releases/tag/v1.0.0",
+}));
+
+const mockToggleSidebar = vi.fn();
+const mockStore = { isSidebarCollapsed: false, toggleSidebar: mockToggleSidebar };
+
+vi.mock("@/store/usePreferencesStore", () => ({
+  usePreferencesStore: () => mockStore,
+}));
+
+const renderSidebar = (pathname: string = Path.HOME) =>
+  render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <Sidebar pathname={pathname} version="1.0.0" />
+    </MemoryRouter>,
+  );
+
+describe("Sidebar (expanded)", () => {
+  beforeEach(() => {
+    mockStore.isSidebarCollapsed = false;
+    mockToggleSidebar.mockClear();
+  });
+
+  it("renders the SpotiArr logo link", () => {
+    renderSidebar();
+    expect(screen.getByAltText("SpotiArr Logo")).toBeTruthy();
+  });
+
+  it("renders a nav element", () => {
+    renderSidebar();
+    expect(screen.getByRole("navigation")).toBeTruthy();
+  });
+
+  it("renders all navigation item labels", () => {
+    renderSidebar();
+    // Labels are translated via t(key) which returns the key
+    // Check that all nav items have their translated labels rendered
+    expect(screen.getByText("navigation.home")).toBeTruthy();
+    expect(screen.getByText("navigation.history")).toBeTruthy();
+    expect(screen.getByText("navigation.settings")).toBeTruthy();
+  });
+
+  it("renders a nav link for each NAV_ITEM", () => {
+    renderSidebar();
+    const links = screen.getAllByRole("link");
+    // +1 for the logo link
+    expect(links.length).toBeGreaterThanOrEqual(NAV_ITEMS.length);
+  });
+
+  it("applies active style to the current route link", () => {
+    renderSidebar(Path.HOME);
+    const homeLabel = screen.getByText("navigation.home");
+    const homeLink = homeLabel.closest("a")!;
+    expect(homeLink.className).toContain("bg-background-hover");
+  });
+
+  it("does not apply active style to an inactive route link", () => {
+    renderSidebar(Path.HOME);
+    const historyLabel = screen.getByText("navigation.history");
+    const historyLink = historyLabel.closest("a")!;
+    expect(historyLink.className).not.toContain("bg-background-hover");
+  });
+
+  it("renders the collapse toggle button", () => {
+    renderSidebar();
+    expect(screen.getByTitle("navigation.collapse")).toBeTruthy();
+  });
+
+  it("calls toggleSidebar when the collapse button is clicked", () => {
+    renderSidebar();
+    fireEvent.click(screen.getByTitle("navigation.collapse"));
+    expect(mockToggleSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders collapse label text when expanded", () => {
+    renderSidebar();
+    expect(screen.getByText("navigation.collapse")).toBeTruthy();
+  });
+});
+
+describe("Sidebar (collapsed)", () => {
+  beforeEach(() => {
+    mockStore.isSidebarCollapsed = true;
+    mockToggleSidebar.mockClear();
+  });
+
+  it("renders the expand button when collapsed", () => {
+    renderSidebar();
+    expect(screen.getByTitle("navigation.expand")).toBeTruthy();
+  });
+
+  it("does not render visible nav label text when collapsed", () => {
+    renderSidebar();
+    // Spans with nav labels should not be in the DOM when collapsed
+    expect(screen.queryByText("navigation.home")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/skeletons/PlaylistSkeleton.test.tsx
+++ b/apps/frontend/src/components/skeletons/PlaylistSkeleton.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PlaylistSkeleton } from "./PlaylistSkeleton";
+
+describe("PlaylistSkeleton", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<PlaylistSkeleton />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders exactly 10 track row skeletons", () => {
+    const { container } = render(<PlaylistSkeleton />);
+    // Each track row has a grid wrapper — the component uses [...Array(10)].map(...)
+    // The rows live under the "Tracks List Skeleton" section.
+    // Count divs that have the track row grid class pattern
+    const trackRows = container.querySelectorAll(".grid.grid-cols-\\[auto_1fr_auto\\]");
+    // Header row + 10 track rows = 11 total; exclude the header
+    expect(trackRows.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("renders a large image skeleton for the cover art", () => {
+    const { container } = render(<PlaylistSkeleton />);
+    // The cover art skeleton has h-48 w-48 classes
+    const coverSkeleton = container.querySelector(".h-48");
+    expect(coverSkeleton).toBeTruthy();
+  });
+
+  it("renders animate-pulse elements (Skeleton components)", () => {
+    const { container } = render(<PlaylistSkeleton />);
+    const pulseEls = container.querySelectorAll(".animate-pulse");
+    expect(pulseEls.length).toBeGreaterThan(5);
+  });
+
+  it("renders action area skeletons (circular buttons)", () => {
+    const { container } = render(<PlaylistSkeleton />);
+    // The download button skeleton has h-12 w-12 rounded-full
+    const circleSkeletons = container.querySelectorAll(".rounded-full");
+    expect(circleSkeletons.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/apps/frontend/src/components/skeletons/SpotifyAuthCardSkeleton.test.tsx
+++ b/apps/frontend/src/components/skeletons/SpotifyAuthCardSkeleton.test.tsx
@@ -1,0 +1,39 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SpotifyAuthCardSkeleton } from "./SpotifyAuthCardSkeleton";
+
+describe("SpotifyAuthCardSkeleton", () => {
+  it("renders without crashing", () => {
+    const { container } = render(<SpotifyAuthCardSkeleton />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders a card container div", () => {
+    const { container } = render(<SpotifyAuthCardSkeleton />);
+    const card = container.firstChild as HTMLElement;
+    expect(card.tagName).toBe("DIV");
+    expect(card.className).toContain("rounded-lg");
+  });
+
+  it("renders multiple animate-pulse placeholder elements", () => {
+    const { container } = render(<SpotifyAuthCardSkeleton />);
+    const pulseEls = container.querySelectorAll(".animate-pulse");
+    expect(pulseEls.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("renders a heading placeholder (h6 circle + title bar)", () => {
+    const { container } = render(<SpotifyAuthCardSkeleton />);
+    // h2 wraps a circle (h-6 w-6) and a title bar (h-6 w-48)
+    const h2 = container.querySelector("h2");
+    expect(h2).toBeTruthy();
+    const innerPulse = h2!.querySelectorAll(".animate-pulse");
+    expect(innerPulse.length).toBe(2);
+  });
+
+  it("renders a button-sized placeholder at the bottom", () => {
+    const { container } = render(<SpotifyAuthCardSkeleton />);
+    // The CTA placeholder is h-10 w-48
+    const ctaPlaceholder = container.querySelector(".h-10.w-48");
+    expect(ctaPlaceholder).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What

Render/behavior unit tests for the untested presentational components:
- **atoms**: Button, Image, Loading, Skeleton
- **errors**: ErrorBoundary, ErrorFallback, GenericErrorState, RouteErrorBoundary
- **layouts**: AppFooter, AppHeader, AppLayout, BottomNavigation, Sidebar
- **skeletons**: PlaylistSkeleton, SpotifyAuthCardSkeleton

## Why

Continues the frontend coverage push (#185/#186/#187/#188). Part of the ratchet goal (#149).

## Coverage notes

- Atoms: prop/children rendering, variant/size/disabled className branches, Button onClick.
- Errors: children-render vs fallback-render when a child throws; retry callback fires.
- Layouts: nav structure/children, active-route highlighting (MemoryRouter), mocked router/i18n/stores.
- Skeletons: renders without crashing, expected placeholder count.

15 files, no source changes. `tsc --noEmit` clean; full suite passing.