### PR TITLE
fix(backend): harden recovery against the mock-masked bug class (audit follow-up)

### DIFF
--- a/apps/backend/src/application/services/playlist.service.ts
+++ b/apps/backend/src/application/services/playlist.service.ts
@@ -66,10 +66,6 @@ export class PlaylistService {
     return this.createPlaylistUseCase.execute(input);
   }
 
-  async save(playlist: IPlaylist): Promise<IPlaylist> {
-    return this.updatePlaylistUseCase.save(playlist);
-  }
-
   async update(id: string, playlist: Partial<IPlaylist>): Promise<void> {
     return this.updatePlaylistUseCase.execute(id, playlist);
   }

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
@@ -59,7 +59,10 @@ export class ScanLibraryUseCase {
         // Completed-file reconciliation pass
         if (this.retryTrackDownloadUseCase) {
           const maxAttempts = this.settingsService
-            ? await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS")
+            ? await this.settingsService.getNumber(
+                "SEARCH_MAX_ATTEMPTS",
+                DEFAULT_SEARCH_MAX_ATTEMPTS,
+              )
             : DEFAULT_SEARCH_MAX_ATTEMPTS;
           const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
 

--- a/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.ts
@@ -18,10 +18,4 @@ export class UpdatePlaylistUseCase {
     await this.playlistRepository.update(id, playlist);
     this.eventBus.emit("playlists-updated");
   }
-
-  async save(playlist: IPlaylist): Promise<IPlaylist> {
-    const savedPlaylist = await this.playlistRepository.save(playlist);
-    this.eventBus.emit("playlists-updated");
-    return savedPlaylist.toPrimitive();
-  }
 }

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
@@ -138,6 +138,20 @@ describe("RecoverErroredTracksUseCase", () => {
     expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-eligible");
   });
 
+  it("continues recovering other tracks when one track's retry throws", async () => {
+    const failing = makeErrorTrack({ id: "track-fail", searchAttempts: 1 });
+    const ok = makeErrorTrack({ id: "track-ok-2", searchAttempts: 1 });
+    trackRepository.findAllByStatuses.mockResolvedValue([failing, ok]);
+    retryTrackDownloadUseCase.execute.mockImplementation((id: string) =>
+      id === "track-fail" ? Promise.reject(new Error("redis down")) : Promise.resolve(undefined),
+    );
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(useCase.execute()).resolves.not.toThrow();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-ok-2");
+  });
+
   it("emits playlists-updated when at least one track is recovered", async () => {
     const track = makeErrorTrack({ id: "track-ok" });
     trackRepository.findAllByStatuses.mockResolvedValue([track]);

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
@@ -26,7 +26,10 @@ export class RecoverErroredTracksUseCase {
 
     const erroredTracks = await this.trackRepository.findAllByStatuses([TrackStatusEnum.Error]);
 
-    const maxAttempts = await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS");
+    const maxAttempts = await this.settingsService.getNumber(
+      "SEARCH_MAX_ATTEMPTS",
+      DEFAULT_SEARCH_MAX_ATTEMPTS,
+    );
     const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
 
     let recovered = 0;
@@ -37,8 +40,15 @@ export class RecoverErroredTracksUseCase {
         continue;
       }
 
-      await this.retryTrackDownloadUseCase.execute(track.id);
-      recovered++;
+      try {
+        await this.retryTrackDownloadUseCase.execute(track.id);
+        recovered++;
+      } catch (error) {
+        console.error(
+          `[RecoverErroredTracks] Failed to re-drive track ${track.id}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
     }
 
     if (recovered > 0) {

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
@@ -26,7 +26,10 @@ export class SearchTrackOnYoutubeUseCase {
       return;
     }
 
-    const maxAttempts = await this.settingsService.getNumber("SEARCH_MAX_ATTEMPTS");
+    const maxAttempts = await this.settingsService.getNumber(
+      "SEARCH_MAX_ATTEMPTS",
+      DEFAULT_SEARCH_MAX_ATTEMPTS,
+    );
     const safeMaxAttempts = maxAttempts >= 1 ? maxAttempts : DEFAULT_SEARCH_MAX_ATTEMPTS;
 
     // Stop re-driving when the failure is permanent: a known-terminal error

--- a/apps/backend/src/presentation/controllers/auth.controller.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.ts
@@ -60,8 +60,8 @@ export class AuthController {
 
   status = async (_req: Request, res: Response) => {
     try {
-      const accessToken = await this.settingsService.getString("spotify_user_access_token");
-      const refreshToken = await this.settingsService.getString("spotify_user_refresh_token");
+      const accessToken = await this.settingsService.getString("spotify_user_access_token", "");
+      const refreshToken = await this.settingsService.getString("spotify_user_refresh_token", "");
 
       res.json({
         authenticated: !!accessToken,


### PR DESCRIPTION
## What

Follow-up to the audit triggered by #181 and #193 — closes the residual instances of the same bug class (runtime failures invisible to mocked tests).

1. **Settings fallback (kills the #181 dead-ternary trap).** `search-track-on-youtube`, `recover-errored-tracks` and `scan-library` read `SEARCH_MAX_ATTEMPTS` with `await getNumber("SEARCH_MAX_ATTEMPTS")` followed by a `>= 1 ? x : DEFAULT` ternary. The ternary is dead code — if the await throws (de-registered key), it never runs. Now the default is passed as the `getNumber` fallback, so a missing registration can no longer silently disable recovery.
2. **Per-track guard in the global Error drainer.** `RecoverErroredTracksUseCase` had no per-iteration try/catch, so one failing re-drive (Redis blip, deleted track) aborted the whole cycle and skipped every remaining Error track. Now each track is guarded, matching `RescueStuckTracksUseCase`.
3. **`auth.controller` status.** The unregistered `spotify_user_access_token` / `refresh_token` keys threw on a fresh install (caught by the handler, degrading to "not authenticated"). Now pass an explicit `""` fallback so correctness no longer depends on the surrounding catch.
4. **Remove dead insert-only `PlaylistService.save` / `UpdatePlaylistUseCase.save`.** Zero callers, but it would reproduce the #193 unique-constraint crash if anyone wired it. Deleted. (`playlistRepository.save` stays — still used legitimately by the create/AI flows.)

## Why

Two production bugs (#181 dormant settings, #193 save-vs-update) were invisible to 775 green tests because the suite mocks the failing dependency. A 3-agent read-only audit hunted the same class — these are the cheap, in-scope residuals.

## Verification

- `pnpm --filter backend run test:run` → **775 passed** (new test: drainer continues when one track's retry throws).
- `tsc --noEmit` → no errors.

## Out of scope (flagged, not done)

- AI resolver (`spotify-url-lookup.client`) swallows rate-limit/circuit-open → AI playlist reports "nothing found" on a transient Spotify outage. Larger, AI-scoped; separate follow-up.
- `FollowedArtistRepository.update*` can throw `P2025` if an artist row is evicted mid-cycle (needs concurrency). Low likelihood.

## Note

Independent of the still-open **#193** (the actual reported-bug fix: re-sync `save`→`update`). #193 must still merge.