### PR TITLE
test(backend): add unit tests for domain entities, errors and helpers

### DIFF
--- a/apps/backend/src/application/services/library.service.test.ts
+++ b/apps/backend/src/application/services/library.service.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { LibraryScanResult, LibraryStats } from "@spotiarr/shared";
+import type { ScanLibraryUseCase } from "../use-cases/library/scan-library.use-case";
+import { LibraryService } from "./library.service";
+
+const MOCK_RESULT: LibraryScanResult = {
+  totalArtists: 3,
+  totalAlbums: 10,
+  totalTracks: 42,
+  totalSize: 1024,
+  lastScannedAt: 1704067200000,
+  scanDuration: 500,
+  artists: [
+    {
+      name: "Artist A",
+      path: "/music/artist-a",
+      albumCount: 2,
+      trackCount: 8,
+      totalSize: 512,
+      image: "https://img/a.jpg",
+      albums: [],
+    },
+    {
+      name: "Artist B",
+      path: "/music/artist-b",
+      albumCount: 8,
+      trackCount: 34,
+      totalSize: 512,
+      image: undefined,
+      albums: [],
+    },
+  ],
+};
+
+function makeUseCase(result: LibraryScanResult = MOCK_RESULT): ScanLibraryUseCase {
+  return { execute: vi.fn().mockResolvedValue(result) } as unknown as ScanLibraryUseCase;
+}
+
+describe("LibraryService.getLibrary", () => {
+  it("calls the use case and returns its result on the first call", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    const result = await svc.getLibrary();
+    expect(result).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("returns the cached result without calling the use case again", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary();
+    const second = await svc.getLibrary();
+    expect(second).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("bypasses the cache when forceRefresh=true", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary();
+    await svc.getLibrary(true);
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent calls — use case executes only once", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    const [r1, r2] = await Promise.all([svc.getLibrary(), svc.getLibrary()]);
+    expect(r1).toEqual(MOCK_RESULT);
+    expect(r2).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("clears scanPromise after the use case resolves (allows a subsequent fresh call)", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary(true);
+    await svc.getLibrary(true);
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates use case rejection", async () => {
+    const uc = { execute: vi.fn().mockRejectedValue(new Error("scan failed")) } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getLibrary()).rejects.toThrow("scan failed");
+  });
+
+  it("clears scanPromise even when use case rejects (allows retry)", async () => {
+    const uc = {
+      execute: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockResolvedValueOnce(MOCK_RESULT),
+    } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getLibrary()).rejects.toThrow("first failure");
+    const result = await svc.getLibrary();
+    expect(result).toEqual(MOCK_RESULT);
+  });
+});
+
+describe("LibraryService.getStats", () => {
+  it("returns stat fields extracted from the library result", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const stats = await svc.getStats();
+    const expected = {
+      totalArtists: MOCK_RESULT.totalArtists,
+      totalAlbums: MOCK_RESULT.totalAlbums,
+      totalTracks: MOCK_RESULT.totalTracks,
+      totalSize: MOCK_RESULT.totalSize,
+      lastScannedAt: MOCK_RESULT.lastScannedAt,
+    };
+    expect(stats).toEqual(expected);
+  });
+
+  it("propagates use case rejection", async () => {
+    const uc = { execute: vi.fn().mockRejectedValue(new Error("stats error")) } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getStats()).rejects.toThrow("stats error");
+  });
+});
+
+describe("LibraryService.getArtists", () => {
+  it("maps artist fields from the library result", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const artists = await svc.getArtists();
+    expect(artists).toEqual([
+      {
+        name: "Artist A",
+        path: "/music/artist-a",
+        albumCount: 2,
+        trackCount: 8,
+        totalSize: 512,
+        image: "https://img/a.jpg",
+      },
+      {
+        name: "Artist B",
+        path: "/music/artist-b",
+        albumCount: 8,
+        trackCount: 34,
+        totalSize: 512,
+        image: undefined,
+      },
+    ]);
+  });
+
+  it("returns an empty array when the library has no artists", async () => {
+    const emptyResult = { ...MOCK_RESULT, artists: [] };
+    const svc = new LibraryService(makeUseCase(emptyResult));
+    expect(await svc.getArtists()).toEqual([]);
+  });
+});
+
+describe("LibraryService.getArtist", () => {
+  it("returns the matching artist when found", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const artist = await svc.getArtist("Artist A");
+    expect(artist?.name).toBe("Artist A");
+  });
+
+  it("returns null when no artist matches the given name", async () => {
+    const svc = new LibraryService(makeUseCase());
+    expect(await svc.getArtist("Unknown")).toBeNull();
+  });
+});
+
+describe("LibraryService.scan", () => {
+  it("triggers a force-refresh and returns the scan result", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    // Warm the cache first
+    await svc.getLibrary();
+    const result = await svc.scan();
+    expect(result).toEqual(MOCK_RESULT);
+    // scan() must bypass the cache
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("LibraryService.clearCache", () => {
+  it("removes the cached result so the next getLibrary call hits the use case again", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary(); // populates cache
+    svc.clearCache();
+    await svc.getLibrary(); // must call use case again
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/application/services/playlist.service.test.ts
+++ b/apps/backend/src/application/services/playlist.service.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  type IPlaylist,
+  type PlaylistPreview,
+  type SpotifyPlaylist,
+  PlaylistTypeEnum,
+  PlaylistStatusEnum,
+  TrackStatusEnum,
+  type DownloadStatusResponse,
+} from "@spotiarr/shared";
+import type { CreatePlaylistUseCase } from "../use-cases/playlists/create-playlist.use-case";
+import type { DeletePlaylistUseCase } from "../use-cases/playlists/delete-playlist.use-case";
+import type { GetMyPlaylistsUseCase } from "../use-cases/playlists/get-my-playlists.use-case";
+import type { GetPlaylistPreviewUseCase } from "../use-cases/playlists/get-playlist-preview.use-case";
+import type { GetPlaylistsUseCase } from "../use-cases/playlists/get-playlists.use-case";
+import type { GetSystemStatusUseCase } from "../use-cases/playlists/get-system-status.use-case";
+import type { RetryPlaylistDownloadsUseCase } from "../use-cases/playlists/retry-playlist-downloads.use-case";
+import type { SyncSubscribedPlaylistsUseCase } from "../use-cases/playlists/sync-subscribed-playlists.use-case";
+import type { UpdatePlaylistUseCase } from "../use-cases/playlists/update-playlist.use-case";
+import { PlaylistService, type PlaylistServiceDependencies } from "./playlist.service";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_PLAYLIST: IPlaylist = {
+  id: "playlist-1",
+  name: "My Playlist",
+  type: PlaylistTypeEnum.Playlist,
+  spotifyUrl: "https://open.spotify.com/playlist/1",
+  subscribed: false,
+};
+
+const MOCK_PREVIEW: PlaylistPreview = {
+  name: "Preview Playlist",
+  type: "playlist",
+  description: null,
+  coverUrl: null,
+  totalTracks: 5,
+  tracks: [],
+};
+
+const MOCK_STATUS: DownloadStatusResponse = {
+  playlistStatusMap: { "playlist-1": PlaylistStatusEnum.Completed },
+  trackStatusMap: { "track-1": TrackStatusEnum.Completed },
+  albumTrackCountMap: {},
+};
+
+const MOCK_SPOTIFY_PLAYLISTS: SpotifyPlaylist[] = [
+  {
+    id: "sp-1",
+    name: "Spotify Playlist",
+    image: null,
+    owner: "user",
+    tracks: 10,
+    spotifyUrl: "https://open.spotify.com/playlist/sp-1",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<PlaylistServiceDependencies> = {}): PlaylistServiceDependencies {
+  return {
+    createPlaylistUseCase: { execute: vi.fn().mockResolvedValue(MOCK_PLAYLIST) } as unknown as CreatePlaylistUseCase,
+    getSystemStatusUseCase: { execute: vi.fn().mockResolvedValue(MOCK_STATUS) } as unknown as GetSystemStatusUseCase,
+    getPlaylistPreviewUseCase: { execute: vi.fn().mockResolvedValue(MOCK_PREVIEW) } as unknown as GetPlaylistPreviewUseCase,
+    syncSubscribedPlaylistsUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as SyncSubscribedPlaylistsUseCase,
+    getPlaylistsUseCase: {
+      findAll: vi.fn().mockResolvedValue([MOCK_PLAYLIST]),
+      findOne: vi.fn().mockResolvedValue(MOCK_PLAYLIST),
+    } as unknown as GetPlaylistsUseCase,
+    deletePlaylistUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as DeletePlaylistUseCase,
+    updatePlaylistUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as UpdatePlaylistUseCase,
+    retryPlaylistDownloadsUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as RetryPlaylistDownloadsUseCase,
+    getMyPlaylistsUseCase: { execute: vi.fn().mockResolvedValue(MOCK_SPOTIFY_PLAYLISTS) } as unknown as GetMyPlaylistsUseCase,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PlaylistService.findAll", () => {
+  it("delegates to getPlaylistsUseCase.findAll and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.findAll();
+    expect(result).toEqual([MOCK_PLAYLIST]);
+    expect(deps.getPlaylistsUseCase.findAll).toHaveBeenCalledWith(true, undefined);
+  });
+
+  it("passes includesTracks=false and where filter through to the use case", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const where: Partial<IPlaylist> = { subscribed: true };
+    await svc.findAll(false, where);
+    expect(deps.getPlaylistsUseCase.findAll).toHaveBeenCalledWith(false, where);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn().mockRejectedValue(new Error("db error")),
+        findOne: vi.fn(),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.findAll()).rejects.toThrow("db error");
+  });
+});
+
+describe("PlaylistService.findOne", () => {
+  it("delegates to getPlaylistsUseCase.findOne and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.findOne("playlist-1");
+    expect(result).toEqual(MOCK_PLAYLIST);
+    expect(deps.getPlaylistsUseCase.findOne).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("returns null when the use case returns null", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn(),
+        findOne: vi.fn().mockResolvedValue(null),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    expect(await svc.findOne("missing")).toBeNull();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn(),
+        findOne: vi.fn().mockRejectedValue(new Error("not found")),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.findOne("x")).rejects.toThrow("not found");
+  });
+});
+
+describe("PlaylistService.remove", () => {
+  it("delegates to deletePlaylistUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.remove("playlist-1");
+    expect(deps.deletePlaylistUseCase.execute).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      deletePlaylistUseCase: { execute: vi.fn().mockRejectedValue(new Error("delete failed")) } as unknown as DeletePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.remove("x")).rejects.toThrow("delete failed");
+  });
+});
+
+describe("PlaylistService.create", () => {
+  it("delegates to createPlaylistUseCase.execute and returns the new playlist", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const input = { kind: "spotifyUrl" as const, spotifyUrl: "https://open.spotify.com/playlist/1" };
+    const result = await svc.create(input);
+    expect(result).toEqual(MOCK_PLAYLIST);
+    expect(deps.createPlaylistUseCase.execute).toHaveBeenCalledWith(input);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      createPlaylistUseCase: { execute: vi.fn().mockRejectedValue(new Error("already exists")) } as unknown as CreatePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.create({ kind: "spotifyUrl", spotifyUrl: "" })).rejects.toThrow("already exists");
+  });
+});
+
+describe("PlaylistService.update", () => {
+  it("delegates to updatePlaylistUseCase.execute with id and patch", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const patch: Partial<IPlaylist> = { name: "New Name" };
+    await svc.update("playlist-1", patch);
+    expect(deps.updatePlaylistUseCase.execute).toHaveBeenCalledWith("playlist-1", patch);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updatePlaylistUseCase: { execute: vi.fn().mockRejectedValue(new Error("update failed")) } as unknown as UpdatePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.update("x", {})).rejects.toThrow("update failed");
+  });
+});
+
+describe("PlaylistService.retryFailedOfPlaylist", () => {
+  it("delegates to retryPlaylistDownloadsUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.retryFailedOfPlaylist("playlist-1");
+    expect(deps.retryPlaylistDownloadsUseCase.execute).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      retryPlaylistDownloadsUseCase: { execute: vi.fn().mockRejectedValue(new Error("retry failed")) } as unknown as RetryPlaylistDownloadsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.retryFailedOfPlaylist("x")).rejects.toThrow("retry failed");
+  });
+});
+
+describe("PlaylistService.checkSubscribedPlaylists", () => {
+  it("delegates to syncSubscribedPlaylistsUseCase.execute", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.checkSubscribedPlaylists();
+    expect(deps.syncSubscribedPlaylistsUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      syncSubscribedPlaylistsUseCase: { execute: vi.fn().mockRejectedValue(new Error("sync failed")) } as unknown as SyncSubscribedPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.checkSubscribedPlaylists()).rejects.toThrow("sync failed");
+  });
+});
+
+describe("PlaylistService.getPreview", () => {
+  it("delegates to getPlaylistPreviewUseCase.execute and returns the preview", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getPreview("https://open.spotify.com/playlist/1");
+    expect(result).toEqual(MOCK_PREVIEW);
+    expect(deps.getPlaylistPreviewUseCase.execute).toHaveBeenCalledWith("https://open.spotify.com/playlist/1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistPreviewUseCase: { execute: vi.fn().mockRejectedValue(new Error("not accessible")) } as unknown as GetPlaylistPreviewUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getPreview("x")).rejects.toThrow("not accessible");
+  });
+});
+
+describe("PlaylistService.getDownloadStatus", () => {
+  it("delegates to getSystemStatusUseCase.execute and returns the status", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getDownloadStatus();
+    expect(result).toEqual(MOCK_STATUS);
+    expect(deps.getSystemStatusUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getSystemStatusUseCase: { execute: vi.fn().mockRejectedValue(new Error("status error")) } as unknown as GetSystemStatusUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getDownloadStatus()).rejects.toThrow("status error");
+  });
+});
+
+describe("PlaylistService.getMyPlaylists", () => {
+  it("delegates to getMyPlaylistsUseCase.execute and returns the list", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getMyPlaylists();
+    expect(result).toEqual(MOCK_SPOTIFY_PLAYLISTS);
+    expect(deps.getMyPlaylistsUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getMyPlaylistsUseCase: { execute: vi.fn().mockRejectedValue(new Error("spotify error")) } as unknown as GetMyPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getMyPlaylists()).rejects.toThrow("spotify error");
+  });
+});

--- a/apps/backend/src/application/services/track.service.test.ts
+++ b/apps/backend/src/application/services/track.service.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it, vi } from "vitest";
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import type { CreateTrackUseCase } from "../use-cases/tracks/create-track.use-case";
+import type { DeleteTrackUseCase } from "../use-cases/tracks/delete-track.use-case";
+import type { DownloadTrackUseCase } from "../use-cases/tracks/download-track.use-case";
+import type { GetTracksUseCase } from "../use-cases/tracks/get-tracks.use-case";
+import type { RetryTrackDownloadUseCase } from "../use-cases/tracks/retry-track-download.use-case";
+import type { SearchTrackOnYoutubeUseCase } from "../use-cases/tracks/search-track-on-youtube.use-case";
+import type { UpdateTrackUseCase } from "../use-cases/tracks/update-track.use-case";
+import { TrackService, type TrackServiceDependencies } from "./track.service";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_TRACK: ITrack = {
+  id: "track-1",
+  name: "Song A",
+  artist: "Artist A",
+  status: TrackStatusEnum.Completed,
+  playlistId: "playlist-1",
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<TrackServiceDependencies> = {}): TrackServiceDependencies {
+  return {
+    searchTrackOnYoutubeUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as SearchTrackOnYoutubeUseCase,
+    downloadTrackUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as DownloadTrackUseCase,
+    createTrackUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as CreateTrackUseCase,
+    deleteTrackUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as DeleteTrackUseCase,
+    getTracksUseCase: {
+      getAll: vi.fn().mockResolvedValue([MOCK_TRACK]),
+      getAllByPlaylist: vi.fn().mockResolvedValue([MOCK_TRACK]),
+      get: vi.fn().mockResolvedValue(MOCK_TRACK),
+      findStuckTracks: vi.fn().mockResolvedValue([MOCK_TRACK]),
+    } as unknown as GetTracksUseCase,
+    retryTrackDownloadUseCase: { execute: vi.fn().mockResolvedValue(undefined) } as unknown as RetryTrackDownloadUseCase,
+    updateTrackUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+      executeIfStatus: vi.fn().mockResolvedValue(true),
+    } as unknown as UpdateTrackUseCase,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TrackService.getAll", () => {
+  it("delegates to getTracksUseCase.getAll and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.getAll();
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.getAll).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes the where filter through to the use case", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const where: Partial<ITrack> = { status: TrackStatusEnum.Error };
+    await svc.getAll(where);
+    expect(deps.getTracksUseCase.getAll).toHaveBeenCalledWith(where);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn().mockRejectedValue(new Error("db error")),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.getAll()).rejects.toThrow("db error");
+  });
+});
+
+describe("TrackService.getAllByPlaylist", () => {
+  it("delegates to getTracksUseCase.getAllByPlaylist and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.getAllByPlaylist("playlist-1");
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.getAllByPlaylist).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn().mockRejectedValue(new Error("playlist not found")),
+        get: vi.fn(),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.getAllByPlaylist("missing")).rejects.toThrow("playlist not found");
+  });
+});
+
+describe("TrackService.get", () => {
+  it("delegates to getTracksUseCase.get and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.get("track-1");
+    expect(result).toEqual(MOCK_TRACK);
+    expect(deps.getTracksUseCase.get).toHaveBeenCalledWith("track-1");
+  });
+
+  it("returns null when the use case returns null", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn().mockResolvedValue(null),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    expect(await svc.get("missing")).toBeNull();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn().mockRejectedValue(new Error("track error")),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.get("x")).rejects.toThrow("track error");
+  });
+});
+
+describe("TrackService.remove", () => {
+  it("delegates to deleteTrackUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.remove("track-1");
+    expect(deps.deleteTrackUseCase.execute).toHaveBeenCalledWith("track-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      deleteTrackUseCase: { execute: vi.fn().mockRejectedValue(new Error("delete failed")) } as unknown as DeleteTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.remove("x")).rejects.toThrow("delete failed");
+  });
+});
+
+describe("TrackService.create", () => {
+  it("delegates to createTrackUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const track: Partial<ITrack> = { name: "New Track", artist: "Artist" };
+    await svc.create(track);
+    expect(deps.createTrackUseCase.execute).toHaveBeenCalledWith(track);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      createTrackUseCase: { execute: vi.fn().mockRejectedValue(new Error("create failed")) } as unknown as CreateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.create({})).rejects.toThrow("create failed");
+  });
+});
+
+describe("TrackService.update", () => {
+  it("delegates to updateTrackUseCase.execute with id and patch", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const patch: Partial<ITrack> = { status: TrackStatusEnum.Completed };
+    await svc.update("track-1", patch);
+    expect(deps.updateTrackUseCase.execute).toHaveBeenCalledWith("track-1", patch);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("update failed")),
+        executeIfStatus: vi.fn(),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.update("x", {})).rejects.toThrow("update failed");
+  });
+});
+
+describe("TrackService.updateStatusIf", () => {
+  it("delegates to updateTrackUseCase.executeIfStatus and returns true on match", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const patch: Partial<ITrack> = { status: TrackStatusEnum.Downloading };
+    const result = await svc.updateStatusIf("track-1", TrackStatusEnum.New, patch);
+    expect(result).toBe(true);
+    expect(deps.updateTrackUseCase.executeIfStatus).toHaveBeenCalledWith("track-1", TrackStatusEnum.New, patch);
+  });
+
+  it("returns false when the status did not match", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn(),
+        executeIfStatus: vi.fn().mockResolvedValue(false),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    const result = await svc.updateStatusIf("track-1", TrackStatusEnum.Completed, {});
+    expect(result).toBe(false);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn(),
+        executeIfStatus: vi.fn().mockRejectedValue(new Error("conditional update failed")),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.updateStatusIf("x", TrackStatusEnum.New, {})).rejects.toThrow("conditional update failed");
+  });
+});
+
+describe("TrackService.retry", () => {
+  it("delegates to retryTrackDownloadUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.retry("track-1");
+    expect(deps.retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      retryTrackDownloadUseCase: { execute: vi.fn().mockRejectedValue(new Error("retry failed")) } as unknown as RetryTrackDownloadUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.retry("x")).rejects.toThrow("retry failed");
+  });
+});
+
+describe("TrackService.findOnYoutube", () => {
+  it("delegates to searchTrackOnYoutubeUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.findOnYoutube(MOCK_TRACK);
+    expect(deps.searchTrackOnYoutubeUseCase.execute).toHaveBeenCalledWith(MOCK_TRACK);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      searchTrackOnYoutubeUseCase: { execute: vi.fn().mockRejectedValue(new Error("youtube error")) } as unknown as SearchTrackOnYoutubeUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.findOnYoutube(MOCK_TRACK)).rejects.toThrow("youtube error");
+  });
+});
+
+describe("TrackService.downloadFromYoutube", () => {
+  it("delegates to downloadTrackUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.downloadFromYoutube(MOCK_TRACK);
+    expect(deps.downloadTrackUseCase.execute).toHaveBeenCalledWith(MOCK_TRACK);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      downloadTrackUseCase: { execute: vi.fn().mockRejectedValue(new Error("download failed")) } as unknown as DownloadTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.downloadFromYoutube(MOCK_TRACK)).rejects.toThrow("download failed");
+  });
+});
+
+describe("TrackService.findStuckTracks", () => {
+  it("delegates to getTracksUseCase.findStuckTracks and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const statuses = [TrackStatusEnum.Downloading, TrackStatusEnum.Searching];
+    const result = await svc.findStuckTracks(statuses, 1000);
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.findStuckTracks).toHaveBeenCalledWith(statuses, 1000);
+  });
+
+  it("returns an empty array when no stuck tracks are found", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn().mockResolvedValue([]),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    expect(await svc.findStuckTracks([TrackStatusEnum.Downloading], 1000)).toEqual([]);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn().mockRejectedValue(new Error("stuck query failed")),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.findStuckTracks([TrackStatusEnum.Downloading], 1000)).rejects.toThrow("stuck query failed");
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import { AppendChatMessageUseCase, type AppendChatMessageInput } from "./append-chat-message.use-case";
+
+describe("AppendChatMessageUseCase", () => {
+  const repository = {
+    append: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: AppendChatMessageUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new AppendChatMessageUseCase(repository as never);
+  });
+
+  describe("success path", () => {
+    it("creates an AiChatMessage and appends it to the repository", async () => {
+      const input: AppendChatMessageInput = {
+        role: "user",
+        contentKey: "chat.greet",
+        contentParams: { name: "Alice" },
+        playlistId: "playlist-99",
+        errorCode: null,
+      };
+
+      await useCase.execute(input);
+
+      expect(repository.append).toHaveBeenCalledOnce();
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended).toBeInstanceOf(AiChatMessage);
+      expect(appended.role).toBe("user");
+      expect(appended.content.key).toBe("chat.greet");
+      expect(appended.content.params).toEqual({ name: "Alice" });
+      expect(appended.playlistId).toBe("playlist-99");
+      expect(appended.errorCode).toBeNull();
+    });
+
+    it("assigns a non-empty uuid as the message id", async () => {
+      const input: AppendChatMessageInput = {
+        role: "assistant",
+        contentKey: "chat.response",
+      };
+
+      await useCase.execute(input);
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(typeof appended.id).toBe("string");
+      expect(appended.id.length).toBeGreaterThan(0);
+    });
+
+    it("sets createdAt to a recent epoch millisecond timestamp", async () => {
+      const before = Date.now();
+      const input: AppendChatMessageInput = {
+        role: "user",
+        contentKey: "chat.ping",
+      };
+
+      await useCase.execute(input);
+
+      const after = Date.now();
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.createdAt).toBeGreaterThanOrEqual(before);
+      expect(appended.createdAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("optional fields default handling", () => {
+    it("defaults playlistId to null when not provided", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.hello" });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.playlistId).toBeNull();
+    });
+
+    it("defaults errorCode to null when not provided", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.hello" });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.errorCode).toBeNull();
+    });
+
+    it("coerces undefined playlistId to null", async () => {
+      await useCase.execute({ role: "assistant", contentKey: "chat.reply", playlistId: undefined });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.playlistId).toBeNull();
+    });
+
+    it("coerces undefined errorCode to null", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.err", errorCode: undefined });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.errorCode).toBeNull();
+    });
+  });
+
+  describe("role variants", () => {
+    it("persists role=user correctly", async () => {
+      await useCase.execute({ role: "user", contentKey: "k" });
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.role).toBe("user");
+    });
+
+    it("persists role=assistant correctly", async () => {
+      await useCase.execute({ role: "assistant", contentKey: "k" });
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.role).toBe("assistant");
+    });
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.append.mockRejectedValue(new Error("storage failure"));
+
+    await expect(
+      useCase.execute({ role: "user", contentKey: "chat.ping" }),
+    ).rejects.toThrow("storage failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ClearChatMessagesUseCase } from "./clear-chat-messages.use-case";
+
+describe("ClearChatMessagesUseCase", () => {
+  const repository = {
+    clear: vi.fn(),
+  };
+
+  let useCase: ClearChatMessagesUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new ClearChatMessagesUseCase(repository as never);
+  });
+
+  it("delegates clearing to the repository and returns the deleted count", async () => {
+    repository.clear.mockResolvedValue(5);
+
+    const result = await useCase.execute();
+
+    expect(repository.clear).toHaveBeenCalledOnce();
+    expect(result).toEqual({ deleted: 5 });
+  });
+
+  it("returns { deleted: 0 } when no messages were stored", async () => {
+    repository.clear.mockResolvedValue(0);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ deleted: 0 });
+  });
+
+  it("returns the exact count reported by the repository", async () => {
+    repository.clear.mockResolvedValue(42);
+
+    const result = await useCase.execute();
+
+    expect(result.deleted).toBe(42);
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.clear.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute()).rejects.toThrow("db failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import { GetChatMessagesUseCase } from "./get-chat-messages.use-case";
+
+const makeMessage = (overrides: Partial<ConstructorParameters<typeof AiChatMessage>[0]> = {}): AiChatMessage =>
+  new AiChatMessage({
+    id: "msg-1",
+    role: "user",
+    content: { key: "chat.hello", params: undefined },
+    playlistId: null,
+    errorCode: null,
+    createdAt: 1_000_000,
+    ...overrides,
+  });
+
+describe("GetChatMessagesUseCase", () => {
+  const repository = {
+    list: vi.fn(),
+  };
+
+  let useCase: GetChatMessagesUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetChatMessagesUseCase(repository as never);
+  });
+
+  it("returns an empty array when the repository has no messages", async () => {
+    repository.list.mockResolvedValue([]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([]);
+  });
+
+  it("maps each AiChatMessage entity to an AiChatMessageDto", async () => {
+    const entity = makeMessage({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "chat.response", params: { count: 3 } },
+      playlistId: "playlist-1",
+      errorCode: "some_error",
+      createdAt: 9_999_999,
+    });
+    repository.list.mockResolvedValue([entity]);
+
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "chat.response", params: { count: 3 } },
+      playlistId: "playlist-1",
+      errorCode: "some_error",
+      createdAt: 9_999_999,
+    });
+  });
+
+  it("preserves order of messages returned by the repository", async () => {
+    const entities = [
+      makeMessage({ id: "msg-1", createdAt: 1000 }),
+      makeMessage({ id: "msg-2", createdAt: 2000 }),
+      makeMessage({ id: "msg-3", createdAt: 3000 }),
+    ];
+    repository.list.mockResolvedValue(entities);
+
+    const result = await useCase.execute();
+
+    expect(result.map((m) => m.id)).toEqual(["msg-1", "msg-2", "msg-3"]);
+  });
+
+  it("maps all entity fields to the DTO (id, role, content, playlistId, errorCode, createdAt)", async () => {
+    const entity = makeMessage({ id: "msg-99", role: "user" });
+    repository.list.mockResolvedValue([entity]);
+
+    const result = await useCase.execute();
+    const dto = result[0];
+
+    expect(dto).toHaveProperty("id");
+    expect(dto).toHaveProperty("role");
+    expect(dto).toHaveProperty("content");
+    expect(dto).toHaveProperty("playlistId");
+    expect(dto).toHaveProperty("errorCode");
+    expect(dto).toHaveProperty("createdAt");
+  });
+
+  it("maps multiple messages correctly", async () => {
+    const entities = [
+      makeMessage({ id: "a", role: "user" }),
+      makeMessage({ id: "b", role: "assistant" }),
+    ];
+    repository.list.mockResolvedValue(entities);
+
+    const result = await useCase.execute();
+
+    expect(result[0].id).toBe("a");
+    expect(result[0].role).toBe("user");
+    expect(result[1].id).toBe("b");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.list.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute()).rejects.toThrow("db failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/get-artwork-backfill-status.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/get-artwork-backfill-status.use-case.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import type { ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { GetArtworkBackfillStatusUseCase } from "./get-artwork-backfill-status.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: "cursor-abc",
+  totalCandidates: 100,
+  processed: 20,
+  skippedExisting: 5,
+  written: 15,
+  failed: 1,
+  externalCalls: 10,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun"> = {
+    getActiveRun: vi.fn(),
+  };
+  return { backfillRepository };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun">,
+) =>
+  new GetArtworkBackfillStatusUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+  );
+
+describe("GetArtworkBackfillStatusUseCase", () => {
+  it("returns idle response when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      runId: null,
+      status: "idle",
+      phase: null,
+      totals: 0,
+      processed: 0,
+      skippedExisting: 0,
+      written: 0,
+      failed: 0,
+      externalCalls: 0,
+      lastCheckpoint: null,
+      rateLimitUntil: null,
+      updatedAt: null,
+    });
+  });
+
+  it("maps active run fields to the response shape", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      runId: "run-1",
+      status: "running",
+      phase: "artists",
+      totals: 100,
+      processed: 20,
+      skippedExisting: 5,
+      written: 15,
+      failed: 1,
+      externalCalls: 10,
+      lastCheckpoint: "cursor-abc",
+      rateLimitUntil: null,
+      updatedAt: "2024-01-01T01:00:00.000Z",
+    });
+  });
+
+  it("serializes rateLimitUntil as ISO string when set", async () => {
+    const { backfillRepository } = makeDeps();
+    const rateLimitDate = new Date("2024-06-01T12:00:00.000Z");
+    const run = makeActiveRun({ rateLimitUntil: rateLimitDate });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.rateLimitUntil).toBe("2024-06-01T12:00:00.000Z");
+  });
+
+  it("maps cursorValue as lastCheckpoint including null", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ cursorValue: null });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.lastCheckpoint).toBeNull();
+  });
+
+  it("maps paused status correctly", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: "paused" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.status).toBe("paused");
+    expect(result.runId).toBe("run-1");
+  });
+
+  it("propagates repository errors", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/pause-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/pause-artwork-backfill.use-case.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { PauseArtworkBackfillUseCase } from "./pause-artwork-backfill.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 100,
+  processed: 10,
+  skippedExisting: 0,
+  written: 10,
+  failed: 0,
+  externalCalls: 5,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus"> = {
+    getActiveRun: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+  return { backfillRepository };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus">,
+) =>
+  new PauseArtworkBackfillUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+  );
+
+describe("PauseArtworkBackfillUseCase", () => {
+  it("throws AppError 404 when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("does not call updateStatus when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(backfillRepository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns paused immediately when run is already paused", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ runId: "run-1", status: "paused" });
+    expect(backfillRepository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("requests pause when run is running", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    const updatedRun = makeActiveRun({ id: "run-1", status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.PauseRequested,
+    });
+    expect(result).toEqual({ runId: "run-1", status: "pause_requested" });
+  });
+
+  it("requests pause when run is in pause_requested state", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    const updatedRun = makeActiveRun({ id: "run-1", status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ runId: "run-1", status: "pause_requested" });
+  });
+
+  it("uses the updated run id in the response", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ id: "run-original", status: ARTWORK_BACKFILL_STATUS.Running });
+    const updatedRun = makeActiveRun({ id: "run-original", status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.runId).toBe("run-original");
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository updateStatus errors", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("update failed");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/resume-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/resume-artwork-backfill.use-case.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillQueuePort } from "@/application/ports/artwork-backfill-queue.port";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { ResumeArtworkBackfillUseCase } from "./resume-artwork-backfill.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "paused",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 100,
+  processed: 10,
+  skippedExisting: 0,
+  written: 10,
+  failed: 0,
+  externalCalls: 5,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus"> = {
+    getActiveRun: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+  const queuePort: ArtworkBackfillQueuePort = {
+    enqueueRun: vi.fn(),
+  };
+  return { backfillRepository, queuePort };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus">,
+  queuePort: ArtworkBackfillQueuePort,
+) =>
+  new ResumeArtworkBackfillUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+    queuePort,
+  );
+
+describe("ResumeArtworkBackfillUseCase", () => {
+  it("throws AppError 404 when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when run is running (not paused)", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when run is in pause_requested state", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("resumes a paused run, updates to running, enqueues, returns running", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    const updatedRun = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.Running,
+      rateLimitUntil: null,
+      error: null,
+    });
+    expect(queuePort.enqueueRun).toHaveBeenCalledWith(updatedRun.id);
+    expect(result).toEqual({ runId: updatedRun.id, status: "running" });
+  });
+
+  it("resumes a paused_rate_limited run", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PausedRateLimited });
+    const updatedRun = makeActiveRun({ id: "run-1", status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.Running,
+      rateLimitUntil: null,
+      error: null,
+    });
+    expect(result).toEqual({ runId: "run-1", status: "running" });
+  });
+
+  it("does not enqueue when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when run is not paused", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository updateStatus errors without enqueuing", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("update failed");
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue enqueueRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    const updatedRun = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockRejectedValue(new Error("queue error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("queue error");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/start-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/start-artwork-backfill.use-case.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillQueuePort } from "@/application/ports/artwork-backfill-queue.port";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { StartArtworkBackfillUseCase } from "./start-artwork-backfill.use-case";
+
+const makeRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 0,
+  processed: 0,
+  skippedExisting: 0,
+  written: 0,
+  failed: 0,
+  externalCalls: 0,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "createRun"> = {
+    getActiveRun: vi.fn(),
+    createRun: vi.fn(),
+  };
+  const queuePort: ArtworkBackfillQueuePort = {
+    enqueueRun: vi.fn(),
+  };
+  return { backfillRepository, queuePort };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "createRun">,
+  queuePort: ArtworkBackfillQueuePort,
+) =>
+  new StartArtworkBackfillUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+    queuePort,
+  );
+
+describe("StartArtworkBackfillUseCase", () => {
+  it("creates a new run and enqueues it when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const newRun = makeRun({ id: "run-new" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(queuePort.enqueueRun).toHaveBeenCalledWith("run-new");
+    expect(result).toEqual({ runId: "run-new", status: "running" });
+  });
+
+  it("throws AppError 409 when a running active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when a pause_requested run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("throws AppError 409 when a paused run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("throws AppError 409 when a paused_rate_limited run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.PausedRateLimited });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("does not create or enqueue when an active blocking run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(backfillRepository.createRun).not.toHaveBeenCalled();
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("allows starting when active run has a completed status", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const completedRun = makeRun({ id: "old-run", status: ARTWORK_BACKFILL_STATUS.Completed });
+    const newRun = makeRun({ id: "new-run" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(completedRun);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(result).toEqual({ runId: "new-run", status: "running" });
+  });
+
+  it("allows starting when active run has an error status", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const errorRun = makeRun({ id: "old-run", status: ARTWORK_BACKFILL_STATUS.Error });
+    const newRun = makeRun({ id: "new-run" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(errorRun);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(result).toEqual({ runId: "new-run", status: "running" });
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository createRun errors without enqueuing", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockRejectedValue(new Error("create failed"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("create failed");
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue enqueueRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const newRun = makeRun({ id: "run-new" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockRejectedValue(new Error("queue error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("queue error");
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/delete-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/delete-playlist.use-case.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import type { EventBus } from "@/domain/events/event-bus";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { DeletePlaylistUseCase } from "./delete-playlist.use-case";
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne" | "delete"> = {
+    findOne: vi.fn(),
+    delete: vi.fn(),
+  };
+  const eventBus: EventBus = {
+    emit: vi.fn(),
+  };
+  return { playlistRepository, eventBus };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne" | "delete">,
+  eventBus: EventBus,
+) =>
+  new DeletePlaylistUseCase(
+    playlistRepository as unknown as PlaylistRepository,
+    eventBus,
+  );
+
+describe("DeletePlaylistUseCase", () => {
+  it("deletes the playlist and emits playlists-updated when found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.delete).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+    expect(playlistRepository.delete).toHaveBeenCalledWith("p1");
+    expect(eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("missing")).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing")).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not delete or emit when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await expect(useCase.execute("missing")).rejects.toThrow();
+
+    expect(playlistRepository.delete).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository findOne errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("db error");
+    expect(playlistRepository.delete).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository delete errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.delete).mockRejectedValue(new Error("delete failed"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("delete failed");
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlists.use-case.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { GetPlaylistsUseCase } from "./get-playlists.use-case";
+import type { IPlaylist } from "@spotiarr/shared";
+
+const makePlaylist = (overrides: Partial<IPlaylist> = {}): Playlist => {
+  const props: IPlaylist = {
+    id: "p1",
+    name: "My Playlist",
+    spotifyUrl: "https://open.spotify.com/playlist/abc",
+    subscribed: true,
+    tracks: [],
+    ...overrides,
+  };
+  return new Playlist(props);
+};
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findAll" | "findOne"> = {
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+  };
+  return { playlistRepository };
+};
+
+const makeUseCase = (playlistRepository: Pick<PlaylistRepository, "findAll" | "findOne">) =>
+  new GetPlaylistsUseCase(playlistRepository as unknown as PlaylistRepository);
+
+describe("GetPlaylistsUseCase", () => {
+  describe("findAll", () => {
+    it("returns primitives of all playlists with default params", async () => {
+      const { playlistRepository } = makeDeps();
+      const playlist = makePlaylist();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(true, undefined);
+      expect(result).toEqual([playlist.toPrimitive()]);
+    });
+
+    it("passes includesTracks=false through to repository", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      await useCase.findAll(false);
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(false, undefined);
+    });
+
+    it("passes where filter through to repository", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      await useCase.findAll(true, { subscribed: true });
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(true, { subscribed: true });
+    });
+
+    it("returns empty array when repository returns none", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns multiple playlists mapped to primitives", async () => {
+      const { playlistRepository } = makeDeps();
+      const p1 = makePlaylist({ id: "p1", name: "A" });
+      const p2 = makePlaylist({ id: "p2", name: "B" });
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([p1, p2]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(p1.toPrimitive());
+      expect(result[1]).toEqual(p2.toPrimitive());
+    });
+
+    it("propagates repository errors", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockRejectedValue(new Error("db error"));
+
+      const useCase = makeUseCase(playlistRepository);
+
+      await expect(useCase.findAll()).rejects.toThrow("db error");
+    });
+  });
+
+  describe("findOne", () => {
+    it("returns primitive of found playlist", async () => {
+      const { playlistRepository } = makeDeps();
+      const playlist = makePlaylist({ id: "p1" });
+      vi.mocked(playlistRepository.findOne).mockResolvedValue(playlist);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findOne("p1");
+
+      expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+      expect(result).toEqual(playlist.toPrimitive());
+    });
+
+    it("returns null when playlist is not found", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findOne("missing");
+
+      expect(result).toBeNull();
+    });
+
+    it("propagates repository errors", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+      const useCase = makeUseCase(playlistRepository);
+
+      await expect(useCase.findOne("p1")).rejects.toThrow("db error");
+    });
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-system-status.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-system-status.use-case.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlaylistStatusEnum, TrackStatusEnum } from "@spotiarr/shared";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { GetSystemStatusUseCase } from "./get-system-status.use-case";
+import type { IPlaylist, ITrack } from "@spotiarr/shared";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "t1",
+  trackUrl: "https://open.spotify.com/track/1",
+  albumUrl: "https://open.spotify.com/album/1",
+  status: TrackStatusEnum.Completed,
+  name: "Track",
+  artist: "Artist",
+  album: "Album",
+  playlistId: "p1",
+  ...overrides,
+});
+
+const makePlaylist = (overrides: Partial<IPlaylist> = {}): Playlist => {
+  const props: IPlaylist = {
+    id: "p1",
+    name: "My Playlist",
+    spotifyUrl: "https://open.spotify.com/playlist/abc",
+    subscribed: true,
+    tracks: [],
+    ...overrides,
+  };
+  return new Playlist(props);
+};
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findAll"> = {
+    findAll: vi.fn(),
+  };
+  return { playlistRepository };
+};
+
+const makeUseCase = (playlistRepository: Pick<PlaylistRepository, "findAll">) =>
+  new GetSystemStatusUseCase(playlistRepository as unknown as PlaylistRepository);
+
+describe("GetSystemStatusUseCase", () => {
+  it("returns empty maps when there are no playlists", async () => {
+    const { playlistRepository } = makeDeps();
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(playlistRepository.findAll).toHaveBeenCalledWith(true);
+    expect(result).toEqual({
+      playlistStatusMap: {},
+      trackStatusMap: {},
+      albumTrackCountMap: {},
+    });
+  });
+
+  it("maps playlist status by spotifyUrl", async () => {
+    const { playlistRepository } = makeDeps();
+    const completedTrack = makeTrack({ status: TrackStatusEnum.Completed });
+    const playlist = makePlaylist({
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+      tracks: [completedTrack],
+    });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.playlistStatusMap).toEqual({
+      "https://open.spotify.com/playlist/abc": PlaylistStatusEnum.Completed,
+    });
+  });
+
+  it("maps track status by trackUrl", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({
+      trackUrl: "https://open.spotify.com/track/x",
+      status: TrackStatusEnum.Error,
+    });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.trackStatusMap["https://open.spotify.com/track/x"]).toBe(TrackStatusEnum.Error);
+  });
+
+  it("counts completed tracks per albumUrl in albumTrackCountMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const albumUrl = "https://open.spotify.com/album/a";
+    const t1 = makeTrack({ id: "t1", trackUrl: "https://open.spotify.com/track/1", albumUrl, status: TrackStatusEnum.Completed });
+    const t2 = makeTrack({ id: "t2", trackUrl: "https://open.spotify.com/track/2", albumUrl, status: TrackStatusEnum.Completed });
+    const t3 = makeTrack({ id: "t3", trackUrl: "https://open.spotify.com/track/3", albumUrl, status: TrackStatusEnum.Error });
+    const playlist = makePlaylist({ tracks: [t1, t2, t3] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    // Only completed tracks count
+    expect(result.albumTrackCountMap[albumUrl]).toBe(2);
+  });
+
+  it("does not add to albumTrackCountMap for non-completed tracks", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({ status: TrackStatusEnum.Error });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.albumTrackCountMap)).toHaveLength(0);
+  });
+
+  it("skips playlist without spotifyUrl in playlistStatusMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const playlist = makePlaylist({ spotifyUrl: undefined });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.playlistStatusMap)).toHaveLength(0);
+  });
+
+  it("skips tracks without trackUrl or status in trackStatusMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({ trackUrl: undefined, status: undefined });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.trackStatusMap)).toHaveLength(0);
+  });
+
+  it("handles playlists with no tracks array gracefully", async () => {
+    const { playlistRepository } = makeDeps();
+    const playlist = makePlaylist({ tracks: undefined });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.trackStatusMap).toEqual({});
+    expect(result.albumTrackCountMap).toEqual({});
+  });
+
+  it("aggregates album counts across multiple playlists", async () => {
+    const { playlistRepository } = makeDeps();
+    const albumUrl = "https://open.spotify.com/album/shared";
+    const t1 = makeTrack({ id: "t1", trackUrl: "https://open.spotify.com/track/1", albumUrl, status: TrackStatusEnum.Completed });
+    const t2 = makeTrack({ id: "t2", trackUrl: "https://open.spotify.com/track/2", albumUrl, status: TrackStatusEnum.Completed });
+    const p1 = makePlaylist({ id: "p1", spotifyUrl: "https://open.spotify.com/playlist/1", tracks: [t1] });
+    const p2 = makePlaylist({ id: "p2", spotifyUrl: "https://open.spotify.com/playlist/2", tracks: [t2] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([p1, p2]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.albumTrackCountMap[albumUrl]).toBe(2);
+  });
+
+  it("propagates repository errors", async () => {
+    const { playlistRepository } = makeDeps();
+    vi.mocked(playlistRepository.findAll).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/retry-playlist-downloads.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/retry-playlist-downloads.use-case.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { TrackStatusEnum } from "@spotiarr/shared";
+import { AppError } from "@/domain/errors/app-error";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import type { ITrack } from "@spotiarr/shared";
+import { RetryPlaylistDownloadsUseCase } from "./retry-playlist-downloads.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "t1",
+  name: "Track",
+  artist: "Artist",
+  album: "Album",
+  trackUrl: "https://open.spotify.com/track/1",
+  albumUrl: "https://open.spotify.com/album/1",
+  playlistId: "p1",
+  status: TrackStatusEnum.Completed,
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne"> = {
+    findOne: vi.fn(),
+  };
+  const trackService = {
+    getAllByPlaylist: vi.fn(),
+    retry: vi.fn(),
+  };
+  return { playlistRepository, trackService };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne">,
+  trackService: { getAllByPlaylist: ReturnType<typeof vi.fn>; retry: ReturnType<typeof vi.fn> },
+) =>
+  new RetryPlaylistDownloadsUseCase(
+    playlistRepository as unknown as PlaylistRepository,
+    trackService as never,
+  );
+
+describe("RetryPlaylistDownloadsUseCase", () => {
+  it("retries only tracks with Error status", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const errorTrack = makeTrack({ id: "t-err", status: TrackStatusEnum.Error });
+    const okTrack = makeTrack({ id: "t-ok", status: TrackStatusEnum.Completed });
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([errorTrack, okTrack]);
+    vi.mocked(trackService.retry).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).toHaveBeenCalledTimes(1);
+    expect(trackService.retry).toHaveBeenCalledWith("t-err");
+  });
+
+  it("does not call retry when no tracks have Error status", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([
+      makeTrack({ status: TrackStatusEnum.Completed }),
+    ]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("does not call retry when track has Error status but no id", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const noIdTrack = makeTrack({ id: undefined, status: TrackStatusEnum.Error });
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([noIdTrack]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("retries all error-status tracks with ids", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const tracks = [
+      makeTrack({ id: "t1", status: TrackStatusEnum.Error }),
+      makeTrack({ id: "t2", status: TrackStatusEnum.Error }),
+      makeTrack({ id: "t3", status: TrackStatusEnum.Error }),
+    ];
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue(tracks);
+    vi.mocked(trackService.retry).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("missing")).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing")).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not fetch tracks when playlist is not found", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await expect(useCase.execute("missing")).rejects.toThrow();
+
+    expect(trackService.getAllByPlaylist).not.toHaveBeenCalled();
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository errors", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("db error");
+  });
+
+  it("propagates trackService.retry errors", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([
+      makeTrack({ id: "t1", status: TrackStatusEnum.Error }),
+    ]);
+    vi.mocked(trackService.retry).mockRejectedValue(new Error("retry failed"));
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("retry failed");
+  });
+
+  it("handles empty tracks array without calling retry", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import type { EventBus } from "@/domain/events/event-bus";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { UpdatePlaylistUseCase } from "./update-playlist.use-case";
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne" | "update"> = {
+    findOne: vi.fn(),
+    update: vi.fn(),
+  };
+  const eventBus: EventBus = {
+    emit: vi.fn(),
+  };
+  return { playlistRepository, eventBus };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne" | "update">,
+  eventBus: EventBus,
+) =>
+  new UpdatePlaylistUseCase(
+    playlistRepository as unknown as PlaylistRepository,
+    eventBus,
+  );
+
+describe("UpdatePlaylistUseCase", () => {
+  it("updates the playlist and emits playlists-updated when found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1", { name: "New Name" });
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+    expect(playlistRepository.update).toHaveBeenCalledWith("p1", { name: "New Name" });
+    expect(eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("missing", {})).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing", {})).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not call update or emit when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await expect(useCase.execute("missing", {})).rejects.toThrow();
+
+    expect(playlistRepository.update).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository findOne errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1", { name: "X" })).rejects.toThrow("db error");
+    expect(playlistRepository.update).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository update errors without emitting", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1", { name: "X" })).rejects.toThrow("update failed");
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("passes partial playlist data through to repository", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockResolvedValue(undefined);
+
+    const patch = { name: "Updated", subscribed: false };
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1", patch);
+
+    expect(playlistRepository.update).toHaveBeenCalledWith("p1", patch);
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/create-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/create-track.use-case.test.ts
@@ -1,0 +1,73 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { CreateTrackUseCase } from "./create-track.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "track-1",
+  name: "Song A",
+  artist: "Artist A",
+  status: TrackStatusEnum.New,
+  playlistId: "playlist-1",
+  youtubeUrl: undefined,
+  spotifyUrl: undefined,
+  trackUrl: undefined,
+  searchAttempts: 0,
+  ...overrides,
+});
+
+describe("CreateTrackUseCase", () => {
+  const trackRepository = {
+    save: vi.fn(),
+  };
+
+  const queueService = {
+    enqueueSearchTrack: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: CreateTrackUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new CreateTrackUseCase(trackRepository as never, queueService as never);
+  });
+
+  it("saves the track to the repository and enqueues it for search", async () => {
+    const input = makeTrack();
+    const savedTrack = new Track(input);
+    trackRepository.save.mockResolvedValue(savedTrack);
+
+    await useCase.execute(input);
+
+    expect(trackRepository.save).toHaveBeenCalledWith(input);
+    expect(queueService.enqueueSearchTrack).toHaveBeenCalledWith(savedTrack.toPrimitive());
+  });
+
+  it("passes the primitive representation of the saved track to the queue service", async () => {
+    const input = makeTrack({ id: "track-2", name: "Song B" });
+    const savedTrack = new Track(input);
+    trackRepository.save.mockResolvedValue(savedTrack);
+
+    await useCase.execute(input);
+
+    const enqueueArg = queueService.enqueueSearchTrack.mock.calls[0][0];
+    expect(enqueueArg).toEqual(savedTrack.toPrimitive());
+    expect(enqueueArg.id).toBe("track-2");
+    expect(enqueueArg.name).toBe("Song B");
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    trackRepository.save.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute(makeTrack())).rejects.toThrow("db failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue service errors without swallowing them", async () => {
+    const savedTrack = new Track(makeTrack());
+    trackRepository.save.mockResolvedValue(savedTrack);
+    queueService.enqueueSearchTrack.mockRejectedValue(new Error("queue failure"));
+
+    await expect(useCase.execute(makeTrack())).rejects.toThrow("queue failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/delete-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/delete-track.use-case.test.ts
@@ -1,0 +1,76 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { Track } from "@/domain/entities/track.entity";
+import { DeleteTrackUseCase } from "./delete-track.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): Track =>
+  new Track({
+    id: "track-1",
+    name: "Song A",
+    artist: "Artist A",
+    status: TrackStatusEnum.New,
+    playlistId: "playlist-1",
+    youtubeUrl: undefined,
+    spotifyUrl: undefined,
+    trackUrl: undefined,
+    searchAttempts: 0,
+    ...overrides,
+  });
+
+describe("DeleteTrackUseCase", () => {
+  const trackRepository = {
+    findOne: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: DeleteTrackUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new DeleteTrackUseCase(trackRepository as never);
+  });
+
+  describe("when the track exists", () => {
+    it("calls repository.delete with the given id", async () => {
+      trackRepository.findOne.mockResolvedValue(makeTrack());
+
+      await useCase.execute("track-1");
+
+      expect(trackRepository.findOne).toHaveBeenCalledWith("track-1");
+      expect(trackRepository.delete).toHaveBeenCalledWith("track-1");
+    });
+  });
+
+  describe("when the track does not exist", () => {
+    it("throws AppError 404 with error code track_not_found", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow(AppError);
+    });
+
+    it("does not call delete when the track is missing", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow();
+      expect(trackRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws with statusCode 404 and errorCode track_not_found", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      const error = await useCase.execute("missing-id").catch((e) => e);
+
+      expect(error).toBeInstanceOf(AppError);
+      expect(error.statusCode).toBe(404);
+      expect(error.errorCode).toBe("track_not_found");
+    });
+  });
+
+  it("propagates unexpected repository errors", async () => {
+    trackRepository.findOne.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("db failure");
+    expect(trackRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/retry-track-download.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/retry-track-download.use-case.test.ts
@@ -1,0 +1,127 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { Track } from "@/domain/entities/track.entity";
+import { RetryTrackDownloadUseCase } from "./retry-track-download.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): Track =>
+  new Track({
+    id: "track-1",
+    name: "Song A",
+    artist: "Artist A",
+    status: TrackStatusEnum.Error,
+    playlistId: "playlist-1",
+    youtubeUrl: "https://youtube.com/watch?v=abc",
+    spotifyUrl: undefined,
+    trackUrl: undefined,
+    searchAttempts: 1,
+    error: "some_error",
+    ...overrides,
+  });
+
+describe("RetryTrackDownloadUseCase", () => {
+  const trackRepository = {
+    findOneWithPlaylist: vi.fn(),
+    update: vi.fn(),
+  };
+
+  const queueService = {
+    enqueueSearchTrack: vi.fn(),
+  };
+
+  let useCase: RetryTrackDownloadUseCase;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    trackRepository.update.mockResolvedValue(undefined);
+    queueService.enqueueSearchTrack.mockResolvedValue(undefined);
+    useCase = new RetryTrackDownloadUseCase(trackRepository as never, queueService as never);
+  });
+
+  describe("when the track exists", () => {
+    it("marks the track as new, updates the repository, and enqueues for search", async () => {
+      const track = makeTrack();
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      expect(trackRepository.findOneWithPlaylist).toHaveBeenCalledWith("track-1");
+      expect(trackRepository.update).toHaveBeenCalledWith("track-1", track);
+      expect(queueService.enqueueSearchTrack).toHaveBeenCalledWith(track.toPrimitive());
+    });
+
+    it("resets the track status to New via markAsNew before persisting", async () => {
+      const track = makeTrack({ status: TrackStatusEnum.Error, error: "some_error" });
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const updatedArg = trackRepository.update.mock.calls[0][1] as Track;
+      expect(updatedArg.status).toBe(TrackStatusEnum.New);
+    });
+
+    it("clears the error field on the track after markAsNew", async () => {
+      const track = makeTrack({ error: "previous_error" });
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const primitive = queueService.enqueueSearchTrack.mock.calls[0][0] as ITrack;
+      expect(primitive.error).toBeUndefined();
+    });
+
+    it("enqueues the primitive representation of the mutated track", async () => {
+      const track = makeTrack();
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const enqueueArg = queueService.enqueueSearchTrack.mock.calls[0][0];
+      expect(enqueueArg).toEqual(track.toPrimitive());
+    });
+  });
+
+  describe("when the track does not exist", () => {
+    it("throws AppError 404 with errorCode track_not_found", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(null);
+
+      const error = await useCase.execute("missing-id").catch((e) => e);
+
+      expect(error).toBeInstanceOf(AppError);
+      expect(error.statusCode).toBe(404);
+      expect(error.errorCode).toBe("track_not_found");
+    });
+
+    it("does not call update or enqueue when the track is missing", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow();
+      expect(trackRepository.update).not.toHaveBeenCalled();
+      expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  it("propagates repository findOneWithPlaylist errors", async () => {
+    trackRepository.findOneWithPlaylist.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("db failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository update errors", async () => {
+    const track = makeTrack();
+    trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+    trackRepository.update.mockRejectedValue(new Error("update failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("update failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue service errors", async () => {
+    const track = makeTrack();
+    trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+    queueService.enqueueSearchTrack.mockRejectedValue(new Error("queue failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("queue failure");
+  });
+});

--- a/apps/backend/src/application/utils/error.utils.test.ts
+++ b/apps/backend/src/application/utils/error.utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage, isError } from "./error.utils";
+
+describe("isError", () => {
+  it("returns true for an Error instance", () => {
+    expect(isError(new Error("oops"))).toBe(true);
+  });
+
+  it("returns true for a subclass of Error", () => {
+    expect(isError(new TypeError("type"))).toBe(true);
+    expect(isError(new RangeError("range"))).toBe(true);
+  });
+
+  it("returns false for a plain string", () => {
+    expect(isError("something went wrong")).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isError(42)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isError(undefined)).toBe(false);
+  });
+
+  it("returns false for a plain object without prototype chain to Error", () => {
+    expect(isError({ message: "not an error" })).toBe(false);
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("returns the message from an Error instance", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns the message from an Error subclass", () => {
+    expect(getErrorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  it("returns the string directly when the error is a string", () => {
+    expect(getErrorMessage("network failure")).toBe("network failure");
+  });
+
+  it("returns the message property from an object that has one", () => {
+    expect(getErrorMessage({ message: "custom object error" })).toBe("custom object error");
+  });
+
+  it("coerces a non-string message property to string", () => {
+    expect(getErrorMessage({ message: 404 })).toBe("404");
+  });
+
+  it("returns 'Unknown error' for null", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for a number", () => {
+    expect(getErrorMessage(42)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for a plain object without a message property", () => {
+    expect(getErrorMessage({ code: 500 })).toBe("Unknown error");
+  });
+});

--- a/apps/backend/src/domain/entities/ai-chat-message.entity.test.ts
+++ b/apps/backend/src/domain/entities/ai-chat-message.entity.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { AiChatMessage, type AiChatMessageProps } from "./ai-chat-message.entity";
+
+function makeProps(overrides: Partial<AiChatMessageProps> = {}): AiChatMessageProps {
+  return {
+    id: "msg-1",
+    role: "user",
+    content: { key: "hello" },
+    playlistId: null,
+    errorCode: null,
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("AiChatMessage constructor", () => {
+  it("maps all props correctly", () => {
+    const props = makeProps({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "response", params: { name: "Alice" } },
+      playlistId: "playlist-1",
+      errorCode: "internal_server_error",
+      createdAt: 1234567890,
+    });
+    const msg = new AiChatMessage(props);
+
+    expect(msg.id).toBe("msg-42");
+    expect(msg.role).toBe("assistant");
+    expect(msg.content).toEqual({ key: "response", params: { name: "Alice" } });
+    expect(msg.playlistId).toBe("playlist-1");
+    expect(msg.errorCode).toBe("internal_server_error");
+    expect(msg.createdAt).toBe(1234567890);
+  });
+
+  it("stores null for playlistId and errorCode when not provided", () => {
+    const msg = new AiChatMessage(makeProps({ playlistId: null, errorCode: null }));
+
+    expect(msg.playlistId).toBeNull();
+    expect(msg.errorCode).toBeNull();
+  });
+
+  it("accepts role 'user'", () => {
+    const msg = new AiChatMessage(makeProps({ role: "user" }));
+    expect(msg.role).toBe("user");
+  });
+
+  it("accepts role 'assistant'", () => {
+    const msg = new AiChatMessage(makeProps({ role: "assistant" }));
+    expect(msg.role).toBe("assistant");
+  });
+
+  it("stores content without params", () => {
+    const msg = new AiChatMessage(makeProps({ content: { key: "simple" } }));
+    expect(msg.content).toEqual({ key: "simple" });
+    expect(msg.content.params).toBeUndefined();
+  });
+
+  it("stores content with params", () => {
+    const msg = new AiChatMessage(
+      makeProps({ content: { key: "greeting", params: { user: "Bob", count: 3 } } }),
+    );
+    expect(msg.content.key).toBe("greeting");
+    expect(msg.content.params).toEqual({ user: "Bob", count: 3 });
+  });
+});

--- a/apps/backend/src/domain/entities/playlist.entity.test.ts
+++ b/apps/backend/src/domain/entities/playlist.entity.test.ts
@@ -1,0 +1,168 @@
+import {
+  PlaylistStatusEnum,
+  PlaylistTypeEnum,
+  TrackStatusEnum,
+  type IPlaylist,
+  type ITrack,
+} from "@spotiarr/shared";
+import { describe, expect, it } from "vitest";
+import { Playlist } from "./playlist.entity";
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Track Name",
+    artist: "Artist",
+    status: TrackStatusEnum.New,
+    ...overrides,
+  };
+}
+
+function makePlaylist(overrides: Partial<IPlaylist> = {}): IPlaylist {
+  return {
+    id: "playlist-1",
+    name: "My Playlist",
+    type: PlaylistTypeEnum.Playlist,
+    spotifyUrl: "https://open.spotify.com/playlist/abc123",
+    subscribed: false,
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("Playlist getters", () => {
+  it("returns all values from props", () => {
+    const props = makePlaylist({
+      id: "pl-42",
+      name: "Test Playlist",
+      type: PlaylistTypeEnum.Album,
+      spotifyUrl: "https://open.spotify.com/album/abc",
+      error: undefined,
+      subscribed: true,
+      coverUrl: "https://cover.url",
+      artistImageUrl: "https://artist.url",
+      owner: "user-1",
+      ownerUrl: "https://open.spotify.com/user/user-1",
+      createdAt: 9999,
+    });
+    const playlist = new Playlist(props);
+
+    expect(playlist.id).toBe("pl-42");
+    expect(playlist.name).toBe("Test Playlist");
+    expect(playlist.type).toBe(PlaylistTypeEnum.Album);
+    expect(playlist.spotifyUrl).toBe("https://open.spotify.com/album/abc");
+    expect(playlist.error).toBeUndefined();
+    expect(playlist.subscribed).toBe(true);
+    expect(playlist.coverUrl).toBe("https://cover.url");
+    expect(playlist.artistImageUrl).toBe("https://artist.url");
+    expect(playlist.owner).toBe("user-1");
+    expect(playlist.ownerUrl).toBe("https://open.spotify.com/user/user-1");
+    expect(playlist.createdAt).toBe(9999);
+  });
+});
+
+describe("Playlist.updateDetails", () => {
+  it("mutates name, type, coverUrl, artistImageUrl, owner, ownerUrl", () => {
+    const playlist = new Playlist(makePlaylist());
+    playlist.updateDetails(
+      "New Name",
+      PlaylistTypeEnum.Artist,
+      "https://new-cover.url",
+      "https://new-artist.url",
+      "owner-2",
+      "https://open.spotify.com/user/owner-2",
+    );
+
+    expect(playlist.name).toBe("New Name");
+    expect(playlist.type).toBe(PlaylistTypeEnum.Artist);
+    expect(playlist.coverUrl).toBe("https://new-cover.url");
+    expect(playlist.artistImageUrl).toBe("https://new-artist.url");
+    expect(playlist.owner).toBe("owner-2");
+    expect(playlist.ownerUrl).toBe("https://open.spotify.com/user/owner-2");
+  });
+
+  it("clears the error field after update", () => {
+    const playlist = new Playlist(makePlaylist({ error: "some error" }));
+    playlist.updateDetails("Updated", PlaylistTypeEnum.Playlist);
+    expect(playlist.error).toBeUndefined();
+  });
+});
+
+describe("Playlist.markAsSubscribed / markAsUnsubscribed", () => {
+  it("markAsSubscribed sets subscribed to true", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: false }));
+    playlist.markAsSubscribed();
+    expect(playlist.subscribed).toBe(true);
+  });
+
+  it("markAsUnsubscribed sets subscribed to false", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: true }));
+    playlist.markAsUnsubscribed();
+    expect(playlist.subscribed).toBe(false);
+  });
+});
+
+describe("Playlist.markAsError", () => {
+  it("sets the error field", () => {
+    const playlist = new Playlist(makePlaylist());
+    playlist.markAsError("sync failed");
+    expect(playlist.error).toBe("sync failed");
+  });
+});
+
+describe("Playlist.toPrimitive", () => {
+  it("returns a shallow copy of props", () => {
+    const props = makePlaylist({ name: "Original" });
+    const playlist = new Playlist(props);
+    const result = playlist.toPrimitive();
+
+    expect(result).toEqual(props);
+    expect(result).not.toBe(props);
+  });
+});
+
+describe("Playlist.calculateStatus", () => {
+  it("returns Error when error is set", () => {
+    const playlist = new Playlist(makePlaylist({ error: "sync failed" }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Error);
+  });
+
+  it("returns Completed when all tracks are Completed", () => {
+    const tracks = [
+      makeTrack({ status: TrackStatusEnum.Completed }),
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Completed }),
+    ];
+    const playlist = new Playlist(makePlaylist({ tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Completed);
+  });
+
+  it("returns Warning when any track has Error status (but not all completed)", () => {
+    const tracks = [
+      makeTrack({ status: TrackStatusEnum.Completed }),
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Error }),
+    ];
+    const playlist = new Playlist(makePlaylist({ tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Warning);
+  });
+
+  it("returns Subscribed when subscribed is true and no tracks have Error", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: true, tracks: [] }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Subscribed);
+  });
+
+  it("returns InProgress when not subscribed and no special conditions", () => {
+    const tracks = [makeTrack({ status: TrackStatusEnum.Downloading })];
+    const playlist = new Playlist(makePlaylist({ subscribed: false, tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+
+  it("returns InProgress when tracks is undefined and not subscribed", () => {
+    const playlist = new Playlist(makePlaylist({ tracks: undefined, subscribed: false }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+
+  it("returns InProgress when tracks is empty and not subscribed", () => {
+    const playlist = new Playlist(makePlaylist({ tracks: [], subscribed: false }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+});

--- a/apps/backend/src/domain/errors/app-error.test.ts
+++ b/apps/backend/src/domain/errors/app-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "./app-error";
+
+describe("AppError", () => {
+  it("is an instance of Error", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("is an instance of AppError", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("assigns statusCode correctly", () => {
+    const err = new AppError(404, "invalid_spotify_url");
+    expect(err.statusCode).toBe(404);
+  });
+
+  it("assigns errorCode correctly", () => {
+    const err = new AppError(400, "internal_server_error");
+    expect(err.errorCode).toBe("internal_server_error");
+  });
+
+  it("defaults message to errorCode when no message is provided", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err.message).toBe("invalid_spotify_url");
+  });
+
+  it("uses the provided message when given", () => {
+    const err = new AppError(400, "invalid_spotify_url", "Custom error message");
+    expect(err.message).toBe("Custom error message");
+  });
+
+  it("defaults isOperational to true", () => {
+    const err = new AppError(500, "internal_server_error");
+    expect(err.isOperational).toBe(true);
+  });
+
+  it("allows isOperational to be set to false", () => {
+    const err = new AppError(500, "internal_server_error", "Fatal error", false);
+    expect(err.isOperational).toBe(false);
+  });
+
+  it("has the standard Error name", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err.name).toBe("Error");
+  });
+});

--- a/apps/backend/src/domain/helpers/deezer-image.helper.test.ts
+++ b/apps/backend/src/domain/helpers/deezer-image.helper.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { upscaleDeezerImage } from "./deezer-image.helper";
+
+describe("upscaleDeezerImage", () => {
+  it("returns null for null", () => {
+    expect(upscaleDeezerImage(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(upscaleDeezerImage(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(upscaleDeezerImage("")).toBeNull();
+  });
+
+  it("replaces a plain size segment like /250x250.jpg with /1000x1000.jpg", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/abc123/250x250.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/abc123/1000x1000.jpg",
+    );
+  });
+
+  it("replaces a size segment with modifier like /250x250-000000.jpg with /1000x1000-000000.jpg", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/abc123/250x250-000000.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/abc123/1000x1000-000000.jpg",
+    );
+  });
+
+  it("returns the original string when no size pattern matches", () => {
+    const url = "https://example.com/image.png";
+    expect(upscaleDeezerImage(url)).toBe("https://example.com/image.png");
+  });
+
+  it("handles a full realistic Deezer URL", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/deadbeef1234/500x500.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/deadbeef1234/1000x1000.jpg",
+    );
+  });
+});

--- a/apps/backend/src/domain/helpers/spotify-url.helper.test.ts
+++ b/apps/backend/src/domain/helpers/spotify-url.helper.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { SpotifyUrlHelper, SpotifyUrlType } from "./spotify-url.helper";
+
+const PLAYLIST_URL = "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M";
+const TRACK_URL = "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC";
+const ALBUM_URL = "https://open.spotify.com/album/6dVIqQ8qmQ5GBnJ9shOYGE";
+const ARTIST_URL = "https://open.spotify.com/artist/06HL4z0CvFAxyc27GXpf02";
+
+describe("SpotifyUrlHelper.getUrlType", () => {
+  it("returns Playlist for a playlist URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(PLAYLIST_URL)).toBe(SpotifyUrlType.Playlist);
+  });
+
+  it("returns Track for a track URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(TRACK_URL)).toBe(SpotifyUrlType.Track);
+  });
+
+  it("returns Album for an album URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(ALBUM_URL)).toBe(SpotifyUrlType.Album);
+  });
+
+  it("returns Artist for an artist URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(ARTIST_URL)).toBe(SpotifyUrlType.Artist);
+  });
+
+  it("throws AppError for empty string", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("")).toThrow(AppError);
+  });
+
+  it("throws AppError for a non-Spotify URL", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("https://youtube.com/watch?v=abc")).toThrow(AppError);
+  });
+
+  it("throws AppError for a Spotify URL with no recognized path segment", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("https://open.spotify.com/user/abc")).toThrow(
+      AppError,
+    );
+  });
+});
+
+describe("SpotifyUrlHelper.isSpotifyUrl", () => {
+  it("returns true for open.spotify.com", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://open.spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns true for spotify.com", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns true for spoti.fi", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://spoti.fi/3abc123")).toBe(true);
+  });
+
+  it("returns false for a non-Spotify URL", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://youtube.com/watch?v=abc")).toBe(false);
+  });
+
+  it("returns false for an invalid URL string", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("SpotifyUrlHelper.isPlaylist / isAlbum / isTrack", () => {
+  it("isPlaylist returns true for a playlist URL", () => {
+    expect(SpotifyUrlHelper.isPlaylist(PLAYLIST_URL)).toBe(true);
+  });
+
+  it("isPlaylist returns false for a track URL", () => {
+    expect(SpotifyUrlHelper.isPlaylist(TRACK_URL)).toBe(false);
+  });
+
+  it("isAlbum returns true for an album URL", () => {
+    expect(SpotifyUrlHelper.isAlbum(ALBUM_URL)).toBe(true);
+  });
+
+  it("isAlbum returns false for a playlist URL", () => {
+    expect(SpotifyUrlHelper.isAlbum(PLAYLIST_URL)).toBe(false);
+  });
+
+  it("isTrack returns true for a track URL", () => {
+    expect(SpotifyUrlHelper.isTrack(TRACK_URL)).toBe(true);
+  });
+
+  it("isTrack returns false for an album URL", () => {
+    expect(SpotifyUrlHelper.isTrack(ALBUM_URL)).toBe(false);
+  });
+});
+
+describe("SpotifyUrlHelper.extractId", () => {
+  it("extracts the ID from a playlist URL", () => {
+    expect(SpotifyUrlHelper.extractId(PLAYLIST_URL)).toBe("37i9dQZF1DXcBWIGoYBM5M");
+  });
+
+  it("extracts the ID from a track URL", () => {
+    expect(SpotifyUrlHelper.extractId(TRACK_URL)).toBe("4uLU6hMCjMI75M1A2tKUQC");
+  });
+
+  it("extracts the ID from an album URL", () => {
+    expect(SpotifyUrlHelper.extractId(ALBUM_URL)).toBe("6dVIqQ8qmQ5GBnJ9shOYGE");
+  });
+
+  it("extracts the ID from an artist URL", () => {
+    expect(SpotifyUrlHelper.extractId(ARTIST_URL)).toBe("06HL4z0CvFAxyc27GXpf02");
+  });
+
+  it("throws AppError when no ID pattern found", () => {
+    expect(() => SpotifyUrlHelper.extractId("https://open.spotify.com/")).toThrow(AppError);
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **domain logic** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (domain logic slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean, `lint` green (0 errors) verified on the full integrated set before slicing

Refs #204