### PR TITLE
test(frontend): unit tests for 23 molecule components

### DIFF
--- a/apps/frontend/src/components/molecules/ApiErrorState.test.tsx
+++ b/apps/frontend/src/components/molecules/ApiErrorState.test.tsx
@@ -1,0 +1,46 @@
+import { ApiErrorCode } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ApiErrorState } from "./ApiErrorState";
+
+vi.mock("./ConnectSpotifyPrompt", () => ({
+  ConnectSpotifyPrompt: ({ onConnect }: any) => (
+    <button onClick={onConnect}>Connect with Spotify</button>
+  ),
+}));
+
+vi.mock("./RateLimitedMessage", () => ({
+  RateLimitedMessage: () => <div>Rate limited</div>,
+}));
+
+describe("ApiErrorState", () => {
+  it("renders nothing when error is null", () => {
+    const { container } = render(<ApiErrorState error={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders generic error message when error is an unknown code", () => {
+    render(<ApiErrorState error={"not_found" as ApiErrorCode} />);
+    expect(screen.getByText("Failed to load data.")).not.toBeNull();
+  });
+
+  it("renders ConnectSpotifyPrompt when error is missing_user_access_token", () => {
+    render(<ApiErrorState error={"missing_user_access_token" as ApiErrorCode} />);
+    expect(screen.getByText("Connect with Spotify")).not.toBeNull();
+  });
+
+  it("clicking connect button in ConnectSpotifyPrompt does not throw", () => {
+    render(<ApiErrorState error={"missing_user_access_token" as ApiErrorCode} />);
+    expect(() => fireEvent.click(screen.getByText("Connect with Spotify"))).not.toThrow();
+  });
+
+  it("renders RateLimitedMessage when error is spotify_rate_limited", () => {
+    render(<ApiErrorState error={"spotify_rate_limited" as ApiErrorCode} />);
+    expect(screen.getByText("Rate limited")).not.toBeNull();
+  });
+
+  it("uses custom message prop for generic errors", () => {
+    render(<ApiErrorState error={"not_found" as ApiErrorCode} message="Custom error message" />);
+    expect(screen.getByText("Custom error message")).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/ArtistDiscographyFilters.test.tsx
+++ b/apps/frontend/src/components/molecules/ArtistDiscographyFilters.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ArtistDiscographyFilters } from "./ArtistDiscographyFilters";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("../atoms/Button", () => ({
+  Button: ({ children, onClick, className }: any) => (
+    <button onClick={onClick} className={className}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("ArtistDiscographyFilters", () => {
+  const onFilterChange = vi.fn();
+
+  it("renders all 3 filter buttons", () => {
+    render(<ArtistDiscographyFilters currentFilter="all" onFilterChange={onFilterChange} />);
+
+    expect(screen.getByText("common.cards.albumTypes.all")).not.toBeNull();
+    expect(screen.getByText("common.cards.albumTypes.album")).not.toBeNull();
+    expect(screen.getByText("common.cards.albumTypes.singlesAndEps")).not.toBeNull();
+  });
+
+  it("calls onFilterChange with 'all' when all button is clicked", () => {
+    const handler = vi.fn();
+    render(<ArtistDiscographyFilters currentFilter="album" onFilterChange={handler} />);
+
+    fireEvent.click(screen.getByText("common.cards.albumTypes.all"));
+    expect(handler).toHaveBeenCalledWith("all");
+  });
+
+  it("calls onFilterChange with 'album' when album button is clicked", () => {
+    const handler = vi.fn();
+    render(<ArtistDiscographyFilters currentFilter="all" onFilterChange={handler} />);
+
+    fireEvent.click(screen.getByText("common.cards.albumTypes.album"));
+    expect(handler).toHaveBeenCalledWith("album");
+  });
+
+  it("calls onFilterChange with 'single' when single button is clicked", () => {
+    const handler = vi.fn();
+    render(<ArtistDiscographyFilters currentFilter="all" onFilterChange={handler} />);
+
+    fireEvent.click(screen.getByText("common.cards.albumTypes.singlesAndEps"));
+    expect(handler).toHaveBeenCalledWith("single");
+  });
+
+  it("active filter button has class containing 'bg-white'", () => {
+    render(<ArtistDiscographyFilters currentFilter="album" onFilterChange={onFilterChange} />);
+
+    const albumButton = screen.getByText("common.cards.albumTypes.album").closest("button");
+    expect(albumButton?.className).toContain("bg-white");
+  });
+
+  it("inactive buttons do not have 'bg-white' class", () => {
+    render(<ArtistDiscographyFilters currentFilter="album" onFilterChange={onFilterChange} />);
+
+    const allButton = screen.getByText("common.cards.albumTypes.all").closest("button");
+    expect(allButton?.className).not.toContain("bg-white");
+
+    const singleButton = screen
+      .getByText("common.cards.albumTypes.singlesAndEps")
+      .closest("button");
+    expect(singleButton?.className).not.toContain("bg-white");
+  });
+});

--- a/apps/frontend/src/components/molecules/ArtistHeader.test.tsx
+++ b/apps/frontend/src/components/molecules/ArtistHeader.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ArtistHeader } from "./ArtistHeader";
+
+describe("ArtistHeader", () => {
+  it("renders the artist name", () => {
+    render(<ArtistHeader name="Daft Punk" />);
+    expect(screen.getByText("Daft Punk")).not.toBeNull();
+  });
+
+  it("wraps name in an anchor with correct href and target='_blank' when spotifyUrl is provided", () => {
+    render(<ArtistHeader name="Daft Punk" spotifyUrl="https://open.spotify.com/artist/123" />);
+
+    const link = screen.getByRole("link", { name: "Daft Punk" });
+    expect(link).not.toBeNull();
+    expect(link.getAttribute("href")).toBe("https://open.spotify.com/artist/123");
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("renders name as plain text without an anchor when spotifyUrl is not provided", () => {
+    render(<ArtistHeader name="Daft Punk" />);
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("Daft Punk")).not.toBeNull();
+  });
+
+  it("renders subtitle when provided", () => {
+    render(<ArtistHeader name="Daft Punk" subtitle="Electronic duo from Paris" />);
+    expect(screen.getByText("Electronic duo from Paris")).not.toBeNull();
+  });
+
+  it("does not render subtitle when omitted", () => {
+    render(<ArtistHeader name="Daft Punk" />);
+    expect(screen.queryByText("Electronic duo from Paris")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/ArtistLinks.test.tsx
+++ b/apps/frontend/src/components/molecules/ArtistLinks.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { ArtistLinks } from "./ArtistLinks";
+
+vi.mock("@/utils/spotify", () => ({
+  isSpotifyUrl: (url: string) => url.startsWith("https://open.spotify.com"),
+  getSpotifyIdFromUrl: (url: string) => url.split("/").pop() ?? null,
+}));
+
+vi.mock("@/routes/routes", () => ({
+  Path: { ARTIST_DETAIL: "/artist/:id" },
+}));
+
+describe("ArtistLinks", () => {
+  it("renders artist name as plain text when no url is provided", () => {
+    render(
+      <MemoryRouter>
+        <ArtistLinks artists={[{ name: "Daft Punk" }]} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Daft Punk")).not.toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders a link when artist has a Spotify URL containing the extracted ID", () => {
+    render(
+      <MemoryRouter>
+        <ArtistLinks
+          artists={[{ name: "Daft Punk", url: "https://open.spotify.com/artist/abc123" }]}
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Daft Punk" });
+    expect(link).not.toBeNull();
+    expect(link.getAttribute("href")).toContain("abc123");
+  });
+
+  it("renders a link using the last path segment when artist has a non-Spotify URL", () => {
+    render(
+      <MemoryRouter>
+        <ArtistLinks artists={[{ name: "Daft Punk", url: "https://example.com/artists/xyz789" }]} />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", { name: "Daft Punk" });
+    expect(link).not.toBeNull();
+    expect(link.getAttribute("href")).toContain("xyz789");
+  });
+
+  it("renders multiple artists separated by commas with no trailing comma on the last", () => {
+    render(
+      <MemoryRouter>
+        <ArtistLinks
+          artists={[
+            { name: "Artist One", url: "https://open.spotify.com/artist/id1" },
+            { name: "Artist Two", url: "https://open.spotify.com/artist/id2" },
+            { name: "Artist Three" },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Artist One")).not.toBeNull();
+    expect(screen.getByText("Artist Two")).not.toBeNull();
+    expect(screen.getByText("Artist Three")).not.toBeNull();
+
+    const container = screen.getByText("Artist One").closest("span")?.parentElement;
+    expect(container?.textContent).toContain(", ");
+    // Last artist has no trailing comma
+    expect(container?.textContent?.endsWith(", ")).toBe(false);
+  });
+
+  it("calls onLinkClick when an artist link is clicked", () => {
+    const onLinkClick = vi.fn();
+    render(
+      <MemoryRouter>
+        <ArtistLinks
+          artists={[{ name: "Daft Punk", url: "https://open.spotify.com/artist/abc123" }]}
+          onLinkClick={onLinkClick}
+        />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "Daft Punk" }));
+    expect(onLinkClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a single artist with no comma separator", () => {
+    render(
+      <MemoryRouter>
+        <ArtistLinks artists={[{ name: "Solo Artist" }]} />
+      </MemoryRouter>,
+    );
+
+    const text = screen.getByText("Solo Artist").closest("span")?.parentElement?.textContent;
+    expect(text).not.toContain(",");
+  });
+});

--- a/apps/frontend/src/components/molecules/ConnectSpotifyPrompt.test.tsx
+++ b/apps/frontend/src/components/molecules/ConnectSpotifyPrompt.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConnectSpotifyPrompt } from "./ConnectSpotifyPrompt";
+
+vi.mock("../atoms/Button", () => ({
+  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}));
+
+describe("ConnectSpotifyPrompt", () => {
+  it("renders the heading 'Connect Spotify'", () => {
+    render(<ConnectSpotifyPrompt onConnect={vi.fn()} />);
+    expect(screen.getByRole("heading", { name: "Connect Spotify" })).not.toBeNull();
+  });
+
+  it("renders the description text", () => {
+    render(<ConnectSpotifyPrompt onConnect={vi.fn()} />);
+    expect(screen.getByText(/connect your Spotify account/i)).not.toBeNull();
+  });
+
+  it("renders the 'Connect with Spotify' button", () => {
+    render(<ConnectSpotifyPrompt onConnect={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Connect with Spotify" })).not.toBeNull();
+  });
+
+  it("calls onConnect when the button is clicked", () => {
+    const onConnect = vi.fn();
+    render(<ConnectSpotifyPrompt onConnect={onConnect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Connect with Spotify" }));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/components/molecules/EmptyState.test.tsx
+++ b/apps/frontend/src/components/molecules/EmptyState.test.tsx
@@ -1,0 +1,33 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { EmptyState } from "./EmptyState";
+
+describe("EmptyState", () => {
+  it("renders the title", () => {
+    render(<EmptyState icon={faMusic} title="No results found" />);
+    expect(screen.getByText("No results found")).not.toBeNull();
+  });
+
+  it("renders the description when provided", () => {
+    render(
+      <EmptyState icon={faMusic} title="No results found" description="Try a different search" />,
+    );
+    expect(screen.getByText("Try a different search")).not.toBeNull();
+  });
+
+  it("does not render a description when omitted", () => {
+    render(<EmptyState icon={faMusic} title="No results found" />);
+    expect(screen.queryByText("Try a different search")).toBeNull();
+  });
+
+  it("renders the action when provided", () => {
+    render(<EmptyState icon={faMusic} title="No results found" action={<button>Retry</button>} />);
+    expect(screen.getByRole("button", { name: "Retry" })).not.toBeNull();
+  });
+
+  it("does not render an action when omitted", () => {
+    render(<EmptyState icon={faMusic} title="No results found" />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PageHeader.test.tsx
+++ b/apps/frontend/src/components/molecules/PageHeader.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageHeader } from "./PageHeader";
+
+describe("PageHeader", () => {
+  it("renders title in h1", () => {
+    render(<PageHeader title="My Title" />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent).toBe("My Title");
+  });
+
+  it("renders description when provided", () => {
+    render(<PageHeader title="Title" description="Some description" />);
+    const desc = screen.queryByText("Some description");
+    expect(desc).not.toBeNull();
+  });
+
+  it("does not render description when omitted", () => {
+    render(<PageHeader title="Title" />);
+    const desc = screen.queryByText("Some description");
+    expect(desc).toBeNull();
+  });
+
+  it("renders action when provided", () => {
+    render(<PageHeader title="Title" action={<button>Action</button>} />);
+    const btn = screen.queryByRole("button", { name: "Action" });
+    expect(btn).not.toBeNull();
+  });
+
+  it("does not render action when omitted", () => {
+    render(<PageHeader title="Title" />);
+    const btn = screen.queryByRole("button");
+    expect(btn).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistCard.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistCard.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistCard } from "./PlaylistCard";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("../atoms/Image", () => ({ Image: ({ alt }: any) => <img alt={alt} /> }));
+vi.mock("../molecules/PlaylistStatusBadge", () => ({
+  PlaylistStatusBadge: () => <span data-testid="status-badge" />,
+}));
+
+const stats = {
+  isDownloading: false,
+  hasErrors: false,
+  isCompleted: true,
+  completedCount: 10,
+  totalCount: 10,
+  errorCount: 0,
+} as any;
+
+describe("PlaylistCard", () => {
+  it("renders playlist name", () => {
+    const playlist = { id: "pl-1", name: "My Playlist", coverUrl: null, subscribed: false } as any;
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={vi.fn()} />);
+    expect(screen.queryByText("My Playlist")).not.toBeNull();
+  });
+
+  it("calls onClick with playlist.id when card is clicked", () => {
+    const playlist = { id: "pl-1", name: "My Playlist", coverUrl: null, subscribed: false } as any;
+    const onClick = vi.fn();
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={onClick} />);
+    fireEvent.click(screen.getByTitle("My Playlist"));
+    expect(onClick).toHaveBeenCalledWith("pl-1");
+  });
+
+  it("shows subscribed bell icon when playlist.subscribed is true", () => {
+    const playlist = { id: "pl-1", name: "My Playlist", coverUrl: null, subscribed: true } as any;
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={vi.fn()} />);
+    expect(screen.queryByTitle("common.cards.tooltips.subscribed")).not.toBeNull();
+  });
+
+  it("does not show bell icon when playlist.subscribed is false", () => {
+    const playlist = { id: "pl-1", name: "My Playlist", coverUrl: null, subscribed: false } as any;
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={vi.fn()} />);
+    expect(screen.queryByTitle("common.cards.tooltips.subscribed")).toBeNull();
+  });
+
+  it("renders fallback text when name is null", () => {
+    const playlist = { id: "pl-1", name: null, coverUrl: null, subscribed: false } as any;
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={vi.fn()} />);
+    expect(screen.queryAllByText("common.cards.unnamedPlaylist").length).toBeGreaterThan(0);
+  });
+
+  it("renders PlaylistStatusBadge", () => {
+    const playlist = { id: "pl-1", name: "My Playlist", coverUrl: null, subscribed: false } as any;
+    render(<PlaylistCard playlist={playlist} stats={stats} onClick={vi.fn()} />);
+    expect(screen.queryByTestId("status-badge")).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistDescription.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistDescription.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistDescription } from "./PlaylistDescription";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+describe("PlaylistDescription", () => {
+  it("shows progress bar when completedCount > 0 and mode is managed (default)", () => {
+    render(<PlaylistDescription completedCount={5} totalCount={10} />);
+    expect(screen.queryByText(/5 \/ 10/)).not.toBeNull();
+  });
+
+  it("shows progress bar when isDownloading=true and totalCount > 0", () => {
+    render(<PlaylistDescription completedCount={0} totalCount={10} isDownloading={true} />);
+    expect(screen.queryByText(/0 \/ 10/)).not.toBeNull();
+  });
+
+  it("shows description text when completedCount=0 and description is provided", () => {
+    render(
+      <PlaylistDescription completedCount={0} totalCount={10} description="A great playlist" />,
+    );
+    expect(screen.queryByText("A great playlist")).not.toBeNull();
+  });
+
+  it("returns nothing when completedCount=0 and no description", () => {
+    const { container } = render(<PlaylistDescription completedCount={0} totalCount={10} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows description instead of progress bar when mode is library", () => {
+    render(
+      <PlaylistDescription
+        completedCount={5}
+        totalCount={10}
+        description="Library desc"
+        mode="library"
+      />,
+    );
+    expect(screen.queryByText(/5 \/ 10/)).toBeNull();
+    expect(screen.queryByText("Library desc")).not.toBeNull();
+  });
+
+  it("shows percentage in the progress bar", () => {
+    render(<PlaylistDescription completedCount={5} totalCount={10} />);
+    expect(screen.queryByText("50%")).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistHeader.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistHeader.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistHeader } from "./PlaylistHeader";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("../atoms/Image", () => ({ Image: ({ alt }: any) => <img alt={alt} /> }));
+
+const baseProps = {
+  title: "My Playlist",
+  type: "album",
+  coverUrl: null,
+  totalCount: 12,
+};
+
+describe("PlaylistHeader", () => {
+  it("renders title in h1", () => {
+    render(<PlaylistHeader {...baseProps} />);
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent).toBe("My Playlist");
+  });
+
+  it("renders typeLabel with first char uppercased", () => {
+    render(<PlaylistHeader {...baseProps} />);
+    expect(screen.queryByText("Album")).not.toBeNull();
+  });
+
+  it("renders totalCount and playlist.songs text", () => {
+    render(<PlaylistHeader {...baseProps} />);
+    expect(screen.queryByText(/12/)).not.toBeNull();
+    expect(screen.queryByText(/playlist\.songs/)).not.toBeNull();
+  });
+
+  it("renders description when provided", () => {
+    render(<PlaylistHeader {...baseProps} description={<p>Cool description</p>} />);
+    expect(screen.queryByText("Cool description")).not.toBeNull();
+  });
+
+  it("does not render description when omitted", () => {
+    render(<PlaylistHeader {...baseProps} />);
+    expect(screen.queryByText("Cool description")).toBeNull();
+  });
+
+  it("renders metadata when provided, with bullet separator", () => {
+    render(<PlaylistHeader {...baseProps} metadata={<span>Some metadata</span>} />);
+    expect(screen.queryByText("Some metadata")).not.toBeNull();
+    expect(screen.queryByText("•")).not.toBeNull();
+  });
+
+  it("does not render bullet separator when metadata is omitted", () => {
+    render(<PlaylistHeader {...baseProps} />);
+    expect(screen.queryByText("•")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistNotFound.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistNotFound.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistNotFound } from "./PlaylistNotFound";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+vi.mock("../atoms/Button", () => ({
+  Button: ({ children, onClick }: any) => <button onClick={onClick}>{children}</button>,
+}));
+
+describe("PlaylistNotFound", () => {
+  it("renders playlist.notFound heading", () => {
+    render(<PlaylistNotFound onGoHome={vi.fn()} />);
+    expect(screen.queryByText("playlist.notFound")).not.toBeNull();
+  });
+
+  it("renders playlist.goBack button", () => {
+    render(<PlaylistNotFound onGoHome={vi.fn()} />);
+    expect(screen.queryByText("playlist.goBack")).not.toBeNull();
+  });
+
+  it("calls onGoHome when button is clicked", () => {
+    const onGoHome = vi.fn();
+    render(<PlaylistNotFound onGoHome={onGoHome} />);
+    fireEvent.click(screen.getByText("playlist.goBack"));
+    expect(onGoHome).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/src/components/molecules/PlaylistStatusBadge.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistStatusBadge.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistStatusBadge } from "./PlaylistStatusBadge";
+
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (key: string) => key }) }));
+
+const baseStats = {
+  isDownloading: false,
+  hasErrors: false,
+  isCompleted: false,
+  completedCount: 0,
+  totalCount: 5,
+  errorCount: 0,
+} as any;
+
+describe("PlaylistStatusBadge", () => {
+  it("downloading state: shows completedCount/totalCount text", () => {
+    render(
+      <PlaylistStatusBadge
+        {...baseStats}
+        isDownloading={true}
+        completedCount={3}
+        totalCount={10}
+      />,
+    );
+    expect(screen.queryByText(/3\/10/)).not.toBeNull();
+  });
+
+  it("error state: shows errorCount and common.cards.status.failed", () => {
+    render(<PlaylistStatusBadge {...baseStats} hasErrors={true} errorCount={2} />);
+    expect(screen.queryByText(/2/)).not.toBeNull();
+    expect(screen.queryByText(/common\.cards\.status\.failed/)).not.toBeNull();
+  });
+
+  it("completed state: shows totalCount and common.cards.status.tracks", () => {
+    render(<PlaylistStatusBadge {...baseStats} isCompleted={true} totalCount={5} />);
+    expect(screen.queryByText(/5/)).not.toBeNull();
+    expect(screen.queryByText(/common\.cards\.status\.tracks/)).not.toBeNull();
+  });
+
+  it("default state: shows totalCount and common.cards.status.tracks", () => {
+    render(<PlaylistStatusBadge {...baseStats} totalCount={7} />);
+    expect(screen.queryByText(/7/)).not.toBeNull();
+    expect(screen.queryByText(/common\.cards\.status\.tracks/)).not.toBeNull();
+  });
+
+  it("downloading takes priority over error when both are true", () => {
+    render(
+      <PlaylistStatusBadge
+        {...baseStats}
+        isDownloading={true}
+        hasErrors={true}
+        completedCount={1}
+        totalCount={5}
+        errorCount={3}
+      />,
+    );
+    expect(screen.queryByText(/1\/5/)).not.toBeNull();
+    expect(screen.queryByText(/common\.cards\.status\.failed/)).toBeNull();
+  });
+
+  it("error state takes priority over completed when both are true", () => {
+    render(
+      <PlaylistStatusBadge
+        {...baseStats}
+        hasErrors={true}
+        isCompleted={true}
+        errorCount={2}
+        totalCount={5}
+      />,
+    );
+    expect(screen.queryByText(/common\.cards\.status\.failed/)).not.toBeNull();
+    expect(screen.queryByText(/common\.cards\.status\.tracks/)).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/PreviewError.test.tsx
+++ b/apps/frontend/src/components/molecules/PreviewError.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PreviewError } from "./PreviewError";
+
+describe("PreviewError", () => {
+  it("renders the heading and default message when no error is provided", () => {
+    render(<PreviewError onGoBack={vi.fn()} />);
+
+    expect(screen.getByText("Preview not available")).not.toBeNull();
+    expect(screen.getByText("Could not load preview")).not.toBeNull();
+  });
+
+  it("renders the stringified error when error prop is provided", () => {
+    render(<PreviewError error="Network timeout" onGoBack={vi.fn()} />);
+
+    expect(screen.getByText("Network timeout")).not.toBeNull();
+  });
+
+  it("renders the go back button", () => {
+    render(<PreviewError onGoBack={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: /go back/i })).not.toBeNull();
+  });
+
+  it("calls onGoBack when the button is clicked", () => {
+    const onGoBack = vi.fn();
+    render(<PreviewError onGoBack={onGoBack} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /go back/i }));
+
+    expect(onGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("stringifies a non-string error value", () => {
+    const error = new Error("Something went wrong");
+    render(<PreviewError error={error} onGoBack={vi.fn()} />);
+
+    expect(screen.getByText(String(error))).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/RateLimitedMessage.test.tsx
+++ b/apps/frontend/src/components/molecules/RateLimitedMessage.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RateLimitedMessage } from "./RateLimitedMessage";
+
+describe("RateLimitedMessage", () => {
+  it("renders the heading", () => {
+    render(<RateLimitedMessage />);
+
+    expect(screen.getByText("Rate Limited")).not.toBeNull();
+  });
+
+  it("renders the descriptive message", () => {
+    render(<RateLimitedMessage />);
+
+    expect(
+      screen.getByText(
+        "Spotify is temporarily limiting requests. Please try again in a few minutes.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("renders without crashing", () => {
+    const { container } = render(<RateLimitedMessage />);
+
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/SearchInput.test.tsx
+++ b/apps/frontend/src/components/molecules/SearchInput.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchInput } from "./SearchInput";
+
+describe("SearchInput", () => {
+  it("renders with the provided value", () => {
+    render(<SearchInput value="hello" onChange={vi.fn()} />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("hello");
+  });
+
+  it("renders with the default placeholder", () => {
+    render(<SearchInput value="" onChange={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("Search...")).not.toBeNull();
+  });
+
+  it("renders with a custom placeholder", () => {
+    render(<SearchInput value="" onChange={vi.fn()} placeholder="Find an artist..." />);
+
+    expect(screen.getByPlaceholderText("Find an artist...")).not.toBeNull();
+  });
+
+  it("calls onChange with the new value when the input changes", () => {
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "daft punk" } });
+
+    expect(onChange).toHaveBeenCalledWith("daft punk");
+  });
+
+  it("calls onSearch when Enter key is pressed and onSearch is provided", () => {
+    const onSearch = vi.fn();
+    render(<SearchInput value="query" onChange={vi.fn()} onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not throw when Enter is pressed without onSearch", () => {
+    render(<SearchInput value="" onChange={vi.fn()} />);
+
+    const input = screen.getByRole("textbox");
+    expect(() => fireEvent.keyDown(input, { key: "Enter" })).not.toThrow();
+  });
+
+  it("does not call onSearch when a key other than Enter is pressed", () => {
+    const onSearch = vi.fn();
+    render(<SearchInput value="" onChange={vi.fn()} onSearch={onSearch} />);
+
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "a" });
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/molecules/SettingSelect.test.tsx
+++ b/apps/frontend/src/components/molecules/SettingSelect.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingSelect } from "./SettingSelect";
+
+const baseProps = {
+  id: "theme-select",
+  label: "Theme",
+  value: "dark",
+  onChange: vi.fn(),
+  options: ["dark", "light", "system"],
+  description: "Choose your preferred theme",
+};
+
+describe("SettingSelect", () => {
+  it("renders the label", () => {
+    render(<SettingSelect {...baseProps} />);
+
+    expect(screen.getByText("Theme")).not.toBeNull();
+  });
+
+  it("renders the description", () => {
+    render(<SettingSelect {...baseProps} />);
+
+    expect(screen.getByText("Choose your preferred theme")).not.toBeNull();
+  });
+
+  it("renders all options", () => {
+    render(<SettingSelect {...baseProps} />);
+
+    expect(screen.getByRole("option", { name: "Dark" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "Light" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "System" })).not.toBeNull();
+  });
+
+  it("has the correct option selected by default", () => {
+    render(<SettingSelect {...baseProps} />);
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("dark");
+  });
+
+  it("calls onChange when the selection changes", () => {
+    const onChange = vi.fn();
+    render(<SettingSelect {...baseProps} onChange={onChange} />);
+
+    const select = screen.getByRole("combobox");
+    fireEvent.change(select, { target: { value: "light" } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a custom formatLabel when provided", () => {
+    render(
+      <SettingSelect
+        {...baseProps}
+        options={["en", "es"]}
+        formatLabel={(opt) => opt.toUpperCase()}
+      />,
+    );
+
+    expect(screen.getByRole("option", { name: "EN" })).not.toBeNull();
+    expect(screen.getByRole("option", { name: "ES" })).not.toBeNull();
+  });
+});

--- a/apps/frontend/src/components/molecules/SettingTextarea.test.tsx
+++ b/apps/frontend/src/components/molecules/SettingTextarea.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingTextarea } from "./SettingTextarea";
+
+const baseProps = {
+  id: "system-prompt",
+  label: "System Prompt",
+  value: "You are a helpful assistant.",
+  onChange: vi.fn(),
+  description: "Enter the AI system prompt",
+};
+
+describe("SettingTextarea", () => {
+  it("renders the label", () => {
+    render(<SettingTextarea {...baseProps} />);
+
+    expect(screen.getByText("System Prompt")).not.toBeNull();
+  });
+
+  it("renders the description", () => {
+    render(<SettingTextarea {...baseProps} />);
+
+    expect(screen.getByText("Enter the AI system prompt")).not.toBeNull();
+  });
+
+  it("renders with the provided string value", () => {
+    render(<SettingTextarea {...baseProps} />);
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("You are a helpful assistant.");
+  });
+
+  it("renders with a numeric value", () => {
+    render(<SettingTextarea {...baseProps} value={42} />);
+
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("42");
+  });
+
+  it("calls onChange when the textarea content changes", () => {
+    const onChange = vi.fn();
+    render(<SettingTextarea {...baseProps} onChange={onChange} />);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Updated prompt" } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("associates label with textarea via htmlFor / id", () => {
+    render(<SettingTextarea {...baseProps} />);
+
+    const label = screen.getByText("System Prompt") as HTMLLabelElement;
+    expect(label.htmlFor).toBe("system-prompt");
+  });
+});

--- a/apps/frontend/src/components/molecules/SettingToggle.test.tsx
+++ b/apps/frontend/src/components/molecules/SettingToggle.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SettingToggle } from "./SettingToggle";
+
+const baseProps = {
+  id: "notifications-toggle",
+  label: "Enable Notifications",
+  description: "Receive push notifications",
+  value: false,
+  onChange: vi.fn(),
+};
+
+describe("SettingToggle", () => {
+  it("renders the label", () => {
+    render(<SettingToggle {...baseProps} />);
+
+    expect(screen.getByText("Enable Notifications")).not.toBeNull();
+  });
+
+  it("renders the description", () => {
+    render(<SettingToggle {...baseProps} />);
+
+    expect(screen.getByText("Receive push notifications")).not.toBeNull();
+  });
+
+  it("renders a button element", () => {
+    render(<SettingToggle {...baseProps} />);
+
+    expect(screen.getByRole("button")).not.toBeNull();
+  });
+
+  it("applies the active color class when value is true", () => {
+    render(<SettingToggle {...baseProps} value={true} />);
+
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-primary");
+  });
+
+  it("applies the inactive color class when value is false", () => {
+    render(<SettingToggle {...baseProps} value={false} />);
+
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-text-muted");
+  });
+
+  it("calls onChange when the button is clicked", () => {
+    const onChange = vi.fn();
+    render(<SettingToggle {...baseProps} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/components/molecules/SpotifyPlaylistCard.test.tsx
+++ b/apps/frontend/src/components/molecules/SpotifyPlaylistCard.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SpotifyPlaylistCard } from "./SpotifyPlaylistCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { count?: number }) => {
+      if (key === "common.by") return "by";
+      if (key === "common.cards.status.tracks") return opts?.count === 1 ? "track" : "tracks";
+      return key;
+    },
+  }),
+}));
+
+vi.mock("../atoms/Image", () => ({
+  Image: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+const baseProps = {
+  id: "playlist-1",
+  name: "My Playlist",
+  image: null,
+  owner: "John Doe",
+  tracks: 10,
+  onClick: vi.fn(),
+};
+
+describe("SpotifyPlaylistCard", () => {
+  it("renders the playlist name", () => {
+    render(<SpotifyPlaylistCard {...baseProps} />);
+
+    expect(screen.getByText("My Playlist")).not.toBeNull();
+  });
+
+  it("renders owner name as plain text when ownerUrl is not provided", () => {
+    render(<SpotifyPlaylistCard {...baseProps} />);
+
+    // "John Doe" is a text node inside a <p> that also contains "by" and "• N tracks",
+    // so use getAllByText with exact:false to match the text node content.
+    expect(screen.getAllByText(/John Doe/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("renders owner as a link when ownerUrl is provided", () => {
+    render(<SpotifyPlaylistCard {...baseProps} ownerUrl="https://open.spotify.com/user/johndoe" />);
+
+    const link = screen.getByRole("link", { name: "John Doe" }) as HTMLAnchorElement;
+    expect(link.href).toBe("https://open.spotify.com/user/johndoe");
+  });
+
+  it("renders track count", () => {
+    render(<SpotifyPlaylistCard {...baseProps} tracks={5} />);
+
+    expect(screen.getByText(/5/)).not.toBeNull();
+  });
+
+  it("calls onClick with the playlist id when the card is clicked", () => {
+    const onClick = vi.fn();
+    render(<SpotifyPlaylistCard {...baseProps} onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("article"));
+
+    expect(onClick).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("does not propagate click when the owner link is clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <SpotifyPlaylistCard
+        {...baseProps}
+        onClick={onClick}
+        ownerUrl="https://open.spotify.com/user/johndoe"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "John Doe" }));
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/components/molecules/StatCard.test.tsx
+++ b/apps/frontend/src/components/molecules/StatCard.test.tsx
@@ -1,0 +1,44 @@
+import { faMusic } from "@fortawesome/free-solid-svg-icons";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StatCard } from "./StatCard";
+
+describe("StatCard", () => {
+  it("renders the label", () => {
+    render(<StatCard label="Total Tracks" value={42} />);
+
+    expect(screen.getByText("Total Tracks")).not.toBeNull();
+  });
+
+  it("renders a numeric value", () => {
+    render(<StatCard label="Albums" value={7} />);
+
+    expect(screen.getByText("7")).not.toBeNull();
+  });
+
+  it("renders a string value", () => {
+    render(<StatCard label="Size" value="1.2 GB" />);
+
+    expect(screen.getByText("1.2 GB")).not.toBeNull();
+  });
+
+  it("renders the icon when provided", () => {
+    const { container } = render(<StatCard label="Tracks" value={10} icon={faMusic} />);
+
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("does not render an icon element when icon is not provided", () => {
+    const { container } = render(<StatCard label="Tracks" value={10} />);
+
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("applies additional className when provided", () => {
+    const { container } = render(
+      <StatCard label="Tracks" value={10} className="my-custom-class" />,
+    );
+
+    expect((container.firstChild as HTMLElement).className).toContain("my-custom-class");
+  });
+});

--- a/apps/frontend/src/components/molecules/Toast.test.tsx
+++ b/apps/frontend/src/components/molecules/Toast.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Toast as ToastType } from "@/contexts/ToastContext";
+import { Toast } from "./Toast";
+
+const makeToast = (overrides: Partial<ToastType> = {}): ToastType => ({
+  id: "toast-1",
+  message: "Operation successful",
+  type: "success",
+  ...overrides,
+});
+
+describe("Toast", () => {
+  it("renders the message", () => {
+    render(<Toast toast={makeToast()} onRemove={vi.fn()} />);
+
+    expect(screen.getByText("Operation successful")).not.toBeNull();
+  });
+
+  it("renders with role alert", () => {
+    render(<Toast toast={makeToast()} onRemove={vi.fn()} />);
+
+    expect(screen.getByRole("alert")).not.toBeNull();
+  });
+
+  it("renders a success toast", () => {
+    const { container } = render(
+      <Toast toast={makeToast({ type: "success" })} onRemove={vi.fn()} />,
+    );
+
+    expect((container.firstChild as HTMLElement).className).toContain("green");
+  });
+
+  it("renders an error toast", () => {
+    const { container } = render(
+      <Toast
+        toast={makeToast({ type: "error", message: "Something failed" })}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    expect((container.firstChild as HTMLElement).className).toContain("red");
+    expect(screen.getByText("Something failed")).not.toBeNull();
+  });
+
+  it("renders a warning toast", () => {
+    const { container } = render(
+      <Toast toast={makeToast({ type: "warning", message: "Be careful" })} onRemove={vi.fn()} />,
+    );
+
+    expect((container.firstChild as HTMLElement).className).toContain("yellow");
+  });
+
+  it("renders an info toast", () => {
+    const { container } = render(
+      <Toast toast={makeToast({ type: "info", message: "FYI" })} onRemove={vi.fn()} />,
+    );
+
+    expect((container.firstChild as HTMLElement).className).toContain("blue");
+  });
+
+  it("renders a close button", () => {
+    render(<Toast toast={makeToast()} onRemove={vi.fn()} />);
+
+    expect(screen.getByRole("button")).not.toBeNull();
+  });
+
+  it("calls onRemove after clicking the close button", () => {
+    vi.useFakeTimers();
+    const onRemove = vi.fn();
+    render(<Toast toast={makeToast({ id: "t-42" })} onRemove={onRemove} />);
+
+    fireEvent.click(screen.getByRole("button"));
+    vi.runAllTimers();
+
+    expect(onRemove).toHaveBeenCalledWith("t-42");
+    vi.useRealTimers();
+  });
+});

--- a/apps/frontend/src/components/molecules/VirtualGrid.test.tsx
+++ b/apps/frontend/src/components/molecules/VirtualGrid.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { VirtualGrid } from "./VirtualGrid";
+
+// react-virtuoso uses ResizeObserver internally
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock Virtuoso to render rows directly (no virtualization in jsdom)
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: <T,>({
+    data,
+    itemContent,
+    components,
+  }: {
+    data: T[];
+    itemContent: (index: number, item: T) => ReactNode;
+    components?: { Footer?: () => ReactNode };
+  }) => (
+    <div data-testid="virtuoso">
+      {data.map((item, index) => (
+        <div key={index}>{itemContent(index, item)}</div>
+      ))}
+      {components?.Footer && <components.Footer />}
+    </div>
+  ),
+}));
+
+// useGridColumns uses window.innerWidth — default jsdom width is 0 → MOBILE columns (2)
+vi.mock("@/hooks/useGridColumns", () => ({
+  useGridColumns: () => 2,
+}));
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: "1", name: "Alpha" },
+  { id: "2", name: "Beta" },
+  { id: "3", name: "Gamma" },
+  { id: "4", name: "Delta" },
+];
+
+describe("VirtualGrid", () => {
+  it("renders all items", () => {
+    render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        itemKey={(item) => item.id}
+      />,
+    );
+
+    expect(screen.getByText("Alpha")).not.toBeNull();
+    expect(screen.getByText("Beta")).not.toBeNull();
+    expect(screen.getByText("Gamma")).not.toBeNull();
+    expect(screen.getByText("Delta")).not.toBeNull();
+  });
+
+  it("renders the emptyState when items is empty", () => {
+    render(
+      <VirtualGrid
+        items={[]}
+        renderItem={(item: Item) => <span>{item.name}</span>}
+        itemKey={(item: Item) => item.id}
+        emptyState={<div>Nothing here</div>}
+      />,
+    );
+
+    expect(screen.getByText("Nothing here")).not.toBeNull();
+  });
+
+  it("does not render emptyState when items are present", () => {
+    render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        itemKey={(item) => item.id}
+        emptyState={<div>Nothing here</div>}
+      />,
+    );
+
+    expect(screen.queryByText("Nothing here")).toBeNull();
+  });
+
+  it("renders the footer when provided", () => {
+    render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        itemKey={(item) => item.id}
+        footer={<div>Load more</div>}
+      />,
+    );
+
+    expect(screen.getByText("Load more")).not.toBeNull();
+  });
+
+  it("groups items into rows based on column count", () => {
+    // With 2 columns and 4 items, we expect 2 rows (grid divs)
+    const { container } = render(
+      <VirtualGrid
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        itemKey={(item) => item.id}
+      />,
+    );
+
+    const rows = container.querySelectorAll(".grid");
+    expect(rows.length).toBe(2);
+  });
+});

--- a/apps/frontend/src/components/molecules/VirtualList.test.tsx
+++ b/apps/frontend/src/components/molecules/VirtualList.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { VirtualList } from "./VirtualList";
+
+// react-virtuoso uses IntersectionObserver and ResizeObserver internally
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock Virtuoso to render items directly (no virtualization in jsdom)
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: <T,>({
+    data,
+    itemContent,
+    components,
+  }: {
+    data: T[];
+    itemContent: (index: number, item: T) => ReactNode;
+    components?: { Footer?: () => ReactNode };
+  }) => (
+    <div data-testid="virtuoso">
+      {data.map((item, index) => (
+        <div key={index}>{itemContent(index, item)}</div>
+      ))}
+      {components?.Footer && <components.Footer />}
+    </div>
+  ),
+}));
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+const items: Item[] = [
+  { id: "1", name: "Item One" },
+  { id: "2", name: "Item Two" },
+  { id: "3", name: "Item Three" },
+];
+
+describe("VirtualList", () => {
+  it("renders all items", () => {
+    render(
+      <VirtualList
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        itemKey={(item) => item.id}
+      />,
+    );
+
+    expect(screen.getByText("Item One")).not.toBeNull();
+    expect(screen.getByText("Item Two")).not.toBeNull();
+    expect(screen.getByText("Item Three")).not.toBeNull();
+  });
+
+  it("renders the emptyState when items is empty", () => {
+    render(
+      <VirtualList
+        items={[]}
+        renderItem={(item: Item) => <span>{item.name}</span>}
+        emptyState={<div>No results</div>}
+      />,
+    );
+
+    expect(screen.getByText("No results")).not.toBeNull();
+  });
+
+  it("does not render emptyState when items is empty but emptyState is not provided", () => {
+    const { container } = render(
+      <VirtualList items={[]} renderItem={(item: Item) => <span>{item.name}</span>} />,
+    );
+
+    expect(container.querySelector("[data-testid='virtuoso']")).not.toBeNull();
+  });
+
+  it("renders footer when provided", () => {
+    render(
+      <VirtualList
+        items={items}
+        renderItem={(item) => <span>{item.name}</span>}
+        footer={<div>Load more</div>}
+      />,
+    );
+
+    expect(screen.getByText("Load more")).not.toBeNull();
+  });
+
+  it("passes index to renderItem", () => {
+    const renderItem = vi.fn((item: Item, index: number) => <span>{`${index}:${item.name}`}</span>);
+    render(<VirtualList items={[items[0]]} renderItem={renderItem} />);
+
+    expect(screen.getByText("0:Item One")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Render/behavior unit tests for all 23 untested molecule components.

## Why

Continues the frontend coverage push (#185/#186/#187/#188/#189). Part of the ratchet goal (#149).

## Coverage notes

- `ApiErrorState`: null guard + `missing_user_access_token` / `spotify_rate_limited` / generic branches.
- `PlaylistStatusBadge`: status→label/variant mapping incl. priority ordering.
- `PlaylistDescription`: progress-bar vs library-mode vs description-only branches.
- `ArtistLinks`: Spotify URL extraction vs non-Spotify last-segment, comma separation.
- Setting* inputs: value render, onChange payload, disabled state.
- `VirtualList`/`VirtualGrid`: mock `react-virtuoso` + `useGridColumns` for deterministic rows in jsdom.
- `Toast`: fake-timer auto-dismiss.

23 files, no source changes. `tsc --noEmit` clean; full suite 992 passing.