### PR TITLE
test(backend): add unit tests for domain entities, errors and helpers

### DIFF
--- a/apps/backend/src/domain/entities/ai-chat-message.entity.test.ts
+++ b/apps/backend/src/domain/entities/ai-chat-message.entity.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { AiChatMessage, type AiChatMessageProps } from "./ai-chat-message.entity";
+
+function makeProps(overrides: Partial<AiChatMessageProps> = {}): AiChatMessageProps {
+  return {
+    id: "msg-1",
+    role: "user",
+    content: { key: "hello" },
+    playlistId: null,
+    errorCode: null,
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("AiChatMessage constructor", () => {
+  it("maps all props correctly", () => {
+    const props = makeProps({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "response", params: { name: "Alice" } },
+      playlistId: "playlist-1",
+      errorCode: "internal_server_error",
+      createdAt: 1234567890,
+    });
+    const msg = new AiChatMessage(props);
+
+    expect(msg.id).toBe("msg-42");
+    expect(msg.role).toBe("assistant");
+    expect(msg.content).toEqual({ key: "response", params: { name: "Alice" } });
+    expect(msg.playlistId).toBe("playlist-1");
+    expect(msg.errorCode).toBe("internal_server_error");
+    expect(msg.createdAt).toBe(1234567890);
+  });
+
+  it("stores null for playlistId and errorCode when not provided", () => {
+    const msg = new AiChatMessage(makeProps({ playlistId: null, errorCode: null }));
+
+    expect(msg.playlistId).toBeNull();
+    expect(msg.errorCode).toBeNull();
+  });
+
+  it("accepts role 'user'", () => {
+    const msg = new AiChatMessage(makeProps({ role: "user" }));
+    expect(msg.role).toBe("user");
+  });
+
+  it("accepts role 'assistant'", () => {
+    const msg = new AiChatMessage(makeProps({ role: "assistant" }));
+    expect(msg.role).toBe("assistant");
+  });
+
+  it("stores content without params", () => {
+    const msg = new AiChatMessage(makeProps({ content: { key: "simple" } }));
+    expect(msg.content).toEqual({ key: "simple" });
+    expect(msg.content.params).toBeUndefined();
+  });
+
+  it("stores content with params", () => {
+    const msg = new AiChatMessage(
+      makeProps({ content: { key: "greeting", params: { user: "Bob", count: 3 } } }),
+    );
+    expect(msg.content.key).toBe("greeting");
+    expect(msg.content.params).toEqual({ user: "Bob", count: 3 });
+  });
+});

--- a/apps/backend/src/domain/entities/playlist.entity.test.ts
+++ b/apps/backend/src/domain/entities/playlist.entity.test.ts
@@ -1,0 +1,168 @@
+import {
+  PlaylistStatusEnum,
+  PlaylistTypeEnum,
+  TrackStatusEnum,
+  type IPlaylist,
+  type ITrack,
+} from "@spotiarr/shared";
+import { describe, expect, it } from "vitest";
+import { Playlist } from "./playlist.entity";
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Track Name",
+    artist: "Artist",
+    status: TrackStatusEnum.New,
+    ...overrides,
+  };
+}
+
+function makePlaylist(overrides: Partial<IPlaylist> = {}): IPlaylist {
+  return {
+    id: "playlist-1",
+    name: "My Playlist",
+    type: PlaylistTypeEnum.Playlist,
+    spotifyUrl: "https://open.spotify.com/playlist/abc123",
+    subscribed: false,
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("Playlist getters", () => {
+  it("returns all values from props", () => {
+    const props = makePlaylist({
+      id: "pl-42",
+      name: "Test Playlist",
+      type: PlaylistTypeEnum.Album,
+      spotifyUrl: "https://open.spotify.com/album/abc",
+      error: undefined,
+      subscribed: true,
+      coverUrl: "https://cover.url",
+      artistImageUrl: "https://artist.url",
+      owner: "user-1",
+      ownerUrl: "https://open.spotify.com/user/user-1",
+      createdAt: 9999,
+    });
+    const playlist = new Playlist(props);
+
+    expect(playlist.id).toBe("pl-42");
+    expect(playlist.name).toBe("Test Playlist");
+    expect(playlist.type).toBe(PlaylistTypeEnum.Album);
+    expect(playlist.spotifyUrl).toBe("https://open.spotify.com/album/abc");
+    expect(playlist.error).toBeUndefined();
+    expect(playlist.subscribed).toBe(true);
+    expect(playlist.coverUrl).toBe("https://cover.url");
+    expect(playlist.artistImageUrl).toBe("https://artist.url");
+    expect(playlist.owner).toBe("user-1");
+    expect(playlist.ownerUrl).toBe("https://open.spotify.com/user/user-1");
+    expect(playlist.createdAt).toBe(9999);
+  });
+});
+
+describe("Playlist.updateDetails", () => {
+  it("mutates name, type, coverUrl, artistImageUrl, owner, ownerUrl", () => {
+    const playlist = new Playlist(makePlaylist());
+    playlist.updateDetails(
+      "New Name",
+      PlaylistTypeEnum.Artist,
+      "https://new-cover.url",
+      "https://new-artist.url",
+      "owner-2",
+      "https://open.spotify.com/user/owner-2",
+    );
+
+    expect(playlist.name).toBe("New Name");
+    expect(playlist.type).toBe(PlaylistTypeEnum.Artist);
+    expect(playlist.coverUrl).toBe("https://new-cover.url");
+    expect(playlist.artistImageUrl).toBe("https://new-artist.url");
+    expect(playlist.owner).toBe("owner-2");
+    expect(playlist.ownerUrl).toBe("https://open.spotify.com/user/owner-2");
+  });
+
+  it("clears the error field after update", () => {
+    const playlist = new Playlist(makePlaylist({ error: "some error" }));
+    playlist.updateDetails("Updated", PlaylistTypeEnum.Playlist);
+    expect(playlist.error).toBeUndefined();
+  });
+});
+
+describe("Playlist.markAsSubscribed / markAsUnsubscribed", () => {
+  it("markAsSubscribed sets subscribed to true", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: false }));
+    playlist.markAsSubscribed();
+    expect(playlist.subscribed).toBe(true);
+  });
+
+  it("markAsUnsubscribed sets subscribed to false", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: true }));
+    playlist.markAsUnsubscribed();
+    expect(playlist.subscribed).toBe(false);
+  });
+});
+
+describe("Playlist.markAsError", () => {
+  it("sets the error field", () => {
+    const playlist = new Playlist(makePlaylist());
+    playlist.markAsError("sync failed");
+    expect(playlist.error).toBe("sync failed");
+  });
+});
+
+describe("Playlist.toPrimitive", () => {
+  it("returns a shallow copy of props", () => {
+    const props = makePlaylist({ name: "Original" });
+    const playlist = new Playlist(props);
+    const result = playlist.toPrimitive();
+
+    expect(result).toEqual(props);
+    expect(result).not.toBe(props);
+  });
+});
+
+describe("Playlist.calculateStatus", () => {
+  it("returns Error when error is set", () => {
+    const playlist = new Playlist(makePlaylist({ error: "sync failed" }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Error);
+  });
+
+  it("returns Completed when all tracks are Completed", () => {
+    const tracks = [
+      makeTrack({ status: TrackStatusEnum.Completed }),
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Completed }),
+    ];
+    const playlist = new Playlist(makePlaylist({ tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Completed);
+  });
+
+  it("returns Warning when any track has Error status (but not all completed)", () => {
+    const tracks = [
+      makeTrack({ status: TrackStatusEnum.Completed }),
+      makeTrack({ id: "track-2", status: TrackStatusEnum.Error }),
+    ];
+    const playlist = new Playlist(makePlaylist({ tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Warning);
+  });
+
+  it("returns Subscribed when subscribed is true and no tracks have Error", () => {
+    const playlist = new Playlist(makePlaylist({ subscribed: true, tracks: [] }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.Subscribed);
+  });
+
+  it("returns InProgress when not subscribed and no special conditions", () => {
+    const tracks = [makeTrack({ status: TrackStatusEnum.Downloading })];
+    const playlist = new Playlist(makePlaylist({ subscribed: false, tracks }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+
+  it("returns InProgress when tracks is undefined and not subscribed", () => {
+    const playlist = new Playlist(makePlaylist({ tracks: undefined, subscribed: false }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+
+  it("returns InProgress when tracks is empty and not subscribed", () => {
+    const playlist = new Playlist(makePlaylist({ tracks: [], subscribed: false }));
+    expect(playlist.calculateStatus()).toBe(PlaylistStatusEnum.InProgress);
+  });
+});

--- a/apps/backend/src/domain/errors/app-error.test.ts
+++ b/apps/backend/src/domain/errors/app-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "./app-error";
+
+describe("AppError", () => {
+  it("is an instance of Error", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("is an instance of AppError", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err).toBeInstanceOf(AppError);
+  });
+
+  it("assigns statusCode correctly", () => {
+    const err = new AppError(404, "invalid_spotify_url");
+    expect(err.statusCode).toBe(404);
+  });
+
+  it("assigns errorCode correctly", () => {
+    const err = new AppError(400, "internal_server_error");
+    expect(err.errorCode).toBe("internal_server_error");
+  });
+
+  it("defaults message to errorCode when no message is provided", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err.message).toBe("invalid_spotify_url");
+  });
+
+  it("uses the provided message when given", () => {
+    const err = new AppError(400, "invalid_spotify_url", "Custom error message");
+    expect(err.message).toBe("Custom error message");
+  });
+
+  it("defaults isOperational to true", () => {
+    const err = new AppError(500, "internal_server_error");
+    expect(err.isOperational).toBe(true);
+  });
+
+  it("allows isOperational to be set to false", () => {
+    const err = new AppError(500, "internal_server_error", "Fatal error", false);
+    expect(err.isOperational).toBe(false);
+  });
+
+  it("has the standard Error name", () => {
+    const err = new AppError(400, "invalid_spotify_url");
+    expect(err.name).toBe("Error");
+  });
+});

--- a/apps/backend/src/domain/helpers/deezer-image.helper.test.ts
+++ b/apps/backend/src/domain/helpers/deezer-image.helper.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { upscaleDeezerImage } from "./deezer-image.helper";
+
+describe("upscaleDeezerImage", () => {
+  it("returns null for null", () => {
+    expect(upscaleDeezerImage(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(upscaleDeezerImage(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(upscaleDeezerImage("")).toBeNull();
+  });
+
+  it("replaces a plain size segment like /250x250.jpg with /1000x1000.jpg", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/abc123/250x250.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/abc123/1000x1000.jpg",
+    );
+  });
+
+  it("replaces a size segment with modifier like /250x250-000000.jpg with /1000x1000-000000.jpg", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/abc123/250x250-000000.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/abc123/1000x1000-000000.jpg",
+    );
+  });
+
+  it("returns the original string when no size pattern matches", () => {
+    const url = "https://example.com/image.png";
+    expect(upscaleDeezerImage(url)).toBe("https://example.com/image.png");
+  });
+
+  it("handles a full realistic Deezer URL", () => {
+    const url = "https://e-cdns-images.dzcdn.net/images/cover/deadbeef1234/500x500.jpg";
+    expect(upscaleDeezerImage(url)).toBe(
+      "https://e-cdns-images.dzcdn.net/images/cover/deadbeef1234/1000x1000.jpg",
+    );
+  });
+});

--- a/apps/backend/src/domain/helpers/spotify-url.helper.test.ts
+++ b/apps/backend/src/domain/helpers/spotify-url.helper.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { SpotifyUrlHelper, SpotifyUrlType } from "./spotify-url.helper";
+
+const PLAYLIST_URL = "https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M";
+const TRACK_URL = "https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC";
+const ALBUM_URL = "https://open.spotify.com/album/6dVIqQ8qmQ5GBnJ9shOYGE";
+const ARTIST_URL = "https://open.spotify.com/artist/06HL4z0CvFAxyc27GXpf02";
+
+describe("SpotifyUrlHelper.getUrlType", () => {
+  it("returns Playlist for a playlist URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(PLAYLIST_URL)).toBe(SpotifyUrlType.Playlist);
+  });
+
+  it("returns Track for a track URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(TRACK_URL)).toBe(SpotifyUrlType.Track);
+  });
+
+  it("returns Album for an album URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(ALBUM_URL)).toBe(SpotifyUrlType.Album);
+  });
+
+  it("returns Artist for an artist URL", () => {
+    expect(SpotifyUrlHelper.getUrlType(ARTIST_URL)).toBe(SpotifyUrlType.Artist);
+  });
+
+  it("throws AppError for empty string", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("")).toThrow(AppError);
+  });
+
+  it("throws AppError for a non-Spotify URL", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("https://youtube.com/watch?v=abc")).toThrow(AppError);
+  });
+
+  it("throws AppError for a Spotify URL with no recognized path segment", () => {
+    expect(() => SpotifyUrlHelper.getUrlType("https://open.spotify.com/user/abc")).toThrow(
+      AppError,
+    );
+  });
+});
+
+describe("SpotifyUrlHelper.isSpotifyUrl", () => {
+  it("returns true for open.spotify.com", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://open.spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns true for spotify.com", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://spotify.com/playlist/abc")).toBe(true);
+  });
+
+  it("returns true for spoti.fi", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://spoti.fi/3abc123")).toBe(true);
+  });
+
+  it("returns false for a non-Spotify URL", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("https://youtube.com/watch?v=abc")).toBe(false);
+  });
+
+  it("returns false for an invalid URL string", () => {
+    expect(SpotifyUrlHelper.isSpotifyUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("SpotifyUrlHelper.isPlaylist / isAlbum / isTrack", () => {
+  it("isPlaylist returns true for a playlist URL", () => {
+    expect(SpotifyUrlHelper.isPlaylist(PLAYLIST_URL)).toBe(true);
+  });
+
+  it("isPlaylist returns false for a track URL", () => {
+    expect(SpotifyUrlHelper.isPlaylist(TRACK_URL)).toBe(false);
+  });
+
+  it("isAlbum returns true for an album URL", () => {
+    expect(SpotifyUrlHelper.isAlbum(ALBUM_URL)).toBe(true);
+  });
+
+  it("isAlbum returns false for a playlist URL", () => {
+    expect(SpotifyUrlHelper.isAlbum(PLAYLIST_URL)).toBe(false);
+  });
+
+  it("isTrack returns true for a track URL", () => {
+    expect(SpotifyUrlHelper.isTrack(TRACK_URL)).toBe(true);
+  });
+
+  it("isTrack returns false for an album URL", () => {
+    expect(SpotifyUrlHelper.isTrack(ALBUM_URL)).toBe(false);
+  });
+});
+
+describe("SpotifyUrlHelper.extractId", () => {
+  it("extracts the ID from a playlist URL", () => {
+    expect(SpotifyUrlHelper.extractId(PLAYLIST_URL)).toBe("37i9dQZF1DXcBWIGoYBM5M");
+  });
+
+  it("extracts the ID from a track URL", () => {
+    expect(SpotifyUrlHelper.extractId(TRACK_URL)).toBe("4uLU6hMCjMI75M1A2tKUQC");
+  });
+
+  it("extracts the ID from an album URL", () => {
+    expect(SpotifyUrlHelper.extractId(ALBUM_URL)).toBe("6dVIqQ8qmQ5GBnJ9shOYGE");
+  });
+
+  it("extracts the ID from an artist URL", () => {
+    expect(SpotifyUrlHelper.extractId(ARTIST_URL)).toBe("06HL4z0CvFAxyc27GXpf02");
+  });
+
+  it("throws AppError when no ID pattern found", () => {
+    expect(() => SpotifyUrlHelper.extractId("https://open.spotify.com/")).toThrow(AppError);
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **domain logic** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (domain logic slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204