### PR TITLE
test(frontend): ratchet coverage thresholds to measured levels (#149)

### DIFF
--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
       // Thresholds sit just under the currently measured coverage so the gate is
       // green on merge. Ratchet these up as coverage improves (issue #149).
       thresholds: {
-        lines: 47,
-        statements: 47,
-        functions: 58,
-        branches: 74,
+        lines: 92,
+        statements: 92,
+        functions: 90,
+        branches: 84,
       },
     },
   },


### PR DESCRIPTION
## What

Raises the frontend vitest coverage gate to match the now-measured coverage:

| Metric | Before | After | Measured |
|--------|--------|-------|----------|
| lines | 47 | **92** | 92.46 |
| statements | 47 | **92** | 92.46 |
| functions | 58 | **90** | 90.70 |
| branches | 74 | **84** | 84.83 |

## Why

After backfilling unit tests across services, hooks (queries/mutations/controllers/custom), stores, contexts, utils, every component (atoms→organisms), and views (#185–#192), real coverage jumped to ~92%. The old thresholds were placeholders sitting just under the previous level. Ratcheting them up locks in the gain — coverage can now only hold or rise; any PR that drops it fails CI.

Thresholds set just under measured values to absorb minor run-to-run variance.

Closes #149.

## Verification

`pnpm --filter frontend test:coverage` passes the gate (exit 0).