### PR TITLE
test(backend): add unit tests for application services and utils

### DIFF
--- a/apps/backend/src/application/services/library.service.test.ts
+++ b/apps/backend/src/application/services/library.service.test.ts
@@ -1,0 +1,193 @@
+import type { LibraryScanResult } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { ScanLibraryUseCase } from "../use-cases/library/scan-library.use-case";
+import { LibraryService } from "./library.service";
+
+const MOCK_RESULT: LibraryScanResult = {
+  totalArtists: 3,
+  totalAlbums: 10,
+  totalTracks: 42,
+  totalSize: 1024,
+  lastScannedAt: 1704067200000,
+  scanDuration: 500,
+  artists: [
+    {
+      name: "Artist A",
+      path: "/music/artist-a",
+      albumCount: 2,
+      trackCount: 8,
+      totalSize: 512,
+      image: "https://img/a.jpg",
+      albums: [],
+    },
+    {
+      name: "Artist B",
+      path: "/music/artist-b",
+      albumCount: 8,
+      trackCount: 34,
+      totalSize: 512,
+      image: undefined,
+      albums: [],
+    },
+  ],
+};
+
+function makeUseCase(result: LibraryScanResult = MOCK_RESULT): ScanLibraryUseCase {
+  return { execute: vi.fn().mockResolvedValue(result) } as unknown as ScanLibraryUseCase;
+}
+
+describe("LibraryService.getLibrary", () => {
+  it("calls the use case and returns its result on the first call", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    const result = await svc.getLibrary();
+    expect(result).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("returns the cached result without calling the use case again", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary();
+    const second = await svc.getLibrary();
+    expect(second).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("bypasses the cache when forceRefresh=true", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary();
+    await svc.getLibrary(true);
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent calls — use case executes only once", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    const [r1, r2] = await Promise.all([svc.getLibrary(), svc.getLibrary()]);
+    expect(r1).toEqual(MOCK_RESULT);
+    expect(r2).toEqual(MOCK_RESULT);
+    expect(uc.execute).toHaveBeenCalledOnce();
+  });
+
+  it("clears scanPromise after the use case resolves (allows a subsequent fresh call)", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary(true);
+    await svc.getLibrary(true);
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates use case rejection", async () => {
+    const uc = {
+      execute: vi.fn().mockRejectedValue(new Error("scan failed")),
+    } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getLibrary()).rejects.toThrow("scan failed");
+  });
+
+  it("clears scanPromise even when use case rejects (allows retry)", async () => {
+    const uc = {
+      execute: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("first failure"))
+        .mockResolvedValueOnce(MOCK_RESULT),
+    } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getLibrary()).rejects.toThrow("first failure");
+    const result = await svc.getLibrary();
+    expect(result).toEqual(MOCK_RESULT);
+  });
+});
+
+describe("LibraryService.getStats", () => {
+  it("returns stat fields extracted from the library result", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const stats = await svc.getStats();
+    const expected = {
+      totalArtists: MOCK_RESULT.totalArtists,
+      totalAlbums: MOCK_RESULT.totalAlbums,
+      totalTracks: MOCK_RESULT.totalTracks,
+      totalSize: MOCK_RESULT.totalSize,
+      lastScannedAt: MOCK_RESULT.lastScannedAt,
+    };
+    expect(stats).toEqual(expected);
+  });
+
+  it("propagates use case rejection", async () => {
+    const uc = {
+      execute: vi.fn().mockRejectedValue(new Error("stats error")),
+    } as unknown as ScanLibraryUseCase;
+    const svc = new LibraryService(uc);
+    await expect(svc.getStats()).rejects.toThrow("stats error");
+  });
+});
+
+describe("LibraryService.getArtists", () => {
+  it("maps artist fields from the library result", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const artists = await svc.getArtists();
+    expect(artists).toEqual([
+      {
+        name: "Artist A",
+        path: "/music/artist-a",
+        albumCount: 2,
+        trackCount: 8,
+        totalSize: 512,
+        image: "https://img/a.jpg",
+      },
+      {
+        name: "Artist B",
+        path: "/music/artist-b",
+        albumCount: 8,
+        trackCount: 34,
+        totalSize: 512,
+        image: undefined,
+      },
+    ]);
+  });
+
+  it("returns an empty array when the library has no artists", async () => {
+    const emptyResult = { ...MOCK_RESULT, artists: [] };
+    const svc = new LibraryService(makeUseCase(emptyResult));
+    expect(await svc.getArtists()).toEqual([]);
+  });
+});
+
+describe("LibraryService.getArtist", () => {
+  it("returns the matching artist when found", async () => {
+    const svc = new LibraryService(makeUseCase());
+    const artist = await svc.getArtist("Artist A");
+    expect(artist?.name).toBe("Artist A");
+  });
+
+  it("returns null when no artist matches the given name", async () => {
+    const svc = new LibraryService(makeUseCase());
+    expect(await svc.getArtist("Unknown")).toBeNull();
+  });
+});
+
+describe("LibraryService.scan", () => {
+  it("triggers a force-refresh and returns the scan result", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    // Warm the cache first
+    await svc.getLibrary();
+    const result = await svc.scan();
+    expect(result).toEqual(MOCK_RESULT);
+    // scan() must bypass the cache
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("LibraryService.clearCache", () => {
+  it("removes the cached result so the next getLibrary call hits the use case again", async () => {
+    const uc = makeUseCase();
+    const svc = new LibraryService(uc);
+    await svc.getLibrary(); // populates cache
+    svc.clearCache();
+    await svc.getLibrary(); // must call use case again
+    expect(uc.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/backend/src/application/services/playlist.service.test.ts
+++ b/apps/backend/src/application/services/playlist.service.test.ts
@@ -1,0 +1,328 @@
+import {
+  type IPlaylist,
+  type PlaylistPreview,
+  type SpotifyPlaylist,
+  PlaylistTypeEnum,
+  PlaylistStatusEnum,
+  TrackStatusEnum,
+  type DownloadStatusResponse,
+} from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { CreatePlaylistUseCase } from "../use-cases/playlists/create-playlist.use-case";
+import type { DeletePlaylistUseCase } from "../use-cases/playlists/delete-playlist.use-case";
+import type { GetMyPlaylistsUseCase } from "../use-cases/playlists/get-my-playlists.use-case";
+import type { GetPlaylistPreviewUseCase } from "../use-cases/playlists/get-playlist-preview.use-case";
+import type { GetPlaylistsUseCase } from "../use-cases/playlists/get-playlists.use-case";
+import type { GetSystemStatusUseCase } from "../use-cases/playlists/get-system-status.use-case";
+import type { RetryPlaylistDownloadsUseCase } from "../use-cases/playlists/retry-playlist-downloads.use-case";
+import type { SyncSubscribedPlaylistsUseCase } from "../use-cases/playlists/sync-subscribed-playlists.use-case";
+import type { UpdatePlaylistUseCase } from "../use-cases/playlists/update-playlist.use-case";
+import { PlaylistService, type PlaylistServiceDependencies } from "./playlist.service";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_PLAYLIST: IPlaylist = {
+  id: "playlist-1",
+  name: "My Playlist",
+  type: PlaylistTypeEnum.Playlist,
+  spotifyUrl: "https://open.spotify.com/playlist/1",
+  subscribed: false,
+};
+
+const MOCK_PREVIEW: PlaylistPreview = {
+  name: "Preview Playlist",
+  type: "playlist",
+  description: null,
+  coverUrl: null,
+  totalTracks: 5,
+  tracks: [],
+};
+
+const MOCK_STATUS: DownloadStatusResponse = {
+  playlistStatusMap: { "playlist-1": PlaylistStatusEnum.Completed },
+  trackStatusMap: { "track-1": TrackStatusEnum.Completed },
+  albumTrackCountMap: {},
+};
+
+const MOCK_SPOTIFY_PLAYLISTS: SpotifyPlaylist[] = [
+  {
+    id: "sp-1",
+    name: "Spotify Playlist",
+    image: null,
+    owner: "user",
+    tracks: 10,
+    spotifyUrl: "https://open.spotify.com/playlist/sp-1",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+function makeDeps(
+  overrides: Partial<PlaylistServiceDependencies> = {},
+): PlaylistServiceDependencies {
+  return {
+    createPlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue(MOCK_PLAYLIST),
+    } as unknown as CreatePlaylistUseCase,
+    getSystemStatusUseCase: {
+      execute: vi.fn().mockResolvedValue(MOCK_STATUS),
+    } as unknown as GetSystemStatusUseCase,
+    getPlaylistPreviewUseCase: {
+      execute: vi.fn().mockResolvedValue(MOCK_PREVIEW),
+    } as unknown as GetPlaylistPreviewUseCase,
+    syncSubscribedPlaylistsUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SyncSubscribedPlaylistsUseCase,
+    getPlaylistsUseCase: {
+      findAll: vi.fn().mockResolvedValue([MOCK_PLAYLIST]),
+      findOne: vi.fn().mockResolvedValue(MOCK_PLAYLIST),
+    } as unknown as GetPlaylistsUseCase,
+    deletePlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DeletePlaylistUseCase,
+    updatePlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as UpdatePlaylistUseCase,
+    retryPlaylistDownloadsUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RetryPlaylistDownloadsUseCase,
+    getMyPlaylistsUseCase: {
+      execute: vi.fn().mockResolvedValue(MOCK_SPOTIFY_PLAYLISTS),
+    } as unknown as GetMyPlaylistsUseCase,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PlaylistService.findAll", () => {
+  it("delegates to getPlaylistsUseCase.findAll and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.findAll();
+    expect(result).toEqual([MOCK_PLAYLIST]);
+    expect(deps.getPlaylistsUseCase.findAll).toHaveBeenCalledWith(true, undefined);
+  });
+
+  it("passes includesTracks=false and where filter through to the use case", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const where: Partial<IPlaylist> = { subscribed: true };
+    await svc.findAll(false, where);
+    expect(deps.getPlaylistsUseCase.findAll).toHaveBeenCalledWith(false, where);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn().mockRejectedValue(new Error("db error")),
+        findOne: vi.fn(),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.findAll()).rejects.toThrow("db error");
+  });
+});
+
+describe("PlaylistService.findOne", () => {
+  it("delegates to getPlaylistsUseCase.findOne and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.findOne("playlist-1");
+    expect(result).toEqual(MOCK_PLAYLIST);
+    expect(deps.getPlaylistsUseCase.findOne).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("returns null when the use case returns null", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn(),
+        findOne: vi.fn().mockResolvedValue(null),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    expect(await svc.findOne("missing")).toBeNull();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistsUseCase: {
+        findAll: vi.fn(),
+        findOne: vi.fn().mockRejectedValue(new Error("not found")),
+      } as unknown as GetPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.findOne("x")).rejects.toThrow("not found");
+  });
+});
+
+describe("PlaylistService.remove", () => {
+  it("delegates to deletePlaylistUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.remove("playlist-1");
+    expect(deps.deletePlaylistUseCase.execute).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      deletePlaylistUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("delete failed")),
+      } as unknown as DeletePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.remove("x")).rejects.toThrow("delete failed");
+  });
+});
+
+describe("PlaylistService.create", () => {
+  it("delegates to createPlaylistUseCase.execute and returns the new playlist", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const input = {
+      kind: "spotifyUrl" as const,
+      spotifyUrl: "https://open.spotify.com/playlist/1",
+    };
+    const result = await svc.create(input);
+    expect(result).toEqual(MOCK_PLAYLIST);
+    expect(deps.createPlaylistUseCase.execute).toHaveBeenCalledWith(input);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      createPlaylistUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("already exists")),
+      } as unknown as CreatePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.create({ kind: "spotifyUrl", spotifyUrl: "" })).rejects.toThrow(
+      "already exists",
+    );
+  });
+});
+
+describe("PlaylistService.update", () => {
+  it("delegates to updatePlaylistUseCase.execute with id and patch", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const patch: Partial<IPlaylist> = { name: "New Name" };
+    await svc.update("playlist-1", patch);
+    expect(deps.updatePlaylistUseCase.execute).toHaveBeenCalledWith("playlist-1", patch);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updatePlaylistUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("update failed")),
+      } as unknown as UpdatePlaylistUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.update("x", {})).rejects.toThrow("update failed");
+  });
+});
+
+describe("PlaylistService.retryFailedOfPlaylist", () => {
+  it("delegates to retryPlaylistDownloadsUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.retryFailedOfPlaylist("playlist-1");
+    expect(deps.retryPlaylistDownloadsUseCase.execute).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      retryPlaylistDownloadsUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("retry failed")),
+      } as unknown as RetryPlaylistDownloadsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.retryFailedOfPlaylist("x")).rejects.toThrow("retry failed");
+  });
+});
+
+describe("PlaylistService.checkSubscribedPlaylists", () => {
+  it("delegates to syncSubscribedPlaylistsUseCase.execute", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    await svc.checkSubscribedPlaylists();
+    expect(deps.syncSubscribedPlaylistsUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      syncSubscribedPlaylistsUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("sync failed")),
+      } as unknown as SyncSubscribedPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.checkSubscribedPlaylists()).rejects.toThrow("sync failed");
+  });
+});
+
+describe("PlaylistService.getPreview", () => {
+  it("delegates to getPlaylistPreviewUseCase.execute and returns the preview", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getPreview("https://open.spotify.com/playlist/1");
+    expect(result).toEqual(MOCK_PREVIEW);
+    expect(deps.getPlaylistPreviewUseCase.execute).toHaveBeenCalledWith(
+      "https://open.spotify.com/playlist/1",
+    );
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getPlaylistPreviewUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("not accessible")),
+      } as unknown as GetPlaylistPreviewUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getPreview("x")).rejects.toThrow("not accessible");
+  });
+});
+
+describe("PlaylistService.getDownloadStatus", () => {
+  it("delegates to getSystemStatusUseCase.execute and returns the status", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getDownloadStatus();
+    expect(result).toEqual(MOCK_STATUS);
+    expect(deps.getSystemStatusUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getSystemStatusUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("status error")),
+      } as unknown as GetSystemStatusUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getDownloadStatus()).rejects.toThrow("status error");
+  });
+});
+
+describe("PlaylistService.getMyPlaylists", () => {
+  it("delegates to getMyPlaylistsUseCase.execute and returns the list", async () => {
+    const deps = makeDeps();
+    const svc = new PlaylistService(deps);
+    const result = await svc.getMyPlaylists();
+    expect(result).toEqual(MOCK_SPOTIFY_PLAYLISTS);
+    expect(deps.getMyPlaylistsUseCase.execute).toHaveBeenCalledOnce();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getMyPlaylistsUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("spotify error")),
+      } as unknown as GetMyPlaylistsUseCase,
+    });
+    const svc = new PlaylistService(deps);
+    await expect(svc.getMyPlaylists()).rejects.toThrow("spotify error");
+  });
+});

--- a/apps/backend/src/application/services/track.service.test.ts
+++ b/apps/backend/src/application/services/track.service.test.ts
@@ -1,0 +1,347 @@
+import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { CreateTrackUseCase } from "../use-cases/tracks/create-track.use-case";
+import type { DeleteTrackUseCase } from "../use-cases/tracks/delete-track.use-case";
+import type { DownloadTrackUseCase } from "../use-cases/tracks/download-track.use-case";
+import type { GetTracksUseCase } from "../use-cases/tracks/get-tracks.use-case";
+import type { RetryTrackDownloadUseCase } from "../use-cases/tracks/retry-track-download.use-case";
+import type { SearchTrackOnYoutubeUseCase } from "../use-cases/tracks/search-track-on-youtube.use-case";
+import type { UpdateTrackUseCase } from "../use-cases/tracks/update-track.use-case";
+import { TrackService, type TrackServiceDependencies } from "./track.service";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MOCK_TRACK: ITrack = {
+  id: "track-1",
+  name: "Song A",
+  artist: "Artist A",
+  status: TrackStatusEnum.Completed,
+  playlistId: "playlist-1",
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<TrackServiceDependencies> = {}): TrackServiceDependencies {
+  return {
+    searchTrackOnYoutubeUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SearchTrackOnYoutubeUseCase,
+    downloadTrackUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DownloadTrackUseCase,
+    createTrackUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CreateTrackUseCase,
+    deleteTrackUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DeleteTrackUseCase,
+    getTracksUseCase: {
+      getAll: vi.fn().mockResolvedValue([MOCK_TRACK]),
+      getAllByPlaylist: vi.fn().mockResolvedValue([MOCK_TRACK]),
+      get: vi.fn().mockResolvedValue(MOCK_TRACK),
+      findStuckTracks: vi.fn().mockResolvedValue([MOCK_TRACK]),
+    } as unknown as GetTracksUseCase,
+    retryTrackDownloadUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RetryTrackDownloadUseCase,
+    updateTrackUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+      executeIfStatus: vi.fn().mockResolvedValue(true),
+    } as unknown as UpdateTrackUseCase,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TrackService.getAll", () => {
+  it("delegates to getTracksUseCase.getAll and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.getAll();
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.getAll).toHaveBeenCalledWith(undefined);
+  });
+
+  it("passes the where filter through to the use case", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const where: Partial<ITrack> = { status: TrackStatusEnum.Error };
+    await svc.getAll(where);
+    expect(deps.getTracksUseCase.getAll).toHaveBeenCalledWith(where);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn().mockRejectedValue(new Error("db error")),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.getAll()).rejects.toThrow("db error");
+  });
+});
+
+describe("TrackService.getAllByPlaylist", () => {
+  it("delegates to getTracksUseCase.getAllByPlaylist and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.getAllByPlaylist("playlist-1");
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.getAllByPlaylist).toHaveBeenCalledWith("playlist-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn().mockRejectedValue(new Error("playlist not found")),
+        get: vi.fn(),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.getAllByPlaylist("missing")).rejects.toThrow("playlist not found");
+  });
+});
+
+describe("TrackService.get", () => {
+  it("delegates to getTracksUseCase.get and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const result = await svc.get("track-1");
+    expect(result).toEqual(MOCK_TRACK);
+    expect(deps.getTracksUseCase.get).toHaveBeenCalledWith("track-1");
+  });
+
+  it("returns null when the use case returns null", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn().mockResolvedValue(null),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    expect(await svc.get("missing")).toBeNull();
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn().mockRejectedValue(new Error("track error")),
+        findStuckTracks: vi.fn(),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.get("x")).rejects.toThrow("track error");
+  });
+});
+
+describe("TrackService.remove", () => {
+  it("delegates to deleteTrackUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.remove("track-1");
+    expect(deps.deleteTrackUseCase.execute).toHaveBeenCalledWith("track-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      deleteTrackUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("delete failed")),
+      } as unknown as DeleteTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.remove("x")).rejects.toThrow("delete failed");
+  });
+});
+
+describe("TrackService.create", () => {
+  it("delegates to createTrackUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const track: Partial<ITrack> = { name: "New Track", artist: "Artist" };
+    await svc.create(track);
+    expect(deps.createTrackUseCase.execute).toHaveBeenCalledWith(track);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      createTrackUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("create failed")),
+      } as unknown as CreateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.create({})).rejects.toThrow("create failed");
+  });
+});
+
+describe("TrackService.update", () => {
+  it("delegates to updateTrackUseCase.execute with id and patch", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const patch: Partial<ITrack> = { status: TrackStatusEnum.Completed };
+    await svc.update("track-1", patch);
+    expect(deps.updateTrackUseCase.execute).toHaveBeenCalledWith("track-1", patch);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("update failed")),
+        executeIfStatus: vi.fn(),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.update("x", {})).rejects.toThrow("update failed");
+  });
+});
+
+describe("TrackService.updateStatusIf", () => {
+  it("delegates to updateTrackUseCase.executeIfStatus and returns true on match", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const patch: Partial<ITrack> = { status: TrackStatusEnum.Downloading };
+    const result = await svc.updateStatusIf("track-1", TrackStatusEnum.New, patch);
+    expect(result).toBe(true);
+    expect(deps.updateTrackUseCase.executeIfStatus).toHaveBeenCalledWith(
+      "track-1",
+      TrackStatusEnum.New,
+      patch,
+    );
+  });
+
+  it("returns false when the status did not match", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn(),
+        executeIfStatus: vi.fn().mockResolvedValue(false),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    const result = await svc.updateStatusIf("track-1", TrackStatusEnum.Completed, {});
+    expect(result).toBe(false);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      updateTrackUseCase: {
+        execute: vi.fn(),
+        executeIfStatus: vi.fn().mockRejectedValue(new Error("conditional update failed")),
+      } as unknown as UpdateTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.updateStatusIf("x", TrackStatusEnum.New, {})).rejects.toThrow(
+      "conditional update failed",
+    );
+  });
+});
+
+describe("TrackService.retry", () => {
+  it("delegates to retryTrackDownloadUseCase.execute with the given id", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.retry("track-1");
+    expect(deps.retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-1");
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      retryTrackDownloadUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("retry failed")),
+      } as unknown as RetryTrackDownloadUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.retry("x")).rejects.toThrow("retry failed");
+  });
+});
+
+describe("TrackService.findOnYoutube", () => {
+  it("delegates to searchTrackOnYoutubeUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.findOnYoutube(MOCK_TRACK);
+    expect(deps.searchTrackOnYoutubeUseCase.execute).toHaveBeenCalledWith(MOCK_TRACK);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      searchTrackOnYoutubeUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("youtube error")),
+      } as unknown as SearchTrackOnYoutubeUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.findOnYoutube(MOCK_TRACK)).rejects.toThrow("youtube error");
+  });
+});
+
+describe("TrackService.downloadFromYoutube", () => {
+  it("delegates to downloadTrackUseCase.execute with the given track", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    await svc.downloadFromYoutube(MOCK_TRACK);
+    expect(deps.downloadTrackUseCase.execute).toHaveBeenCalledWith(MOCK_TRACK);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      downloadTrackUseCase: {
+        execute: vi.fn().mockRejectedValue(new Error("download failed")),
+      } as unknown as DownloadTrackUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.downloadFromYoutube(MOCK_TRACK)).rejects.toThrow("download failed");
+  });
+});
+
+describe("TrackService.findStuckTracks", () => {
+  it("delegates to getTracksUseCase.findStuckTracks and returns its result", async () => {
+    const deps = makeDeps();
+    const svc = new TrackService(deps);
+    const statuses = [TrackStatusEnum.Downloading, TrackStatusEnum.Searching];
+    const result = await svc.findStuckTracks(statuses, 1000);
+    expect(result).toEqual([MOCK_TRACK]);
+    expect(deps.getTracksUseCase.findStuckTracks).toHaveBeenCalledWith(statuses, 1000);
+  });
+
+  it("returns an empty array when no stuck tracks are found", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn().mockResolvedValue([]),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    expect(await svc.findStuckTracks([TrackStatusEnum.Downloading], 1000)).toEqual([]);
+  });
+
+  it("propagates use case rejection", async () => {
+    const deps = makeDeps({
+      getTracksUseCase: {
+        getAll: vi.fn(),
+        getAllByPlaylist: vi.fn(),
+        get: vi.fn(),
+        findStuckTracks: vi.fn().mockRejectedValue(new Error("stuck query failed")),
+      } as unknown as GetTracksUseCase,
+    });
+    const svc = new TrackService(deps);
+    await expect(svc.findStuckTracks([TrackStatusEnum.Downloading], 1000)).rejects.toThrow(
+      "stuck query failed",
+    );
+  });
+});

--- a/apps/backend/src/application/utils/error.utils.test.ts
+++ b/apps/backend/src/application/utils/error.utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { getErrorMessage, isError } from "./error.utils";
+
+describe("isError", () => {
+  it("returns true for an Error instance", () => {
+    expect(isError(new Error("oops"))).toBe(true);
+  });
+
+  it("returns true for a subclass of Error", () => {
+    expect(isError(new TypeError("type"))).toBe(true);
+    expect(isError(new RangeError("range"))).toBe(true);
+  });
+
+  it("returns false for a plain string", () => {
+    expect(isError("something went wrong")).toBe(false);
+  });
+
+  it("returns false for a number", () => {
+    expect(isError(42)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isError(undefined)).toBe(false);
+  });
+
+  it("returns false for a plain object without prototype chain to Error", () => {
+    expect(isError({ message: "not an error" })).toBe(false);
+  });
+});
+
+describe("getErrorMessage", () => {
+  it("returns the message from an Error instance", () => {
+    expect(getErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns the message from an Error subclass", () => {
+    expect(getErrorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  it("returns the string directly when the error is a string", () => {
+    expect(getErrorMessage("network failure")).toBe("network failure");
+  });
+
+  it("returns the message property from an object that has one", () => {
+    expect(getErrorMessage({ message: "custom object error" })).toBe("custom object error");
+  });
+
+  it("coerces a non-string message property to string", () => {
+    expect(getErrorMessage({ message: 404 })).toBe("404");
+  });
+
+  it("returns 'Unknown error' for null", () => {
+    expect(getErrorMessage(null)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for undefined", () => {
+    expect(getErrorMessage(undefined)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for a number", () => {
+    expect(getErrorMessage(42)).toBe("Unknown error");
+  });
+
+  it("returns 'Unknown error' for a plain object without a message property", () => {
+    expect(getErrorMessage({ code: 500 })).toBe("Unknown error");
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **application services & utils** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (application services & utils slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204