### PR TITLE
chore(backend): exclude domain contract interfaces from coverage

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -22,6 +22,12 @@ export default defineConfig({
         "src/app.ts",
         "src/container.ts",
         "src/testing/**",
+        // Domain contracts: pure interface declarations (repositories, queue/event
+        // service ports). No executable code, so they cannot carry coverage and only
+        // drag the measured number down. Implementations live in infrastructure.
+        "src/domain/repositories/**",
+        "src/domain/services/**",
+        "src/domain/events/**",
         // Route files are pure Express wiring (router.<verb>(path, controller)); the logic
         // they delegate to lives in controllers and middleware, which are unit-tested.
         "src/presentation/routes/**/*.routes.ts",


### PR DESCRIPTION
## What

Exclude `src/domain/{repositories,services,events}/**` from coverage. These are pure TypeScript interface declarations (repository contracts, queue/event service ports) — they emit no JS, so v8 reported them as misleading `0%` rows.

## Why

Implementations live in `infrastructure` and are already unit-tested there. The interfaces carry ~0 weight in the aggregate, so this **does not change the measured number** (92.16 lines / 87.77 branches) — it only removes noise from the report.

## Evidence

- `pnpm --filter backend test:coverage` → gate exit 0, All files unchanged at **92.16 / 87.77 / 93.59 / 92.16**.
- Domain interface rows no longer appear in the report.