### PR TITLE
test(backend): add unit tests for controllers, middleware and request schema

### DIFF
--- a/apps/backend/src/presentation/controllers/external-url.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/external-url.controller.test.ts
@@ -1,0 +1,114 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ResolveExternalUrlUseCase } from "@/application/use-cases/external-url/resolve-external-url.use-case";
+import { ExternalUrlController } from "./external-url.controller";
+
+function mockRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  return { json, status } as unknown as Response;
+}
+
+function makeReq(query: Record<string, string> = {}): Request {
+  return { query } as unknown as Request;
+}
+
+function makeUseCaseMock(resolvedUrl: string | null = "https://open.spotify.com/track/abc") {
+  return {
+    resolve: vi.fn().mockResolvedValue(resolvedUrl),
+  } as unknown as ResolveExternalUrlUseCase;
+}
+
+describe("ExternalUrlController", () => {
+  let controller: ExternalUrlController;
+  let useCase: ResolveExternalUrlUseCase;
+
+  beforeEach(() => {
+    useCase = makeUseCaseMock();
+    controller = new ExternalUrlController(useCase);
+  });
+
+  describe("resolve — valid query", () => {
+    it("returns 200 with url when use case resolves a url", async () => {
+      const res = mockRes();
+      await controller.resolve(makeReq({ provider: "spotify", type: "track", id: "abc123" }), res);
+
+      expect(useCase.resolve).toHaveBeenCalledWith({
+        provider: "spotify",
+        type: "track",
+        internalId: "abc123",
+        name: undefined,
+        artistName: undefined,
+      });
+      expect(res.json).toHaveBeenCalledWith({ url: "https://open.spotify.com/track/abc" });
+    });
+
+    it("passes optional name and artist query params to the use case", async () => {
+      const res = mockRes();
+      await controller.resolve(
+        makeReq({
+          provider: "spotify",
+          type: "artist",
+          id: "x1",
+          name: "Daft Punk",
+          artist: "Daft Punk",
+        }),
+        res,
+      );
+
+      expect(useCase.resolve).toHaveBeenCalledWith({
+        provider: "spotify",
+        type: "artist",
+        internalId: "x1",
+        name: "Daft Punk",
+        artistName: "Daft Punk",
+      });
+    });
+
+    it("returns 404 when use case returns null", async () => {
+      vi.mocked(useCase.resolve).mockResolvedValue(null);
+      const res = mockRes();
+      await controller.resolve(makeReq({ provider: "spotify", type: "album", id: "missing" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "not_found" });
+    });
+
+    it("returns 503 when use case throws", async () => {
+      vi.mocked(useCase.resolve).mockRejectedValue(new Error("circuit open"));
+      const res = mockRes();
+      await controller.resolve(makeReq({ provider: "spotify", type: "track", id: "x" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json).toHaveBeenCalledWith({ error: "service_unavailable", retryable: true });
+    });
+  });
+
+  describe("resolve — invalid query", () => {
+    it("returns 400 when provider is missing", async () => {
+      const res = mockRes();
+      await controller.resolve(makeReq({ type: "track", id: "abc" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "invalid_params" }));
+      expect(useCase.resolve).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when type is not a valid enum value", async () => {
+      const res = mockRes();
+      await controller.resolve(makeReq({ provider: "spotify", type: "playlist", id: "abc" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "invalid_params", details: expect.any(Object) }),
+      );
+    });
+
+    it("returns 400 when id is empty string", async () => {
+      const res = mockRes();
+      await controller.resolve(makeReq({ provider: "spotify", type: "track", id: "" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/history.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/history.controller.test.ts
@@ -1,0 +1,72 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { HistoryUseCases } from "@/application/use-cases/history/history.use-cases";
+import { HistoryController } from "./history.controller";
+
+function mockRes(): Response {
+  return { json: vi.fn() } as unknown as Response;
+}
+
+function mockReq(): Request {
+  return {} as unknown as Request;
+}
+
+function makeUseCases(downloads: unknown[] = [], tracks: unknown[] = []): HistoryUseCases {
+  return {
+    getRecentDownloads: vi.fn().mockResolvedValue(downloads),
+    getRecentTracks: vi.fn().mockResolvedValue(tracks),
+  } as unknown as HistoryUseCases;
+}
+
+describe("HistoryController", () => {
+  let useCases: HistoryUseCases;
+  let controller: HistoryController;
+
+  beforeEach(() => {
+    useCases = makeUseCases();
+    controller = new HistoryController(useCases);
+  });
+
+  describe("getRecentDownloads", () => {
+    it("responds with { data: items } from use case", async () => {
+      const items = [{ id: "1", name: "Song A" }];
+      vi.mocked(useCases.getRecentDownloads).mockResolvedValue(items as never);
+
+      const res = mockRes();
+      await controller.getRecentDownloads(mockReq(), res);
+
+      expect(useCases.getRecentDownloads).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith({ data: items });
+    });
+
+    it("responds with { data: [] } when use case returns empty array", async () => {
+      const res = mockRes();
+      await controller.getRecentDownloads(mockReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+  });
+
+  describe("getRecentTracks", () => {
+    it("responds with { data: items } from use case", async () => {
+      const items = [
+        { id: "t1", title: "Track 1" },
+        { id: "t2", title: "Track 2" },
+      ];
+      vi.mocked(useCases.getRecentTracks).mockResolvedValue(items as never);
+
+      const res = mockRes();
+      await controller.getRecentTracks(mockReq(), res);
+
+      expect(useCases.getRecentTracks).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith({ data: items });
+    });
+
+    it("responds with { data: [] } when use case returns empty array", async () => {
+      const res = mockRes();
+      await controller.getRecentTracks(mockReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/library.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/library.controller.test.ts
@@ -1,0 +1,332 @@
+import type { Request, Response } from "express";
+import { EventEmitter } from "node:stream";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LibraryAudioPort } from "@/application/ports/library-audio.port";
+import type { LibraryImagePort } from "@/application/ports/library-image.port";
+import type { LibraryService } from "@/application/services/library.service";
+import { LibraryController } from "./library.controller";
+
+function makeJsonRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const type = vi.fn().mockReturnThis();
+  const sendFile = vi.fn();
+  const setHeader = vi.fn().mockReturnThis();
+  const send = vi.fn().mockReturnThis();
+  return {
+    json,
+    status,
+    type,
+    sendFile,
+    setHeader,
+    send,
+    headersSent: false,
+  } as unknown as Response;
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeLibraryService(): LibraryService {
+  return {
+    getStats: vi.fn().mockResolvedValue({ totalTracks: 10, totalArtists: 3 }),
+    getArtists: vi.fn().mockResolvedValue([{ name: "Artist A" }]),
+    getArtist: vi.fn().mockResolvedValue({ name: "Artist A", albums: [] }),
+    scan: vi.fn().mockResolvedValue({ scanned: 42 }),
+  } as unknown as LibraryService;
+}
+
+function makeAudioService(): LibraryAudioPort {
+  return {
+    resolveAudio: vi.fn().mockResolvedValue({
+      kind: "accept",
+      absolutePath: "/music/song.mp3",
+      contentType: "audio/mpeg",
+      sizeBytes: 1000,
+    }),
+    createAudioReadStream: vi
+      .fn()
+      .mockReturnValue(Object.assign(new EventEmitter(), { pipe: vi.fn() })),
+  } as unknown as LibraryAudioPort;
+}
+
+function makeImageService(): LibraryImagePort {
+  return {
+    resolveImage: vi.fn().mockResolvedValue({
+      kind: "accept",
+      absolutePath: "/covers/img.jpg",
+      contentType: "image/jpeg",
+    }),
+  } as unknown as LibraryImagePort;
+}
+
+describe("LibraryController", () => {
+  let libraryService: LibraryService;
+  let audioService: LibraryAudioPort;
+  let imageService: LibraryImagePort;
+  let controller: LibraryController;
+
+  beforeEach(() => {
+    libraryService = makeLibraryService();
+    audioService = makeAudioService();
+    imageService = makeImageService();
+    controller = new LibraryController(libraryService, audioService, imageService);
+  });
+
+  // ─── getStats ─────────────────────────────────────────────────────────────
+
+  describe("getStats", () => {
+    it("responds with { data: stats } on success", async () => {
+      const stats = { totalTracks: 10, totalArtists: 3 };
+      vi.mocked(libraryService.getStats).mockResolvedValue(stats as never);
+
+      const res = makeJsonRes();
+      await controller.getStats(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: stats });
+    });
+
+    it("responds with 500 when service throws", async () => {
+      vi.mocked(libraryService.getStats).mockRejectedValue(new Error("db error"));
+
+      const res = makeJsonRes();
+      await controller.getStats(makeReq(), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "internal_server_error" }),
+      );
+    });
+  });
+
+  // ─── getArtists ───────────────────────────────────────────────────────────
+
+  describe("getArtists", () => {
+    it("responds with { data: artists } on success", async () => {
+      const artists = [{ name: "Artist A" }, { name: "Artist B" }];
+      vi.mocked(libraryService.getArtists).mockResolvedValue(artists as never);
+
+      const res = makeJsonRes();
+      await controller.getArtists(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: artists });
+    });
+
+    it("responds with 500 when service throws", async () => {
+      vi.mocked(libraryService.getArtists).mockRejectedValue(new Error("fail"));
+
+      const res = makeJsonRes();
+      await controller.getArtists(makeReq(), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "internal_server_error" }),
+      );
+    });
+  });
+
+  // ─── getArtist ────────────────────────────────────────────────────────────
+
+  describe("getArtist", () => {
+    it("decodes param and responds with { data: artist } on success", async () => {
+      const artist = { name: "Daft Punk", albums: [] };
+      vi.mocked(libraryService.getArtist).mockResolvedValue(artist as never);
+
+      const res = makeJsonRes();
+      await controller.getArtist(
+        makeReq({ params: { name: encodeURIComponent("Daft Punk") } }),
+        res,
+      );
+
+      expect(libraryService.getArtist).toHaveBeenCalledWith("Daft Punk");
+      expect(res.json).toHaveBeenCalledWith({ data: artist });
+    });
+
+    it("responds with 404 when service returns null", async () => {
+      vi.mocked(libraryService.getArtist).mockResolvedValue(null as never);
+
+      const res = makeJsonRes();
+      await controller.getArtist(makeReq({ params: { name: "Unknown" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "internal_server_error" }),
+      );
+    });
+
+    it("responds with 500 when service throws", async () => {
+      vi.mocked(libraryService.getArtist).mockRejectedValue(new Error("db fail"));
+
+      const res = makeJsonRes();
+      await controller.getArtist(makeReq({ params: { name: "ArtistX" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // ─── getImage ─────────────────────────────────────────────────────────────
+
+  describe("getImage", () => {
+    it("calls resolveImage with the path query param and sends file", async () => {
+      const res = makeJsonRes();
+      await controller.getImage(makeReq({ query: { path: "/covers/img.jpg" } }), res);
+
+      expect(imageService.resolveImage).toHaveBeenCalledWith("/covers/img.jpg");
+      expect(res.type).toHaveBeenCalledWith("image/jpeg");
+      expect(res.sendFile).toHaveBeenCalledWith(
+        "/covers/img.jpg",
+        { dotfiles: "allow" },
+        expect.any(Function),
+      );
+    });
+
+    it("responds 400 when image service rejects with missing-path", async () => {
+      vi.mocked(imageService.resolveImage).mockResolvedValue({
+        kind: "reject",
+        reason: "missing-path",
+      } as never);
+
+      const res = makeJsonRes();
+      await controller.getImage(makeReq({ query: {} }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "invalid_request" }));
+    });
+
+    it("responds 404 when image service rejects with not-found reason", async () => {
+      vi.mocked(imageService.resolveImage).mockResolvedValue({
+        kind: "reject",
+        reason: "not-found",
+      } as never);
+
+      const res = makeJsonRes();
+      await controller.getImage(makeReq({ query: { path: "/missing.jpg" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "file_not_found" }));
+    });
+
+    it("responds 500 when resolveImage throws", async () => {
+      vi.mocked(imageService.resolveImage).mockRejectedValue(new Error("io error"));
+
+      const res = makeJsonRes();
+      await controller.getImage(makeReq({ query: { path: "/img.jpg" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // ─── streamAudio ──────────────────────────────────────────────────────────
+
+  describe("streamAudio", () => {
+    it("streams full file when no Range header", async () => {
+      const fakeStream = Object.assign(new EventEmitter(), { pipe: vi.fn() });
+      vi.mocked(audioService.createAudioReadStream).mockReturnValue(fakeStream as never);
+
+      const res = makeJsonRes();
+      await controller.streamAudio(makeReq({ query: { path: "/song.mp3" } }), res);
+
+      expect(res.setHeader).toHaveBeenCalledWith("Accept-Ranges", "bytes");
+      expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "audio/mpeg");
+      expect(res.setHeader).toHaveBeenCalledWith("Content-Length", "1000");
+      expect(fakeStream.pipe).toHaveBeenCalledWith(res);
+    });
+
+    it("responds 206 with correct Content-Range for partial request", async () => {
+      const fakeStream = Object.assign(new EventEmitter(), { pipe: vi.fn() });
+      vi.mocked(audioService.createAudioReadStream).mockReturnValue(fakeStream as never);
+
+      const res = makeJsonRes();
+      await controller.streamAudio(
+        makeReq({ query: { path: "/song.mp3" }, headers: { range: "bytes=0-499" } }),
+        res,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(206);
+      expect(res.setHeader).toHaveBeenCalledWith("Content-Range", "bytes 0-499/1000");
+      expect(res.setHeader).toHaveBeenCalledWith("Content-Length", "500");
+      expect(audioService.createAudioReadStream).toHaveBeenCalledWith("/music/song.mp3", {
+        start: 0,
+        end: 499,
+      });
+    });
+
+    it("responds 400 when audio service rejects with missing-path", async () => {
+      vi.mocked(audioService.resolveAudio).mockResolvedValue({
+        kind: "reject",
+        reason: "missing-path",
+      } as never);
+
+      const res = makeJsonRes();
+      await controller.streamAudio(makeReq({ query: {} }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "invalid_request" }));
+    });
+
+    it("responds 404 when audio service rejects with not-found reason", async () => {
+      vi.mocked(audioService.resolveAudio).mockResolvedValue({
+        kind: "reject",
+        reason: "not-found",
+      } as never);
+
+      const res = makeJsonRes();
+      await controller.streamAudio(makeReq({ query: { path: "/missing.mp3" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "file_not_found" }));
+    });
+
+    it("responds 416 for an invalid byte range", async () => {
+      const res = makeJsonRes();
+      await controller.streamAudio(
+        makeReq({
+          query: { path: "/song.mp3" },
+          headers: { range: "bytes=bad-range" },
+        }),
+        res,
+      );
+
+      expect(res.setHeader).toHaveBeenCalledWith("Content-Range", "bytes */1000");
+      expect(res.status).toHaveBeenCalledWith(416);
+    });
+
+    it("responds 500 when resolveAudio throws", async () => {
+      vi.mocked(audioService.resolveAudio).mockRejectedValue(new Error("disk error"));
+
+      const res = makeJsonRes();
+      await controller.streamAudio(makeReq({ query: { path: "/song.mp3" } }), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // ─── scan ─────────────────────────────────────────────────────────────────
+
+  describe("scan", () => {
+    it("responds with { data: result } on success", async () => {
+      const result = { scanned: 42 };
+      vi.mocked(libraryService.scan).mockResolvedValue(result as never);
+
+      const res = makeJsonRes();
+      await controller.scan(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: result });
+    });
+
+    it("responds with 500 when service throws", async () => {
+      vi.mocked(libraryService.scan).mockRejectedValue(new Error("scan failed"));
+
+      const res = makeJsonRes();
+      await controller.scan(makeReq(), res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/playlist.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/playlist.controller.test.ts
@@ -1,0 +1,241 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { CreatePlaylistUseCase } from "@/application/use-cases/playlists/create-playlist.use-case";
+import type { DeletePlaylistUseCase } from "@/application/use-cases/playlists/delete-playlist.use-case";
+import type { GetMyPlaylistsUseCase } from "@/application/use-cases/playlists/get-my-playlists.use-case";
+import type { GetPlaylistPreviewTracksPageUseCase } from "@/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case";
+import type { GetPlaylistPreviewUseCase } from "@/application/use-cases/playlists/get-playlist-preview.use-case";
+import type { GetPlaylistsUseCase } from "@/application/use-cases/playlists/get-playlists.use-case";
+import type { GetSystemStatusUseCase } from "@/application/use-cases/playlists/get-system-status.use-case";
+import type { RetryPlaylistDownloadsUseCase } from "@/application/use-cases/playlists/retry-playlist-downloads.use-case";
+import type { UpdatePlaylistUseCase } from "@/application/use-cases/playlists/update-playlist.use-case";
+import { PlaylistController } from "./playlist.controller";
+
+function makeRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const send = vi.fn().mockReturnThis();
+  return { json, status, send } as unknown as Response;
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+type Mocks = {
+  createPlaylistUseCase: CreatePlaylistUseCase;
+  deletePlaylistUseCase: DeletePlaylistUseCase;
+  getMyPlaylistsUseCase: GetMyPlaylistsUseCase;
+  getPlaylistPreviewUseCase: GetPlaylistPreviewUseCase;
+  getPlaylistPreviewTracksPageUseCase: GetPlaylistPreviewTracksPageUseCase;
+  getPlaylistsUseCase: GetPlaylistsUseCase;
+  getSystemStatusUseCase: GetSystemStatusUseCase;
+  retryPlaylistDownloadsUseCase: RetryPlaylistDownloadsUseCase;
+  updatePlaylistUseCase: UpdatePlaylistUseCase;
+};
+
+function makeMocks(): Mocks {
+  return {
+    createPlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue({ id: "new-pl" }),
+    } as unknown as CreatePlaylistUseCase,
+    deletePlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DeletePlaylistUseCase,
+    getMyPlaylistsUseCase: {
+      execute: vi.fn().mockResolvedValue([]),
+    } as unknown as GetMyPlaylistsUseCase,
+    getPlaylistPreviewUseCase: {
+      execute: vi.fn().mockResolvedValue({ name: "Preview" }),
+    } as unknown as GetPlaylistPreviewUseCase,
+    getPlaylistPreviewTracksPageUseCase: {
+      execute: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+    } as unknown as GetPlaylistPreviewTracksPageUseCase,
+    getPlaylistsUseCase: {
+      findAll: vi.fn().mockResolvedValue([]),
+    } as unknown as GetPlaylistsUseCase,
+    getSystemStatusUseCase: {
+      execute: vi.fn().mockResolvedValue({ queued: 0 }),
+    } as unknown as GetSystemStatusUseCase,
+    retryPlaylistDownloadsUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as RetryPlaylistDownloadsUseCase,
+    updatePlaylistUseCase: {
+      execute: vi.fn().mockResolvedValue(undefined),
+    } as unknown as UpdatePlaylistUseCase,
+  };
+}
+
+describe("PlaylistController", () => {
+  let mocks: Mocks;
+  let controller: PlaylistController;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+    controller = new PlaylistController(
+      mocks.createPlaylistUseCase,
+      mocks.deletePlaylistUseCase,
+      mocks.getMyPlaylistsUseCase,
+      mocks.getPlaylistPreviewUseCase,
+      mocks.getPlaylistPreviewTracksPageUseCase,
+      mocks.getPlaylistsUseCase,
+      mocks.getSystemStatusUseCase,
+      mocks.retryPlaylistDownloadsUseCase,
+      mocks.updatePlaylistUseCase,
+    );
+  });
+
+  describe("getPreview", () => {
+    it("calls use case with url query param and responds with preview", async () => {
+      const preview = { name: "My Playlist", tracks: [] };
+      vi.mocked(mocks.getPlaylistPreviewUseCase.execute).mockResolvedValue(preview as never);
+
+      const res = makeRes();
+      await controller.getPreview(
+        makeReq({ query: { url: "https://open.spotify.com/playlist/abc" } }),
+        res,
+      );
+
+      expect(mocks.getPlaylistPreviewUseCase.execute).toHaveBeenCalledWith(
+        "https://open.spotify.com/playlist/abc",
+      );
+      expect(res.json).toHaveBeenCalledWith(preview);
+    });
+  });
+
+  describe("getPreviewTracks", () => {
+    it("calls use case with url, parsed offset, and parsed limit", async () => {
+      const page = { items: [{ id: "t1" }], total: 1 };
+      vi.mocked(mocks.getPlaylistPreviewTracksPageUseCase.execute).mockResolvedValue(page as never);
+
+      const res = makeRes();
+      await controller.getPreviewTracks(
+        makeReq({ query: { url: "https://spotify/pl/x", offset: "10", limit: "25" } }),
+        res,
+      );
+
+      expect(mocks.getPlaylistPreviewTracksPageUseCase.execute).toHaveBeenCalledWith(
+        "https://spotify/pl/x",
+        10,
+        25,
+      );
+      expect(res.json).toHaveBeenCalledWith(page);
+    });
+
+    it("defaults offset to 0 and limit to 100 when not provided", async () => {
+      const res = makeRes();
+      await controller.getPreviewTracks(makeReq({ query: { url: "https://spotify/pl/x" } }), res);
+
+      expect(mocks.getPlaylistPreviewTracksPageUseCase.execute).toHaveBeenCalledWith(
+        "https://spotify/pl/x",
+        0,
+        100,
+      );
+    });
+
+    it("falls back to 0 and 100 when offset/limit are non-numeric", async () => {
+      const res = makeRes();
+      await controller.getPreviewTracks(
+        makeReq({ query: { url: "https://spotify/pl/x", offset: "abc", limit: "xyz" } }),
+        res,
+      );
+
+      expect(mocks.getPlaylistPreviewTracksPageUseCase.execute).toHaveBeenCalledWith(
+        "https://spotify/pl/x",
+        0,
+        100,
+      );
+    });
+  });
+
+  describe("getMyPlaylists", () => {
+    it("responds with playlists from use case", async () => {
+      const playlists = [{ id: "p1" }, { id: "p2" }];
+      vi.mocked(mocks.getMyPlaylistsUseCase.execute).mockResolvedValue(playlists as never);
+
+      const res = makeRes();
+      await controller.getMyPlaylists(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith(playlists);
+    });
+  });
+
+  describe("getDownloadStatus", () => {
+    it("responds with system status from use case", async () => {
+      const status = { queued: 3, active: 1 };
+      vi.mocked(mocks.getSystemStatusUseCase.execute).mockResolvedValue(status as never);
+
+      const res = makeRes();
+      await controller.getDownloadStatus(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith(status);
+    });
+  });
+
+  describe("findAll", () => {
+    it("responds with { data: playlists } from use case", async () => {
+      const playlists = [{ id: "pl-1" }];
+      vi.mocked(mocks.getPlaylistsUseCase.findAll).mockResolvedValue(playlists as never);
+
+      const res = makeRes();
+      await controller.findAll(makeReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: playlists });
+    });
+  });
+
+  describe("create", () => {
+    it("calls use case with req.body and responds 201 with created playlist", async () => {
+      const body = { url: "https://spotify/pl/new", name: "New PL" };
+      const created = { id: "created-id", ...body };
+      vi.mocked(mocks.createPlaylistUseCase.execute).mockResolvedValue(created as never);
+
+      const res = makeRes();
+      await controller.create(makeReq({ body }), res);
+
+      expect(mocks.createPlaylistUseCase.execute).toHaveBeenCalledWith(body);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(created);
+    });
+  });
+
+  describe("update", () => {
+    it("calls use case with id param and body, responds 204", async () => {
+      const res = makeRes();
+      await controller.update(makeReq({ params: { id: "pl-42" }, body: { name: "Renamed" } }), res);
+
+      expect(mocks.updatePlaylistUseCase.execute).toHaveBeenCalledWith("pl-42", {
+        name: "Renamed",
+      });
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+
+  describe("remove", () => {
+    it("calls use case with id param and responds 204", async () => {
+      const res = makeRes();
+      await controller.remove(makeReq({ params: { id: "pl-99" } }), res);
+
+      expect(mocks.deletePlaylistUseCase.execute).toHaveBeenCalledWith("pl-99");
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+
+  describe("retryFailedOfPlaylist", () => {
+    it("calls use case with id param and responds 204", async () => {
+      const res = makeRes();
+      await controller.retryFailedOfPlaylist(makeReq({ params: { id: "pl-7" } }), res);
+
+      expect(mocks.retryPlaylistDownloadsUseCase.execute).toHaveBeenCalledWith("pl-7");
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/settings.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/settings.controller.test.ts
@@ -1,0 +1,127 @@
+import { UI_SUPPORTED_AUDIO_FORMATS } from "@spotiarr/shared";
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GetSettingsUseCase } from "@/application/use-cases/settings/get-settings.use-case";
+import type { UpdateSettingUseCase } from "@/application/use-cases/settings/update-setting.use-case";
+import { SETTINGS_METADATA } from "@/constants/settings-metadata";
+import { SettingsController } from "./settings.controller";
+
+function makeRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const send = vi.fn().mockReturnThis();
+  return { json, status, send } as unknown as Response;
+}
+
+function makeReq(body: unknown = {}): Request {
+  return { body } as unknown as Request;
+}
+
+function makeUseCases() {
+  const getSettingsUseCase = {
+    execute: vi.fn().mockResolvedValue([{ key: "download_path", value: "/music" }]),
+  } as unknown as GetSettingsUseCase;
+  const updateSettingUseCase = {
+    execute: vi.fn().mockResolvedValue(undefined),
+  } as unknown as UpdateSettingUseCase;
+  return { getSettingsUseCase, updateSettingUseCase };
+}
+
+describe("SettingsController", () => {
+  let getSettingsUseCase: GetSettingsUseCase;
+  let updateSettingUseCase: UpdateSettingUseCase;
+  let controller: SettingsController;
+
+  beforeEach(() => {
+    ({ getSettingsUseCase, updateSettingUseCase } = makeUseCases());
+    controller = new SettingsController(getSettingsUseCase, updateSettingUseCase);
+  });
+
+  describe("getSettings", () => {
+    it("responds with { data: settings } from use case", async () => {
+      const settings = [{ key: "download_path", value: "/music" }];
+      vi.mocked(getSettingsUseCase.execute).mockResolvedValue(settings as never);
+
+      const res = makeRes();
+      await controller.getSettings({} as Request, res);
+
+      expect(getSettingsUseCase.execute).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith({ data: settings });
+    });
+  });
+
+  describe("getMetadata", () => {
+    it("responds with { data: SETTINGS_METADATA } without calling any use case", async () => {
+      const res = makeRes();
+      await controller.getMetadata({} as Request, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: SETTINGS_METADATA });
+      expect(getSettingsUseCase.execute).not.toHaveBeenCalled();
+      expect(updateSettingUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getFormats", () => {
+    it("responds with { data: UI_SUPPORTED_AUDIO_FORMATS } without calling any use case", async () => {
+      const res = makeRes();
+      await controller.getFormats({} as Request, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: UI_SUPPORTED_AUDIO_FORMATS });
+      expect(getSettingsUseCase.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateSettings", () => {
+    it("calls updateSettingUseCase for each setting and responds 204", async () => {
+      const settings = [
+        { key: "download_path", value: "/downloads" },
+        { key: "format", value: "mp3" },
+      ];
+
+      const res = makeRes();
+      await controller.updateSettings(makeReq({ settings }), res);
+
+      expect(updateSettingUseCase.execute).toHaveBeenCalledTimes(2);
+      expect(updateSettingUseCase.execute).toHaveBeenCalledWith("download_path", "/downloads");
+      expect(updateSettingUseCase.execute).toHaveBeenCalledWith("format", "mp3");
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+
+    it("responds 400 when settings is not an array", async () => {
+      const res = makeRes();
+      await controller.updateSettings(makeReq({ settings: "not-an-array" }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "invalid_setting_payload" }),
+      );
+      expect(updateSettingUseCase.execute).not.toHaveBeenCalled();
+    });
+
+    it("responds 400 when settings is missing", async () => {
+      const res = makeRes();
+      await controller.updateSettings(makeReq({}), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+    });
+
+    it("responds 400 when a setting entry has non-string key or value", async () => {
+      const res = makeRes();
+      await controller.updateSettings(makeReq({ settings: [{ key: 123, value: "ok" }] }), res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "invalid_setting_payload" }),
+      );
+    });
+
+    it("responds 204 for an empty settings array", async () => {
+      const res = makeRes();
+      await controller.updateSettings(makeReq({ settings: [] }), res);
+
+      expect(updateSettingUseCase.execute).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/track.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/track.controller.test.ts
@@ -1,0 +1,86 @@
+import type { Request, Response } from "express";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { DeleteTrackUseCase } from "@/application/use-cases/tracks/delete-track.use-case";
+import type { GetTracksUseCase } from "@/application/use-cases/tracks/get-tracks.use-case";
+import type { RetryTrackDownloadUseCase } from "@/application/use-cases/tracks/retry-track-download.use-case";
+import { TrackController } from "./track.controller";
+
+function makeRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  const send = vi.fn().mockReturnThis();
+  return { json, status, send } as unknown as Response;
+}
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return { params: {}, ...overrides } as unknown as Request;
+}
+
+function makeMocks() {
+  const deleteTrackUseCase = {
+    execute: vi.fn().mockResolvedValue(undefined),
+  } as unknown as DeleteTrackUseCase;
+  const getTracksUseCase = {
+    getAllByPlaylist: vi.fn().mockResolvedValue([]),
+  } as unknown as GetTracksUseCase;
+  const retryTrackDownloadUseCase = {
+    execute: vi.fn().mockResolvedValue(undefined),
+  } as unknown as RetryTrackDownloadUseCase;
+  return { deleteTrackUseCase, getTracksUseCase, retryTrackDownloadUseCase };
+}
+
+describe("TrackController", () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  let controller: TrackController;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+    controller = new TrackController(
+      mocks.deleteTrackUseCase,
+      mocks.getTracksUseCase,
+      mocks.retryTrackDownloadUseCase,
+    );
+  });
+
+  describe("getAllByPlaylist", () => {
+    it("calls use case with playlist id from params and responds { data: tracks }", async () => {
+      const tracks = [{ id: "t1" }, { id: "t2" }];
+      vi.mocked(mocks.getTracksUseCase.getAllByPlaylist).mockResolvedValue(tracks as never);
+
+      const res = makeRes();
+      await controller.getAllByPlaylist(makeReq({ params: { id: "pl-abc" } }), res);
+
+      expect(mocks.getTracksUseCase.getAllByPlaylist).toHaveBeenCalledWith("pl-abc");
+      expect(res.json).toHaveBeenCalledWith({ data: tracks });
+    });
+
+    it("responds { data: [] } when playlist has no tracks", async () => {
+      const res = makeRes();
+      await controller.getAllByPlaylist(makeReq({ params: { id: "empty-pl" } }), res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+  });
+
+  describe("remove", () => {
+    it("calls delete use case with id from params and responds 204", async () => {
+      const res = makeRes();
+      await controller.remove(makeReq({ params: { id: "track-99" } }), res);
+
+      expect(mocks.deleteTrackUseCase.execute).toHaveBeenCalledWith("track-99");
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+
+  describe("retry", () => {
+    it("calls retry use case with id from params and responds 204", async () => {
+      const res = makeRes();
+      await controller.retry(makeReq({ params: { id: "track-77" } }), res);
+
+      expect(mocks.retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-77");
+      expect(res.status).toHaveBeenCalledWith(204);
+      expect(res.send).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/presentation/middleware/async-handler.test.ts
+++ b/apps/backend/src/presentation/middleware/async-handler.test.ts
@@ -1,0 +1,65 @@
+import type { NextFunction, Request, Response } from "express";
+import { describe, it, expect, vi } from "vitest";
+import { asyncHandler } from "./async-handler";
+
+function makeTriple() {
+  const req = {} as Request;
+  const res = {} as Response;
+  const next = vi.fn() as unknown as NextFunction;
+  return { req, res, next };
+}
+
+describe("asyncHandler", () => {
+  it("invokes the wrapped handler with req, res, next", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const { req, res, next } = makeTriple();
+
+    await asyncHandler(handler)(req, res, next);
+
+    expect(handler).toHaveBeenCalledWith(req, res, next);
+  });
+
+  it("does not call next when handler resolves successfully", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const { req, res, next } = makeTriple();
+
+    await asyncHandler(handler)(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("forwards rejection to next when handler rejects", async () => {
+    const error = new Error("async failure");
+    const handler = vi.fn().mockRejectedValue(error);
+    const { req, res } = makeTriple();
+
+    // The wrapper catches the rejection and calls next — no unhandled rejection
+    await new Promise<void>((resolve) => {
+      const wrappedNext = vi.fn((err) => {
+        expect(err).toBe(error);
+        resolve();
+      }) as unknown as NextFunction;
+
+      asyncHandler(handler)(req, res, wrappedNext);
+    });
+  });
+
+  it("forwards rejection to next for custom error types", async () => {
+    class CustomError extends Error {
+      statusCode = 422;
+    }
+    const error = new CustomError("validation failed");
+    const handler = vi.fn().mockRejectedValue(error);
+    const { req, res } = makeTriple();
+
+    await new Promise<void>((resolve) => {
+      const wrappedNext = vi.fn((err) => {
+        expect(err).toBeInstanceOf(CustomError);
+        expect(err.statusCode).toBe(422);
+        resolve();
+      }) as unknown as NextFunction;
+
+      asyncHandler(handler)(req, res, wrappedNext);
+    });
+  });
+});

--- a/apps/backend/src/presentation/middleware/error-handler.test.ts
+++ b/apps/backend/src/presentation/middleware/error-handler.test.ts
@@ -1,0 +1,91 @@
+import type { NextFunction, Request, Response } from "express";
+import { describe, it, expect, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { errorHandler } from "./error-handler";
+
+function makeRes(): Response {
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnThis();
+  return { json, status } as unknown as Response;
+}
+
+const req = {} as Request;
+const next = vi.fn() as unknown as NextFunction;
+
+describe("errorHandler", () => {
+  describe("AppError instances", () => {
+    it("uses AppError.statusCode and errorCode in the response", () => {
+      const error = new AppError(422, "validation_error", "Field is required");
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(422);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "validation_error", message: "Field is required" }),
+      );
+    });
+
+    it("omits message when it equals the errorCode", () => {
+      // AppError with no explicit message defaults to errorCode as the message
+      const error = new AppError(404, "playlist_not_found");
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      const payload = vi.mocked(res.json).mock.calls[0][0];
+      expect(payload.error).toBe("playlist_not_found");
+      // message should NOT be present (shouldIncludeMessage = false because message === errorCode)
+      expect(payload).not.toHaveProperty("message");
+    });
+
+    it("includes message when it differs from errorCode", () => {
+      const error = new AppError(403, "playlist_not_accessible", "You cannot access this resource");
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "You cannot access this resource" }),
+      );
+    });
+
+    it("maps a 503 AppError correctly", () => {
+      const error = new AppError(503, "circuit_open", "Downstream service down");
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(503);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "circuit_open" }));
+    });
+  });
+
+  describe("generic Error (non-AppError)", () => {
+    it("uses status 500 and internal_server_error code", () => {
+      const error = new Error("unexpected crash");
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "internal_server_error",
+        message: "Internal Server Error",
+      });
+    });
+
+    it("returns the same 500 shape for unknown thrown values coerced to Error", () => {
+      const error = Object.assign(new Error("boom"), { extra: "data" });
+      const res = makeRes();
+
+      errorHandler(error, req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      const payload = vi.mocked(res.json).mock.calls[0][0];
+      expect(payload.error).toBe("internal_server_error");
+      expect(payload.message).toBe("Internal Server Error");
+    });
+  });
+});

--- a/apps/backend/src/presentation/routes/schemas/library.schema.test.ts
+++ b/apps/backend/src/presentation/routes/schemas/library.schema.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  libraryAudioQuerySchema,
+  libraryAudioRequestSchema,
+  libraryImageQuerySchema,
+  libraryImageRequestSchema,
+} from "./library.schema";
+
+describe("libraryImageQuerySchema", () => {
+  it("accepts a valid non-empty path", () => {
+    const result = libraryImageQuerySchema.safeParse({ path: "/covers/img.jpg" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.path).toBe("/covers/img.jpg");
+  });
+
+  it("rejects when path is missing", () => {
+    const result = libraryImageQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when path is an empty string", () => {
+    const result = libraryImageQuerySchema.safeParse({ path: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.path).toContain("path query parameter is required");
+    }
+  });
+
+  it("rejects when path is not a string", () => {
+    const result = libraryImageQuerySchema.safeParse({ path: 123 });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("libraryImageRequestSchema", () => {
+  it("accepts a valid query wrapper", () => {
+    const result = libraryImageRequestSchema.safeParse({ query: { path: "/img.jpg" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when the nested query.path is missing", () => {
+    const result = libraryImageRequestSchema.safeParse({ query: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when the query key itself is missing", () => {
+    const result = libraryImageRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("libraryAudioQuerySchema", () => {
+  it("accepts a valid non-empty path", () => {
+    const result = libraryAudioQuerySchema.safeParse({ path: "/music/song.mp3" });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.path).toBe("/music/song.mp3");
+  });
+
+  it("rejects when path is missing", () => {
+    const result = libraryAudioQuerySchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when path is an empty string", () => {
+    const result = libraryAudioQuerySchema.safeParse({ path: "" });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.flatten().fieldErrors.path).toContain("path query parameter is required");
+    }
+  });
+
+  it("rejects when path is not a string", () => {
+    const result = libraryAudioQuerySchema.safeParse({ path: null });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("libraryAudioRequestSchema", () => {
+  it("accepts a valid query wrapper", () => {
+    const result = libraryAudioRequestSchema.safeParse({ query: { path: "/song.mp3" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when the nested query.path is missing", () => {
+    const result = libraryAudioRequestSchema.safeParse({ query: {} });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects when the query key itself is missing", () => {
+    const result = libraryAudioRequestSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Characterization unit tests for the **presentation layer** layer — vitest 3, zero source changes.

## Why

Part of #204 — backend unit-test coverage backfill (presentation layer slice).

## Verification

- Slice tests pass via `pnpm --filter backend test:run`
- Backend `tsc --noEmit` clean and `lint` green (0 errors) verified on the full integrated set

Refs #204