### PR TITLE
chore(backend): ratchet coverage thresholds to measured levels (#204)

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -12,12 +12,12 @@ export default defineConfig({
       include: ["src/**/*.ts"],
       exclude: ["src/**/*.test.ts", "src/**/index.ts", "src/infrastructure/setup/**"],
       // Thresholds sit just under the currently measured coverage so the gate is
-      // green on merge. Ratchet these up as coverage improves (issue #149).
+      // green on merge. Ratchet these up as coverage improves (issue #204).
       thresholds: {
-        lines: 52,
-        statements: 52,
-        functions: 53,
-        branches: 72,
+        lines: 76,
+        statements: 76,
+        functions: 85,
+        branches: 82,
       },
     },
   },


### PR DESCRIPTION
## What

Ratchets backend vitest coverage thresholds up to the levels measured after the unit-test backfill.

| Metric | Before | After | Measured |
|--------|--------|-------|----------|
| Statements | 52 | 76 | 76.83 |
| Branches | 72 | 82 | 82.39 |
| Functions | 53 | 85 | 85.32 |
| Lines | 52 | 76 | 76.83 |

## Why

Final piece of #204. The backfill (PRs #207, #208, #210–#216) raised backend coverage substantially; thresholds now lock that in so regressions fail CI. Margin (~1pt) left under measured values to absorb v8 run-to-run jitter.

## Verification

- `pnpm --filter backend test:coverage` → gate passes (exit 0)

Closes #204