### PR TITLE
fix(backend): re-sync subscribed playlist uses update, not save (real root cause of missing new-track downloads)

### DIFF
--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.test.ts
@@ -74,6 +74,21 @@ describe("SyncSubscribedPlaylistsUseCase", () => {
     );
   }
 
+  it("persists refreshed details with update (not save) and creates newly-added tracks", async () => {
+    // Regression: an existing subscribed playlist must be persisted via update().
+    // save() does an insert and threw a unique-constraint violation on
+    // spotifyUrl, which aborted the whole sync so new tracks were never created.
+    trackService.getAllByPlaylist.mockResolvedValue([]);
+
+    await makeUseCase().execute();
+
+    expect(playlistRepository.update).toHaveBeenCalledWith("playlist-1", expect.anything());
+    expect(playlistRepository.save).not.toHaveBeenCalled();
+    expect(trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Song", playlistId: "playlist-1" }),
+    );
+  });
+
   it("dedupes using trackUrl instead of legacy spotifyUrl semantics", async () => {
     const existingTrack: ITrack = {
       name: "Song",

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -55,7 +55,8 @@ export class SyncSubscribedPlaylistsUseCase {
           details.owner,
           details.ownerUrl,
         );
-        await this.playlistRepository.save(playlist);
+        // update, not save: save() inserts and would fail the spotifyUrl unique constraint.
+        await this.playlistRepository.update(playlist.id, playlist);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         const errorCode = error instanceof AppError ? error.errorCode : undefined;


### PR DESCRIPTION
## What

`SyncSubscribedPlaylistsUseCase` now persists a re-synced playlist's refreshed details with `playlistRepository.update(id, playlist)` instead of `save(playlist)`.

## Why — this is the actual reported bug

`save()` runs `prisma.playlist.create()` (an insert). For an already-subscribed playlist the row exists, so it threw `Unique constraint failed on (spotifyUrl)`. That throw was swallowed by the sync's generic `catch` (`markAsError` + `continue`) — **before** the new-track detection/creation block. Result: every re-sync of an existing subscribed playlist aborted silently, and **newly-added Spotify tracks were never created or downloaded**.

This is the literal "subscribed playlist detects new songs but never downloads them" report. Confirmed live: the sync logged `Retrieved 5 tracks` then silently caught `prisma.playlist.create() … Unique constraint failed on (spotifyUrl)` at `sync-subscribed-playlists.use-case.ts:60`.

## Verification

- `pnpm --filter backend run test:run` → **775 passed** (new regression test).
- `tsc --noEmit` → no errors.
- Found by manual runtime testing (subscribe → add song → re-sync), then instrumenting the swallowed catch.

## Why tests missed it

Every sync unit test mocks `playlistRepository.save` as a no-op, so the mock never enforced the unique constraint. Added a regression test asserting the sync calls `update` (not `save`) and creates the newly-added track.

## Note

This is a pre-existing bug, independent of the track-recovery redesign (#175–#184). The redesign hardened recovery of already-created tracks; this fixes track *creation* on re-sync.