### PR TITLE
test(frontend): unit tests for 14 organism components

### DIFF
--- a/apps/frontend/src/components/organisms/ArtistDiscography.test.tsx
+++ b/apps/frontend/src/components/organisms/ArtistDiscography.test.tsx
@@ -1,0 +1,152 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ArtistDiscography } from "./ArtistDiscography";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    itemKey,
+    renderItem,
+    footer,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+    footer?: ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+      {footer}
+    </div>
+  ),
+}));
+
+vi.mock("../molecules/AlbumCard", () => ({
+  AlbumCard: ({
+    albumName,
+    onCardClick,
+  }: {
+    albumId: string;
+    albumName: string;
+    onCardClick: () => void;
+    onArtistClick: (artistId: string) => void;
+  }) => (
+    <button type="button" onClick={onCardClick}>
+      {albumName}
+    </button>
+  ),
+}));
+
+vi.mock("../molecules/ArtistDiscographyFilters", () => ({
+  ArtistDiscographyFilters: ({
+    onFilterChange,
+  }: {
+    currentFilter: string;
+    onFilterChange: (f: string) => void;
+  }) => (
+    <button type="button" onClick={() => onFilterChange("single")}>
+      change-filter
+    </button>
+  ),
+}));
+
+const makeRelease = (albumId: string, albumName: string): ArtistRelease => ({
+  albumId,
+  albumName,
+  artistId: "artist-1",
+  artistName: "Test Artist",
+  artistImageUrl: null,
+  coverUrl: null,
+  albumType: "album",
+  releaseDate: "2023-01-01",
+});
+
+const defaultProps = {
+  filter: "all" as const,
+  onFilterChange: vi.fn(),
+  filteredAlbums: [makeRelease("a1", "Album One"), makeRelease("a2", "Album Two")],
+  visibleItems: 10,
+  isLoadingMore: false,
+  onShowMore: vi.fn(),
+  canShowMore: false,
+  onDiscographyItemClick: vi.fn(),
+  onArtistClick: vi.fn(),
+};
+
+describe("ArtistDiscography", () => {
+  it("renders one card per album in the list", () => {
+    render(<ArtistDiscography {...defaultProps} />);
+
+    expect(screen.getByText("Album One")).toBeTruthy();
+    expect(screen.getByText("Album Two")).toBeTruthy();
+  });
+
+  it("shows empty state when filteredAlbums is empty", () => {
+    render(<ArtistDiscography {...defaultProps} filteredAlbums={[]} />);
+
+    expect(screen.getByText("artist.discography.emptyFiltered")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Album One" })).toBeNull();
+  });
+
+  it("calls onDiscographyItemClick when an album card is clicked", () => {
+    const onDiscographyItemClick = vi.fn();
+    render(<ArtistDiscography {...defaultProps} onDiscographyItemClick={onDiscographyItemClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Album One" }));
+
+    expect(onDiscographyItemClick).toHaveBeenCalledWith(defaultProps.filteredAlbums[0]);
+  });
+
+  it("renders Show More button when canShowMore is true", () => {
+    render(<ArtistDiscography {...defaultProps} canShowMore={true} />);
+
+    expect(screen.getByText("artist.discography.showMore")).toBeTruthy();
+  });
+
+  it("calls onShowMore when Show More button is clicked", () => {
+    const onShowMore = vi.fn();
+    render(<ArtistDiscography {...defaultProps} canShowMore={true} onShowMore={onShowMore} />);
+
+    fireEvent.click(screen.getByText("artist.discography.showMore"));
+
+    expect(onShowMore).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render Show More button when canShowMore is false", () => {
+    render(<ArtistDiscography {...defaultProps} canShowMore={false} />);
+
+    expect(screen.queryByText("artist.discography.showMore")).toBeNull();
+  });
+
+  it("slices albums to visibleItems count", () => {
+    const albums = [
+      makeRelease("a1", "Album One"),
+      makeRelease("a2", "Album Two"),
+      makeRelease("a3", "Album Three"),
+    ];
+    render(<ArtistDiscography {...defaultProps} filteredAlbums={albums} visibleItems={2} />);
+
+    expect(screen.getByText("Album One")).toBeTruthy();
+    expect(screen.getByText("Album Two")).toBeTruthy();
+    expect(screen.queryByText("Album Three")).toBeNull();
+  });
+
+  it("calls onFilterChange when filter is changed", () => {
+    const onFilterChange = vi.fn();
+    render(<ArtistDiscography {...defaultProps} onFilterChange={onFilterChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "change-filter" }));
+
+    expect(onFilterChange).toHaveBeenCalledWith("single");
+  });
+});

--- a/apps/frontend/src/components/organisms/ArtistList.test.tsx
+++ b/apps/frontend/src/components/organisms/ArtistList.test.tsx
@@ -1,0 +1,82 @@
+import type { FollowedArtist } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ArtistList } from "./ArtistList";
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    itemKey,
+    renderItem,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../molecules/ArtistCard", () => ({
+  ArtistCard: ({
+    id,
+    name,
+    onClick,
+  }: {
+    id: string;
+    name: string;
+    image: string | null;
+    spotifyUrl: string | null;
+    onClick: (id: string) => void;
+  }) => (
+    <button type="button" onClick={() => onClick(id)}>
+      {name}
+    </button>
+  ),
+}));
+
+const makeArtist = (id: string, name: string): FollowedArtist => ({
+  id,
+  name,
+  image: null,
+  spotifyUrl: null,
+});
+
+describe("ArtistList", () => {
+  it("renders one card per artist", () => {
+    const artists = [makeArtist("a1", "Daft Punk"), makeArtist("a2", "Radiohead")];
+    render(<ArtistList artists={artists} onClick={vi.fn()} />);
+
+    expect(screen.getByText("Daft Punk")).toBeTruthy();
+    expect(screen.getByText("Radiohead")).toBeTruthy();
+  });
+
+  it("renders nothing when artists list is empty", () => {
+    const { container } = render(<ArtistList artists={[]} onClick={vi.fn()} />);
+
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("calls onClick with the correct artist id when a card is clicked", () => {
+    const onClick = vi.fn();
+    const artists = [makeArtist("a1", "Daft Punk")];
+    render(<ArtistList artists={artists} onClick={onClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Daft Punk" }));
+
+    expect(onClick).toHaveBeenCalledWith("a1");
+  });
+
+  it("renders two cards for two artists", () => {
+    const artists = [makeArtist("a1", "Daft Punk"), makeArtist("a2", "Radiohead")];
+    render(<ArtistList artists={artists} onClick={vi.fn()} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/apps/frontend/src/components/organisms/HistoryList.test.tsx
+++ b/apps/frontend/src/components/organisms/HistoryList.test.tsx
@@ -1,0 +1,133 @@
+import type { PlaylistHistory } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import type { Playlist } from "@/types";
+import { HistoryList } from "./HistoryList";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+  };
+});
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkPlaylistStatus: () => new Map<string, { isDownloaded: boolean; isDownloading: boolean }>(),
+}));
+
+vi.mock("../molecules/VirtualList", () => ({
+  VirtualList: <T,>({
+    items,
+    itemKey,
+    renderItem,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makeHistoryItem = (
+  playlistId: string | null,
+  name: string,
+  spotifyUrl: string | null = null,
+): PlaylistHistory => ({
+  playlistId,
+  playlistName: name,
+  playlistSpotifyUrl: spotifyUrl,
+  trackCount: 10,
+  lastCompletedAt: 1700000000000,
+});
+
+const defaultProps = {
+  history: [
+    makeHistoryItem("p1", "Playlist Alpha", "https://open.spotify.com/playlist/abc"),
+    makeHistoryItem("p2", "Playlist Beta"),
+  ],
+  activePlaylists: [] as Playlist[],
+  recreatingUrl: null,
+  onRecreate: vi.fn(),
+  onItemClick: vi.fn(),
+};
+
+describe("HistoryList", () => {
+  it("renders one row per history item", () => {
+    render(
+      <MemoryRouter>
+        <HistoryList {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Playlist Alpha")).toBeTruthy();
+    expect(screen.getByText("Playlist Beta")).toBeTruthy();
+  });
+
+  it("renders nothing when history is empty", () => {
+    render(
+      <MemoryRouter>
+        <HistoryList {...defaultProps} history={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText("Playlist Alpha")).toBeNull();
+  });
+
+  it("calls onItemClick when a history row is clicked", () => {
+    const onItemClick = vi.fn();
+    render(
+      <MemoryRouter>
+        <HistoryList {...defaultProps} onItemClick={onItemClick} />
+      </MemoryRouter>,
+    );
+
+    const rows = document.querySelectorAll('[class*="cursor-pointer"]');
+    fireEvent.click(rows[0]);
+
+    expect(onItemClick).toHaveBeenCalledWith(defaultProps.history[0], undefined);
+  });
+
+  it("renders the recreate button for items with a spotifyUrl", () => {
+    render(
+      <MemoryRouter>
+        <HistoryList {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    const buttons = screen.getAllByRole("button");
+    // Playlist Alpha has a spotifyUrl, so it gets a recreate button
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows downloading state when item is downloading", () => {
+    vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+      useBulkPlaylistStatus: () => {
+        const map = new Map<string, { isDownloaded: boolean; isDownloading: boolean }>();
+        map.set("https://open.spotify.com/playlist/abc", {
+          isDownloaded: false,
+          isDownloading: true,
+        });
+        return map;
+      },
+    }));
+
+    render(
+      <MemoryRouter>
+        <HistoryList {...defaultProps} />
+      </MemoryRouter>,
+    );
+
+    // The component renders when item is downloading — just verify it renders without crashing
+    expect(screen.getByText("Playlist Alpha")).toBeTruthy();
+  });
+});

--- a/apps/frontend/src/components/organisms/LibraryArtistList.test.tsx
+++ b/apps/frontend/src/components/organisms/LibraryArtistList.test.tsx
@@ -1,0 +1,94 @@
+import type { LibraryArtist } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { LibraryArtistList } from "./LibraryArtistList";
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    itemKey,
+    renderItem,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../molecules/LibraryArtistCard", () => ({
+  LibraryArtistCard: ({
+    artist,
+    onClick,
+  }: {
+    artist: LibraryArtist;
+    onClick?: (artist: LibraryArtist) => void;
+  }) => (
+    <button type="button" onClick={() => onClick?.(artist)} aria-label={`open-${artist.name}`}>
+      {artist.name}
+    </button>
+  ),
+}));
+
+const makeArtist = (name: string, path: string): LibraryArtist => ({
+  name,
+  path,
+  albumCount: 2,
+  trackCount: 20,
+  totalSize: 5000,
+  albums: [],
+});
+
+describe("LibraryArtistList", () => {
+  it("renders one card per artist", () => {
+    const artists = [
+      makeArtist("Daft Punk", "/library/daft-punk"),
+      makeArtist("Radiohead", "/library/radiohead"),
+    ];
+    render(<LibraryArtistList artists={artists} />);
+
+    expect(screen.getByText("Daft Punk")).toBeTruthy();
+    expect(screen.getByText("Radiohead")).toBeTruthy();
+  });
+
+  it("renders nothing when artists list is empty", () => {
+    const { container } = render(<LibraryArtistList artists={[]} />);
+
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("calls onArtistClick with the correct artist when a card is clicked", () => {
+    const onArtistClick = vi.fn();
+    const artists = [makeArtist("Daft Punk", "/library/daft-punk")];
+    render(<LibraryArtistList artists={artists} onArtistClick={onArtistClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "open-Daft Punk" }));
+
+    expect(onArtistClick).toHaveBeenCalledWith(artists[0]);
+  });
+
+  it("renders two cards for two artists", () => {
+    const artists = [
+      makeArtist("Daft Punk", "/library/daft-punk"),
+      makeArtist("Radiohead", "/library/radiohead"),
+    ];
+    render(<LibraryArtistList artists={artists} />);
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+  });
+
+  it("works without onArtistClick prop (optional)", () => {
+    const artists = [makeArtist("Daft Punk", "/library/daft-punk")];
+    expect(() => {
+      render(<LibraryArtistList artists={artists} />);
+      fireEvent.click(screen.getByRole("button", { name: "open-Daft Punk" }));
+    }).not.toThrow();
+  });
+});

--- a/apps/frontend/src/components/organisms/LibraryArtistProfile.test.tsx
+++ b/apps/frontend/src/components/organisms/LibraryArtistProfile.test.tsx
@@ -1,0 +1,106 @@
+import type { LibraryAlbum, LibraryArtist } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { LibraryArtistProfile } from "./LibraryArtistProfile";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("../molecules/ArtistHeader", () => ({
+  ArtistHeader: ({ name, subtitle }: { name: string; subtitle?: React.ReactNode }) => (
+    <div>
+      <h1>{name}</h1>
+      <div>{subtitle}</div>
+    </div>
+  ),
+}));
+
+vi.mock("./LibraryAlbumList", () => ({
+  LibraryAlbumList: ({
+    albums,
+    onAlbumClick,
+  }: {
+    albums: LibraryAlbum[];
+    artistName: string;
+    onAlbumClick: (album: LibraryAlbum) => void;
+  }) => (
+    <div>
+      {albums.map((album) => (
+        <button
+          key={album.path}
+          type="button"
+          onClick={() => onAlbumClick(album)}
+          aria-label={`open-${album.name}`}
+        >
+          {album.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const makeAlbum = (name: string): LibraryAlbum => ({
+  name,
+  path: `/library/artist/${name}`,
+  artist: "Test Artist",
+  trackCount: 10,
+  totalSize: 1000,
+  year: 2020,
+  tracks: [],
+});
+
+const makeArtist = (overrides?: Partial<LibraryArtist>): LibraryArtist => ({
+  name: "Daft Punk",
+  path: "/library/daft-punk",
+  albumCount: 2,
+  trackCount: 20,
+  totalSize: 5000,
+  albums: [makeAlbum("Discovery"), makeAlbum("Random Access Memories")],
+  ...overrides,
+});
+
+describe("LibraryArtistProfile", () => {
+  it("renders the artist name", () => {
+    render(<LibraryArtistProfile artist={makeArtist()} onAlbumClick={vi.fn()} />);
+
+    expect(screen.getByText("Daft Punk")).toBeTruthy();
+  });
+
+  it("renders one button per album in the list", () => {
+    render(<LibraryArtistProfile artist={makeArtist()} onAlbumClick={vi.fn()} />);
+
+    expect(screen.getByRole("button", { name: "open-Discovery" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "open-Random Access Memories" })).toBeTruthy();
+  });
+
+  it("calls onAlbumClick with the album name when an album is clicked", () => {
+    const onAlbumClick = vi.fn();
+    render(<LibraryArtistProfile artist={makeArtist()} onAlbumClick={onAlbumClick} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "open-Discovery" }));
+
+    expect(onAlbumClick).toHaveBeenCalledWith("Discovery");
+  });
+
+  it("shows album count in the subtitle", () => {
+    render(<LibraryArtistProfile artist={makeArtist({ albumCount: 3 })} onAlbumClick={vi.fn()} />);
+
+    expect(screen.getByText(/3/)).toBeTruthy();
+  });
+
+  it("shows track count in the subtitle", () => {
+    render(<LibraryArtistProfile artist={makeArtist({ trackCount: 42 })} onAlbumClick={vi.fn()} />);
+
+    expect(screen.getByText(/42/)).toBeTruthy();
+  });
+
+  it("renders with empty albums list without crashing", () => {
+    render(<LibraryArtistProfile artist={makeArtist({ albums: [] })} onAlbumClick={vi.fn()} />);
+
+    expect(screen.getByText("Daft Punk")).toBeTruthy();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/organisms/ReleasesList.test.tsx
+++ b/apps/frontend/src/components/organisms/ReleasesList.test.tsx
@@ -1,0 +1,115 @@
+import type { ArtistRelease } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ReleasesList } from "./ReleasesList";
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    itemKey,
+    renderItem,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../molecules/AlbumCard", () => ({
+  AlbumCard: ({
+    albumName,
+    onCardClick,
+    onArtistClick,
+    artistId,
+  }: {
+    albumId: string;
+    albumName: string;
+    artistId: string;
+    artistName: string;
+    coverUrl: string | null;
+    releaseDate?: string;
+    albumType?: string;
+    onCardClick: () => void;
+    onArtistClick: (artistId: string) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={onCardClick} aria-label={`open-${albumName}`}>
+        {albumName}
+      </button>
+      <button
+        type="button"
+        onClick={() => onArtistClick(artistId)}
+        aria-label={`artist-${artistId}`}
+      >
+        artist-link
+      </button>
+    </div>
+  ),
+}));
+
+const makeRelease = (albumId: string, albumName: string, artistId = "artist-1"): ArtistRelease => ({
+  albumId,
+  albumName,
+  artistId,
+  artistName: "Test Artist",
+  artistImageUrl: null,
+  coverUrl: null,
+  albumType: "album",
+  releaseDate: "2023-01-01",
+});
+
+describe("ReleasesList", () => {
+  it("renders one card per release", () => {
+    const releases = [makeRelease("r1", "Album One"), makeRelease("r2", "Album Two")];
+    render(<ReleasesList releases={releases} onReleaseClick={vi.fn()} onArtistClick={vi.fn()} />);
+
+    expect(screen.getByText("Album One")).toBeTruthy();
+    expect(screen.getByText("Album Two")).toBeTruthy();
+  });
+
+  it("renders nothing when releases list is empty", () => {
+    const { container } = render(
+      <ReleasesList releases={[]} onReleaseClick={vi.fn()} onArtistClick={vi.fn()} />,
+    );
+
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("calls onReleaseClick with the correct release when a card is clicked", () => {
+    const onReleaseClick = vi.fn();
+    const releases = [makeRelease("r1", "Album One")];
+    render(
+      <ReleasesList releases={releases} onReleaseClick={onReleaseClick} onArtistClick={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "open-Album One" }));
+
+    expect(onReleaseClick).toHaveBeenCalledWith(releases[0]);
+  });
+
+  it("calls onArtistClick with the correct artistId when artist link is clicked", () => {
+    const onArtistClick = vi.fn();
+    const releases = [makeRelease("r1", "Album One", "artist-42")];
+    render(
+      <ReleasesList releases={releases} onReleaseClick={vi.fn()} onArtistClick={onArtistClick} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "artist-artist-42" }));
+
+    expect(onArtistClick).toHaveBeenCalledWith("artist-42");
+  });
+
+  it("renders two cards for two releases", () => {
+    const releases = [makeRelease("r1", "Album One"), makeRelease("r2", "Album Two")];
+    render(<ReleasesList releases={releases} onReleaseClick={vi.fn()} onArtistClick={vi.fn()} />);
+
+    expect(screen.getAllByRole("button").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/apps/frontend/src/components/organisms/SearchAlbumGrid.test.tsx
+++ b/apps/frontend/src/components/organisms/SearchAlbumGrid.test.tsx
@@ -1,0 +1,119 @@
+import { ArtistRelease } from "@spotiarr/shared";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchAlbumGrid } from "./SearchAlbumGrid";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string, opts?: Record<string, unknown>) =>
+        opts ? `${key}:${JSON.stringify(opts)}` : key,
+    }),
+  };
+});
+
+vi.mock("@/hooks/useAlbumListDownloadStates", () => ({
+  useAlbumListDownloadStates: () =>
+    new Map<string, { isDownloaded: boolean; isDownloading: boolean }>(),
+}));
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    renderItem,
+    itemKey,
+  }: {
+    items: T[];
+    renderItem: (item: T) => React.ReactNode;
+    itemKey: (item: T) => string;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makeAlbum = (albumId: string, albumName = `Album ${albumId}`): ArtistRelease => ({
+  albumId,
+  albumName,
+  artistId: `artist-${albumId}`,
+  artistName: "Test Artist",
+  artistImageUrl: null,
+  coverUrl: null,
+  spotifyUrl: `https://open.spotify.com/album/${albumId}`,
+  totalTracks: 10,
+});
+
+describe("SearchAlbumGrid", () => {
+  it("renders one card per album", () => {
+    render(
+      <SearchAlbumGrid
+        albums={[makeAlbum("a1"), makeAlbum("a2")]}
+        onClick={vi.fn()}
+        onArtistClick={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Album a1")).toBeTruthy();
+    expect(screen.getByText("Album a2")).toBeTruthy();
+  });
+
+  it("renders nothing when the albums list is empty", () => {
+    const { container } = render(
+      <SearchAlbumGrid
+        albums={[]}
+        onClick={vi.fn()}
+        onArtistClick={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+    expect(container.querySelectorAll("article")).toHaveLength(0);
+  });
+
+  it("calls onClick with spotifyUrl, artistId, albumId when the card button is clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <SearchAlbumGrid
+        albums={[makeAlbum("b1", "Beach Album")]}
+        onClick={onClick}
+        onArtistClick={vi.fn()}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    // AlbumCard renders a button with aria-label containing the album name
+    const cardBtn = screen.getByRole("button", { name: /Beach Album/i });
+    fireEvent.click(cardBtn);
+
+    expect(onClick).toHaveBeenCalledWith({
+      spotifyUrl: "https://open.spotify.com/album/b1",
+      artistId: "artist-b1",
+      albumId: "b1",
+    });
+  });
+
+  it("calls onArtistClick with artistId when the artist button is clicked", () => {
+    const onArtistClick = vi.fn();
+    render(
+      <SearchAlbumGrid
+        albums={[makeAlbum("c1")]}
+        onClick={vi.fn()}
+        onArtistClick={onArtistClick}
+        onDownload={vi.fn()}
+      />,
+    );
+
+    // AlbumCard renders an artist <button> whose text content is the artist name.
+    // The card itself is a separate button with a compound aria-label.
+    // We select the button whose accessible name IS exactly the artist name text.
+    const buttons = screen.getAllByRole("button");
+    const artistBtn = buttons.find((btn) => btn.textContent?.trim() === "Test Artist")!;
+    fireEvent.click(artistBtn);
+
+    expect(onArtistClick).toHaveBeenCalledWith("artist-c1");
+  });
+});

--- a/apps/frontend/src/components/organisms/SearchArtistGrid.test.tsx
+++ b/apps/frontend/src/components/organisms/SearchArtistGrid.test.tsx
@@ -1,0 +1,82 @@
+import { FollowedArtist } from "@spotiarr/shared";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchArtistGrid } from "./SearchArtistGrid";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    renderItem,
+    itemKey,
+  }: {
+    items: T[];
+    renderItem: (item: T) => React.ReactNode;
+    itemKey: (item: T) => string;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makeArtist = (id: string, name = `Artist ${id}`): FollowedArtist => ({
+  id,
+  name,
+  image: null,
+  spotifyUrl: `https://open.spotify.com/artist/${id}`,
+});
+
+describe("SearchArtistGrid", () => {
+  it("renders one card per artist", () => {
+    render(
+      <SearchArtistGrid
+        artists={[makeArtist("ar1", "Radiohead"), makeArtist("ar2", "Portishead")]}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Radiohead")).toBeTruthy();
+    expect(screen.getByText("Portishead")).toBeTruthy();
+  });
+
+  it("renders nothing when the artists list is empty", () => {
+    const { container } = render(<SearchArtistGrid artists={[]} onClick={vi.fn()} />);
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("calls onClick with the artist id when a card is clicked", () => {
+    const onClick = vi.fn();
+    render(<SearchArtistGrid artists={[makeArtist("ar3", "Massive Attack")]} onClick={onClick} />);
+
+    // ArtistCard renders a <button aria-label={name}>
+    const btn = screen.getByRole("button", { name: "Massive Attack" });
+    fireEvent.click(btn);
+
+    expect(onClick).toHaveBeenCalledWith("ar3");
+  });
+
+  it("calls onClick with the correct id for each artist in a multi-item list", () => {
+    const onClick = vi.fn();
+    render(
+      <SearchArtistGrid
+        artists={[makeArtist("x1", "Aphex Twin"), makeArtist("x2", "Autechre")]}
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Autechre" }));
+
+    expect(onClick).toHaveBeenCalledWith("x2");
+  });
+});

--- a/apps/frontend/src/components/organisms/SearchGridSection.test.tsx
+++ b/apps/frontend/src/components/organisms/SearchGridSection.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SearchGridSection } from "./SearchGridSection";
+
+describe("SearchGridSection", () => {
+  it("renders the section title", () => {
+    render(
+      <SearchGridSection title="Albums">
+        <div>child</div>
+      </SearchGridSection>,
+    );
+    expect(screen.getByRole("heading", { level: 2, name: "Albums" })).toBeTruthy();
+  });
+
+  it("renders children inside the grid container", () => {
+    render(
+      <SearchGridSection title="Artists">
+        <div data-testid="child-a">A</div>
+        <div data-testid="child-b">B</div>
+      </SearchGridSection>,
+    );
+    expect(screen.getByTestId("child-a")).toBeTruthy();
+    expect(screen.getByTestId("child-b")).toBeTruthy();
+  });
+
+  it("renders a <section> element as the root", () => {
+    const { container } = render(
+      <SearchGridSection title="Tracks">
+        <span>item</span>
+      </SearchGridSection>,
+    );
+    expect(container.querySelector("section")).toBeTruthy();
+  });
+
+  it("renders with an empty children list without throwing", () => {
+    expect(() => render(<SearchGridSection title="Empty">{null}</SearchGridSection>)).not.toThrow();
+  });
+});

--- a/apps/frontend/src/components/organisms/SearchTrackList.test.tsx
+++ b/apps/frontend/src/components/organisms/SearchTrackList.test.tsx
@@ -1,0 +1,110 @@
+import { NormalizedTrack } from "@spotiarr/shared";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchTrackList } from "./SearchTrackList";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("react-router-dom", () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkTrackStatus: () => new Map(),
+}));
+
+vi.mock("../molecules/VirtualList", () => ({
+  VirtualList: <T,>({
+    items,
+    renderItem,
+    itemKey,
+  }: {
+    items: T[];
+    renderItem: (item: T, index: number) => React.ReactNode;
+    itemKey: (item: T) => string;
+  }) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={itemKey(item)}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../atoms/Image", () => ({
+  Image: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+vi.mock("../molecules/TrackStatusIndicator", () => ({
+  TrackStatusIndicator: ({
+    index,
+    onDownload,
+  }: {
+    index: number;
+    onDownload?: (e: React.MouseEvent) => void;
+  }) => (
+    <div data-testid="status-indicator" data-index={index}>
+      {onDownload && (
+        <button type="button" onClick={onDownload} aria-label="download">
+          download
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+const makeTrack = (overrides: Partial<NormalizedTrack> = {}): NormalizedTrack => ({
+  name: "Normalized Track",
+  artist: "Some Artist",
+  trackUrl: "https://open.spotify.com/track/nt1",
+  artists: [],
+  ...overrides,
+});
+
+describe("SearchTrackList", () => {
+  it("renders one row per track", () => {
+    const tracks = [
+      makeTrack({ name: "Song A", trackUrl: "url-a" }),
+      makeTrack({ name: "Song B", trackUrl: "url-b" }),
+    ];
+    render(<SearchTrackList tracks={tracks} onDownload={vi.fn()} />);
+    expect(screen.getByText("Song A")).toBeTruthy();
+    expect(screen.getByText("Song B")).toBeTruthy();
+  });
+
+  it("renders nothing when the tracks list is empty", () => {
+    render(<SearchTrackList tracks={[]} onDownload={vi.fn()} />);
+    expect(screen.queryAllByTestId("status-indicator")).toHaveLength(0);
+  });
+
+  it("calls onDownload with the original NormalizedTrack when the download button is clicked", () => {
+    const onDownload = vi.fn();
+    const track = makeTrack({ name: "Click Me", trackUrl: "https://open.spotify.com/track/dl" });
+    render(<SearchTrackList tracks={[track]} onDownload={onDownload} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "download" }));
+
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onDownload).toHaveBeenCalledWith(expect.objectContaining({ name: "Click Me" }));
+  });
+});

--- a/apps/frontend/src/components/organisms/SpotifyAuthCard.test.tsx
+++ b/apps/frontend/src/components/organisms/SpotifyAuthCard.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useSpotifyAuthController } from "@/hooks/controllers/useSpotifyAuthController";
+import { SpotifyAuthCard } from "./SpotifyAuthCard";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("@/hooks/controllers/useSpotifyAuthController");
+
+vi.mock("../skeletons/SpotifyAuthCardSkeleton", () => ({
+  SpotifyAuthCardSkeleton: () => <div data-testid="auth-skeleton" />,
+}));
+
+const mockUseSpotifyAuthController = vi.mocked(useSpotifyAuthController);
+
+const notAuthLoading = () =>
+  mockUseSpotifyAuthController.mockReturnValue({
+    isAuthenticated: false,
+    hasRefreshToken: false,
+    isLoading: true,
+    login: vi.fn(),
+    logout: vi.fn(),
+  });
+
+const notAuth = (overrides?: { login?: () => void; logout?: () => void }) =>
+  mockUseSpotifyAuthController.mockReturnValue({
+    isAuthenticated: false,
+    hasRefreshToken: false,
+    isLoading: false,
+    login: overrides?.login ?? vi.fn(),
+    logout: overrides?.logout ?? vi.fn(),
+  });
+
+const authenticated = (overrides?: { login?: () => void; logout?: () => void }) =>
+  mockUseSpotifyAuthController.mockReturnValue({
+    isAuthenticated: true,
+    hasRefreshToken: true,
+    isLoading: false,
+    login: overrides?.login ?? vi.fn(),
+    logout: overrides?.logout ?? vi.fn(),
+  });
+
+describe("SpotifyAuthCard", () => {
+  it("renders skeleton while loading", () => {
+    notAuthLoading();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByTestId("auth-skeleton")).toBeTruthy();
+    expect(screen.queryByText("auth.title")).toBeNull();
+  });
+
+  it("renders connect button when not authenticated", () => {
+    notAuth();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByRole("button", { name: /auth\.connectButton/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /auth\.disconnectButton/i })).toBeNull();
+  });
+
+  it("renders disconnect button when authenticated", () => {
+    authenticated();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByRole("button", { name: /auth\.disconnectButton/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /auth\.connectButton/i })).toBeNull();
+  });
+
+  it("calls login when connect button is clicked", () => {
+    const login = vi.fn();
+    notAuth({ login });
+
+    render(<SpotifyAuthCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auth\.connectButton/i }));
+
+    expect(login).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls logout when disconnect button is clicked", () => {
+    const logout = vi.fn();
+    authenticated({ logout });
+
+    render(<SpotifyAuthCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /auth\.disconnectButton/i }));
+
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows disconnected status text when not authenticated", () => {
+    notAuth();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByText("auth.disconnectedStatus")).toBeTruthy();
+    expect(screen.getByText("auth.disconnectedDescription")).toBeTruthy();
+  });
+
+  it("shows connected status text when authenticated", () => {
+    authenticated();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByText("auth.connectedStatus")).toBeTruthy();
+    expect(screen.getByText("auth.connectedDescription")).toBeTruthy();
+  });
+
+  it("shows info panel only when not authenticated", () => {
+    notAuth();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.getByText("auth.whyConnect")).toBeTruthy();
+  });
+
+  it("does not show info panel when authenticated", () => {
+    authenticated();
+
+    render(<SpotifyAuthCard />);
+
+    expect(screen.queryByText("auth.whyConnect")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/organisms/SpotifyPlaylistList.test.tsx
+++ b/apps/frontend/src/components/organisms/SpotifyPlaylistList.test.tsx
@@ -1,0 +1,75 @@
+import { SpotifyPlaylist } from "@spotiarr/shared";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SpotifyPlaylistList } from "./SpotifyPlaylistList";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    renderItem,
+    itemKey,
+  }: {
+    items: T[];
+    renderItem: (item: T) => React.ReactNode;
+    itemKey: (item: T) => string;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makePlaylists = (...ids: string[]): SpotifyPlaylist[] =>
+  ids.map((id) => ({
+    id,
+    name: `Playlist ${id}`,
+    image: null,
+    owner: "test-owner",
+    tracks: 10,
+    spotifyUrl: `https://open.spotify.com/playlist/${id}`,
+  }));
+
+describe("SpotifyPlaylistList", () => {
+  it("renders one card per playlist", () => {
+    render(<SpotifyPlaylistList playlists={makePlaylists("p1", "p2")} onClick={vi.fn()} />);
+    expect(screen.getByText("Playlist p1")).toBeTruthy();
+    expect(screen.getByText("Playlist p2")).toBeTruthy();
+  });
+
+  it("renders nothing interactive when the list is empty", () => {
+    const { container } = render(<SpotifyPlaylistList playlists={[]} onClick={vi.fn()} />);
+    expect(container.querySelectorAll("article")).toHaveLength(0);
+  });
+
+  it("calls onClick with the playlist id when a card is clicked", () => {
+    const onClick = vi.fn();
+    render(<SpotifyPlaylistList playlists={makePlaylists("abc")} onClick={onClick} />);
+
+    const article = screen.getByRole("article");
+    fireEvent.click(article);
+
+    expect(onClick).toHaveBeenCalledWith("abc");
+  });
+
+  it("calls onClick with the correct id for each playlist in a multi-item list", () => {
+    const onClick = vi.fn();
+    render(<SpotifyPlaylistList playlists={makePlaylists("x1", "x2")} onClick={onClick} />);
+
+    const articles = screen.getAllByRole("article");
+    fireEvent.click(articles[1]);
+
+    expect(onClick).toHaveBeenCalledWith("x2");
+  });
+});

--- a/apps/frontend/src/components/organisms/ToastContainer.test.tsx
+++ b/apps/frontend/src/components/organisms/ToastContainer.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ToastProvider, useToast } from "@/contexts/ToastContext";
+import { ToastContainer } from "./ToastContainer";
+
+// Helper component that exposes addToast to test code via a ref callback
+const AddToastTrigger = ({
+  onMount,
+}: {
+  onMount: (add: (msg: string, type: "success" | "error" | "info" | "warning") => void) => void;
+}) => {
+  const { addToast } = useToast();
+  onMount(addToast);
+  return null;
+};
+
+const renderWithProvider = (
+  onMount: (add: (msg: string, type: "success" | "error" | "info" | "warning") => void) => void,
+) => {
+  return render(
+    <ToastProvider>
+      <AddToastTrigger onMount={onMount} />
+      <ToastContainer />
+    </ToastProvider>,
+  );
+};
+
+describe("ToastContainer", () => {
+  it("renders nothing when there are no toasts", () => {
+    const { container } = render(
+      <ToastProvider>
+        <ToastContainer />
+      </ToastProvider>,
+    );
+    expect(container.querySelectorAll("[role='alert']")).toHaveLength(0);
+  });
+
+  it("renders a toast when one is added", () => {
+    let addToast!: (msg: string, type: "success" | "error" | "info" | "warning") => void;
+    renderWithProvider((fn) => {
+      addToast = fn;
+    });
+
+    act(() => {
+      addToast("Hello toast", "success");
+    });
+
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+    expect(screen.getByText("Hello toast")).toBeTruthy();
+  });
+
+  it("renders multiple toasts when several are added", () => {
+    let addToast!: (msg: string, type: "success" | "error" | "info" | "warning") => void;
+    renderWithProvider((fn) => {
+      addToast = fn;
+    });
+
+    act(() => {
+      addToast("First", "success");
+      addToast("Second", "error");
+      addToast("Third", "info");
+    });
+
+    expect(screen.getAllByRole("alert")).toHaveLength(3);
+    expect(screen.getByText("First")).toBeTruthy();
+    expect(screen.getByText("Second")).toBeTruthy();
+    expect(screen.getByText("Third")).toBeTruthy();
+  });
+
+  it("clicking the close button triggers removal flow without throwing", () => {
+    let addToast!: (msg: string, type: "success" | "error" | "info" | "warning") => void;
+    renderWithProvider((fn) => {
+      addToast = fn;
+    });
+
+    act(() => {
+      addToast("Closable toast", "warning");
+    });
+
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+
+    const closeBtn = screen.getByRole("button");
+    expect(() => fireEvent.click(closeBtn)).not.toThrow();
+  });
+
+  it("throws when useToast is used outside ToastProvider", () => {
+    // Confirm the hook enforces provider boundary
+    const Bad = () => {
+      useToast();
+      return null;
+    };
+    expect(() => render(<Bad />)).toThrow("useToast must be used within a ToastProvider");
+  });
+});

--- a/apps/frontend/src/components/organisms/TrackList.test.tsx
+++ b/apps/frontend/src/components/organisms/TrackList.test.tsx
@@ -1,0 +1,165 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TrackList, TrackListTrack } from "./TrackList";
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  };
+});
+
+vi.mock("react-router-dom", () => ({
+  Link: ({
+    to,
+    children,
+    className,
+  }: {
+    to: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={to} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/hooks/queries/useDownloadStatus", () => ({
+  useBulkTrackStatus: () => new Map<string, TrackStatusEnum>(),
+}));
+
+vi.mock("../molecules/VirtualList", () => ({
+  VirtualList: <T,>({
+    items,
+    renderItem,
+    itemKey,
+  }: {
+    items: T[];
+    renderItem: (item: T, index: number) => React.ReactNode;
+    itemKey: (item: T) => string;
+  }) => (
+    <div>
+      {items.map((item, index) => (
+        <div key={itemKey(item)}>{renderItem(item, index)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../atoms/Image", () => ({
+  Image: ({ alt }: { alt: string }) => <img alt={alt} />,
+}));
+
+vi.mock("../molecules/TrackStatusIndicator", () => ({
+  TrackStatusIndicator: ({
+    index,
+    onDownload,
+    status,
+  }: {
+    index: number;
+    onDownload?: (e: React.MouseEvent) => void;
+    status?: TrackStatusEnum;
+  }) => (
+    <div data-testid="status-indicator" data-index={index} data-status={status ?? "none"}>
+      {onDownload && (
+        <button type="button" onClick={onDownload} aria-label="download">
+          download
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+const makeTrack = (overrides: Partial<TrackListTrack> = {}): TrackListTrack => ({
+  name: "Track One",
+  artist: "Artist One",
+  trackUrl: "https://open.spotify.com/track/t1",
+  durationMs: 180000,
+  ...overrides,
+});
+
+describe("TrackList", () => {
+  it("renders one row per track", () => {
+    const tracks = [
+      makeTrack({ name: "Track A", trackUrl: "url-a" }),
+      makeTrack({ name: "Track B", trackUrl: "url-b" }),
+    ];
+    render(<TrackList tracks={tracks} onDownload={vi.fn()} />);
+    expect(screen.getByText("Track A")).toBeTruthy();
+    expect(screen.getByText("Track B")).toBeTruthy();
+  });
+
+  it("renders nothing when the tracks list is empty", () => {
+    render(<TrackList tracks={[]} onDownload={vi.fn()} />);
+    expect(screen.queryAllByTestId("status-indicator")).toHaveLength(0);
+  });
+
+  it("renders the artist name for each track", () => {
+    render(<TrackList tracks={[makeTrack({ artist: "Portishead" })]} onDownload={vi.fn()} />);
+    expect(screen.getByText("Portishead")).toBeTruthy();
+  });
+
+  it("renders the formatted duration when durationMs is provided", () => {
+    // 180000ms = 3:00
+    render(<TrackList tracks={[makeTrack({ durationMs: 180000 })]} onDownload={vi.fn()} />);
+    expect(screen.getByText("3:00")).toBeTruthy();
+  });
+
+  it("renders --:-- when durationMs is absent", () => {
+    render(<TrackList tracks={[makeTrack({ durationMs: undefined })]} onDownload={vi.fn()} />);
+    expect(screen.getByText("--:--")).toBeTruthy();
+  });
+
+  it("calls onDownload when the download button in the status indicator is clicked", () => {
+    const onDownload = vi.fn();
+    const track = makeTrack({
+      name: "Downloadable",
+      trackUrl: "https://open.spotify.com/track/dl",
+    });
+    render(<TrackList tracks={[track]} onDownload={onDownload} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "download" }));
+    expect(onDownload).toHaveBeenCalledTimes(1);
+    expect(onDownload).toHaveBeenCalledWith(expect.objectContaining({ name: "Downloadable" }));
+  });
+
+  it("passes index starting at 1 to TrackStatusIndicator", () => {
+    const tracks = [
+      makeTrack({ name: "T1", trackUrl: "url-1" }),
+      makeTrack({ name: "T2", trackUrl: "url-2" }),
+    ];
+    render(<TrackList tracks={tracks} onDownload={vi.fn()} />);
+    const indicators = screen.getAllByTestId("status-indicator");
+    expect(indicators[0].getAttribute("data-index")).toBe("1");
+    expect(indicators[1].getAttribute("data-index")).toBe("2");
+  });
+
+  it("renders a link for spotify trackUrl", () => {
+    render(
+      <TrackList
+        tracks={[
+          makeTrack({ name: "Linked Track", trackUrl: "https://open.spotify.com/track/abc" }),
+        ]}
+        onDownload={vi.fn()}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Linked Track" });
+    expect(link).toBeTruthy();
+    expect((link as HTMLAnchorElement).href).toContain("/preview");
+  });
+
+  it("renders no download button when trackUrl is missing", () => {
+    render(
+      <TrackList
+        tracks={[makeTrack({ name: "No URL", trackUrl: undefined })]}
+        onDownload={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "download" })).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Render/behavior unit tests for all 14 untested organism components.

## Why

Continues the frontend coverage push (#185/#186/#187/#188/#189/#190). Part of the ratchet goal (#149).

## Coverage notes

- List organisms (ArtistList, HistoryList, ReleasesList, LibraryArtistList, Search*Grid/List, SpotifyPlaylistList, TrackList): item render, empty state, item-click callbacks, multi-item interaction.
- `TrackList`: artist/duration formatting, `--:--` fallback, download callback, spotify link, no-download-button branch.
- `ToastContainer`: empty vs single vs multiple toasts, close button, provider boundary.
- `LibraryArtistProfile`: mocks `LibraryAlbumList` to isolate.
- `react-virtuoso` mocked to render items directly in jsdom; `react-i18next` mocks use `importOriginal` to preserve `initReactI18next`.

14 files, no source changes. `tsc --noEmit` clean; full suite 939 passing.