### PR TITLE
test(backend): add unit tests for tracks and ai use-cases

### DIFF
--- a/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/append-chat-message.use-case.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import {
+  AppendChatMessageUseCase,
+  type AppendChatMessageInput,
+} from "./append-chat-message.use-case";
+
+describe("AppendChatMessageUseCase", () => {
+  const repository = {
+    append: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: AppendChatMessageUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new AppendChatMessageUseCase(repository as never);
+  });
+
+  describe("success path", () => {
+    it("creates an AiChatMessage and appends it to the repository", async () => {
+      const input: AppendChatMessageInput = {
+        role: "user",
+        contentKey: "chat.greet",
+        contentParams: { name: "Alice" },
+        playlistId: "playlist-99",
+        errorCode: null,
+      };
+
+      await useCase.execute(input);
+
+      expect(repository.append).toHaveBeenCalledOnce();
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended).toBeInstanceOf(AiChatMessage);
+      expect(appended.role).toBe("user");
+      expect(appended.content.key).toBe("chat.greet");
+      expect(appended.content.params).toEqual({ name: "Alice" });
+      expect(appended.playlistId).toBe("playlist-99");
+      expect(appended.errorCode).toBeNull();
+    });
+
+    it("assigns a non-empty uuid as the message id", async () => {
+      const input: AppendChatMessageInput = {
+        role: "assistant",
+        contentKey: "chat.response",
+      };
+
+      await useCase.execute(input);
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(typeof appended.id).toBe("string");
+      expect(appended.id.length).toBeGreaterThan(0);
+    });
+
+    it("sets createdAt to a recent epoch millisecond timestamp", async () => {
+      const before = Date.now();
+      const input: AppendChatMessageInput = {
+        role: "user",
+        contentKey: "chat.ping",
+      };
+
+      await useCase.execute(input);
+
+      const after = Date.now();
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.createdAt).toBeGreaterThanOrEqual(before);
+      expect(appended.createdAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("optional fields default handling", () => {
+    it("defaults playlistId to null when not provided", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.hello" });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.playlistId).toBeNull();
+    });
+
+    it("defaults errorCode to null when not provided", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.hello" });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.errorCode).toBeNull();
+    });
+
+    it("coerces undefined playlistId to null", async () => {
+      await useCase.execute({ role: "assistant", contentKey: "chat.reply", playlistId: undefined });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.playlistId).toBeNull();
+    });
+
+    it("coerces undefined errorCode to null", async () => {
+      await useCase.execute({ role: "user", contentKey: "chat.err", errorCode: undefined });
+
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.errorCode).toBeNull();
+    });
+  });
+
+  describe("role variants", () => {
+    it("persists role=user correctly", async () => {
+      await useCase.execute({ role: "user", contentKey: "k" });
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.role).toBe("user");
+    });
+
+    it("persists role=assistant correctly", async () => {
+      await useCase.execute({ role: "assistant", contentKey: "k" });
+      const appended = repository.append.mock.calls[0][0] as AiChatMessage;
+      expect(appended.role).toBe("assistant");
+    });
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.append.mockRejectedValue(new Error("storage failure"));
+
+    await expect(useCase.execute({ role: "user", contentKey: "chat.ping" })).rejects.toThrow(
+      "storage failure",
+    );
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/clear-chat-messages.use-case.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ClearChatMessagesUseCase } from "./clear-chat-messages.use-case";
+
+describe("ClearChatMessagesUseCase", () => {
+  const repository = {
+    clear: vi.fn(),
+  };
+
+  let useCase: ClearChatMessagesUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new ClearChatMessagesUseCase(repository as never);
+  });
+
+  it("delegates clearing to the repository and returns the deleted count", async () => {
+    repository.clear.mockResolvedValue(5);
+
+    const result = await useCase.execute();
+
+    expect(repository.clear).toHaveBeenCalledOnce();
+    expect(result).toEqual({ deleted: 5 });
+  });
+
+  it("returns { deleted: 0 } when no messages were stored", async () => {
+    repository.clear.mockResolvedValue(0);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ deleted: 0 });
+  });
+
+  it("returns the exact count reported by the repository", async () => {
+    repository.clear.mockResolvedValue(42);
+
+    const result = await useCase.execute();
+
+    expect(result.deleted).toBe(42);
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.clear.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute()).rejects.toThrow("db failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/ai/get-chat-messages.use-case.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AiChatMessage } from "@/domain/entities/ai-chat-message.entity";
+import { GetChatMessagesUseCase } from "./get-chat-messages.use-case";
+
+const makeMessage = (
+  overrides: Partial<ConstructorParameters<typeof AiChatMessage>[0]> = {},
+): AiChatMessage =>
+  new AiChatMessage({
+    id: "msg-1",
+    role: "user",
+    content: { key: "chat.hello", params: undefined },
+    playlistId: null,
+    errorCode: null,
+    createdAt: 1_000_000,
+    ...overrides,
+  });
+
+describe("GetChatMessagesUseCase", () => {
+  const repository = {
+    list: vi.fn(),
+  };
+
+  let useCase: GetChatMessagesUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new GetChatMessagesUseCase(repository as never);
+  });
+
+  it("returns an empty array when the repository has no messages", async () => {
+    repository.list.mockResolvedValue([]);
+
+    const result = await useCase.execute();
+
+    expect(result).toEqual([]);
+  });
+
+  it("maps each AiChatMessage entity to an AiChatMessageDto", async () => {
+    const entity = makeMessage({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "chat.response", params: { count: 3 } },
+      playlistId: "playlist-1",
+      errorCode: "some_error",
+      createdAt: 9_999_999,
+    });
+    repository.list.mockResolvedValue([entity]);
+
+    const result = await useCase.execute();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "msg-42",
+      role: "assistant",
+      content: { key: "chat.response", params: { count: 3 } },
+      playlistId: "playlist-1",
+      errorCode: "some_error",
+      createdAt: 9_999_999,
+    });
+  });
+
+  it("preserves order of messages returned by the repository", async () => {
+    const entities = [
+      makeMessage({ id: "msg-1", createdAt: 1000 }),
+      makeMessage({ id: "msg-2", createdAt: 2000 }),
+      makeMessage({ id: "msg-3", createdAt: 3000 }),
+    ];
+    repository.list.mockResolvedValue(entities);
+
+    const result = await useCase.execute();
+
+    expect(result.map((m) => m.id)).toEqual(["msg-1", "msg-2", "msg-3"]);
+  });
+
+  it("maps all entity fields to the DTO (id, role, content, playlistId, errorCode, createdAt)", async () => {
+    const entity = makeMessage({ id: "msg-99", role: "user" });
+    repository.list.mockResolvedValue([entity]);
+
+    const result = await useCase.execute();
+    const dto = result[0];
+
+    expect(dto).toHaveProperty("id");
+    expect(dto).toHaveProperty("role");
+    expect(dto).toHaveProperty("content");
+    expect(dto).toHaveProperty("playlistId");
+    expect(dto).toHaveProperty("errorCode");
+    expect(dto).toHaveProperty("createdAt");
+  });
+
+  it("maps multiple messages correctly", async () => {
+    const entities = [
+      makeMessage({ id: "a", role: "user" }),
+      makeMessage({ id: "b", role: "assistant" }),
+    ];
+    repository.list.mockResolvedValue(entities);
+
+    const result = await useCase.execute();
+
+    expect(result[0].id).toBe("a");
+    expect(result[0].role).toBe("user");
+    expect(result[1].id).toBe("b");
+    expect(result[1].role).toBe("assistant");
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    repository.list.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute()).rejects.toThrow("db failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/create-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/create-track.use-case.test.ts
@@ -1,0 +1,73 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { CreateTrackUseCase } from "./create-track.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "track-1",
+  name: "Song A",
+  artist: "Artist A",
+  status: TrackStatusEnum.New,
+  playlistId: "playlist-1",
+  youtubeUrl: undefined,
+  spotifyUrl: undefined,
+  trackUrl: undefined,
+  searchAttempts: 0,
+  ...overrides,
+});
+
+describe("CreateTrackUseCase", () => {
+  const trackRepository = {
+    save: vi.fn(),
+  };
+
+  const queueService = {
+    enqueueSearchTrack: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: CreateTrackUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new CreateTrackUseCase(trackRepository as never, queueService as never);
+  });
+
+  it("saves the track to the repository and enqueues it for search", async () => {
+    const input = makeTrack();
+    const savedTrack = new Track(input);
+    trackRepository.save.mockResolvedValue(savedTrack);
+
+    await useCase.execute(input);
+
+    expect(trackRepository.save).toHaveBeenCalledWith(input);
+    expect(queueService.enqueueSearchTrack).toHaveBeenCalledWith(savedTrack.toPrimitive());
+  });
+
+  it("passes the primitive representation of the saved track to the queue service", async () => {
+    const input = makeTrack({ id: "track-2", name: "Song B" });
+    const savedTrack = new Track(input);
+    trackRepository.save.mockResolvedValue(savedTrack);
+
+    await useCase.execute(input);
+
+    const enqueueArg = queueService.enqueueSearchTrack.mock.calls[0][0];
+    expect(enqueueArg).toEqual(savedTrack.toPrimitive());
+    expect(enqueueArg.id).toBe("track-2");
+    expect(enqueueArg.name).toBe("Song B");
+  });
+
+  it("propagates repository errors without swallowing them", async () => {
+    trackRepository.save.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute(makeTrack())).rejects.toThrow("db failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue service errors without swallowing them", async () => {
+    const savedTrack = new Track(makeTrack());
+    trackRepository.save.mockResolvedValue(savedTrack);
+    queueService.enqueueSearchTrack.mockRejectedValue(new Error("queue failure"));
+
+    await expect(useCase.execute(makeTrack())).rejects.toThrow("queue failure");
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/delete-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/delete-track.use-case.test.ts
@@ -1,0 +1,76 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { AppError } from "@/domain/errors/app-error";
+import { DeleteTrackUseCase } from "./delete-track.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): Track =>
+  new Track({
+    id: "track-1",
+    name: "Song A",
+    artist: "Artist A",
+    status: TrackStatusEnum.New,
+    playlistId: "playlist-1",
+    youtubeUrl: undefined,
+    spotifyUrl: undefined,
+    trackUrl: undefined,
+    searchAttempts: 0,
+    ...overrides,
+  });
+
+describe("DeleteTrackUseCase", () => {
+  const trackRepository = {
+    findOne: vi.fn(),
+    delete: vi.fn().mockResolvedValue(undefined),
+  };
+
+  let useCase: DeleteTrackUseCase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCase = new DeleteTrackUseCase(trackRepository as never);
+  });
+
+  describe("when the track exists", () => {
+    it("calls repository.delete with the given id", async () => {
+      trackRepository.findOne.mockResolvedValue(makeTrack());
+
+      await useCase.execute("track-1");
+
+      expect(trackRepository.findOne).toHaveBeenCalledWith("track-1");
+      expect(trackRepository.delete).toHaveBeenCalledWith("track-1");
+    });
+  });
+
+  describe("when the track does not exist", () => {
+    it("throws AppError 404 with error code track_not_found", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow(AppError);
+    });
+
+    it("does not call delete when the track is missing", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow();
+      expect(trackRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it("throws with statusCode 404 and errorCode track_not_found", async () => {
+      trackRepository.findOne.mockResolvedValue(null);
+
+      const error = await useCase.execute("missing-id").catch((e) => e);
+
+      expect(error).toBeInstanceOf(AppError);
+      expect(error.statusCode).toBe(404);
+      expect(error.errorCode).toBe("track_not_found");
+    });
+  });
+
+  it("propagates unexpected repository errors", async () => {
+    trackRepository.findOne.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("db failure");
+    expect(trackRepository.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/tracks/retry-track-download.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/retry-track-download.use-case.test.ts
@@ -1,0 +1,127 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Track } from "@/domain/entities/track.entity";
+import { AppError } from "@/domain/errors/app-error";
+import { RetryTrackDownloadUseCase } from "./retry-track-download.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): Track =>
+  new Track({
+    id: "track-1",
+    name: "Song A",
+    artist: "Artist A",
+    status: TrackStatusEnum.Error,
+    playlistId: "playlist-1",
+    youtubeUrl: "https://youtube.com/watch?v=abc",
+    spotifyUrl: undefined,
+    trackUrl: undefined,
+    searchAttempts: 1,
+    error: "some_error",
+    ...overrides,
+  });
+
+describe("RetryTrackDownloadUseCase", () => {
+  const trackRepository = {
+    findOneWithPlaylist: vi.fn(),
+    update: vi.fn(),
+  };
+
+  const queueService = {
+    enqueueSearchTrack: vi.fn(),
+  };
+
+  let useCase: RetryTrackDownloadUseCase;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    trackRepository.update.mockResolvedValue(undefined);
+    queueService.enqueueSearchTrack.mockResolvedValue(undefined);
+    useCase = new RetryTrackDownloadUseCase(trackRepository as never, queueService as never);
+  });
+
+  describe("when the track exists", () => {
+    it("marks the track as new, updates the repository, and enqueues for search", async () => {
+      const track = makeTrack();
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      expect(trackRepository.findOneWithPlaylist).toHaveBeenCalledWith("track-1");
+      expect(trackRepository.update).toHaveBeenCalledWith("track-1", track);
+      expect(queueService.enqueueSearchTrack).toHaveBeenCalledWith(track.toPrimitive());
+    });
+
+    it("resets the track status to New via markAsNew before persisting", async () => {
+      const track = makeTrack({ status: TrackStatusEnum.Error, error: "some_error" });
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const updatedArg = trackRepository.update.mock.calls[0][1] as Track;
+      expect(updatedArg.status).toBe(TrackStatusEnum.New);
+    });
+
+    it("clears the error field on the track after markAsNew", async () => {
+      const track = makeTrack({ error: "previous_error" });
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const primitive = queueService.enqueueSearchTrack.mock.calls[0][0] as ITrack;
+      expect(primitive.error).toBeUndefined();
+    });
+
+    it("enqueues the primitive representation of the mutated track", async () => {
+      const track = makeTrack();
+      trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+
+      await useCase.execute("track-1");
+
+      const enqueueArg = queueService.enqueueSearchTrack.mock.calls[0][0];
+      expect(enqueueArg).toEqual(track.toPrimitive());
+    });
+  });
+
+  describe("when the track does not exist", () => {
+    it("throws AppError 404 with errorCode track_not_found", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(null);
+
+      const error = await useCase.execute("missing-id").catch((e) => e);
+
+      expect(error).toBeInstanceOf(AppError);
+      expect(error.statusCode).toBe(404);
+      expect(error.errorCode).toBe("track_not_found");
+    });
+
+    it("does not call update or enqueue when the track is missing", async () => {
+      trackRepository.findOneWithPlaylist.mockResolvedValue(null);
+
+      await expect(useCase.execute("missing-id")).rejects.toThrow();
+      expect(trackRepository.update).not.toHaveBeenCalled();
+      expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+    });
+  });
+
+  it("propagates repository findOneWithPlaylist errors", async () => {
+    trackRepository.findOneWithPlaylist.mockRejectedValue(new Error("db failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("db failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository update errors", async () => {
+    const track = makeTrack();
+    trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+    trackRepository.update.mockRejectedValue(new Error("update failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("update failure");
+    expect(queueService.enqueueSearchTrack).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue service errors", async () => {
+    const track = makeTrack();
+    trackRepository.findOneWithPlaylist.mockResolvedValue(track);
+    queueService.enqueueSearchTrack.mockRejectedValue(new Error("queue failure"));
+
+    await expect(useCase.execute("track-1")).rejects.toThrow("queue failure");
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **tracks & ai use-cases** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (tracks & ai use-cases slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204