### PR TITLE
test(backend): add unit tests for playlists and artwork-backfill use-cases

### DIFF
--- a/apps/backend/src/application/use-cases/artwork-backfill/get-artwork-backfill-status.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/get-artwork-backfill-status.use-case.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import type { ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { GetArtworkBackfillStatusUseCase } from "./get-artwork-backfill-status.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: "cursor-abc",
+  totalCandidates: 100,
+  processed: 20,
+  skippedExisting: 5,
+  written: 15,
+  failed: 1,
+  externalCalls: 10,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun"> = {
+    getActiveRun: vi.fn(),
+  };
+  return { backfillRepository };
+};
+
+const makeUseCase = (backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun">) =>
+  new GetArtworkBackfillStatusUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+  );
+
+describe("GetArtworkBackfillStatusUseCase", () => {
+  it("returns idle response when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      runId: null,
+      status: "idle",
+      phase: null,
+      totals: 0,
+      processed: 0,
+      skippedExisting: 0,
+      written: 0,
+      failed: 0,
+      externalCalls: 0,
+      lastCheckpoint: null,
+      rateLimitUntil: null,
+      updatedAt: null,
+    });
+  });
+
+  it("maps active run fields to the response shape", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({
+      runId: "run-1",
+      status: "running",
+      phase: "artists",
+      totals: 100,
+      processed: 20,
+      skippedExisting: 5,
+      written: 15,
+      failed: 1,
+      externalCalls: 10,
+      lastCheckpoint: "cursor-abc",
+      rateLimitUntil: null,
+      updatedAt: "2024-01-01T01:00:00.000Z",
+    });
+  });
+
+  it("serializes rateLimitUntil as ISO string when set", async () => {
+    const { backfillRepository } = makeDeps();
+    const rateLimitDate = new Date("2024-06-01T12:00:00.000Z");
+    const run = makeActiveRun({ rateLimitUntil: rateLimitDate });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.rateLimitUntil).toBe("2024-06-01T12:00:00.000Z");
+  });
+
+  it("maps cursorValue as lastCheckpoint including null", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ cursorValue: null });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.lastCheckpoint).toBeNull();
+  });
+
+  it("maps paused status correctly", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: "paused" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.status).toBe("paused");
+    expect(result.runId).toBe("run-1");
+  });
+
+  it("propagates repository errors", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/pause-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/pause-artwork-backfill.use-case.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { PauseArtworkBackfillUseCase } from "./pause-artwork-backfill.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 100,
+  processed: 10,
+  skippedExisting: 0,
+  written: 10,
+  failed: 0,
+  externalCalls: 5,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus"> = {
+    getActiveRun: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+  return { backfillRepository };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus">,
+) =>
+  new PauseArtworkBackfillUseCase(backfillRepository as unknown as ArtworkBackfillRepositoryPort);
+
+describe("PauseArtworkBackfillUseCase", () => {
+  it("throws AppError 404 when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("does not call updateStatus when no active run exists", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(backfillRepository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns paused immediately when run is already paused", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ runId: "run-1", status: "paused" });
+    expect(backfillRepository.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("requests pause when run is running", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    const updatedRun = makeActiveRun({
+      id: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.PauseRequested,
+    });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.PauseRequested,
+    });
+    expect(result).toEqual({ runId: "run-1", status: "pause_requested" });
+  });
+
+  it("requests pause when run is in pause_requested state", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    const updatedRun = makeActiveRun({
+      id: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.PauseRequested,
+    });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result).toEqual({ runId: "run-1", status: "pause_requested" });
+  });
+
+  it("uses the updated run id in the response", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ id: "run-original", status: ARTWORK_BACKFILL_STATUS.Running });
+    const updatedRun = makeActiveRun({
+      id: "run-original",
+      status: ARTWORK_BACKFILL_STATUS.PauseRequested,
+    });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+
+    const useCase = makeUseCase(backfillRepository);
+    const result = await useCase.execute();
+
+    expect(result.runId).toBe("run-original");
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository updateStatus errors", async () => {
+    const { backfillRepository } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(backfillRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("update failed");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/resume-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/resume-artwork-backfill.use-case.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillQueuePort } from "@/application/ports/artwork-backfill-queue.port";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { ResumeArtworkBackfillUseCase } from "./resume-artwork-backfill.use-case";
+
+const makeActiveRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "paused",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 100,
+  processed: 10,
+  skippedExisting: 0,
+  written: 10,
+  failed: 0,
+  externalCalls: 5,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T01:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus"> = {
+    getActiveRun: vi.fn(),
+    updateStatus: vi.fn(),
+  };
+  const queuePort: ArtworkBackfillQueuePort = {
+    enqueueRun: vi.fn(),
+  };
+  return { backfillRepository, queuePort };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "updateStatus">,
+  queuePort: ArtworkBackfillQueuePort,
+) =>
+  new ResumeArtworkBackfillUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+    queuePort,
+  );
+
+describe("ResumeArtworkBackfillUseCase", () => {
+  it("throws AppError 404 when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when run is running (not paused)", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when run is in pause_requested state", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("resumes a paused run, updates to running, enqueues, returns running", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    const updatedRun = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.Running,
+      rateLimitUntil: null,
+      error: null,
+    });
+    expect(queuePort.enqueueRun).toHaveBeenCalledWith(updatedRun.id);
+    expect(result).toEqual({ runId: updatedRun.id, status: "running" });
+  });
+
+  it("resumes a paused_rate_limited run", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.PausedRateLimited });
+    const updatedRun = makeActiveRun({ id: "run-1", status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.updateStatus).toHaveBeenCalledWith({
+      runId: "run-1",
+      status: ARTWORK_BACKFILL_STATUS.Running,
+      rateLimitUntil: null,
+      error: null,
+    });
+    expect(result).toEqual({ runId: "run-1", status: "running" });
+  });
+
+  it("does not enqueue when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("does not enqueue when run is not paused", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository updateStatus errors without enqueuing", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("update failed");
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue enqueueRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const run = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    const updatedRun = makeActiveRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(run);
+    vi.mocked(backfillRepository.updateStatus).mockResolvedValue(updatedRun);
+    vi.mocked(queuePort.enqueueRun).mockRejectedValue(new Error("queue error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("queue error");
+  });
+});

--- a/apps/backend/src/application/use-cases/artwork-backfill/start-artwork-backfill.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artwork-backfill/start-artwork-backfill.use-case.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtworkBackfillQueuePort } from "@/application/ports/artwork-backfill-queue.port";
+import type { ArtworkBackfillRepositoryPort } from "@/application/ports/artwork-backfill-repository.port";
+import { ARTWORK_BACKFILL_STATUS, type ArtworkBackfillRun } from "@/domain/artwork-backfill.types";
+import { AppError } from "@/domain/errors/app-error";
+import { StartArtworkBackfillUseCase } from "./start-artwork-backfill.use-case";
+
+const makeRun = (overrides: Partial<ArtworkBackfillRun> = {}): ArtworkBackfillRun => ({
+  id: "run-1",
+  status: "running",
+  phase: "artists",
+  cursorKind: "artist",
+  cursorValue: null,
+  totalCandidates: 0,
+  processed: 0,
+  skippedExisting: 0,
+  written: 0,
+  failed: 0,
+  externalCalls: 0,
+  rateLimitUntil: null,
+  error: null,
+  createdAt: new Date("2024-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2024-01-01T00:00:00.000Z"),
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "createRun"> = {
+    getActiveRun: vi.fn(),
+    createRun: vi.fn(),
+  };
+  const queuePort: ArtworkBackfillQueuePort = {
+    enqueueRun: vi.fn(),
+  };
+  return { backfillRepository, queuePort };
+};
+
+const makeUseCase = (
+  backfillRepository: Pick<ArtworkBackfillRepositoryPort, "getActiveRun" | "createRun">,
+  queuePort: ArtworkBackfillQueuePort,
+) =>
+  new StartArtworkBackfillUseCase(
+    backfillRepository as unknown as ArtworkBackfillRepositoryPort,
+    queuePort,
+  );
+
+describe("StartArtworkBackfillUseCase", () => {
+  it("creates a new run and enqueues it when no active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const newRun = makeRun({ id: "run-new" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(queuePort.enqueueRun).toHaveBeenCalledWith("run-new");
+    expect(result).toEqual({ runId: "run-new", status: "running" });
+  });
+
+  it("throws AppError 409 when a running active run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow(AppError);
+    await expect(useCase.execute()).rejects.toMatchObject({
+      statusCode: 409,
+      errorCode: "invalid_request",
+    });
+  });
+
+  it("throws AppError 409 when a pause_requested run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.PauseRequested });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("throws AppError 409 when a paused run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Paused });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("throws AppError 409 when a paused_rate_limited run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.PausedRateLimited });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it("does not create or enqueue when an active blocking run exists", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const activeRun = makeRun({ status: ARTWORK_BACKFILL_STATUS.Running });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(activeRun);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    await expect(useCase.execute()).rejects.toThrow();
+
+    expect(backfillRepository.createRun).not.toHaveBeenCalled();
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("allows starting when active run has a completed status", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const completedRun = makeRun({ id: "old-run", status: ARTWORK_BACKFILL_STATUS.Completed });
+    const newRun = makeRun({ id: "new-run" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(completedRun);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(result).toEqual({ runId: "new-run", status: "running" });
+  });
+
+  it("allows starting when active run has an error status", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const errorRun = makeRun({ id: "old-run", status: ARTWORK_BACKFILL_STATUS.Error });
+    const newRun = makeRun({ id: "new-run" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(errorRun);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+    const result = await useCase.execute();
+
+    expect(backfillRepository.createRun).toHaveBeenCalledOnce();
+    expect(result).toEqual({ runId: "new-run", status: "running" });
+  });
+
+  it("propagates repository getActiveRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+
+  it("propagates repository createRun errors without enqueuing", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockRejectedValue(new Error("create failed"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("create failed");
+    expect(queuePort.enqueueRun).not.toHaveBeenCalled();
+  });
+
+  it("propagates queue enqueueRun errors", async () => {
+    const { backfillRepository, queuePort } = makeDeps();
+    const newRun = makeRun({ id: "run-new" });
+    vi.mocked(backfillRepository.getActiveRun).mockResolvedValue(null);
+    vi.mocked(backfillRepository.createRun).mockResolvedValue(newRun);
+    vi.mocked(queuePort.enqueueRun).mockRejectedValue(new Error("queue error"));
+
+    const useCase = makeUseCase(backfillRepository, queuePort);
+
+    await expect(useCase.execute()).rejects.toThrow("queue error");
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/delete-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/delete-playlist.use-case.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import type { EventBus } from "@/domain/events/event-bus";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { DeletePlaylistUseCase } from "./delete-playlist.use-case";
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne" | "delete"> = {
+    findOne: vi.fn(),
+    delete: vi.fn(),
+  };
+  const eventBus: EventBus = {
+    emit: vi.fn(),
+  };
+  return { playlistRepository, eventBus };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne" | "delete">,
+  eventBus: EventBus,
+) => new DeletePlaylistUseCase(playlistRepository as unknown as PlaylistRepository, eventBus);
+
+describe("DeletePlaylistUseCase", () => {
+  it("deletes the playlist and emits playlists-updated when found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.delete).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1");
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+    expect(playlistRepository.delete).toHaveBeenCalledWith("p1");
+    expect(eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("missing")).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing")).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not delete or emit when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await expect(useCase.execute("missing")).rejects.toThrow();
+
+    expect(playlistRepository.delete).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository findOne errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("db error");
+    expect(playlistRepository.delete).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository delete errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.delete).mockRejectedValue(new Error("delete failed"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("delete failed");
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlists.use-case.test.ts
@@ -1,0 +1,130 @@
+import type { IPlaylist } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { GetPlaylistsUseCase } from "./get-playlists.use-case";
+
+const makePlaylist = (overrides: Partial<IPlaylist> = {}): Playlist => {
+  const props: IPlaylist = {
+    id: "p1",
+    name: "My Playlist",
+    spotifyUrl: "https://open.spotify.com/playlist/abc",
+    subscribed: true,
+    tracks: [],
+    ...overrides,
+  };
+  return new Playlist(props);
+};
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findAll" | "findOne"> = {
+    findAll: vi.fn(),
+    findOne: vi.fn(),
+  };
+  return { playlistRepository };
+};
+
+const makeUseCase = (playlistRepository: Pick<PlaylistRepository, "findAll" | "findOne">) =>
+  new GetPlaylistsUseCase(playlistRepository as unknown as PlaylistRepository);
+
+describe("GetPlaylistsUseCase", () => {
+  describe("findAll", () => {
+    it("returns primitives of all playlists with default params", async () => {
+      const { playlistRepository } = makeDeps();
+      const playlist = makePlaylist();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(true, undefined);
+      expect(result).toEqual([playlist.toPrimitive()]);
+    });
+
+    it("passes includesTracks=false through to repository", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      await useCase.findAll(false);
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(false, undefined);
+    });
+
+    it("passes where filter through to repository", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      await useCase.findAll(true, { subscribed: true });
+
+      expect(playlistRepository.findAll).toHaveBeenCalledWith(true, { subscribed: true });
+    });
+
+    it("returns empty array when repository returns none", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns multiple playlists mapped to primitives", async () => {
+      const { playlistRepository } = makeDeps();
+      const p1 = makePlaylist({ id: "p1", name: "A" });
+      const p2 = makePlaylist({ id: "p2", name: "B" });
+      vi.mocked(playlistRepository.findAll).mockResolvedValue([p1, p2]);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findAll();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual(p1.toPrimitive());
+      expect(result[1]).toEqual(p2.toPrimitive());
+    });
+
+    it("propagates repository errors", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findAll).mockRejectedValue(new Error("db error"));
+
+      const useCase = makeUseCase(playlistRepository);
+
+      await expect(useCase.findAll()).rejects.toThrow("db error");
+    });
+  });
+
+  describe("findOne", () => {
+    it("returns primitive of found playlist", async () => {
+      const { playlistRepository } = makeDeps();
+      const playlist = makePlaylist({ id: "p1" });
+      vi.mocked(playlistRepository.findOne).mockResolvedValue(playlist);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findOne("p1");
+
+      expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+      expect(result).toEqual(playlist.toPrimitive());
+    });
+
+    it("returns null when playlist is not found", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+      const useCase = makeUseCase(playlistRepository);
+      const result = await useCase.findOne("missing");
+
+      expect(result).toBeNull();
+    });
+
+    it("propagates repository errors", async () => {
+      const { playlistRepository } = makeDeps();
+      vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+      const useCase = makeUseCase(playlistRepository);
+
+      await expect(useCase.findOne("p1")).rejects.toThrow("db error");
+    });
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/get-system-status.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-system-status.use-case.test.ts
@@ -1,0 +1,209 @@
+import { PlaylistStatusEnum, TrackStatusEnum } from "@spotiarr/shared";
+import type { IPlaylist, ITrack } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { Playlist } from "@/domain/entities/playlist.entity";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { GetSystemStatusUseCase } from "./get-system-status.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "t1",
+  trackUrl: "https://open.spotify.com/track/1",
+  albumUrl: "https://open.spotify.com/album/1",
+  status: TrackStatusEnum.Completed,
+  name: "Track",
+  artist: "Artist",
+  album: "Album",
+  playlistId: "p1",
+  ...overrides,
+});
+
+const makePlaylist = (overrides: Partial<IPlaylist> = {}): Playlist => {
+  const props: IPlaylist = {
+    id: "p1",
+    name: "My Playlist",
+    spotifyUrl: "https://open.spotify.com/playlist/abc",
+    subscribed: true,
+    tracks: [],
+    ...overrides,
+  };
+  return new Playlist(props);
+};
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findAll"> = {
+    findAll: vi.fn(),
+  };
+  return { playlistRepository };
+};
+
+const makeUseCase = (playlistRepository: Pick<PlaylistRepository, "findAll">) =>
+  new GetSystemStatusUseCase(playlistRepository as unknown as PlaylistRepository);
+
+describe("GetSystemStatusUseCase", () => {
+  it("returns empty maps when there are no playlists", async () => {
+    const { playlistRepository } = makeDeps();
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(playlistRepository.findAll).toHaveBeenCalledWith(true);
+    expect(result).toEqual({
+      playlistStatusMap: {},
+      trackStatusMap: {},
+      albumTrackCountMap: {},
+    });
+  });
+
+  it("maps playlist status by spotifyUrl", async () => {
+    const { playlistRepository } = makeDeps();
+    const completedTrack = makeTrack({ status: TrackStatusEnum.Completed });
+    const playlist = makePlaylist({
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+      tracks: [completedTrack],
+    });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.playlistStatusMap).toEqual({
+      "https://open.spotify.com/playlist/abc": PlaylistStatusEnum.Completed,
+    });
+  });
+
+  it("maps track status by trackUrl", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({
+      trackUrl: "https://open.spotify.com/track/x",
+      status: TrackStatusEnum.Error,
+    });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.trackStatusMap["https://open.spotify.com/track/x"]).toBe(TrackStatusEnum.Error);
+  });
+
+  it("counts completed tracks per albumUrl in albumTrackCountMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const albumUrl = "https://open.spotify.com/album/a";
+    const t1 = makeTrack({
+      id: "t1",
+      trackUrl: "https://open.spotify.com/track/1",
+      albumUrl,
+      status: TrackStatusEnum.Completed,
+    });
+    const t2 = makeTrack({
+      id: "t2",
+      trackUrl: "https://open.spotify.com/track/2",
+      albumUrl,
+      status: TrackStatusEnum.Completed,
+    });
+    const t3 = makeTrack({
+      id: "t3",
+      trackUrl: "https://open.spotify.com/track/3",
+      albumUrl,
+      status: TrackStatusEnum.Error,
+    });
+    const playlist = makePlaylist({ tracks: [t1, t2, t3] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    // Only completed tracks count
+    expect(result.albumTrackCountMap[albumUrl]).toBe(2);
+  });
+
+  it("does not add to albumTrackCountMap for non-completed tracks", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({ status: TrackStatusEnum.Error });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.albumTrackCountMap)).toHaveLength(0);
+  });
+
+  it("skips playlist without spotifyUrl in playlistStatusMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const playlist = makePlaylist({ spotifyUrl: undefined });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.playlistStatusMap)).toHaveLength(0);
+  });
+
+  it("skips tracks without trackUrl or status in trackStatusMap", async () => {
+    const { playlistRepository } = makeDeps();
+    const track = makeTrack({ trackUrl: undefined, status: undefined });
+    const playlist = makePlaylist({ tracks: [track] });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(Object.keys(result.trackStatusMap)).toHaveLength(0);
+  });
+
+  it("handles playlists with no tracks array gracefully", async () => {
+    const { playlistRepository } = makeDeps();
+    const playlist = makePlaylist({ tracks: undefined });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([playlist]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.trackStatusMap).toEqual({});
+    expect(result.albumTrackCountMap).toEqual({});
+  });
+
+  it("aggregates album counts across multiple playlists", async () => {
+    const { playlistRepository } = makeDeps();
+    const albumUrl = "https://open.spotify.com/album/shared";
+    const t1 = makeTrack({
+      id: "t1",
+      trackUrl: "https://open.spotify.com/track/1",
+      albumUrl,
+      status: TrackStatusEnum.Completed,
+    });
+    const t2 = makeTrack({
+      id: "t2",
+      trackUrl: "https://open.spotify.com/track/2",
+      albumUrl,
+      status: TrackStatusEnum.Completed,
+    });
+    const p1 = makePlaylist({
+      id: "p1",
+      spotifyUrl: "https://open.spotify.com/playlist/1",
+      tracks: [t1],
+    });
+    const p2 = makePlaylist({
+      id: "p2",
+      spotifyUrl: "https://open.spotify.com/playlist/2",
+      tracks: [t2],
+    });
+    vi.mocked(playlistRepository.findAll).mockResolvedValue([p1, p2]);
+
+    const useCase = makeUseCase(playlistRepository);
+    const result = await useCase.execute();
+
+    expect(result.albumTrackCountMap[albumUrl]).toBe(2);
+  });
+
+  it("propagates repository errors", async () => {
+    const { playlistRepository } = makeDeps();
+    vi.mocked(playlistRepository.findAll).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository);
+
+    await expect(useCase.execute()).rejects.toThrow("db error");
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/retry-playlist-downloads.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/retry-playlist-downloads.use-case.test.ts
@@ -1,0 +1,154 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
+import type { ITrack } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { RetryPlaylistDownloadsUseCase } from "./retry-playlist-downloads.use-case";
+
+const makeTrack = (overrides: Partial<ITrack> = {}): ITrack => ({
+  id: "t1",
+  name: "Track",
+  artist: "Artist",
+  album: "Album",
+  trackUrl: "https://open.spotify.com/track/1",
+  albumUrl: "https://open.spotify.com/album/1",
+  playlistId: "p1",
+  status: TrackStatusEnum.Completed,
+  ...overrides,
+});
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne"> = {
+    findOne: vi.fn(),
+  };
+  const trackService = {
+    getAllByPlaylist: vi.fn(),
+    retry: vi.fn(),
+  };
+  return { playlistRepository, trackService };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne">,
+  trackService: { getAllByPlaylist: ReturnType<typeof vi.fn>; retry: ReturnType<typeof vi.fn> },
+) =>
+  new RetryPlaylistDownloadsUseCase(
+    playlistRepository as unknown as PlaylistRepository,
+    trackService as never,
+  );
+
+describe("RetryPlaylistDownloadsUseCase", () => {
+  it("retries only tracks with Error status", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const errorTrack = makeTrack({ id: "t-err", status: TrackStatusEnum.Error });
+    const okTrack = makeTrack({ id: "t-ok", status: TrackStatusEnum.Completed });
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([errorTrack, okTrack]);
+    vi.mocked(trackService.retry).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).toHaveBeenCalledTimes(1);
+    expect(trackService.retry).toHaveBeenCalledWith("t-err");
+  });
+
+  it("does not call retry when no tracks have Error status", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([
+      makeTrack({ status: TrackStatusEnum.Completed }),
+    ]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("does not call retry when track has Error status but no id", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const noIdTrack = makeTrack({ id: undefined, status: TrackStatusEnum.Error });
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([noIdTrack]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("retries all error-status tracks with ids", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    const tracks = [
+      makeTrack({ id: "t1", status: TrackStatusEnum.Error }),
+      makeTrack({ id: "t2", status: TrackStatusEnum.Error }),
+      makeTrack({ id: "t3", status: TrackStatusEnum.Error }),
+    ];
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue(tracks);
+    vi.mocked(trackService.retry).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("missing")).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing")).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not fetch tracks when playlist is not found", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await expect(useCase.execute("missing")).rejects.toThrow();
+
+    expect(trackService.getAllByPlaylist).not.toHaveBeenCalled();
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository errors", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("db error");
+  });
+
+  it("propagates trackService.retry errors", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([
+      makeTrack({ id: "t1", status: TrackStatusEnum.Error }),
+    ]);
+    vi.mocked(trackService.retry).mockRejectedValue(new Error("retry failed"));
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+
+    await expect(useCase.execute("p1")).rejects.toThrow("retry failed");
+  });
+
+  it("handles empty tracks array without calling retry", async () => {
+    const { playlistRepository, trackService } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(trackService.getAllByPlaylist).mockResolvedValue([]);
+
+    const useCase = makeUseCase(playlistRepository, trackService);
+    await useCase.execute("p1");
+
+    expect(trackService.retry).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/update-playlist.use-case.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import type { EventBus } from "@/domain/events/event-bus";
+import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { UpdatePlaylistUseCase } from "./update-playlist.use-case";
+
+const makeDeps = () => {
+  const playlistRepository: Pick<PlaylistRepository, "findOne" | "update"> = {
+    findOne: vi.fn(),
+    update: vi.fn(),
+  };
+  const eventBus: EventBus = {
+    emit: vi.fn(),
+  };
+  return { playlistRepository, eventBus };
+};
+
+const makeUseCase = (
+  playlistRepository: Pick<PlaylistRepository, "findOne" | "update">,
+  eventBus: EventBus,
+) => new UpdatePlaylistUseCase(playlistRepository as unknown as PlaylistRepository, eventBus);
+
+describe("UpdatePlaylistUseCase", () => {
+  it("updates the playlist and emits playlists-updated when found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockResolvedValue(undefined);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1", { name: "New Name" });
+
+    expect(playlistRepository.findOne).toHaveBeenCalledWith("p1");
+    expect(playlistRepository.update).toHaveBeenCalledWith("p1", { name: "New Name" });
+    expect(eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("throws AppError 404 when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("missing", {})).rejects.toThrow(AppError);
+    await expect(useCase.execute("missing", {})).rejects.toMatchObject({
+      statusCode: 404,
+      errorCode: "playlist_not_found",
+    });
+  });
+
+  it("does not call update or emit when playlist is not found", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue(null);
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await expect(useCase.execute("missing", {})).rejects.toThrow();
+
+    expect(playlistRepository.update).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository findOne errors", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockRejectedValue(new Error("db error"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1", { name: "X" })).rejects.toThrow("db error");
+    expect(playlistRepository.update).not.toHaveBeenCalled();
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("propagates repository update errors without emitting", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockRejectedValue(new Error("update failed"));
+
+    const useCase = makeUseCase(playlistRepository, eventBus);
+
+    await expect(useCase.execute("p1", { name: "X" })).rejects.toThrow("update failed");
+    expect(eventBus.emit).not.toHaveBeenCalled();
+  });
+
+  it("passes partial playlist data through to repository", async () => {
+    const { playlistRepository, eventBus } = makeDeps();
+    vi.mocked(playlistRepository.findOne).mockResolvedValue({ id: "p1" } as never);
+    vi.mocked(playlistRepository.update).mockResolvedValue(undefined);
+
+    const patch = { name: "Updated", subscribed: false };
+    const useCase = makeUseCase(playlistRepository, eventBus);
+    await useCase.execute("p1", patch);
+
+    expect(playlistRepository.update).toHaveBeenCalledWith("p1", patch);
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **playlists & artwork-backfill use-cases** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (playlists & artwork-backfill use-cases slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204