### PR TITLE
test(backend): add unit tests for messaging, jobs and infra services

### DIFF
--- a/apps/backend/src/infrastructure/jobs/catalog-sync.job.test.ts
+++ b/apps/backend/src/infrastructure/jobs/catalog-sync.job.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("catalogSyncJob interval guard", () => {
+  const getCatalogSyncState = vi.fn();
+  const getSyncState = vi.fn();
+  const feedRepository = { getCatalogSyncState, getSyncState };
+
+  const settingsService = {
+    getNumber: vi.fn((key: string) => {
+      if (key === "CATALOG_SYNC_INTERVAL_HOURS") return Promise.resolve(6);
+      return Promise.resolve(0);
+    }),
+  };
+
+  const catalogSyncAddMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.doMock("../../container", () => ({
+      getContainer: vi.fn(() => ({ settingsService, feedRepository })),
+    }));
+    vi.doMock("../setup/queues", () => ({
+      getCatalogSyncQueue: () => ({ add: catalogSyncAddMock }),
+    }));
+    // Default: both sync states idle
+    getCatalogSyncState.mockResolvedValue({ status: "idle" });
+    getSyncState.mockResolvedValue({ status: "idle" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("../../container");
+    vi.doUnmock("../setup/queues");
+  });
+
+  it("enqueues a catalog-sync job on the first execution", async () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).toHaveBeenCalledOnce();
+    expect(catalogSyncAddMock).toHaveBeenCalledWith(
+      "catalog-sync",
+      {},
+      expect.objectContaining({ jobId: expect.stringContaining("catalog-sync-") }),
+    );
+  });
+
+  it("skips enqueue when not enough time has elapsed since last run", async () => {
+    vi.setSystemTime(new Date("2026-01-01T01:00:00Z"));
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance less than 6 hours
+    vi.advanceTimersByTime(60_000);
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues again after the full interval has elapsed", async () => {
+    vi.setSystemTime(new Date("2026-01-01T02:00:00Z"));
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance exactly 6 hours
+    vi.advanceTimersByTime(6 * 60 * 60_000);
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips enqueue when catalog sync is already running", async () => {
+    vi.setSystemTime(new Date("2026-01-01T03:00:00Z"));
+    getCatalogSyncState.mockResolvedValue({ status: "running" });
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).not.toHaveBeenCalled();
+  });
+
+  it("skips enqueue when feed sync is already running", async () => {
+    vi.setSystemTime(new Date("2026-01-01T04:00:00Z"));
+    getSyncState.mockResolvedValue({ status: "running" });
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors and does not throw", async () => {
+    vi.setSystemTime(new Date("2026-01-01T05:00:00Z"));
+    settingsService.getNumber.mockRejectedValueOnce(new Error("settings failure"));
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await expect(catalogSyncJob.execute()).resolves.not.toThrow();
+  });
+
+  it("uses 6 hours as safe interval when configured value is 0 or negative", async () => {
+    vi.setSystemTime(new Date("2026-01-01T06:00:00Z"));
+    settingsService.getNumber.mockResolvedValue(0);
+    const { catalogSyncJob } = await import("./catalog-sync.job");
+
+    await catalogSyncJob.execute();
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance less than 6 hours — guard should block
+    vi.advanceTimersByTime(3 * 60 * 60_000);
+    await catalogSyncJob.execute();
+
+    expect(catalogSyncAddMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/infrastructure/jobs/feed-sync.job.test.ts
+++ b/apps/backend/src/infrastructure/jobs/feed-sync.job.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("feedSyncJob interval guard", () => {
+  const getSyncState = vi.fn();
+  const feedRepository = { getSyncState };
+
+  const settingsService = {
+    getNumber: vi.fn((key: string) => {
+      if (key === "RELEASES_SYNC_INTERVAL_MINUTES") return Promise.resolve(60);
+      return Promise.resolve(0);
+    }),
+  };
+
+  const feedSyncAddMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.resetModules();
+    vi.doMock("../../container", () => ({
+      getContainer: vi.fn(() => ({ settingsService, feedRepository })),
+    }));
+    vi.doMock("../setup/queues", () => ({
+      getFeedSyncQueue: () => ({ add: feedSyncAddMock }),
+    }));
+    // Default: sync state idle
+    getSyncState.mockResolvedValue({ status: "idle" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("../../container");
+    vi.doUnmock("../setup/queues");
+  });
+
+  it("enqueues a feed-sync job on the first execution", async () => {
+    vi.setSystemTime(new Date("2026-02-01T00:00:00Z"));
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await feedSyncJob.execute();
+
+    expect(feedSyncAddMock).toHaveBeenCalledOnce();
+    expect(feedSyncAddMock).toHaveBeenCalledWith(
+      "feed-sync",
+      {},
+      expect.objectContaining({ jobId: expect.stringContaining("feed-sync-") }),
+    );
+  });
+
+  it("skips enqueue when not enough time has elapsed since last run", async () => {
+    vi.setSystemTime(new Date("2026-02-01T01:00:00Z"));
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await feedSyncJob.execute();
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance less than 60 minutes
+    vi.advanceTimersByTime(10 * 60_000);
+    await feedSyncJob.execute();
+
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enqueues again after the full interval has elapsed", async () => {
+    vi.setSystemTime(new Date("2026-02-01T02:00:00Z"));
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await feedSyncJob.execute();
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance exactly 60 minutes
+    vi.advanceTimersByTime(60 * 60_000);
+    await feedSyncJob.execute();
+
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips enqueue when sync is already running", async () => {
+    vi.setSystemTime(new Date("2026-02-01T03:00:00Z"));
+    getSyncState.mockResolvedValue({ status: "running" });
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await feedSyncJob.execute();
+
+    expect(feedSyncAddMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors and does not throw", async () => {
+    vi.setSystemTime(new Date("2026-02-01T04:00:00Z"));
+    settingsService.getNumber.mockRejectedValueOnce(new Error("settings failure"));
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await expect(feedSyncJob.execute()).resolves.not.toThrow();
+  });
+
+  it("uses 60 minutes as safe interval when configured value is 0 or negative", async () => {
+    vi.setSystemTime(new Date("2026-02-01T05:00:00Z"));
+    settingsService.getNumber.mockResolvedValue(0);
+    const { feedSyncJob } = await import("./feed-sync.job");
+
+    await feedSyncJob.execute();
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(1);
+
+    // Advance less than 60 minutes — guard should block
+    vi.advanceTimersByTime(30 * 60_000);
+    await feedSyncJob.execute();
+
+    expect(feedSyncAddMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/infrastructure/messaging/app-event-bus.test.ts
+++ b/apps/backend/src/infrastructure/messaging/app-event-bus.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import { AppEventBus } from "./app-event-bus";
+
+describe("AppEventBus", () => {
+  it("constructs without an SSE emitter and still works", () => {
+    const bus = new AppEventBus();
+    expect(bus).toBeInstanceOf(AppEventBus);
+  });
+
+  it("forwards emitted events to internal Node.js listeners", () => {
+    const bus = new AppEventBus();
+    const listener = vi.fn();
+    bus.on("test-event", listener);
+
+    bus.emit("test-event", { foo: "bar" });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith({ foo: "bar" });
+  });
+
+  it("calls the SSE emitter with the event name and data", () => {
+    const sseEmitter = vi.fn();
+    const bus = new AppEventBus(sseEmitter);
+
+    bus.emit("playlist-updated", { id: 42 });
+
+    expect(sseEmitter).toHaveBeenCalledOnce();
+    expect(sseEmitter).toHaveBeenCalledWith("playlist-updated", { id: 42 });
+  });
+
+  it("calls both internal listeners and SSE emitter on a single emit", () => {
+    const sseEmitter = vi.fn();
+    const bus = new AppEventBus(sseEmitter);
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    bus.on("my-event", listenerA);
+    bus.on("my-event", listenerB);
+
+    bus.emit("my-event", "payload");
+
+    expect(listenerA).toHaveBeenCalledWith("payload");
+    expect(listenerB).toHaveBeenCalledWith("payload");
+    expect(sseEmitter).toHaveBeenCalledWith("my-event", "payload");
+  });
+
+  it("emits to SSE even when there are no internal listeners", () => {
+    const sseEmitter = vi.fn();
+    const bus = new AppEventBus(sseEmitter);
+
+    bus.emit("orphan-event", { x: 1 });
+
+    expect(sseEmitter).toHaveBeenCalledOnce();
+    expect(sseEmitter).toHaveBeenCalledWith("orphan-event", { x: 1 });
+  });
+
+  it("returns the boolean result from the underlying EventEmitter emit", () => {
+    const bus = new AppEventBus();
+    const listener = vi.fn();
+    bus.on("has-listener", listener);
+
+    const withListener = bus.emit("has-listener");
+    const withoutListener = bus.emit("no-listener");
+
+    expect(withListener).toBe(true);
+    expect(withoutListener).toBe(false);
+  });
+
+  it("emits events with undefined data when no data argument is provided", () => {
+    const sseEmitter = vi.fn();
+    const bus = new AppEventBus(sseEmitter);
+    const listener = vi.fn();
+    bus.on("no-data-event", listener);
+
+    bus.emit("no-data-event");
+
+    expect(listener).toHaveBeenCalledWith(undefined);
+    expect(sseEmitter).toHaveBeenCalledWith("no-data-event", undefined);
+  });
+
+  it("supports multiple independent subscriptions on different event names", () => {
+    const bus = new AppEventBus();
+    const fooListener = vi.fn();
+    const barListener = vi.fn();
+    bus.on("foo", fooListener);
+    bus.on("bar", barListener);
+
+    bus.emit("foo", 1);
+    bus.emit("bar", 2);
+
+    expect(fooListener).toHaveBeenCalledWith(1);
+    expect(barListener).toHaveBeenCalledWith(2);
+    expect(fooListener).not.toHaveBeenCalledWith(2);
+    expect(barListener).not.toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/backend/src/infrastructure/messaging/bullmq-artwork-backfill-queue.service.test.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-artwork-backfill-queue.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const addMock = vi.fn();
+
+vi.mock("../setup/queues", () => ({
+  getArtworkBackfillQueue: () => ({ add: addMock }),
+}));
+
+describe("BullMqArtworkBackfillQueueService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a job named 'artwork-backfill-run' with the runId in the payload", async () => {
+    const { BullMqArtworkBackfillQueueService } =
+      await import("./bullmq-artwork-backfill-queue.service");
+    const service = new BullMqArtworkBackfillQueueService();
+
+    await service.enqueueRun("run-123");
+
+    expect(addMock).toHaveBeenCalledOnce();
+    expect(addMock).toHaveBeenCalledWith(
+      "artwork-backfill-run",
+      { runId: "run-123" },
+      expect.objectContaining({ jobId: "artwork-backfill-active" }),
+    );
+  });
+
+  it("uses a stable jobId 'artwork-backfill-active' to deduplicate concurrent runs", async () => {
+    const { BullMqArtworkBackfillQueueService } =
+      await import("./bullmq-artwork-backfill-queue.service");
+    const service = new BullMqArtworkBackfillQueueService();
+
+    await service.enqueueRun("run-abc");
+
+    const [, , opts] = addMock.mock.calls[0];
+    expect(opts.jobId).toBe("artwork-backfill-active");
+  });
+
+  it("sets removeOnComplete to true so finished jobs do not pile up", async () => {
+    const { BullMqArtworkBackfillQueueService } =
+      await import("./bullmq-artwork-backfill-queue.service");
+    const service = new BullMqArtworkBackfillQueueService();
+
+    await service.enqueueRun("run-xyz");
+
+    const [, , opts] = addMock.mock.calls[0];
+    expect(opts.removeOnComplete).toBe(true);
+  });
+
+  it("propagates queue errors to the caller", async () => {
+    const { BullMqArtworkBackfillQueueService } =
+      await import("./bullmq-artwork-backfill-queue.service");
+    const service = new BullMqArtworkBackfillQueueService();
+    addMock.mockRejectedValueOnce(new Error("redis unavailable"));
+
+    await expect(service.enqueueRun("run-fail")).rejects.toThrow("redis unavailable");
+  });
+});

--- a/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.test.ts
+++ b/apps/backend/src/infrastructure/messaging/bullmq-track-queue.service.test.ts
@@ -1,0 +1,136 @@
+import type { ITrack } from "@spotiarr/shared";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const downloadAddMock = vi.fn();
+const searchAddMock = vi.fn();
+
+vi.mock("../setup/queues", () => ({
+  getTrackDownloadQueue: () => ({ add: downloadAddMock }),
+  getTrackSearchQueue: () => ({ add: searchAddMock }),
+}));
+
+const baseTrack: ITrack = {
+  id: "track-1",
+  name: "Some Track",
+  artist: "Some Artist",
+  album: "Some Album",
+  albumArtist: "Some Artist",
+  status: "new" as any,
+  trackNumber: 3,
+  discNumber: 1,
+  durationMs: 240000,
+  playlistIndex: null,
+  playlistId: null,
+  error: null,
+  youtubeUrl: null,
+  spotifyId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as unknown as ITrack;
+
+describe("BullMqTrackQueueService — enqueueSearchTrack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a 'search-track' job with the track as data", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueSearchTrack(baseTrack);
+
+    expect(searchAddMock).toHaveBeenCalledOnce();
+    expect(searchAddMock).toHaveBeenCalledWith(
+      "search-track",
+      baseTrack,
+      expect.objectContaining({ jobId: `id-${baseTrack.id}` }),
+    );
+  });
+
+  it("uses the track id to form the jobId for search", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueSearchTrack({ ...baseTrack, id: "abc-99" } as unknown as ITrack);
+
+    const [, , opts] = searchAddMock.mock.calls[0];
+    expect(opts.jobId).toBe("id-abc-99");
+  });
+
+  it("propagates search queue errors to the caller", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+    searchAddMock.mockRejectedValueOnce(new Error("search queue down"));
+
+    await expect(service.enqueueSearchTrack(baseTrack)).rejects.toThrow("search queue down");
+  });
+});
+
+describe("BullMqTrackQueueService — enqueueDownloadTrack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enqueues a 'download-track' job with the track as data", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueDownloadTrack(baseTrack);
+
+    expect(downloadAddMock).toHaveBeenCalledOnce();
+    expect(downloadAddMock).toHaveBeenCalledWith(
+      "download-track",
+      baseTrack,
+      expect.objectContaining({ jobId: `download-${baseTrack.id}` }),
+    );
+  });
+
+  it("defaults to 3 attempts when no options are provided", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueDownloadTrack(baseTrack);
+
+    const [, , opts] = downloadAddMock.mock.calls[0];
+    expect(opts.attempts).toBe(3);
+  });
+
+  it("uses the maxRetries option when provided", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueDownloadTrack(baseTrack, { maxRetries: 7 });
+
+    const [, , opts] = downloadAddMock.mock.calls[0];
+    expect(opts.attempts).toBe(7);
+  });
+
+  it("uses exponential backoff with a 5 second delay", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueDownloadTrack(baseTrack);
+
+    const [, , opts] = downloadAddMock.mock.calls[0];
+    expect(opts.backoff).toEqual({ type: "exponential", delay: 5000 });
+  });
+
+  it("sets both removeOnComplete and removeOnFail to prevent stale jobId locks", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+
+    await service.enqueueDownloadTrack(baseTrack);
+
+    const [, , opts] = downloadAddMock.mock.calls[0];
+    expect(opts.removeOnComplete).toBe(true);
+    expect(opts.removeOnFail).toBe(true);
+  });
+
+  it("propagates download queue errors to the caller", async () => {
+    const { BullMqTrackQueueService } = await import("./bullmq-track-queue.service");
+    const service = new BullMqTrackQueueService();
+    downloadAddMock.mockRejectedValueOnce(new Error("download queue down"));
+
+    await expect(service.enqueueDownloadTrack(baseTrack)).rejects.toThrow("download queue down");
+  });
+});

--- a/apps/backend/src/infrastructure/services/embedded-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/services/embedded-artwork-source.service.test.ts
@@ -1,0 +1,155 @@
+import { parseFile } from "music-metadata";
+import { mkdir, writeFile } from "node:fs/promises";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EmbeddedArtworkSourceService } from "./embedded-artwork-source.service";
+
+// Mock music-metadata and fs/promises before importing the service
+vi.mock("music-metadata", () => ({
+  parseFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+const parseFileMock = vi.mocked(parseFile);
+const mkdirMock = vi.mocked(mkdir);
+const writeFileMock = vi.mocked(writeFile);
+
+describe("EmbeddedArtworkSourceService", () => {
+  let service: EmbeddedArtworkSourceService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new EmbeddedArtworkSourceService();
+  });
+
+  it("returns null when the track list is empty", async () => {
+    const result = await service.extractFromTracks([]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no track contains embedded artwork", async () => {
+    parseFileMock.mockResolvedValue({ common: { picture: [] } } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the picture has no data", async () => {
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/jpeg", data: null }] },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the picture format is unsupported", async () => {
+    parseFileMock.mockResolvedValue({
+      common: {
+        picture: [{ format: "image/bmp", data: Buffer.from("fakebytes") }],
+      },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+    expect(result).toBeNull();
+  });
+
+  it("extracts artwork from a jpeg picture and writes it to a temp file", async () => {
+    const fakeData = Buffer.from("jpeg-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/jpeg", data: fakeData }] },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/^file:\/\//);
+    expect(result).toMatch(/\.jpg$/);
+    expect(mkdirMock).toHaveBeenCalledOnce();
+    expect(writeFileMock).toHaveBeenCalledOnce();
+    expect(writeFileMock).toHaveBeenCalledWith(expect.stringContaining(".jpg"), fakeData);
+  });
+
+  it("extracts artwork from a png picture", async () => {
+    const fakeData = Buffer.from("png-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/png", data: fakeData }] },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+
+    expect(result).toMatch(/\.png$/);
+  });
+
+  it("extracts artwork from a webp picture", async () => {
+    const fakeData = Buffer.from("webp-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/webp", data: fakeData }] },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+
+    expect(result).toMatch(/\.webp$/);
+  });
+
+  it("accepts 'image/jpg' as an alias for jpeg and uses .jpg extension", async () => {
+    const fakeData = Buffer.from("jpg-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/jpg", data: fakeData }] },
+    } as any);
+
+    const result = await service.extractFromTracks(["/music/track.mp3"]);
+
+    expect(result).toMatch(/\.jpg$/);
+  });
+
+  it("skips a failing track and tries the next one", async () => {
+    const fakeData = Buffer.from("jpeg-data");
+    parseFileMock.mockRejectedValueOnce(new Error("corrupt file")).mockResolvedValueOnce({
+      common: { picture: [{ format: "image/jpeg", data: fakeData }] },
+    } as any);
+
+    const result = await service.extractFromTracks([
+      "/music/bad-track.mp3",
+      "/music/good-track.mp3",
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/^file:\/\//);
+  });
+
+  it("returns null when all tracks fail to parse", async () => {
+    parseFileMock.mockRejectedValue(new Error("parse error"));
+
+    const result = await service.extractFromTracks(["/music/a.mp3", "/music/b.mp3"]);
+    expect(result).toBeNull();
+  });
+
+  it("writes to the spotiarr-artwork-backfill subdirectory of tmpdir", async () => {
+    const fakeData = Buffer.from("jpeg-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/jpeg", data: fakeData }] },
+    } as any);
+
+    await service.extractFromTracks(["/music/track.mp3"]);
+
+    const mkdirPath = mkdirMock.mock.calls[0][0] as string;
+    expect(mkdirPath).toContain("spotiarr-artwork-backfill");
+  });
+
+  it("creates the tmp directory with recursive: true", async () => {
+    const fakeData = Buffer.from("jpeg-data");
+    parseFileMock.mockResolvedValue({
+      common: { picture: [{ format: "image/jpeg", data: fakeData }] },
+    } as any);
+
+    await service.extractFromTracks(["/music/track.mp3"]);
+
+    expect(mkdirMock).toHaveBeenCalledWith(expect.stringContaining("spotiarr-artwork-backfill"), {
+      recursive: true,
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/services/file-system-m3u.service.test.ts
+++ b/apps/backend/src/infrastructure/services/file-system-m3u.service.test.ts
@@ -1,0 +1,256 @@
+import { TrackStatusEnum, type IPlaylist, type ITrack } from "@spotiarr/shared";
+import * as fs from "fs";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FileSystemM3uService } from "./file-system-m3u.service";
+
+vi.mock("fs", () => ({
+  writeFileSync: vi.fn(),
+}));
+
+const writeFileSyncMock = vi.mocked(fs.writeFileSync);
+
+function makePlaylist(overrides: Partial<IPlaylist> = {}): IPlaylist {
+  return {
+    id: "pl-1",
+    name: "My Playlist",
+    spotifyId: "spotify-pl-1",
+    description: null,
+    coverUrl: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as unknown as IPlaylist;
+}
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "track-1",
+    name: "Cool Song",
+    artist: "Cool Artist",
+    albumArtist: "Cool Artist",
+    album: "Cool Album",
+    status: TrackStatusEnum.Completed,
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 180000,
+    playlistIndex: 1,
+    playlistId: "pl-1",
+    error: null,
+    youtubeUrl: null,
+    spotifyId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as unknown as ITrack;
+}
+
+function makeSettingsService(enabled = true) {
+  return {
+    getBoolean: vi.fn().mockResolvedValue(enabled),
+    getString: vi.fn().mockResolvedValue("mp3"),
+  } as any;
+}
+
+function makeTrackPathService(fileName = "01 - Cool Artist - Cool Song.mp3") {
+  return {
+    getTrackFileName: vi.fn().mockResolvedValue(`/downloads/Playlists/My Playlist/${fileName}`),
+  } as any;
+}
+
+describe("FileSystemM3uService — generateM3uFile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when M3U generation is disabled", async () => {
+    const settings = makeSettingsService(false);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there are no completed tracks", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const pendingTrack = makeTrack({ status: TrackStatusEnum.New });
+
+    await service.generateM3uFile(playlist, [pendingTrack], "/downloads/Playlists/My Playlist");
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it("writes an M3U8 file when there is at least one completed track", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    expect(writeFileSyncMock).toHaveBeenCalledOnce();
+  });
+
+  it("writes the file with UTF-8 encoding", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    const [, , encoding] = writeFileSyncMock.mock.calls[0];
+    expect(encoding).toBe("utf-8");
+  });
+
+  it("generates content starting with #EXTM3U header", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toMatch(/^#EXTM3U/);
+  });
+
+  it("includes the playlist name in the #PLAYLIST directive", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist({ name: "Chill Vibes" });
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/Chill Vibes");
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toContain("#PLAYLIST:Chill Vibes");
+  });
+
+  it("includes #EXTINF line with duration and artist/title", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    // 180000ms = 180s
+    const track = makeTrack({ durationMs: 180000, artist: "Artist", name: "Title" });
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toContain("#EXTINF:180,Artist - Title");
+  });
+
+  it("uses -1 as duration when track has no durationMs", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack({ durationMs: null as any });
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toContain("#EXTINF:-1,");
+  });
+
+  it("includes #EXTART line with the artist name", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack({ artist: "The Beatles" });
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist");
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toContain("#EXTART:The Beatles");
+  });
+
+  it("only includes completed tracks, filtering out non-completed ones", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const completedTrack = makeTrack({ id: "t1", name: "Done Track" });
+    const pendingTrack = makeTrack({
+      id: "t2",
+      name: "Pending Track",
+      status: TrackStatusEnum.New,
+    });
+
+    await service.generateM3uFile(
+      playlist,
+      [completedTrack, pendingTrack],
+      "/downloads/Playlists/My Playlist",
+    );
+
+    const [, content] = writeFileSyncMock.mock.calls[0];
+    expect(String(content)).toContain("Done Track");
+    expect(String(content)).not.toContain("Pending Track");
+  });
+
+  it("sanitizes the playlist name in the output file path", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = makeTrackPathService();
+    const service = new FileSystemM3uService(settings, trackPath);
+    // Name with characters that need sanitization
+    const playlist = makePlaylist({ name: 'My: "Playlist"' });
+    const track = makeTrack();
+
+    await service.generateM3uFile(playlist, [track], "/downloads/Playlists");
+
+    const [filePath] = writeFileSyncMock.mock.calls[0];
+    // The written path must not contain colon or quotes
+    expect(String(filePath)).not.toMatch(/[:"]/);
+  });
+
+  it("swallows errors and does not throw", async () => {
+    const settings = makeSettingsService(true);
+    const trackPath = {
+      getTrackFileName: vi.fn().mockRejectedValue(new Error("path failure")),
+    } as any;
+    const service = new FileSystemM3uService(settings, trackPath);
+    const playlist = makePlaylist();
+    const track = makeTrack();
+
+    await expect(
+      service.generateM3uFile(playlist, [track], "/downloads/Playlists/My Playlist"),
+    ).resolves.not.toThrow();
+  });
+});
+
+describe("FileSystemM3uService — getCompletedTracksCount", () => {
+  it("returns the number of completed tracks", () => {
+    const service = new FileSystemM3uService({} as any, {} as any);
+    const tracks = [
+      makeTrack({ status: TrackStatusEnum.Completed }),
+      makeTrack({ status: TrackStatusEnum.New }),
+      makeTrack({ status: TrackStatusEnum.Completed }),
+    ];
+
+    expect(service.getCompletedTracksCount(tracks)).toBe(2);
+  });
+
+  it("returns 0 when no tracks are completed", () => {
+    const service = new FileSystemM3uService({} as any, {} as any);
+    const tracks = [makeTrack({ status: TrackStatusEnum.New })];
+
+    expect(service.getCompletedTracksCount(tracks)).toBe(0);
+  });
+
+  it("returns 0 for an empty track list", () => {
+    const service = new FileSystemM3uService({} as any, {} as any);
+    expect(service.getCompletedTracksCount([])).toBe(0);
+  });
+});

--- a/apps/backend/src/infrastructure/services/file-system-track-path.service.test.ts
+++ b/apps/backend/src/infrastructure/services/file-system-track-path.service.test.ts
@@ -1,0 +1,205 @@
+import type { ITrack } from "@spotiarr/shared";
+import { mkdir } from "node:fs/promises";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FileSystemTrackPathService } from "./file-system-track-path.service";
+
+vi.mock("../setup/environment", () => ({
+  getEnv: () => ({ DOWNLOADS: "/music" }),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mkdirMock = vi.mocked(mkdir);
+
+function makeSettingsService(format = "mp3") {
+  return {
+    getString: vi.fn().mockResolvedValue(format),
+  } as any;
+}
+
+function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
+  return {
+    id: "t1",
+    name: "Cool Song",
+    artist: "Cool Artist",
+    albumArtist: "Album Artist",
+    album: "Cool Album",
+    trackNumber: 3,
+    discNumber: 1,
+    durationMs: 200000,
+    playlistIndex: 5,
+    status: "completed" as any,
+    error: null,
+    youtubeUrl: null,
+    spotifyId: null,
+    playlistId: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as unknown as ITrack;
+}
+
+describe("FileSystemTrackPathService — path building", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("getMusicLibraryPath returns the DOWNLOADS env value", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    expect(service.getMusicLibraryPath()).toBe("/music");
+  });
+
+  it("getArtistFolderPath resolves Artist under the library root", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    const result = service.getArtistFolderPath("Radiohead");
+    expect(result).toBe("/music/Radiohead");
+  });
+
+  it("getAlbumFolderPath resolves Artist/Album under the library root", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    const result = service.getAlbumFolderPath("Radiohead", "OK Computer");
+    expect(result).toBe("/music/Radiohead/OK Computer");
+  });
+
+  it("getPlaylistsLibraryPath resolves Playlists/ under the library root", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    expect(service.getPlaylistsLibraryPath()).toBe("/music/Playlists");
+  });
+
+  it("getPlaylistFolderPath resolves a named playlist under Playlists/", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    expect(service.getPlaylistFolderPath("Chill Vibes")).toBe("/music/Playlists/Chill Vibes");
+  });
+});
+
+describe("FileSystemTrackPathService — stripFileIllegalChars", () => {
+  it("replaces illegal characters with hyphens", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    expect(service.stripFileIllegalChars('AC/DC: "The Band"')).toBe("AC-DC- -The Band-");
+  });
+
+  it("leaves safe characters unchanged", () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+    expect(service.stripFileIllegalChars("Safe Name 123")).toBe("Safe Name 123");
+  });
+});
+
+describe("FileSystemTrackPathService — getTrackFileName (album track)", () => {
+  it("builds an album track path using albumArtist, album, and track number", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({
+      name: "Creep",
+      albumArtist: "Radiohead",
+      album: "Pablo Honey",
+      trackNumber: 2,
+      discNumber: 1,
+      playlistIndex: undefined,
+    });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toBe("/music/Radiohead/Pablo Honey/02 - Creep.mp3");
+  });
+
+  it("pads track number to 2 digits", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({ trackNumber: 1, playlistIndex: undefined });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toContain("01 -");
+  });
+
+  it("adds a disc prefix when discNumber > 1", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({
+      trackNumber: 3,
+      discNumber: 2,
+      playlistIndex: undefined,
+    });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toContain("2-03 -");
+  });
+
+  it("omits disc prefix when discNumber is 1", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({ discNumber: 1, playlistIndex: undefined });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).not.toMatch(/^\d+-/);
+  });
+
+  it("uses 'Unknown Artist' when albumArtist and artist are both absent", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({
+      albumArtist: undefined as any,
+      artist: undefined as any,
+      playlistIndex: undefined,
+    });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toContain("Unknown Artist");
+  });
+
+  it("uses 'Unknown Album' when album is absent", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({ album: undefined as any, playlistIndex: undefined });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toContain("Unknown Album");
+  });
+
+  it("uses the format from settings as the file extension", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("flac"));
+    const track = makeTrack({ playlistIndex: undefined });
+
+    const result = await service.getTrackFileName(track);
+
+    expect(result).toMatch(/\.flac$/);
+  });
+});
+
+describe("FileSystemTrackPathService — getTrackFileName (playlist track)", () => {
+  it("builds a playlist track path using playlistIndex when provided", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({ playlistIndex: 7, albumArtist: "Artist", name: "Song" });
+
+    const result = await service.getTrackFileName(track, "My Playlist");
+
+    expect(result).toContain("Playlists");
+    expect(result).toContain("My Playlist");
+    expect(result).toContain("07 - Artist - Song.mp3");
+  });
+
+  it("falls back to trackNumber when playlistIndex is null", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService("mp3"));
+    const track = makeTrack({
+      playlistIndex: undefined,
+      trackNumber: 4,
+      albumArtist: "A",
+      name: "T",
+    });
+
+    const result = await service.getTrackFileName(track, "PL");
+
+    expect(result).toContain("04 - A - T.mp3");
+  });
+});
+
+describe("FileSystemTrackPathService — ensureParentDirectory", () => {
+  it("calls mkdir with recursive: true on the parent directory", async () => {
+    const service = new FileSystemTrackPathService(makeSettingsService());
+
+    await service.ensureParentDirectory("/music/Artist/Album/01 - Track.mp3");
+
+    expect(mkdirMock).toHaveBeenCalledOnce();
+    expect(mkdirMock).toHaveBeenCalledWith("/music/Artist/Album", { recursive: true });
+  });
+});

--- a/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.test.ts
+++ b/apps/backend/src/infrastructure/services/noop-spotify-artwork-source.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { ArtworkBackfillCandidate } from "@/application/ports/artwork-backfill-sources.port";
+import { NoopSpotifyArtworkSourceService } from "./noop-spotify-artwork-source.service";
+
+const artistCandidate: ArtworkBackfillCandidate = {
+  type: "artist",
+  cursorValue: "cursor-1",
+  artistName: "Radiohead",
+  artistSpotifyId: "spotify-artist-1",
+};
+
+const albumCandidate: ArtworkBackfillCandidate = {
+  type: "album",
+  cursorValue: "cursor-2",
+  artistName: "Radiohead",
+  albumName: "OK Computer",
+  albumSpotifyId: "spotify-album-1",
+};
+
+describe("NoopSpotifyArtworkSourceService", () => {
+  it("findArtistImageUrl always returns null", async () => {
+    const service = new NoopSpotifyArtworkSourceService();
+    const result = await service.findArtistImageUrl(artistCandidate);
+    expect(result).toBeNull();
+  });
+
+  it("findAlbumCoverUrl always returns null", async () => {
+    const service = new NoopSpotifyArtworkSourceService();
+    const result = await service.findAlbumCoverUrl(albumCandidate);
+    expect(result).toBeNull();
+  });
+
+  it("findArtistImageUrl returns null for any candidate shape", async () => {
+    const service = new NoopSpotifyArtworkSourceService();
+    const result = await service.findArtistImageUrl(albumCandidate);
+    expect(result).toBeNull();
+  });
+
+  it("findAlbumCoverUrl returns null for any candidate shape", async () => {
+    const service = new NoopSpotifyArtworkSourceService();
+    const result = await service.findAlbumCoverUrl(artistCandidate);
+    expect(result).toBeNull();
+  });
+
+  it("implements ArtworkBackfillExternalSourcePort (duck-type check)", () => {
+    const service = new NoopSpotifyArtworkSourceService();
+    expect(typeof service.findArtistImageUrl).toBe("function");
+    expect(typeof service.findAlbumCoverUrl).toBe("function");
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **messaging, jobs & infra services** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (messaging, jobs & infra services slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204