### PR TITLE
test(backend): add unit tests for external infra utilities

### DIFF
--- a/apps/backend/src/infrastructure/external/promise-cache.test.ts
+++ b/apps/backend/src/infrastructure/external/promise-cache.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PromiseCache } from "./promise-cache";
+
+describe("PromiseCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("in-flight dedup", () => {
+    it("returns the same promise for concurrent calls with the same key", () => {
+      const cache = new PromiseCache();
+      const fn = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      const p1 = cache.getOrSet("key", fn);
+      const p2 = cache.getOrSet("key", fn);
+
+      expect(p1).toBe(p2);
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls fn again for a different key", () => {
+      const cache = new PromiseCache();
+      const fn = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      cache.getOrSet("key-a", fn);
+      cache.getOrSet("key-b", fn);
+
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("error eviction", () => {
+    it("evicts the entry on rejection so the next call retries", async () => {
+      const cache = new PromiseCache();
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("transient"))
+        .mockResolvedValue("recovered");
+
+      const first = cache.getOrSet("key", fn);
+      await expect(first).rejects.toThrow("transient");
+
+      // After rejection the entry is evicted; fn should be called again
+      const second = cache.getOrSet("key", fn);
+      await expect(second).resolves.toBe("recovered");
+
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("TTL eviction", () => {
+    it("evicts a resolved entry after the TTL expires and re-calls fn", async () => {
+      const ttlMs = 1_000;
+      const cache = new PromiseCache({ ttlMs });
+
+      let resolveFirst!: (v: string) => void;
+      const fn = vi
+        .fn()
+        .mockReturnValueOnce(new Promise<string>((r) => (resolveFirst = r)))
+        .mockResolvedValue("fresh");
+
+      const p1 = cache.getOrSet("key", fn);
+      resolveFirst("cached");
+      await p1; // let the resolution propagate so `resolved = true`
+      await vi.advanceTimersByTimeAsync(0); // flush microtasks
+
+      // Advance past TTL — resolved entry should be evicted
+      await vi.advanceTimersByTimeAsync(ttlMs + 1);
+
+      const p2 = cache.getOrSet("key", fn);
+      await expect(p2).resolves.toBe("fresh");
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it("the TTL timer does NOT proactively evict an in-flight promise (only resolved ones)", async () => {
+      const ttlMs = 500;
+      const cache = new PromiseCache({ ttlMs });
+
+      // Never-resolving promise — still in-flight past TTL
+      const fn = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      cache.getOrSet("key", fn);
+
+      // Let the TTL timer fire while the promise is still pending —
+      // the timer's `if (resolved) cleanup()` guard means the entry stays.
+      // However, getOrSet on a stale entry WILL re-invoke fn because
+      // isCacheEntryStale returns true on subsequent calls.
+      await vi.advanceTimersByTimeAsync(ttlMs + 100);
+
+      // A second getOrSet after TTL sees the entry as stale and calls fn again.
+      cache.getOrSet("key", fn);
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("clear", () => {
+    it("clear(key) removes only that entry", async () => {
+      const cache = new PromiseCache();
+      const fn = vi.fn().mockResolvedValue("v");
+
+      cache.getOrSet("a", fn);
+      cache.getOrSet("b", fn);
+      await vi.runAllTimersAsync();
+
+      cache.clear("a");
+
+      cache.getOrSet("a", fn); // should call fn again
+      cache.getOrSet("b", fn); // should reuse — but entry was already evicted on resolve; call fn again too
+
+      expect(fn.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+
+    it("clear() with no argument removes all entries", async () => {
+      const cache = new PromiseCache();
+      const fn = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      cache.getOrSet("x", fn);
+      cache.getOrSet("y", fn);
+
+      cache.clear();
+
+      cache.getOrSet("x", fn);
+      cache.getOrSet("y", fn);
+
+      expect(fn).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe("constructor TTL floor", () => {
+    it("clamps ttlMs to at least 1", () => {
+      // Should not throw; the cache is usable
+      const cache = new PromiseCache({ ttlMs: -100 });
+      const fn = vi.fn().mockResolvedValue("ok");
+      expect(() => cache.getOrSet("k", fn)).not.toThrow();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/cover-url.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/cover-url.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { pickBestCover, upgradeDeezerCoverUrl } from "./cover-url";
+
+describe("pickBestCover", () => {
+  it("returns undefined when all fields are absent", () => {
+    expect(pickBestCover({})).toBeUndefined();
+  });
+
+  it("prefers cover_xl over everything else", () => {
+    expect(
+      pickBestCover({
+        cover_xl: "https://cdn.dz/xl.jpg",
+        cover_big: "https://cdn.dz/big.jpg",
+        cover_medium: "https://cdn.dz/medium.jpg",
+        cover: "https://cdn.dz/cover.jpg",
+      }),
+    ).toBe("https://cdn.dz/xl.jpg");
+  });
+
+  it("falls back to cover_big when cover_xl is absent", () => {
+    expect(
+      pickBestCover({
+        cover_big: "https://cdn.dz/big.jpg",
+        cover_medium: "https://cdn.dz/medium.jpg",
+        cover: "https://cdn.dz/cover.jpg",
+      }),
+    ).toBe("https://cdn.dz/big.jpg");
+  });
+
+  it("falls back to cover_medium when cover_xl and cover_big are absent", () => {
+    expect(
+      pickBestCover({
+        cover_medium: "https://cdn.dz/medium.jpg",
+        cover: "https://cdn.dz/cover.jpg",
+      }),
+    ).toBe("https://cdn.dz/medium.jpg");
+  });
+
+  it("falls back to cover when only base cover is present", () => {
+    expect(pickBestCover({ cover: "https://cdn.dz/cover.jpg" })).toBe("https://cdn.dz/cover.jpg");
+  });
+
+  it("treats empty string as falsy and skips to next field", () => {
+    expect(
+      pickBestCover({
+        cover_xl: "",
+        cover_big: "https://cdn.dz/big.jpg",
+      }),
+    ).toBe("https://cdn.dz/big.jpg");
+  });
+});
+
+describe("upgradeDeezerCoverUrl", () => {
+  it("returns null for null input", () => {
+    expect(upgradeDeezerCoverUrl(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(upgradeDeezerCoverUrl(undefined)).toBeNull();
+  });
+
+  it("appends size=xl for api.deezer.com album image URLs", () => {
+    const url = "https://api.deezer.com/album/12345/image";
+    const result = upgradeDeezerCoverUrl(url);
+    expect(result).toContain("size=xl");
+  });
+
+  it("preserves existing query params and adds size=xl for api.deezer.com URLs", () => {
+    const url = "https://api.deezer.com/album/12345/image?foo=bar";
+    const result = upgradeDeezerCoverUrl(url);
+    expect(result).toContain("foo=bar");
+    expect(result).toContain("size=xl");
+  });
+
+  it("replaces the size segment in CDN URLs", () => {
+    const url = "https://cdns-images.dzcdn.net/images/cover/abc123/250x250-none.jpg";
+    const result = upgradeDeezerCoverUrl(url);
+    expect(result).toBe("https://cdns-images.dzcdn.net/images/cover/abc123/1000x1000-none.jpg");
+  });
+
+  it("returns the URL unchanged for non-Deezer URLs", () => {
+    const url = "https://example.com/image.jpg";
+    expect(upgradeDeezerCoverUrl(url)).toBe(url);
+  });
+
+  it("handles CDN URLs with different size segments correctly", () => {
+    const url = "https://cdns-images.dzcdn.net/images/cover/hash/120x120-000000.jpg";
+    const result = upgradeDeezerCoverUrl(url);
+    expect(result).toBe("https://cdns-images.dzcdn.net/images/cover/hash/1000x1000-000000.jpg");
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/deezer-artist-lookup.adapter.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/deezer-artist-lookup.adapter.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeezerArtistLookupAdapter } from "./deezer-artist-lookup.adapter";
+
+function makeDeezerClient(overrides: Record<string, unknown> = {}) {
+  return {
+    searchArtist: vi.fn().mockResolvedValue(null),
+    getArtistById: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+const artistWithAllPictures = {
+  id: 1,
+  name: "Test Artist",
+  picture: "https://cdn.deezer.com/images/artist/hash/120x120-abc.jpg",
+  picture_medium: "https://cdn.deezer.com/images/artist/hash/250x250-abc.jpg",
+  picture_big: "https://cdn.deezer.com/images/artist/hash/500x500-abc.jpg",
+  picture_xl: "https://cdn.deezer.com/images/artist/hash/1000x1000-abc.jpg",
+};
+
+describe("DeezerArtistLookupAdapter", () => {
+  describe("searchArtist", () => {
+    it("returns null when client returns null", async () => {
+      const adapter = new DeezerArtistLookupAdapter(makeDeezerClient() as never);
+      const result = await adapter.searchArtist("Unknown");
+      expect(result).toBeNull();
+    });
+
+    it("returns DeezerArtistResult with id, name, and picture", async () => {
+      const client = makeDeezerClient({
+        searchArtist: vi.fn().mockResolvedValue(artistWithAllPictures),
+      });
+      const adapter = new DeezerArtistLookupAdapter(client as never);
+
+      const result = await adapter.searchArtist("Test Artist");
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(1);
+      expect(result?.name).toBe("Test Artist");
+      expect(result?.picture).toBeTruthy();
+    });
+
+    it("returns null when client throws", async () => {
+      const client = makeDeezerClient({
+        searchArtist: vi.fn().mockRejectedValue(new Error("network error")),
+      });
+      const adapter = new DeezerArtistLookupAdapter(client as never);
+
+      const result = await adapter.searchArtist("Artist");
+      expect(result).toBeNull();
+    });
+
+    it("returns null picture when artist has no picture URLs", async () => {
+      const client = makeDeezerClient({
+        searchArtist: vi.fn().mockResolvedValue({ id: 2, name: "No Pic Artist" }),
+      });
+      const adapter = new DeezerArtistLookupAdapter(client as never);
+
+      const result = await adapter.searchArtist("No Pic Artist");
+      expect(result?.picture).toBeNull();
+    });
+  });
+
+  describe("getArtistById", () => {
+    it("returns null when client returns null", async () => {
+      const adapter = new DeezerArtistLookupAdapter(makeDeezerClient() as never);
+      const result = await adapter.getArtistById("999");
+      expect(result).toBeNull();
+    });
+
+    it("returns DeezerArtistResult with id, name, and picture", async () => {
+      const client = makeDeezerClient({
+        getArtistById: vi.fn().mockResolvedValue(artistWithAllPictures),
+      });
+      const adapter = new DeezerArtistLookupAdapter(client as never);
+
+      const result = await adapter.getArtistById("1");
+
+      expect(result?.id).toBe(1);
+      expect(result?.name).toBe("Test Artist");
+      expect(result?.picture).toBeTruthy();
+    });
+
+    it("returns null when client throws", async () => {
+      const client = makeDeezerClient({
+        getArtistById: vi.fn().mockRejectedValue(new Error("boom")),
+      });
+      const adapter = new DeezerArtistLookupAdapter(client as never);
+
+      const result = await adapter.getArtistById("1");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/providers/deezer/picture.test.ts
+++ b/apps/backend/src/infrastructure/external/providers/deezer/picture.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { pickBestDeezerArtistPicture } from "./picture";
+
+describe("pickBestDeezerArtistPicture", () => {
+  it("returns null when all picture fields are absent", () => {
+    const result = pickBestDeezerArtistPicture({ id: 1, name: "Artist" });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all picture fields are null/undefined", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture: undefined,
+      picture_medium: undefined,
+      picture_big: undefined,
+      picture_xl: undefined,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("prefers picture_xl over all others", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture: "https://cdn.deezer.com/images/artist/hash/120x120-abc.jpg",
+      picture_medium: "https://cdn.deezer.com/images/artist/hash/250x250-abc.jpg",
+      picture_big: "https://cdn.deezer.com/images/artist/hash/500x500-abc.jpg",
+      picture_xl: "https://cdn.deezer.com/images/artist/hash/1000x1000-abc.jpg",
+    });
+    // upscaleDeezerImage on xl URL replaces dimension, result should still be 1000x1000
+    expect(result).toContain("1000x1000");
+  });
+
+  it("falls back to picture_big when picture_xl is absent", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture_big: "https://cdn.deezer.com/images/artist/hash/500x500-abc.jpg",
+    });
+    expect(result).toContain("1000x1000");
+  });
+
+  it("falls back to picture_medium when picture_xl and picture_big are absent", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture_medium: "https://cdn.deezer.com/images/artist/hash/250x250-abc.jpg",
+    });
+    expect(result).toContain("1000x1000");
+  });
+
+  it("falls back to picture when only base picture is available", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture: "https://cdn.deezer.com/images/artist/hash/120x120-abc.jpg",
+    });
+    expect(result).toContain("1000x1000");
+  });
+
+  it("upscales a CDN URL by replacing the size segment", () => {
+    const result = pickBestDeezerArtistPicture({
+      id: 1,
+      name: "Artist",
+      picture_xl: "https://cdn.deezer.com/images/artist/abc123/500x500-000000-80-0-0.jpg",
+    });
+    expect(result).toBe("https://cdn.deezer.com/images/artist/abc123/1000x1000-000000-80-0-0.jpg");
+  });
+});

--- a/apps/backend/src/infrastructure/external/rate-limiter.test.ts
+++ b/apps/backend/src/infrastructure/external/rate-limiter.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RateLimiter } from "./rate-limiter";
+
+describe("RateLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("immediate execution", () => {
+    it("executes immediately when below max concurrency", async () => {
+      const limiter = new RateLimiter({ maxConcurrency: 2, minIntervalMs: 0 });
+      const fn = vi.fn().mockResolvedValue("result");
+
+      const promise = limiter.queueRequest(fn);
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe("result");
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the resolved value of the wrapped function", async () => {
+      const limiter = new RateLimiter({ minIntervalMs: 0 });
+      const fn = vi.fn().mockResolvedValue(42);
+
+      const promise = limiter.queueRequest(fn);
+      await vi.runAllTimersAsync();
+
+      await expect(promise).resolves.toBe(42);
+    });
+
+    it("propagates rejection from the wrapped function", async () => {
+      const limiter = new RateLimiter({ minIntervalMs: 0 });
+      const fn = vi.fn().mockImplementation(() => Promise.reject(new Error("boom")));
+
+      // Attach assertion immediately so the rejection is handled before it can go unhandled
+      const assertion = expect(limiter.queueRequest(fn)).rejects.toThrow("boom");
+      await vi.runAllTimersAsync();
+      await assertion;
+    });
+  });
+
+  describe("queue overflow", () => {
+    it("rejects immediately when queue is at max capacity", async () => {
+      const limiter = new RateLimiter({
+        maxConcurrency: 1,
+        maxQueueSize: 1,
+        queueTimeoutMs: 60_000,
+        minIntervalMs: 0,
+      });
+
+      // Never-resolving tasks — suppress all unhandled rejections from queue timeouts
+      const pending1 = limiter.queueRequest(() => new Promise(() => {}));
+      pending1.catch(() => {});
+
+      const pending2 = limiter.queueRequest(() => new Promise(() => {}));
+      pending2.catch(() => {});
+
+      // This one overflows
+      await expect(limiter.queueRequest(vi.fn())).rejects.toMatchObject({
+        statusCode: 503,
+        errorCode: "rate_limiter_overflow",
+      });
+    });
+  });
+
+  describe("queue timeout", () => {
+    it("rejects queued items that wait beyond queueTimeoutMs", async () => {
+      const limiter = new RateLimiter({
+        maxConcurrency: 1,
+        queueTimeoutMs: 1_000,
+        minIntervalMs: 0,
+      });
+
+      // occupy the single slot with a never-resolving task; suppress unhandled rejection
+      const neverResolve = new Promise<never>(() => {});
+      neverResolve.catch(() => {});
+      const blockFn = vi.fn().mockReturnValue(neverResolve);
+      const blockPromise = limiter.queueRequest(blockFn);
+      blockPromise.catch(() => {}); // suppress
+      await vi.advanceTimersByTimeAsync(0); // let the active slot be taken
+
+      // queue a second request that will time out — attach assertion before advancing timers
+      const queuedFn = vi.fn().mockImplementation(() => Promise.resolve("ok"));
+      const queuedAssertion = expect(limiter.queueRequest(queuedFn)).rejects.toThrow(
+        /Queue timeout/,
+      );
+
+      // advance past the timeout
+      await vi.advanceTimersByTimeAsync(1_001);
+
+      await queuedAssertion;
+    });
+  });
+
+  describe("concurrency limit", () => {
+    it("does not start a second task while first is active (minInterval=0)", async () => {
+      const limiter = new RateLimiter({ maxConcurrency: 1, minIntervalMs: 0 });
+
+      let firstResolve!: () => void;
+      const firstFn = vi.fn().mockReturnValue(new Promise<void>((r) => (firstResolve = r)));
+      const secondFn = vi.fn().mockResolvedValue("second");
+
+      const first = limiter.queueRequest(firstFn);
+      const second = limiter.queueRequest(secondFn);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(firstFn).toHaveBeenCalledTimes(1);
+      expect(secondFn).toHaveBeenCalledTimes(0);
+
+      firstResolve();
+      await vi.runAllTimersAsync();
+
+      await first;
+      await expect(second).resolves.toBe("second");
+      expect(secondFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs up to maxConcurrency tasks simultaneously", async () => {
+      const limiter = new RateLimiter({ maxConcurrency: 3, minIntervalMs: 0 });
+      const resolvers: Array<() => void> = [];
+
+      const fns = Array.from({ length: 3 }, (_, i) =>
+        vi.fn().mockReturnValue(
+          new Promise<number>((r) => {
+            resolvers.push(() => r(i));
+          }),
+        ),
+      );
+
+      const promises = fns.map((fn) => limiter.queueRequest(fn));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // All three should have been called
+      fns.forEach((fn) => expect(fn).toHaveBeenCalledTimes(1));
+
+      resolvers.forEach((r) => r());
+      await vi.runAllTimersAsync();
+      await Promise.all(promises);
+    });
+  });
+
+  describe("minInterval enforcement", () => {
+    it("delays the second execution by minIntervalMs", async () => {
+      const limiter = new RateLimiter({ maxConcurrency: 2, minIntervalMs: 500 });
+      const calls: number[] = [];
+
+      const fn = vi.fn().mockImplementation(() => {
+        calls.push(Date.now());
+        return Promise.resolve("ok");
+      });
+
+      const p1 = limiter.queueRequest(fn);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const p2 = limiter.queueRequest(fn);
+      await vi.runAllTimersAsync();
+
+      await p1;
+      await p2;
+
+      expect(calls).toHaveLength(2);
+      expect(calls[1] - calls[0]).toBeGreaterThanOrEqual(500);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/spotify-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/external/spotify-artwork-source.service.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { SpotifyArtworkSourceService } from "./spotify-artwork-source.service";
+
+function makeArtistClient(overrides: Record<string, unknown> = {}) {
+  return {
+    getArtistRaw: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+}
+
+function makeAlbumClient(overrides: Record<string, unknown> = {}) {
+  return {
+    getAlbumDetails: vi.fn().mockResolvedValue({ images: [] }),
+    ...overrides,
+  };
+}
+
+function makeSearchClient(overrides: Record<string, unknown> = {}) {
+  return {
+    searchCatalog: vi.fn().mockResolvedValue({ artists: [], albums: [] }),
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Record<string, unknown> = {}) {
+  return {
+    artistName: "Test Artist",
+    artistSpotifyId: undefined,
+    albumName: undefined,
+    albumSpotifyId: undefined,
+    ...overrides,
+  };
+}
+
+describe("SpotifyArtworkSourceService", () => {
+  describe("findArtistImageUrl", () => {
+    it("returns the artist image when found by spotifyId", async () => {
+      const artistClient = makeArtistClient({
+        getArtistRaw: vi.fn().mockResolvedValue({
+          images: [{ url: "https://i.scdn.co/artist.jpg" }],
+        }),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        artistClient as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      const result = await service.findArtistImageUrl(
+        makeCandidate({ artistSpotifyId: "abc123" }) as never,
+      );
+
+      expect(result).toBe("https://i.scdn.co/artist.jpg");
+    });
+
+    it("falls back to search when getArtistRaw returns no images", async () => {
+      const artistClient = makeArtistClient({
+        getArtistRaw: vi.fn().mockResolvedValue({ images: [] }),
+      });
+      const searchClient = makeSearchClient({
+        searchCatalog: vi.fn().mockResolvedValue({
+          artists: [{ image: "https://search.img/artist.jpg" }],
+          albums: [],
+        }),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        artistClient as never,
+        makeAlbumClient() as never,
+        searchClient as never,
+      );
+
+      const result = await service.findArtistImageUrl(
+        makeCandidate({ artistSpotifyId: "abc" }) as never,
+      );
+
+      expect(result).toBe("https://search.img/artist.jpg");
+    });
+
+    it("uses search directly when no artistSpotifyId is provided", async () => {
+      const searchClient = makeSearchClient({
+        searchCatalog: vi.fn().mockResolvedValue({
+          artists: [{ image: "https://search.img/no-id.jpg" }],
+          albums: [],
+        }),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        makeAlbumClient() as never,
+        searchClient as never,
+      );
+
+      const result = await service.findArtistImageUrl(makeCandidate() as never);
+
+      expect(result).toBe("https://search.img/no-id.jpg");
+    });
+
+    it("returns null when search returns no artist results", async () => {
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      const result = await service.findArtistImageUrl(makeCandidate() as never);
+      expect(result).toBeNull();
+    });
+
+    it("re-throws a 429 AppError as spotify_rate_limited", async () => {
+      const artistClient = makeArtistClient({
+        getArtistRaw: vi
+          .fn()
+          .mockRejectedValue(new AppError(429, "spotify_rate_limited", "rate limited")),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        artistClient as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      await expect(
+        service.findArtistImageUrl(makeCandidate({ artistSpotifyId: "x" }) as never),
+      ).rejects.toMatchObject({ statusCode: 429, errorCode: "spotify_rate_limited" });
+    });
+
+    it("wraps circuit_open errors as 429 spotify_rate_limited", async () => {
+      const circuitError = Object.assign(new Error("circuit open"), { errorCode: "circuit_open" });
+      const artistClient = makeArtistClient({
+        getArtistRaw: vi.fn().mockRejectedValue(circuitError),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        artistClient as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      await expect(
+        service.findArtistImageUrl(makeCandidate({ artistSpotifyId: "x" }) as never),
+      ).rejects.toMatchObject({ statusCode: 429, errorCode: "spotify_rate_limited" });
+    });
+
+    it("wraps unknown errors as 502 internal_server_error", async () => {
+      const artistClient = makeArtistClient({
+        getArtistRaw: vi.fn().mockRejectedValue(new Error("unknown")),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        artistClient as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      await expect(
+        service.findArtistImageUrl(makeCandidate({ artistSpotifyId: "x" }) as never),
+      ).rejects.toMatchObject({ statusCode: 502, errorCode: "internal_server_error" });
+    });
+  });
+
+  describe("findAlbumCoverUrl", () => {
+    it("returns null immediately when albumName is missing", async () => {
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      const result = await service.findAlbumCoverUrl(makeCandidate() as never);
+      expect(result).toBeNull();
+    });
+
+    it("returns the album image when found by albumSpotifyId", async () => {
+      const albumClient = makeAlbumClient({
+        getAlbumDetails: vi.fn().mockResolvedValue({
+          images: [{ url: "https://i.scdn.co/album.jpg" }],
+        }),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        albumClient as never,
+        makeSearchClient() as never,
+      );
+
+      const result = await service.findAlbumCoverUrl(
+        makeCandidate({ albumName: "Great Album", albumSpotifyId: "sp1" }) as never,
+      );
+
+      expect(result).toBe("https://i.scdn.co/album.jpg");
+    });
+
+    it("falls back to search when getAlbumDetails returns no images", async () => {
+      const albumClient = makeAlbumClient({
+        getAlbumDetails: vi.fn().mockResolvedValue({ images: [] }),
+      });
+      const searchClient = makeSearchClient({
+        searchCatalog: vi.fn().mockResolvedValue({
+          artists: [],
+          albums: [{ coverUrl: "https://search.img/album.jpg" }],
+        }),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        albumClient as never,
+        searchClient as never,
+      );
+
+      const result = await service.findAlbumCoverUrl(
+        makeCandidate({ albumName: "Great Album", albumSpotifyId: "sp1" }) as never,
+      );
+
+      expect(result).toBe("https://search.img/album.jpg");
+    });
+
+    it("returns null when search returns no album results", async () => {
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        makeAlbumClient() as never,
+        makeSearchClient() as never,
+      );
+
+      const result = await service.findAlbumCoverUrl(
+        makeCandidate({ albumName: "Unknown Album" }) as never,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("re-throws errors through classifyError", async () => {
+      const albumClient = makeAlbumClient({
+        getAlbumDetails: vi.fn().mockRejectedValue(new Error("network error")),
+      });
+
+      const service = new SpotifyArtworkSourceService(
+        makeArtistClient() as never,
+        albumClient as never,
+        makeSearchClient() as never,
+      );
+
+      await expect(
+        service.findAlbumCoverUrl(
+          makeCandidate({ albumName: "Album", albumSpotifyId: "sp2" }) as never,
+        ),
+      ).rejects.toMatchObject({ statusCode: 502 });
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/external/youtube-download.service.test.ts
+++ b/apps/backend/src/infrastructure/external/youtube-download.service.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import { YoutubeDownloadService } from "./youtube-download.service";
+
+// Mock ytdlp-nodejs so no real binary is invoked
+const mockDownloadAsync = vi.fn();
+const mockGetInfoAsync = vi.fn();
+
+vi.mock("ytdlp-nodejs", () => ({
+  YtDlp: vi.fn().mockImplementation(() => ({
+    downloadAsync: mockDownloadAsync,
+    getInfoAsync: mockGetInfoAsync,
+  })),
+}));
+
+vi.mock("./youtube.constants", () => ({
+  YOUTUBE_HEADERS: { "User-Agent": "test-agent" },
+}));
+
+function makeSettings(overrides: Record<string, string | number> = {}) {
+  return {
+    getString: vi.fn().mockImplementation((key: string) => Promise.resolve(overrides[key] ?? "")),
+    getNumber: vi.fn().mockImplementation((key: string) => Promise.resolve(overrides[key] ?? 0)),
+  };
+}
+
+function makeSearchService(path = "/usr/bin/yt-dlp") {
+  return {
+    getYtDlpPath: vi.fn().mockReturnValue(path),
+  };
+}
+
+function makeTrack(overrides: Record<string, unknown> = {}) {
+  return {
+    artist: "Test Artist",
+    name: "Test Track",
+    youtubeUrl: "https://youtu.be/abc123",
+    ...overrides,
+  };
+}
+
+describe("YoutubeDownloadService", () => {
+  describe("downloadAndFormat", () => {
+    it("throws a 400 AppError when youtubeUrl is missing", async () => {
+      const service = new YoutubeDownloadService(
+        makeSettings() as never,
+        makeSearchService() as never,
+      );
+
+      await expect(
+        service.downloadAndFormat(makeTrack({ youtubeUrl: undefined }) as never, "/output/path"),
+      ).rejects.toMatchObject({ statusCode: 400, errorCode: "internal_server_error" });
+    });
+
+    it("calls downloadAsync with the track url and output path", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({ duration: 180 });
+
+      const service = new YoutubeDownloadService(
+        makeSettings() as never,
+        makeSearchService() as never,
+      );
+
+      const result = await service.downloadAndFormat(makeTrack() as never, "/music/track.mp3");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        "https://youtu.be/abc123",
+        expect.objectContaining({ output: "/music/track.mp3" }),
+      );
+      expect(result.durationMs).toBe(180_000);
+    });
+
+    it("uses the configured audio format when valid", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({ duration: 60 });
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ FORMAT: "flac" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out.flac");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ format: expect.objectContaining({ type: "flac" }) }),
+      );
+    });
+
+    it("falls back to the default format for an invalid format setting", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({});
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ FORMAT: "wav_invalid" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          format: expect.objectContaining({ filter: "audioonly" }),
+        }),
+      );
+    });
+
+    it("maps quality setting 'good' to 5", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({});
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ YT_AUDIO_QUALITY: "good" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ format: expect.objectContaining({ quality: 5 }) }),
+      );
+    });
+
+    it("maps quality setting 'acceptable' to 9", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({});
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ YT_AUDIO_QUALITY: "acceptable" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ format: expect.objectContaining({ quality: 9 }) }),
+      );
+    });
+
+    it("passes cookies file path via --cookies when YT_COOKIES contains '/'", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({});
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ YT_COOKIES: "/config/cookies.txt" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          cookies: "/config/cookies.txt",
+          cookiesFromBrowser: undefined,
+        }),
+      );
+    });
+
+    it("passes browser name via cookiesFromBrowser when YT_COOKIES is a browser name", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({});
+
+      const service = new YoutubeDownloadService(
+        makeSettings({ YT_COOKIES: "firefox" }) as never,
+        makeSearchService() as never,
+      );
+
+      await service.downloadAndFormat(makeTrack() as never, "/out");
+
+      expect(mockDownloadAsync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          cookies: undefined,
+          cookiesFromBrowser: "firefox",
+        }),
+      );
+    });
+
+    it("returns undefined durationMs when getInfoAsync throws", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockRejectedValue(new Error("info unavailable"));
+
+      const service = new YoutubeDownloadService(
+        makeSettings() as never,
+        makeSearchService() as never,
+      );
+
+      const result = await service.downloadAndFormat(makeTrack() as never, "/out");
+      expect(result.durationMs).toBeUndefined();
+    });
+
+    it("returns undefined durationMs when duration is not a positive number", async () => {
+      mockDownloadAsync.mockResolvedValue(undefined);
+      mockGetInfoAsync.mockResolvedValue({ duration: 0 });
+
+      const service = new YoutubeDownloadService(
+        makeSettings() as never,
+        makeSearchService() as never,
+      );
+
+      const result = await service.downloadAndFormat(makeTrack() as never, "/out");
+      expect(result.durationMs).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## What

Adds backend unit tests for the `infrastructure/external` layer — characterization tests, zero source changes.

Coverage added (7 files, 1027 lines):
- `promise-cache.ts` — in-flight dedup, TTL, eviction
- `rate-limiter.ts` — token bucket / spacing behavior
- Deezer providers: `cover-url`, `deezer-artist-lookup.adapter`, `picture`
- `spotify-artwork-source.service.ts`
- `youtube-download.service.ts`

## Why

Part of #204 — backend unit coverage backfill. This PR covers the external-infra slice; remaining backend domains (other services, repositories, workers) follow in later slices.

## Verification

- `pnpm --filter backend test:run` → 110 files, 841 tests passing
- `pnpm --filter backend exec tsc --noEmit` → clean

## Notes

Required a stale build refresh during verification (`prisma generate` + `@spotiarr/shared` rebuild) for the `searchAttempts` / `lastActivityAt` fields added in #176/#178 — generated artifacts only, not committed.

Refs #204
