### PR TITLE
test(backend): add unit tests for database repositories and adapters

### DIFF
--- a/apps/backend/src/infrastructure/database/connectivity.adapter.test.ts
+++ b/apps/backend/src/infrastructure/database/connectivity.adapter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { prisma } from "@/infrastructure/setup/prisma";
+import { getTrackDownloadQueue } from "@/infrastructure/setup/queues";
+import { ConnectivityAdapter } from "./connectivity.adapter";
+
+vi.mock("@/infrastructure/setup/prisma", () => ({
+  prisma: {
+    $queryRaw: vi.fn(),
+  },
+}));
+
+vi.mock("@/infrastructure/setup/queues", () => ({
+  getTrackDownloadQueue: vi.fn(),
+}));
+
+describe("ConnectivityAdapter", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("pingDatabase", () => {
+    it("calls prisma.$queryRaw with SELECT 1", async () => {
+      vi.mocked(prisma.$queryRaw).mockResolvedValue([{ 1: 1 }] as any);
+
+      const adapter = new ConnectivityAdapter();
+      await adapter.pingDatabase();
+
+      expect(prisma.$queryRaw).toHaveBeenCalledOnce();
+    });
+
+    it("propagates rejection from $queryRaw", async () => {
+      vi.mocked(prisma.$queryRaw).mockRejectedValue(new Error("DB unreachable"));
+
+      const adapter = new ConnectivityAdapter();
+      await expect(adapter.pingDatabase()).rejects.toThrow("DB unreachable");
+    });
+  });
+
+  describe("pingRedis", () => {
+    it("calls client.ping() via the queue client", async () => {
+      const ping = vi.fn().mockResolvedValue("PONG");
+      vi.mocked(getTrackDownloadQueue).mockReturnValue({
+        client: Promise.resolve({ ping }),
+      } as any);
+
+      const adapter = new ConnectivityAdapter();
+      await adapter.pingRedis();
+
+      expect(ping).toHaveBeenCalledOnce();
+    });
+
+    it("rejects with timeout error when ping does not resolve within 2000ms", async () => {
+      vi.useFakeTimers();
+
+      const ping = vi.fn().mockReturnValue(new Promise(() => {})); // never resolves
+      vi.mocked(getTrackDownloadQueue).mockReturnValue({
+        client: Promise.resolve({ ping }),
+      } as any);
+
+      const adapter = new ConnectivityAdapter();
+      const pingPromise = adapter.pingRedis().catch((e) => e);
+
+      await vi.advanceTimersByTimeAsync(2001);
+
+      const error = await pingPromise;
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("redis ping timed out");
+
+      vi.useRealTimers();
+    });
+
+    it("propagates rejection when client.ping() rejects", async () => {
+      const ping = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+      vi.mocked(getTrackDownloadQueue).mockReturnValue({
+        client: Promise.resolve({ ping }),
+      } as any);
+
+      const adapter = new ConnectivityAdapter();
+      await expect(adapter.pingRedis()).rejects.toThrow("ECONNREFUSED");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/external-url-cache.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/external-url-cache.repository.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ExternalUrlCacheRepository } from "./external-url-cache.repository";
+
+describe("ExternalUrlCacheRepository", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("find", () => {
+    it("returns the externalUrl when a row is found", async () => {
+      const prisma = {
+        externalUrlCache: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue({ externalUrl: "https://open.spotify.com/track/abc" }),
+        },
+      } as any;
+
+      const repo = new ExternalUrlCacheRepository(prisma);
+      const result = await repo.find("spotify", "track", "abc123");
+
+      expect(result).toBe("https://open.spotify.com/track/abc");
+      expect(prisma.externalUrlCache.findFirst).toHaveBeenCalledWith({
+        where: { provider: "spotify", type: "track", internalId: "abc123" },
+        select: { externalUrl: true },
+      });
+    });
+
+    it("returns null when no row is found", async () => {
+      const prisma = {
+        externalUrlCache: {
+          findFirst: vi.fn().mockResolvedValue(null),
+        },
+      } as any;
+
+      const repo = new ExternalUrlCacheRepository(prisma);
+      const result = await repo.find("spotify", "album", "notfound");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("save", () => {
+    it("calls upsert with correct where/create/update args", async () => {
+      const prisma = {
+        externalUrlCache: {
+          upsert: vi.fn().mockResolvedValue(undefined),
+        },
+      } as any;
+
+      const repo = new ExternalUrlCacheRepository(prisma);
+      await repo.save({
+        provider: "spotify",
+        type: "track",
+        internalId: "t1",
+        name: "Song Title",
+        artistName: "Artist Name",
+        externalUrl: "https://spotify.com/t1",
+      });
+
+      expect(prisma.externalUrlCache.upsert).toHaveBeenCalledWith({
+        where: {
+          provider_type_internalId: { provider: "spotify", type: "track", internalId: "t1" },
+        },
+        create: {
+          provider: "spotify",
+          type: "track",
+          internalId: "t1",
+          name: "Song Title",
+          artistName: "Artist Name",
+          externalUrl: "https://spotify.com/t1",
+        },
+        update: {
+          externalUrl: "https://spotify.com/t1",
+          name: "Song Title",
+          artistName: "Artist Name",
+        },
+      });
+    });
+
+    it("coalesces undefined name and artistName to null in create and update", async () => {
+      const prisma = {
+        externalUrlCache: {
+          upsert: vi.fn().mockResolvedValue(undefined),
+        },
+      } as any;
+
+      const repo = new ExternalUrlCacheRepository(prisma);
+      await repo.save({
+        provider: "spotify",
+        type: "track",
+        internalId: "t2",
+        externalUrl: "https://spotify.com/t2",
+      });
+
+      const call = vi.mocked(prisma.externalUrlCache.upsert).mock.calls[0][0];
+      expect(call.create.name).toBeNull();
+      expect(call.create.artistName).toBeNull();
+      expect(call.update.name).toBeNull();
+      expect(call.update.artistName).toBeNull();
+    });
+
+    it("propagates upsert rejections", async () => {
+      const prisma = {
+        externalUrlCache: {
+          upsert: vi.fn().mockRejectedValue(new Error("DB error")),
+        },
+      } as any;
+
+      const repo = new ExternalUrlCacheRepository(prisma);
+      await expect(
+        repo.save({ provider: "spotify", type: "track", internalId: "t3", externalUrl: "url" }),
+      ).rejects.toThrow("DB error");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-ai-chat-message.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-ai-chat-message.repository.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { prisma } from "../setup/prisma";
+import { PrismaAiChatMessageRepository } from "./prisma-ai-chat-message.repository";
+
+// Mock the default prisma singleton BEFORE importing the repository.
+vi.mock("../setup/prisma", () => ({
+  prisma: {
+    aiChatMessage: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+describe("PrismaAiChatMessageRepository — no-arg constructor fallback", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses the default module prisma when constructed without arguments", async () => {
+    vi.mocked(prisma.aiChatMessage.findMany).mockResolvedValue([]);
+
+    const repo = new PrismaAiChatMessageRepository();
+    await repo.list();
+
+    expect(prisma.aiChatMessage.findMany).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-history.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-history.repository.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { prisma } from "../setup/prisma";
+import { PrismaHistoryRepository } from "./prisma-history.repository";
+
+vi.mock("../setup/prisma", () => ({
+  prisma: {
+    downloadHistory: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+    },
+    playlist: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+describe("PrismaHistoryRepository", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("findAll", () => {
+    it("maps BigInt completedAt to Number", async () => {
+      vi.mocked(prisma.downloadHistory.findMany).mockResolvedValue([
+        {
+          id: "h1",
+          playlistId: "p1",
+          playlistName: "My Playlist",
+          playlistSpotifyUrl: null,
+          trackId: "t1",
+          trackName: "Track One",
+          artist: "Artist",
+          album: "Album",
+          trackUrl: null,
+          completedAt: BigInt(1700000000000),
+        },
+      ] as any);
+
+      const repo = new PrismaHistoryRepository();
+      const result = await repo.findAll();
+
+      expect(result[0].completedAt).toBe(1700000000000);
+      expect(typeof result[0].completedAt).toBe("number");
+    });
+
+    it("passes the limit argument to findMany", async () => {
+      vi.mocked(prisma.downloadHistory.findMany).mockResolvedValue([]);
+
+      const repo = new PrismaHistoryRepository();
+      await repo.findAll(25);
+
+      expect(prisma.downloadHistory.findMany).toHaveBeenCalledWith({
+        take: 25,
+        orderBy: { completedAt: "desc" },
+      });
+    });
+
+    it("returns an empty array when there are no history rows", async () => {
+      vi.mocked(prisma.downloadHistory.findMany).mockResolvedValue([]);
+
+      const repo = new PrismaHistoryRepository();
+      const result = await repo.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("createFromTrack", () => {
+    it("looks up the playlist when playlistId is set and stores its name", async () => {
+      vi.mocked(prisma.playlist.findUnique).mockResolvedValue({
+        name: "Jazz Vibes",
+        spotifyUrl: "https://spotify.com/playlist/jv",
+      } as any);
+      vi.mocked(prisma.downloadHistory.create).mockResolvedValue({} as any);
+
+      const repo = new PrismaHistoryRepository();
+      await repo.createFromTrack({
+        id: "t1",
+        playlistId: "p1",
+        name: "Track A",
+        artist: "Coltrane",
+        album: "A Love Supreme",
+        trackUrl: null,
+      } as any);
+
+      expect(prisma.playlist.findUnique).toHaveBeenCalledWith({
+        where: { id: "p1" },
+        select: { name: true, spotifyUrl: true },
+      });
+      const createArg = vi.mocked(prisma.downloadHistory.create).mock.calls[0][0];
+      expect(createArg.data.playlistName).toBe("Jazz Vibes");
+      expect(createArg.data.playlistSpotifyUrl).toBe("https://spotify.com/playlist/jv");
+    });
+
+    it("skips the playlist lookup when playlistId is absent", async () => {
+      vi.mocked(prisma.downloadHistory.create).mockResolvedValue({} as any);
+
+      const repo = new PrismaHistoryRepository();
+      await repo.createFromTrack({
+        id: "t2",
+        playlistId: undefined,
+        name: "Track B",
+        artist: "Miles",
+        album: null,
+        trackUrl: null,
+      } as any);
+
+      expect(prisma.playlist.findUnique).not.toHaveBeenCalled();
+      const createArg = vi.mocked(prisma.downloadHistory.create).mock.calls[0][0];
+      expect(createArg.data.playlistName).toBe("Unknown");
+    });
+
+    it("stores completedAt as a BigInt", async () => {
+      vi.mocked(prisma.playlist.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.downloadHistory.create).mockResolvedValue({} as any);
+
+      const repo = new PrismaHistoryRepository();
+      await repo.createFromTrack({
+        id: "t3",
+        playlistId: "p2",
+        name: "Track C",
+        artist: "Monk",
+        album: null,
+        trackUrl: null,
+      } as any);
+
+      const createArg = vi.mocked(prisma.downloadHistory.create).mock.calls[0][0];
+      expect(typeof createArg.data.completedAt).toBe("bigint");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-playlist.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-playlist.repository.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { prisma } from "../setup/prisma";
+import { PrismaPlaylistRepository } from "./prisma-playlist.repository";
+
+vi.mock("../setup/prisma", () => ({
+  prisma: {
+    playlist: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+function makeDbPlaylist(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pl-1",
+    name: "Test Playlist",
+    type: "playlist",
+    spotifyUrl: "https://open.spotify.com/playlist/pl-1",
+    error: null,
+    subscribed: false,
+    createdAt: BigInt(1700000000000),
+    coverUrl: null,
+    artistImageUrl: null,
+    owner: null,
+    ownerUrl: null,
+    tracks: undefined,
+    ...overrides,
+  };
+}
+
+describe("PrismaPlaylistRepository", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("findAll", () => {
+    it("returns mapped Playlist entities with BigInt createdAt converted to Number", async () => {
+      vi.mocked(prisma.playlist.findMany).mockResolvedValue([makeDbPlaylist()] as any);
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.findAll();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("pl-1");
+      expect(result[0].createdAt).toBe(1700000000000);
+      expect(typeof result[0].createdAt).toBe("number");
+    });
+
+    it("returns an empty array when no playlists exist", async () => {
+      vi.mocked(prisma.playlist.findMany).mockResolvedValue([]);
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it("includes tracks in the query when includesTracks is true", async () => {
+      vi.mocked(prisma.playlist.findMany).mockResolvedValue([]);
+
+      const repo = new PrismaPlaylistRepository();
+      await repo.findAll(true);
+
+      expect(prisma.playlist.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ include: { tracks: true } }),
+      );
+    });
+  });
+
+  describe("findOne", () => {
+    it("returns null when the playlist does not exist", async () => {
+      vi.mocked(prisma.playlist.findUnique).mockResolvedValue(null);
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.findOne("nonexistent");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns a Playlist entity when found", async () => {
+      vi.mocked(prisma.playlist.findUnique).mockResolvedValue(makeDbPlaylist() as any);
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.findOne("pl-1");
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("pl-1");
+      expect(result!.name).toBe("Test Playlist");
+    });
+  });
+
+  describe("save", () => {
+    it("calls create with BigInt createdAt and returns mapped Playlist", async () => {
+      const fixedNow = 1700000000000;
+      vi.mocked(prisma.playlist.create).mockResolvedValue(
+        makeDbPlaylist({ createdAt: BigInt(fixedNow) }) as any,
+      );
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.save({
+        id: "pl-new",
+        name: "New Playlist",
+        type: "playlist" as any,
+        spotifyUrl: "https://open.spotify.com/playlist/new",
+        subscribed: false,
+        createdAt: fixedNow,
+      });
+
+      const createArg = vi.mocked(prisma.playlist.create).mock.calls[0][0];
+      expect(typeof createArg.data.createdAt).toBe("bigint");
+      expect(result.id).toBe("pl-1");
+    });
+
+    it("defaults spotifyUrl to empty string when not provided", async () => {
+      vi.mocked(prisma.playlist.create).mockResolvedValue(makeDbPlaylist() as any);
+
+      const repo = new PrismaPlaylistRepository();
+      await repo.save({
+        id: "pl-2",
+        name: "Playlist",
+        type: "playlist" as any,
+        subscribed: false,
+      } as any);
+
+      const createArg = vi.mocked(prisma.playlist.create).mock.calls[0][0];
+      expect(createArg.data.spotifyUrl).toBe("");
+    });
+  });
+
+  describe("delete", () => {
+    it("calls prisma.playlist.delete with the given id", async () => {
+      vi.mocked(prisma.playlist.delete).mockResolvedValue(makeDbPlaylist() as any);
+
+      const repo = new PrismaPlaylistRepository();
+      await repo.delete("pl-1");
+
+      expect(prisma.playlist.delete).toHaveBeenCalledWith({ where: { id: "pl-1" } });
+    });
+  });
+
+  describe("mapToPlaylist", () => {
+    it("maps tracks when they are present on the DB row", async () => {
+      const dbRow = makeDbPlaylist({
+        tracks: [
+          {
+            id: "tr-1",
+            name: "Track One",
+            artist: "Artist",
+            album: null,
+            albumYear: null,
+            trackNumber: null,
+            spotifyUrl: null,
+            trackUrl: null,
+            albumUrl: null,
+            artists: null,
+            youtubeUrl: null,
+            status: "completed",
+            error: null,
+            createdAt: BigInt(1700000000000),
+            completedAt: null,
+            playlistId: "pl-1",
+          },
+        ],
+      });
+      vi.mocked(prisma.playlist.findUnique).mockResolvedValue(dbRow as any);
+
+      const repo = new PrismaPlaylistRepository();
+      const result = await repo.findOne("pl-1");
+
+      expect(result!.tracks).toHaveLength(1);
+      expect(result!.tracks![0].id).toBe("tr-1");
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/prisma-settings.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/prisma-settings.repository.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { prisma } from "../setup/prisma";
+import { PrismaSettingsRepository } from "./prisma-settings.repository";
+
+vi.mock("../setup/prisma", () => ({
+  prisma: {
+    setting: {
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+describe("PrismaSettingsRepository", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe("findAll", () => {
+    it("maps BigInt updatedAt to a numeric string", async () => {
+      vi.mocked(prisma.setting.findMany).mockResolvedValue([
+        { key: "theme", value: "dark", updatedAt: BigInt(1700000000000) },
+      ] as any);
+
+      const repo = new PrismaSettingsRepository();
+      const result = await repo.findAll();
+
+      expect(result[0].updatedAt).toBe("1700000000000");
+    });
+
+    it("returns undefined for updatedAt when the DB value is null", async () => {
+      vi.mocked(prisma.setting.findMany).mockResolvedValue([
+        { key: "lang", value: "en", updatedAt: null },
+      ] as any);
+
+      const repo = new PrismaSettingsRepository();
+      const result = await repo.findAll();
+
+      expect(result[0].updatedAt).toBeUndefined();
+    });
+  });
+
+  describe("get", () => {
+    it("returns the setting value when the key exists", async () => {
+      vi.mocked(prisma.setting.findUnique).mockResolvedValue({
+        key: "theme",
+        value: "dark",
+        updatedAt: null,
+      } as any);
+
+      const repo = new PrismaSettingsRepository();
+      const result = await repo.get("theme");
+
+      expect(result).toBe("dark");
+    });
+
+    it("returns undefined when the key does not exist", async () => {
+      vi.mocked(prisma.setting.findUnique).mockResolvedValue(null);
+
+      const repo = new PrismaSettingsRepository();
+      const result = await repo.get("nonexistent");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("set", () => {
+    it("calls upsert with BigInt updatedAt in both update and create", async () => {
+      vi.mocked(prisma.setting.upsert).mockResolvedValue({} as any);
+
+      const repo = new PrismaSettingsRepository();
+      await repo.set("theme", "light");
+
+      const call = vi.mocked(prisma.setting.upsert).mock.calls[0][0];
+      expect(call.where).toEqual({ key: "theme" });
+      expect(call.update.value).toBe("light");
+      expect(typeof call.update.updatedAt).toBe("bigint");
+      expect(call.create.key).toBe("theme");
+      expect(call.create.value).toBe("light");
+      expect(typeof call.create.updatedAt).toBe("bigint");
+    });
+  });
+
+  describe("delete", () => {
+    it("resolves without throwing when the record is not found (P2025 — idempotent)", async () => {
+      const notFoundError = Object.assign(new Error("Record not found"), { code: "P2025" });
+      vi.mocked(prisma.setting.delete).mockRejectedValue(notFoundError);
+
+      const repo = new PrismaSettingsRepository();
+      await expect(repo.delete("gone")).resolves.toBeUndefined();
+    });
+
+    it("rethrows other errors as AppError with internal_server_error", async () => {
+      vi.mocked(prisma.setting.delete).mockRejectedValue(new Error("Connection lost"));
+
+      const repo = new PrismaSettingsRepository();
+      await expect(repo.delete("theme")).rejects.toBeInstanceOf(AppError);
+      await expect(repo.delete("theme")).rejects.toMatchObject({
+        statusCode: 500,
+        errorCode: "internal_server_error",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **database repositories** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (database repositories slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204