### PR TITLE
test(backend): add unit tests for 10 Spotify external clients

### DIFF
--- a/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/spotify/spotify-url-lookup.client.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "../../circuit-breaker";
+import { RateLimiter } from "../../rate-limiter";
+import { SpotifyAuthService } from "../../spotify-auth.service";
+import { SpotifyUrlLookupClient } from "./spotify-url-lookup.client";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifyUrlLookupClient", () => {
+  let authService: SpotifyAuthService;
+  let settingsService: SettingsPort;
+  let circuitBreaker: CircuitBreaker;
+  let rateLimiter: RateLimiter;
+  let client: SpotifyUrlLookupClient;
+
+  beforeEach(() => {
+    authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn().mockResolvedValue("test-user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService;
+    settingsService = {
+      getString: vi.fn().mockResolvedValue("US"),
+    } as unknown as SettingsPort;
+    circuitBreaker = new CircuitBreaker();
+    rateLimiter = new RateLimiter({ maxConcurrency: 5, minIntervalMs: 0, queueTimeoutMs: 5000 });
+    client = new SpotifyUrlLookupClient(authService, settingsService, circuitBreaker, rateLimiter);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("resolveArtistUrl()", () => {
+    it("returns spotify URL from first result", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            artists: {
+              items: [{ external_urls: { spotify: "https://open.spotify.com/artist/123" } }],
+            },
+          }),
+        ),
+      );
+
+      const result = await client.resolveArtistUrl("The Beatles");
+
+      expect(result).toBe("https://open.spotify.com/artist/123");
+    });
+
+    it("returns null when items is empty", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ artists: { items: [] } })));
+
+      const result = await client.resolveArtistUrl("Nonexistent Artist");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null on network error", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failed")));
+
+      const result = await client.resolveArtistUrl("Any Artist");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("resolveAlbumUrl()", () => {
+    it("builds query as 'name artistName' when artist is provided", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          albums: {
+            items: [{ external_urls: { spotify: "https://open.spotify.com/album/456" } }],
+          },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.resolveAlbumUrl("Dark Side", "Pink Floyd");
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("Dark");
+      expect(calledUrl).toContain("Pink");
+      expect(result).toBe("https://open.spotify.com/album/456");
+    });
+
+    it("uses just name when no artist provided", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          albums: {
+            items: [{ external_urls: { spotify: "https://open.spotify.com/album/789" } }],
+          },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.resolveAlbumUrl("Dark Side");
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("Dark");
+      expect(calledUrl).not.toContain("Pink");
+      expect(result).toBe("https://open.spotify.com/album/789");
+    });
+  });
+
+  describe("resolveTrackUrl()", () => {
+    it("returns spotify URL for track", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            tracks: {
+              items: [{ external_urls: { spotify: "https://open.spotify.com/track/abc" } }],
+            },
+          }),
+        ),
+      );
+
+      const result = await client.resolveTrackUrl("Bohemian Rhapsody", "Queen");
+
+      expect(result).toBe("https://open.spotify.com/track/abc");
+    });
+
+    it("returns null when API returns non-ok response", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 400 })));
+
+      const result = await client.resolveTrackUrl("Some Track");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-album.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-album.client.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { AppError } from "@/domain/errors/app-error";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { PromiseCache } from "./promise-cache";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyAlbumClient } from "./spotify-album.client";
+import { SpotifyAuthService } from "./spotify-auth.service";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifyAlbumClient", () => {
+  let client: SpotifyAlbumClient;
+
+  beforeEach(() => {
+    const authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn(),
+      refreshUserToken: vi.fn(),
+    } as unknown as SpotifyAuthService;
+
+    const settingsService = {
+      getString: vi.fn().mockResolvedValue("US"),
+    } as unknown as SettingsPort;
+
+    const requestCache = new PromiseCache({ ttlMs: 30_000 });
+    const circuitBreaker = new CircuitBreaker();
+    const rateLimiter = new RateLimiter({
+      maxConcurrency: 5,
+      minIntervalMs: 0,
+      queueTimeoutMs: 5000,
+    });
+
+    client = new SpotifyAlbumClient(
+      authService,
+      settingsService,
+      requestCache,
+      circuitBreaker,
+      rateLimiter,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("getAlbumDetails()", () => {
+    it("fetches album by id and returns parsed JSON", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(jsonResponse({ name: "Test Album", id: "abc123" })),
+      );
+
+      const result = await client.getAlbumDetails("abc123");
+
+      expect(result.name).toBe("Test Album");
+    });
+
+    it("throws AppError(404) with errorCode album_not_found on 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      await expect(client.getAlbumDetails("missing-id")).rejects.toMatchObject({
+        statusCode: 404,
+        errorCode: "album_not_found",
+      });
+    });
+
+    it("throws AppError on non-ok status other than 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+
+      await expect(client.getAlbumDetails("error-id")).rejects.toBeInstanceOf(AppError);
+    });
+  });
+
+  describe("getAlbumTracks()", () => {
+    it("returns NormalizedTracks for a single-page album", async () => {
+      const albumBody = {
+        id: "album-1",
+        name: "Album",
+        images: [{ url: "http://img" }],
+        artists: [{ name: "Artist" }],
+        release_date: "2020-01-01",
+        total_tracks: 1,
+      };
+
+      const tracksBody = {
+        items: [
+          {
+            name: "Track 1",
+            artists: [{ name: "Artist" }],
+            external_urls: { spotify: "https://open.spotify.com/track/1" },
+          },
+        ],
+        total: 1,
+        limit: 50,
+        offset: 0,
+        next: null,
+      };
+
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(jsonResponse(albumBody))
+          .mockResolvedValueOnce(jsonResponse(tracksBody)),
+      );
+
+      const tracks = await client.getAlbumTracks("album-1");
+
+      expect(tracks.length).toBe(1);
+      expect(tracks[0].name).toBe("Track 1");
+      expect(tracks[0].album).toBe("Album");
+    });
+
+    it("handles pagination and accumulates tracks from multiple pages", async () => {
+      const albumBody = {
+        id: "album-2",
+        name: "Big Album",
+        images: [],
+        artists: [{ name: "Band" }],
+        release_date: "2021-06-01",
+        total_tracks: 2,
+      };
+
+      const tracksPage1 = {
+        items: [{ name: "Track A", artists: [{ name: "Band" }] }],
+        total: 2,
+        limit: 50,
+        offset: 0,
+        next: "https://api.spotify.com/v1/albums/album-2/tracks?limit=50&offset=50",
+      };
+
+      const tracksPage2 = {
+        items: [{ name: "Track B", artists: [{ name: "Band" }] }],
+        total: 2,
+        limit: 50,
+        offset: 50,
+        next: null,
+      };
+
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(jsonResponse(albumBody))
+          .mockResolvedValueOnce(jsonResponse(tracksPage1))
+          .mockResolvedValueOnce(jsonResponse(tracksPage2)),
+      );
+
+      const tracks = await client.getAlbumTracks("album-2");
+
+      expect(tracks.length).toBe(2);
+      expect(tracks[0].name).toBe("Track A");
+      expect(tracks[1].name).toBe("Track B");
+    });
+
+    it("throws AppError(404) when album not found", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      await expect(client.getAlbumTracks("not-found")).rejects.toMatchObject({
+        statusCode: 404,
+        errorCode: "album_not_found",
+      });
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-artist.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artist.client.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { PromiseCache } from "./promise-cache";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyArtistClient } from "./spotify-artist.client";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+const buildClient = () => {
+  const authService = {
+    getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+    getUserToken: vi.fn(),
+    refreshUserToken: vi.fn(),
+  } as unknown as SpotifyAuthService;
+
+  const settingsService = {
+    getString: vi.fn().mockResolvedValue("US"),
+  } as unknown as SettingsPort;
+
+  const requestCache = new PromiseCache({ ttlMs: 30_000 });
+  const circuitBreaker = new CircuitBreaker();
+  const rateLimiter = new RateLimiter({
+    maxConcurrency: 5,
+    minIntervalMs: 0,
+    queueTimeoutMs: 5000,
+  });
+
+  return new SpotifyArtistClient(
+    authService,
+    settingsService,
+    requestCache,
+    circuitBreaker,
+    rateLimiter,
+    "interactive",
+  );
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SpotifyArtistClient", () => {
+  describe("getArtistRaw()", () => {
+    it("returns artist data on success", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            name: "The Beatles",
+            images: [{ url: "http://img.jpg" }],
+            external_urls: { spotify: "https://open.spotify.com/artist/123" },
+            genres: ["rock"],
+          }),
+        ),
+      );
+
+      const client = buildClient();
+      const result = await client.getArtistRaw("artist-123");
+
+      expect(result).not.toBeNull();
+      expect(result?.name).toBe("The Beatles");
+      expect(result?.genres).toContain("rock");
+    });
+
+    it("returns null on non-ok response (404)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      const client = buildClient();
+      const result = await client.getArtistRaw("artist-404");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null on network error", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+      const client = buildClient();
+      const result = await client.getArtistRaw("artist-err");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("getArtistDetails()", () => {
+    it("maps artist data to expected shape", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            name: "The Beatles",
+            images: [{ url: "http://img.jpg" }],
+            external_urls: { spotify: "https://open.spotify.com/artist/123" },
+            genres: ["rock", "pop"],
+          }),
+        ),
+      );
+
+      const client = buildClient();
+      const result = await client.getArtistDetails("artist-123");
+
+      expect(result.name).toBe("The Beatles");
+      expect(result.image).toBe("http://img.jpg");
+      expect(result.spotifyUrl).toBe("https://open.spotify.com/artist/123");
+    });
+
+    it("returns 'Unknown Artist' when getArtistRaw returns null (non-ok response)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      const client = buildClient();
+      const result = await client.getArtistDetails("artist-404");
+
+      expect(result.name).toBe("Unknown Artist");
+      expect(result.genres).toEqual([]);
+    });
+
+    it("includes genres array", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            name: "The Beatles",
+            images: [{ url: "http://img.jpg" }],
+            external_urls: { spotify: "https://open.spotify.com/artist/123" },
+            genres: ["rock", "pop"],
+          }),
+        ),
+      );
+
+      const client = buildClient();
+      const result = await client.getArtistDetails("artist-123");
+
+      expect(result.genres).toEqual(["rock", "pop"]);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-base.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-base.client.test.ts
@@ -1,0 +1,154 @@
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyBaseClient } from "./spotify-base.client";
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+class TestableBase extends SpotifyBaseClient {
+  public callGetMarket(): Promise<string> {
+    return this.getMarket();
+  }
+  public callClearMarketCache(): void {
+    this.clearMarketCache();
+  }
+  public callLog(msg: string, level?: "debug" | "error" | "warn"): void {
+    this.log(msg, level);
+  }
+}
+
+describe("SpotifyBaseClient", () => {
+  let authService: SpotifyAuthService;
+  let settingsService: { getString: ReturnType<typeof vi.fn> } & SettingsPort;
+  let circuitBreaker: CircuitBreaker;
+  let rateLimiter: RateLimiter;
+  let base: TestableBase;
+
+  beforeEach(() => {
+    authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn().mockResolvedValue("test-user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService;
+
+    settingsService = {
+      getString: vi.fn(),
+    } as unknown as { getString: ReturnType<typeof vi.fn> } & SettingsPort;
+
+    circuitBreaker = new CircuitBreaker();
+    rateLimiter = new RateLimiter({ maxConcurrency: 5, minIntervalMs: 0, queueTimeoutMs: 5000 });
+    base = new TestableBase(authService, settingsService, "TestCtx", circuitBreaker, rateLimiter);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("getMarket()", () => {
+    it("calls settingsService.getString with SPOTIFY_MARKET and returns the value", async () => {
+      (settingsService.getString as ReturnType<typeof vi.fn>).mockResolvedValue("US");
+
+      const result = await base.callGetMarket();
+
+      expect(settingsService.getString).toHaveBeenCalledWith("SPOTIFY_MARKET");
+      expect(result).toBe("US");
+    });
+
+    it("returns 'ES' as fallback when getString throws", async () => {
+      (settingsService.getString as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Setting not found"),
+      );
+
+      const result = await base.callGetMarket();
+
+      expect(result).toBe("ES");
+    });
+
+    it("caches the market and only calls getString once on repeated calls", async () => {
+      (settingsService.getString as ReturnType<typeof vi.fn>).mockResolvedValue("DE");
+
+      const first = await base.callGetMarket();
+      const second = await base.callGetMarket();
+      const third = await base.callGetMarket();
+
+      expect(first).toBe("DE");
+      expect(second).toBe("DE");
+      expect(third).toBe("DE");
+      expect(settingsService.getString).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches from settingsService after clearMarketCache()", async () => {
+      (settingsService.getString as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce("FR")
+        .mockResolvedValueOnce("JP");
+
+      const first = await base.callGetMarket();
+      expect(first).toBe("FR");
+
+      base.callClearMarketCache();
+
+      const second = await base.callGetMarket();
+      expect(second).toBe("JP");
+      expect(settingsService.getString).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("log()", () => {
+    it("calls console.error on 'error' level", () => {
+      const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      base.callLog("something went wrong", "error");
+
+      expect(spy).toHaveBeenCalledWith("[TestCtx]", "something went wrong");
+    });
+
+    it("calls console.warn on 'warn' level", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      base.callLog("heads up", "warn");
+
+      expect(spy).toHaveBeenCalledWith("[TestCtx]", "heads up");
+    });
+
+    it("does not call console.log for 'debug' level when NODE_ENV is not 'development'", () => {
+      // getEnv() returns the validated env captured at validateEnvironment() time.
+      // In the test environment NODE_ENV is typically "test", so console.log is never called.
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      base.callLog("debug message", "debug");
+
+      // Characterization: log is suppressed unless NODE_ENV === "development"
+      // We cannot guarantee NODE_ENV during tests, so we assert the actual behavior.
+      const nodeEnv = process.env.NODE_ENV;
+      if (nodeEnv !== "development") {
+        expect(spy).not.toHaveBeenCalled();
+      } else {
+        expect(spy).toHaveBeenCalledWith("[TestCtx]", "debug message");
+      }
+    });
+
+    it("defaults to 'debug' level when no level is provided", () => {
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      base.callLog("implicit debug");
+
+      // Neither error nor warn should be called for the default level
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+      // console.log may or may not be called depending on NODE_ENV — no assertion needed
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-circuit-breaker.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-circuit-breaker.adapter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { CircuitBreaker } from "./circuit-breaker";
+import { SpotifyCircuitBreakerAdapter } from "./spotify-circuit-breaker.adapter";
+
+describe("SpotifyCircuitBreakerAdapter", () => {
+  let circuitBreaker: CircuitBreaker;
+  let adapter: SpotifyCircuitBreakerAdapter;
+
+  beforeEach(() => {
+    circuitBreaker = new CircuitBreaker();
+    adapter = new SpotifyCircuitBreakerAdapter(circuitBreaker);
+  });
+
+  it("returns false when the circuit is closed", () => {
+    expect(adapter.isOpen()).toBe(false);
+  });
+
+  it("returns true when the circuit is open after notifyRateLimit", () => {
+    // Open for 60 seconds — the first notifyRateLimit call has backoff multiplier = 2^0 = 1
+    circuitBreaker.notifyRateLimit(60);
+
+    expect(adapter.isOpen()).toBe(true);
+  });
+
+  it("delegates isOpen directly to CircuitBreaker.isOpen", () => {
+    // Verify adapter result matches the underlying circuit breaker state
+    expect(adapter.isOpen()).toBe(circuitBreaker.isOpen());
+
+    circuitBreaker.notifyRateLimit(60);
+
+    expect(adapter.isOpen()).toBe(circuitBreaker.isOpen());
+    expect(adapter.isOpen()).toBe(true);
+  });
+
+  it("returns false after the circuit open window has passed", () => {
+    // Open for 0 seconds — window is immediately in the past
+    circuitBreaker.notifyRateLimit(0);
+
+    // With 0 seconds * backoff (min 1) = 0ms, the window expires instantly
+    // Depending on timing it may be false already
+    expect(adapter.isOpen()).toBe(circuitBreaker.isOpen());
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-http.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-http.client.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyHttpClient } from "./spotify-http.client";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifyHttpClient", () => {
+  let authService: SpotifyAuthService;
+  let client: SpotifyHttpClient;
+
+  beforeEach(() => {
+    authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn().mockResolvedValue("test-user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService;
+
+    const circuitBreaker = new CircuitBreaker();
+    const rateLimiter = new RateLimiter({
+      maxConcurrency: 5,
+      minIntervalMs: 0,
+      queueTimeoutMs: 5000,
+    });
+    client = new SpotifyHttpClient(authService, circuitBreaker, rateLimiter, "user");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("fetchWithAppToken()", () => {
+    it("adds Authorization header with Bearer app token", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, 200));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.fetchWithAppToken("https://api.spotify.com/v1/test");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+        "Bearer test-app-token",
+      );
+    });
+
+    it("passes through a 200 response", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ ok: true }, 200)));
+
+      const response = await client.fetchWithAppToken("https://api.spotify.com/v1/test");
+
+      expect(response.status).toBe(200);
+    });
+
+    it("throws AppError(429) when Spotify rate-limits via circuit breaker", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response("", {
+            status: 429,
+            headers: { "Retry-After": "1" },
+          }),
+        ),
+      );
+
+      await expect(
+        client.fetchWithAppToken("https://api.spotify.com/v1/test"),
+      ).rejects.toMatchObject({
+        statusCode: 429,
+        errorCode: "spotify_rate_limited",
+      });
+    });
+  });
+
+  describe("fetchWithUserToken()", () => {
+    it("adds Authorization header with Bearer user token", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}, 200));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.fetchWithUserToken("https://api.spotify.com/v1/me");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect((init.headers as Record<string, string>)["Authorization"]).toBe(
+        "Bearer test-user-token",
+      );
+    });
+
+    it("refreshes token on 401 and retries with the new token", async () => {
+      (authService.refreshUserToken as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+      (authService.getUserToken as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce("test-user-token")
+        .mockResolvedValueOnce("new-user-token");
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(new Response("", { status: 401 }))
+        .mockResolvedValueOnce(jsonResponse({}, 200));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await client.fetchWithUserToken("https://api.spotify.com/v1/me");
+
+      expect(response.status).toBe(200);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      const [, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit];
+      expect((secondInit.headers as Record<string, string>)["Authorization"]).toBe(
+        "Bearer new-user-token",
+      );
+    });
+
+    it("returns original 401 response when refreshUserToken returns false", async () => {
+      (authService.refreshUserToken as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 401 })));
+
+      const response = await client.fetchWithUserToken("https://api.spotify.com/v1/me");
+
+      expect(response.status).toBe(401);
+    });
+
+    it("does not retry on non-401 errors and returns response directly", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(new Response("", { status: 404 }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const response = await client.fetchWithUserToken("https://api.spotify.com/v1/me");
+
+      expect(response.status).toBe(404);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-playlist.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-playlist.client.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { AppError } from "@/domain/errors/app-error";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { PromiseCache } from "./promise-cache";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyAlbumClient } from "./spotify-album.client";
+import { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyPlaylistClient } from "./spotify-playlist.client";
+import { SpotifyTrackClient } from "./spotify-track.client";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifyPlaylistClient", () => {
+  let authService: SpotifyAuthService;
+  let settingsService: SettingsPort;
+  let circuitBreaker: CircuitBreaker;
+  let rateLimiter: RateLimiter;
+  let requestCache: PromiseCache;
+  let mockTrackClient: SpotifyTrackClient;
+  let mockAlbumClient: SpotifyAlbumClient;
+  let client: SpotifyPlaylistClient;
+
+  beforeEach(() => {
+    authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn().mockResolvedValue("test-user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService;
+    settingsService = {
+      getString: vi.fn().mockResolvedValue("US"),
+    } as unknown as SettingsPort;
+    circuitBreaker = new CircuitBreaker();
+    rateLimiter = new RateLimiter({ maxConcurrency: 5, minIntervalMs: 0, queueTimeoutMs: 5000 });
+    requestCache = new PromiseCache({ ttlMs: 30_000 });
+    mockTrackClient = { getTrackDetails: vi.fn() } as unknown as SpotifyTrackClient;
+    mockAlbumClient = { getAlbumTracks: vi.fn() } as unknown as SpotifyAlbumClient;
+    client = new SpotifyPlaylistClient(
+      authService,
+      settingsService,
+      mockTrackClient,
+      mockAlbumClient,
+      requestCache,
+      circuitBreaker,
+      rateLimiter,
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("getPlaylistMetadata()", () => {
+    it("returns metadata on success when app token works", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            name: "My Playlist",
+            images: [{ url: "http://cover.jpg" }],
+            owner: {
+              display_name: "User",
+              external_urls: { spotify: "https://spotify.com/user" },
+            },
+            tracks: { total: 42 },
+          }),
+        ),
+      );
+
+      const result = await client.getPlaylistMetadata("https://open.spotify.com/playlist/abc123");
+
+      expect(result.name).toBe("My Playlist");
+      expect(result.image).toBe("http://cover.jpg");
+      expect(result.owner).toBe("User");
+      expect(result.totalTracks).toBe(42);
+    });
+
+    it("falls back to user token when app token returns 404", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(new Response("", { status: 404 }))
+          .mockResolvedValueOnce(
+            jsonResponse({
+              name: "Private Playlist",
+              images: [],
+              owner: { display_name: "Private User" },
+              tracks: { total: 5 },
+            }),
+          ),
+      );
+
+      const result = await client.getPlaylistMetadata("https://open.spotify.com/playlist/abc123");
+
+      expect(result.name).toBe("Private Playlist");
+    });
+
+    it("throws AppError(404) with errorCode playlist_not_found if both tokens get 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      await expect(
+        client.getPlaylistMetadata("https://open.spotify.com/playlist/abc123"),
+      ).rejects.toMatchObject({ errorCode: "playlist_not_found" });
+    });
+
+    it("throws AppError on 500", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+
+      await expect(
+        client.getPlaylistMetadata("https://open.spotify.com/playlist/abc123"),
+      ).rejects.toBeInstanceOf(AppError);
+    });
+  });
+
+  describe("getAllPlaylistTracks()", () => {
+    it("returns single track for track URL", async () => {
+      vi.mocked(mockTrackClient.getTrackDetails).mockResolvedValue({
+        name: "Track",
+        artist: "Artist",
+        artists: [{ name: "Artist" }],
+      } as never);
+
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/track/abc123");
+
+      expect(tracks).toHaveLength(1);
+    });
+
+    it("returns album tracks for album URL", async () => {
+      vi.mocked(mockAlbumClient.getAlbumTracks).mockResolvedValue([
+        {
+          name: "Album Track",
+          artist: "Artist",
+          artists: [{ name: "Artist" }],
+          album: "Album",
+        } as never,
+      ]);
+
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/album/abc123");
+
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].name).toBe("Album Track");
+    });
+
+    it("returns paginated playlist tracks for playlist URL", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            items: [
+              {
+                item: {
+                  name: "Playlist Track",
+                  artists: [{ name: "Artist" }],
+                  external_urls: {},
+                  album: {
+                    name: "Album",
+                    images: [],
+                    release_date: "2020",
+                    total_tracks: 10,
+                  },
+                },
+              },
+            ],
+            next: null,
+          }),
+        ),
+      );
+
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/playlist/abc123");
+
+      expect(tracks).toHaveLength(1);
+      expect(tracks[0].name).toBe("Playlist Track");
+    });
+
+    it("filters null items from playlist response", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            items: [
+              { item: null },
+              {
+                item: {
+                  name: "Valid Track",
+                  artists: [{ name: "Artist" }],
+                  external_urls: {},
+                  album: {
+                    name: "Album",
+                    images: [],
+                    release_date: "2020",
+                    total_tracks: 1,
+                  },
+                },
+              },
+            ],
+            next: null,
+          }),
+        ),
+      );
+
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/playlist/abc123");
+
+      expect(tracks).toHaveLength(1);
+    });
+
+    it("falls back to app token when user token throws missing_user_access_token", async () => {
+      vi.mocked(authService.getUserToken).mockRejectedValue(
+        new AppError(401, "missing_user_access_token", "No user token"),
+      );
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            items: [
+              {
+                item: {
+                  name: "Fallback Track",
+                  artists: [{ name: "Artist" }],
+                  external_urls: {},
+                  album: {
+                    name: "Album",
+                    images: [],
+                    release_date: "2020",
+                    total_tracks: 1,
+                  },
+                },
+              },
+            ],
+            next: null,
+          }),
+        ),
+      );
+
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/playlist/abc123");
+
+      expect(tracks).toHaveLength(1);
+    });
+
+    it("throws AppError(403) with errorCode playlist_not_accessible on 403", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 403 })));
+
+      await expect(
+        client.getAllPlaylistTracks("https://open.spotify.com/playlist/abc123"),
+      ).rejects.toMatchObject({ errorCode: "playlist_not_accessible" });
+    });
+
+    it("returns empty array for unrecognized URL type", async () => {
+      const tracks = await client.getAllPlaylistTracks("https://open.spotify.com/show/abc123");
+
+      expect(tracks).toEqual([]);
+    });
+  });
+
+  describe("getPlaylistTracksPage()", () => {
+    it("returns empty page for non-playlist URLs", async () => {
+      const result = await client.getPlaylistTracksPage(
+        "https://open.spotify.com/album/abc",
+        0,
+        10,
+      );
+
+      expect(result).toEqual({
+        tracks: [],
+        total: 0,
+        hasMore: false,
+        nextOffset: null,
+      });
+    });
+
+    it("returns tracks and pagination info on success", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          jsonResponse({
+            items: [
+              {
+                item: {
+                  name: "Page Track",
+                  artists: [{ name: "A" }],
+                  external_urls: {},
+                  album: {
+                    name: "X",
+                    images: [],
+                    release_date: "2020",
+                    total_tracks: 5,
+                  },
+                },
+              },
+            ],
+            next: "https://api.spotify.com/v1/playlists/abc/items?offset=100&limit=50",
+            total: 150,
+          }),
+        ),
+      );
+
+      const result = await client.getPlaylistTracksPage(
+        "https://open.spotify.com/playlist/abc",
+        50,
+        50,
+      );
+
+      expect(result.tracks).toHaveLength(1);
+      expect(result.total).toBe(150);
+      expect(result.hasMore).toBe(true);
+      expect(result.nextOffset).toBe(100);
+    });
+
+    it("returns hasMore=false when next is null", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(jsonResponse({ items: [], next: null, total: 0 })),
+      );
+
+      const result = await client.getPlaylistTracksPage(
+        "https://open.spotify.com/playlist/abc",
+        0,
+        10,
+      );
+
+      expect(result.hasMore).toBe(false);
+      expect(result.nextOffset).toBeNull();
+    });
+
+    it("throws AppError(404) on 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      await expect(
+        client.getPlaylistTracksPage("https://open.spotify.com/playlist/abc", 0, 10),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-search.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-search.client.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { AppError } from "@/domain/errors/app-error";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { PromiseCache } from "./promise-cache";
+import { RateLimiter } from "./rate-limiter";
+import { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifySearchClient } from "./spotify-search.client";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+describe("SpotifySearchClient", () => {
+  let authService: SpotifyAuthService;
+  let settingsService: SettingsPort;
+  let circuitBreaker: CircuitBreaker;
+  let rateLimiter: RateLimiter;
+  let requestCache: PromiseCache;
+
+  beforeEach(() => {
+    authService = {
+      getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+      getUserToken: vi.fn().mockResolvedValue("test-user-token"),
+      refreshUserToken: vi.fn().mockResolvedValue(false),
+    } as unknown as SpotifyAuthService;
+    settingsService = {
+      getString: vi.fn().mockResolvedValue("US"),
+    } as unknown as SettingsPort;
+    circuitBreaker = new CircuitBreaker();
+    rateLimiter = new RateLimiter({ maxConcurrency: 5, minIntervalMs: 0, queueTimeoutMs: 5000 });
+    requestCache = new PromiseCache({ ttlMs: 30_000 });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  describe("searchCatalog()", () => {
+    it("returns empty result when query is blank string", async () => {
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      const result = await client.searchCatalog("");
+      expect(result).toEqual({ tracks: [], albums: [], artists: [] });
+      expect(vi.mocked(authService.getAppToken)).not.toHaveBeenCalled();
+    });
+
+    it("returns empty result when query is whitespace", async () => {
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      const result = await client.searchCatalog("   ");
+      expect(result).toEqual({ tracks: [], albums: [], artists: [] });
+      expect(vi.mocked(authService.getAppToken)).not.toHaveBeenCalled();
+    });
+
+    it("returns tracks from Spotify response", async () => {
+      // searchCatalog groups types by limit: default artist=5, track+album=10 → 2 search requests
+      // (order is non-deterministic due to Promise.all). Then getArtistImagesBatch fires a 3rd
+      // request. Use mockImplementation to route by URL rather than call order.
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (url.includes("/v1/artists?ids=")) {
+          return Promise.resolve(
+            jsonResponse({ artists: [{ id: "a1", images: [{ url: "http://artist.jpg" }] }] }),
+          );
+        }
+        if (url.includes("type=track")) {
+          return Promise.resolve(
+            jsonResponse({
+              tracks: {
+                items: [
+                  {
+                    name: "Song",
+                    artists: [
+                      {
+                        id: "a1",
+                        name: "Artist1",
+                        external_urls: { spotify: "https://open.spotify.com/artist/a1" },
+                      },
+                    ],
+                    album: {
+                      name: "Album1",
+                      images: [{ url: "http://cover.jpg" }],
+                      release_date: "2020-01-01",
+                      total_tracks: 10,
+                      external_urls: { spotify: "https://open.spotify.com/album/a1" },
+                    },
+                    preview_url: null,
+                    external_urls: { spotify: "https://open.spotify.com/track/t1" },
+                    track_number: 1,
+                    duration_ms: 180000,
+                  },
+                ],
+              },
+              albums: { items: [] },
+            }),
+          );
+        }
+        // artist search group
+        return Promise.resolve(jsonResponse({ artists: { items: [] } }));
+      });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      const result = await client.searchCatalog("Song");
+
+      expect(result.tracks).toHaveLength(1);
+      expect(result.tracks[0].name).toBe("Song");
+      expect(result.tracks[0].artist).toBe("Artist1");
+    });
+
+    it("throws AppError on non-ok response (500)", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      await expect(client.searchCatalog("test")).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("includes market param when includeMarket is true (default)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          tracks: { items: [] },
+          albums: { items: [] },
+          artists: { items: [] },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      await client.searchCatalog("test", ["track"], {}, { includeMarket: true });
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).toContain("market=US");
+    });
+
+    it("omits market param when includeMarket is false", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({
+          tracks: { items: [] },
+          albums: { items: [] },
+          artists: { items: [] },
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const client = new SpotifySearchClient(
+        authService,
+        settingsService,
+        requestCache,
+        circuitBreaker,
+        rateLimiter,
+      );
+      await client.searchCatalog("test", ["track"], {}, { includeMarket: false });
+
+      const calledUrl = fetchMock.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("market=");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-track.client.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-track.client.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import type { SettingsPort } from "@/application/ports/settings.port";
+import { AppError } from "@/domain/errors/app-error";
+import { validateEnvironment } from "@/infrastructure/setup/environment";
+import { CircuitBreaker } from "./circuit-breaker";
+import { PromiseCache } from "./promise-cache";
+import { RateLimiter } from "./rate-limiter";
+import type { SpotifyAuthService } from "./spotify-auth.service";
+import { SpotifyTrackClient } from "./spotify-track.client";
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeAll(() => {
+  process.env.SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID ?? "test-client-id";
+  process.env.SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET ?? "test-client-secret";
+  process.env.SPOTIFY_REDIRECT_URI =
+    process.env.SPOTIFY_REDIRECT_URI ?? "http://localhost:3000/auth/spotify/callback";
+  validateEnvironment();
+});
+
+const buildClient = (requestCache?: PromiseCache) => {
+  const authService = {
+    getAppToken: vi.fn().mockResolvedValue("test-app-token"),
+    getUserToken: vi.fn(),
+    refreshUserToken: vi.fn(),
+  } as unknown as SpotifyAuthService;
+
+  const settingsService = {
+    getString: vi.fn().mockResolvedValue("US"),
+  } as unknown as SettingsPort;
+
+  const circuitBreaker = new CircuitBreaker();
+  const rateLimiter = new RateLimiter({
+    maxConcurrency: 5,
+    minIntervalMs: 0,
+    queueTimeoutMs: 5000,
+  });
+
+  return new SpotifyTrackClient(
+    authService,
+    settingsService,
+    circuitBreaker,
+    rateLimiter,
+    "interactive",
+    requestCache,
+  );
+};
+
+const makeTrackPayload = (overrides?: Record<string, unknown>) => ({
+  name: "Test Track",
+  artists: [{ name: "Artist", external_urls: { spotify: "https://spotify.com/artist/1" } }],
+  album: {
+    name: "Test Album",
+    images: [{ url: "http://cover.jpg" }],
+    release_date: "2020-01-01",
+    total_tracks: 10,
+  },
+  preview_url: "http://preview.mp3",
+  duration_ms: 180000,
+  track_number: 1,
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SpotifyTrackClient", () => {
+  describe("getTrackDetails()", () => {
+    it("returns NormalizedTrack on success", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(makeTrackPayload())));
+
+      const client = buildClient();
+      const result = await client.getTrackDetails("track-1");
+
+      expect(result.name).toBe("Test Track");
+      expect(result.artist).toBe("Artist");
+      expect(result.album).toBe("Test Album");
+    });
+
+    it("throws AppError(404) on 404", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 404 })));
+
+      const client = buildClient();
+
+      await expect(client.getTrackDetails("track-404")).rejects.toMatchObject({
+        statusCode: 404,
+        errorCode: "track_not_found",
+      });
+    });
+
+    it("throws AppError('spotify_rate_limited') when fetch returns 429", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response("Retry-After: 60", {
+            status: 429,
+            headers: { "Retry-After": "60" },
+          }),
+        ),
+      );
+
+      const client = buildClient();
+
+      await expect(client.getTrackDetails("track-429")).rejects.toMatchObject({
+        errorCode: "spotify_rate_limited",
+      });
+    });
+
+    it("throws AppError on 500", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+
+      const client = buildClient();
+
+      await expect(client.getTrackDetails("track-500")).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("calls fetch only once for the same track id (caching)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(jsonResponse(makeTrackPayload()));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const sharedCache = new PromiseCache({ ttlMs: 30_000 });
+      const client = buildClient(sharedCache);
+
+      await client.getTrackDetails("track-1");
+      await client.getTrackDetails("track-1");
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-track.mapper.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-track.mapper.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { SpotifyTrackMapper } from "./spotify-track.mapper";
+import type { SpotifyAlbum, SpotifyTrack } from "./spotify.types";
+
+function makeTrack(overrides: Partial<SpotifyTrack> = {}): SpotifyTrack {
+  return {
+    id: "track-1",
+    name: "Test Track",
+    artists: [
+      { name: "Artist One", external_urls: { spotify: "https://open.spotify.com/artist/1" } },
+    ],
+    album: {
+      name: "Test Album",
+      external_urls: { spotify: "https://open.spotify.com/album/1" },
+      images: [{ url: "https://i.scdn.co/image/cover.jpg" }],
+      release_date: "2020-06-12",
+      total_tracks: 10,
+      artists: [
+        {
+          name: "Album Artist",
+          external_urls: { spotify: "https://open.spotify.com/artist/album" },
+        },
+      ],
+    } as SpotifyAlbum,
+    external_urls: { spotify: "https://open.spotify.com/track/1" },
+    preview_url: "https://p.scdn.co/preview/1",
+    duration_ms: 210000,
+    track_number: 3,
+    disc_number: 1,
+    ...overrides,
+  } as SpotifyTrack;
+}
+
+describe("SpotifyTrackMapper.toNormalizedTrack", () => {
+  it("maps a full SpotifyTrack with all fields", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.name).toBe("Test Track");
+    expect(result.artist).toBe("Artist One");
+    expect(result.album).toBe("Test Album");
+    expect(result.albumUrl).toBe("https://open.spotify.com/album/1");
+    expect(result.albumCoverUrl).toBe("https://i.scdn.co/image/cover.jpg");
+    expect(result.albumYear).toBe(2020);
+    expect(result.trackUrl).toBe("https://open.spotify.com/track/1");
+    expect(result.previewUrl).toBe("https://p.scdn.co/preview/1");
+    expect(result.durationMs).toBe(210000);
+    expect(result.trackNumber).toBe(3);
+    expect(result.discNumber).toBe(1);
+    expect(result.totalTracks).toBe(10);
+    expect(result.primaryArtist).toBe("Artist One");
+    expect(result.artists).toEqual([
+      { name: "Artist One", url: "https://open.spotify.com/artist/1" },
+    ]);
+  });
+
+  it("joins multiple artists with a comma", () => {
+    const track = makeTrack({
+      artists: [
+        { name: "Artist A", external_urls: { spotify: "https://open.spotify.com/artist/a" } },
+        { name: "Artist B", external_urls: { spotify: "https://open.spotify.com/artist/b" } },
+        { name: "Artist C", external_urls: { spotify: "https://open.spotify.com/artist/c" } },
+      ],
+    });
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.artist).toBe("Artist A, Artist B, Artist C");
+    expect(result.primaryArtist).toBe("Artist A");
+    expect(result.artists).toHaveLength(3);
+  });
+
+  it("returns undefined album fields when track has no album", () => {
+    const track = makeTrack({ album: undefined });
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.album).toBeUndefined();
+    expect(result.albumUrl).toBeUndefined();
+    expect(result.albumCoverUrl).toBeUndefined();
+    expect(result.albumYear).toBeUndefined();
+    expect(result.totalTracks).toBeUndefined();
+    expect(result.albumArtist).toBeUndefined();
+  });
+
+  it("prefers context.albumCoverUrl over track.album.images[0].url", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track, {
+      albumCoverUrl: "https://context.example.com/cover.jpg",
+    });
+
+    expect(result.albumCoverUrl).toBe("https://context.example.com/cover.jpg");
+  });
+
+  it("extracts albumYear from the first 4 chars of release_date", () => {
+    const track = makeTrack({
+      album: {
+        ...makeTrack().album!,
+        release_date: "2020-06-12",
+      } as SpotifyAlbum,
+    });
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.albumYear).toBe(2020);
+  });
+
+  it("sets unavailable=true when context.isUnavailable is true", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track, { isUnavailable: true });
+
+    expect(result.unavailable).toBe(true);
+  });
+
+  it("leaves unavailable undefined when isUnavailable is not set", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.unavailable).toBeUndefined();
+  });
+
+  it("uses album.artists[0].name as albumArtist", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.albumArtist).toBe("Album Artist");
+  });
+
+  it("uses context.primaryArtistImage when provided", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track, {
+      primaryArtistImage: "https://i.scdn.co/image/artist.jpg",
+    });
+
+    expect(result.primaryArtistImage).toBe("https://i.scdn.co/image/artist.jpg");
+  });
+
+  it("defaults primaryArtistImage to null when not in context", () => {
+    const track = makeTrack();
+    const result = SpotifyTrackMapper.toNormalizedTrack(track);
+
+    expect(result.primaryArtistImage).toBeNull();
+  });
+
+  it("prefers context.album over track.album", () => {
+    const track = makeTrack();
+    const contextAlbum: SpotifyAlbum = {
+      name: "Context Album",
+      external_urls: { spotify: "https://open.spotify.com/album/ctx" },
+      images: [{ url: "https://i.scdn.co/image/ctx.jpg" }],
+      release_date: "2023-01-01",
+      total_tracks: 5,
+      artists: [
+        {
+          name: "Context Artist",
+          external_urls: { spotify: "https://open.spotify.com/artist/ctx" },
+        },
+      ],
+    } as SpotifyAlbum;
+
+    const result = SpotifyTrackMapper.toNormalizedTrack(track, { album: contextAlbum });
+
+    expect(result.album).toBe("Context Album");
+    expect(result.albumYear).toBe(2023);
+    expect(result.albumArtist).toBe("Context Artist");
+  });
+});


### PR DESCRIPTION
## What
Characterization unit tests for the 10 untested Spotify infrastructure clients.

- `spotify-http.client`, `spotify-base.client`, `spotify-search.client`, `spotify-album.client`, `spotify-artist.client`, `spotify-track.client`, `spotify-playlist.client`
- `spotify-track.mapper`, `spotify-circuit-breaker.adapter`, `providers/spotify/spotify-url-lookup.client`

## Scope
75 new tests, **zero source changes** (characterization only). First slice of the backend test backfill mirroring the frontend coverage work (#185-194).

## Verification
- `pnpm --filter backend test:run` → 851 passed (was 776)
- No new `tsc` errors; build excludes test files.