### PR TITLE
test(backend): cover controller error and edge-case branches (wave 3A)

### DIFF
--- a/apps/backend/src/presentation/controllers/artist.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/artist.controller.test.ts
@@ -1,8 +1,10 @@
+import type { ArtistDetail } from "@spotiarr/shared";
 import type { Request, Response } from "express";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { GetAlbumTracksUseCase } from "@/application/use-cases/artists/get-album-tracks.use-case";
 import type { GetArtistAlbumsUseCase } from "@/application/use-cases/artists/get-artist-albums.use-case";
 import type { GetArtistDetailUseCase } from "@/application/use-cases/artists/get-artist-detail.use-case";
+import { AppError } from "@/domain/errors/app-error";
 import { ArtistController } from "./artist.controller";
 
 function mockRes(): Response {
@@ -15,20 +17,317 @@ function mockRes(): Response {
   } as unknown as Response;
 }
 
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    params: {},
+    query: {},
+    headers: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
 function makeController(
   partial: {
+    getArtistDetailUseCase?: Partial<GetArtistDetailUseCase>;
+    getArtistAlbumsUseCase?: Partial<GetArtistAlbumsUseCase>;
     getAlbumTracksUseCase?: Partial<GetAlbumTracksUseCase>;
   } = {},
 ): ArtistController {
   return new ArtistController(
-    {} as unknown as GetArtistDetailUseCase,
-    {} as unknown as GetArtistAlbumsUseCase,
+    {
+      execute: vi.fn().mockResolvedValue({ id: "artist-1", name: "Artist" }),
+      ...partial.getArtistDetailUseCase,
+    } as unknown as GetArtistDetailUseCase,
+    {
+      execute: vi.fn().mockResolvedValue([]),
+      ...partial.getArtistAlbumsUseCase,
+    } as unknown as GetArtistAlbumsUseCase,
     {
       execute: vi.fn().mockResolvedValue([]),
       ...partial.getAlbumTracksUseCase,
     } as unknown as GetAlbumTracksUseCase,
   );
 }
+
+// ─── getArtistDetail ──────────────────────────────────────────────────────────
+
+describe("ArtistController.getArtistDetail", () => {
+  let controller: ArtistController;
+
+  beforeEach(() => {
+    controller = makeController();
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when id param is missing", async () => {
+    const req = makeReq({ params: {} });
+    const res = mockRes();
+
+    await controller.getArtistDetail(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "missing_artist_id" });
+  });
+
+  it("calls the use case and returns JSON on success", async () => {
+    const detail: ArtistDetail = { id: "artist-1", name: "Test Artist" } as unknown as ArtistDetail;
+    const executeUseCase = vi.fn().mockResolvedValue(detail);
+    controller = makeController({
+      getArtistDetailUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: {} });
+    const res = mockRes();
+
+    await controller.getArtistDetail(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 25);
+    expect(res.json).toHaveBeenCalledWith(detail);
+  });
+
+  it("uses the provided limit query param when valid", async () => {
+    const executeUseCase = vi.fn().mockResolvedValue({});
+    controller = makeController({
+      getArtistDetailUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: { limit: "10" } });
+    const res = mockRes();
+
+    await controller.getArtistDetail(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 10);
+  });
+
+  it("defaults limit to 25 when limit query param is invalid", async () => {
+    const executeUseCase = vi.fn().mockResolvedValue({});
+    controller = makeController({
+      getArtistDetailUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: { limit: "not-a-number" } });
+    const res = mockRes();
+
+    await controller.getArtistDetail(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 25);
+  });
+
+  it("defaults limit to 25 when limit is zero or negative", async () => {
+    const executeUseCase = vi.fn().mockResolvedValue({});
+    controller = makeController({
+      getArtistDetailUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: { limit: "0" } });
+    const res = mockRes();
+
+    await controller.getArtistDetail(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 25);
+  });
+
+  it("deduplicates concurrent requests with the same key and returns the cached promise result", async () => {
+    let resolveDetail!: (v: ArtistDetail) => void;
+    const detail = { id: "artist-1" } as unknown as ArtistDetail;
+    const slowPromise = new Promise<ArtistDetail>((r) => {
+      resolveDetail = r;
+    });
+    const executeUseCase = vi.fn().mockReturnValue(slowPromise);
+    controller = makeController({
+      getArtistDetailUseCase: { execute: executeUseCase },
+    });
+
+    const req1 = makeReq({
+      params: { id: "artist-1" },
+      query: {},
+      headers: { authorization: "Bearer token" },
+    });
+    const req2 = makeReq({
+      params: { id: "artist-1" },
+      query: {},
+      headers: { authorization: "Bearer token" },
+    });
+    const res1 = mockRes();
+    const res2 = mockRes();
+
+    // Start first request (will be in-flight)
+    const p1 = controller.getArtistDetail(req1, res1);
+    // Start second request with same key — should attach to in-flight promise
+    const p2 = controller.getArtistDetail(req2, res2);
+
+    resolveDetail(detail);
+    await Promise.all([p1, p2]);
+
+    // The use case should only have been invoked once
+    expect(executeUseCase).toHaveBeenCalledTimes(1);
+    expect(res1.json).toHaveBeenCalledWith(detail);
+    expect(res2.json).toHaveBeenCalledWith(detail);
+  });
+});
+
+// ─── pruneActiveDetailRequests — TTL and size-cap ─────────────────────────────
+
+describe("ArtistController.getArtistDetail — pruning", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("prunes stale in-flight entries whose TTL (30 s) has expired", async () => {
+    vi.useFakeTimers();
+
+    // Artist-A: slow in-flight request
+    let resolveA!: (v: ArtistDetail) => void;
+    const slowA = new Promise<ArtistDetail>((r) => {
+      resolveA = r;
+    });
+    const executeForA = vi.fn().mockReturnValue(slowA);
+    const controllerA = makeController({ getArtistDetailUseCase: { execute: executeForA } });
+
+    // Fire request A with a unique auth token to isolate the key
+    const reqA = makeReq({
+      params: { id: "prune-ttl-artist" },
+      query: {},
+      headers: { authorization: "prune-ttl-token" },
+    });
+    const resA = mockRes();
+    // Don't await — leave it in-flight so the key stays in the map
+    const pA = controllerA.getArtistDetail(reqA, resA);
+
+    // Advance time beyond ACTIVE_DETAIL_REQUEST_TTL_MS (30 000 ms)
+    vi.advanceTimersByTime(31_000);
+
+    // Artist-B: a different request on the same controller triggers pruning
+    const detail = { id: "prune-ttl-artist-b" } as unknown as ArtistDetail;
+    const executeForB = vi.fn().mockResolvedValue(detail);
+    const controllerB = makeController({ getArtistDetailUseCase: { execute: executeForB } });
+    const reqB = makeReq({
+      params: { id: "prune-ttl-artist-b" },
+      query: {},
+      headers: { authorization: "prune-ttl-token-b" },
+    });
+    const resB = mockRes();
+    await controllerB.getArtistDetail(reqB, resB);
+
+    expect(resB.json).toHaveBeenCalledWith(detail);
+
+    // Clean up the hanging promise so vitest doesn't complain
+    resolveA({ id: "prune-ttl-artist" } as unknown as ArtistDetail);
+    await pA;
+  });
+
+  it("evicts the oldest entry when in-flight map reaches MAX_ACTIVE_DETAIL_REQUESTS (200)", async () => {
+    // Fill 200 in-flight slots using a separate controller instance
+    // Each request uses a unique artist ID to get a unique key
+    const resolvers: Array<(v: ArtistDetail) => void> = [];
+    const fillerController = makeController({
+      getArtistDetailUseCase: {
+        execute: vi.fn().mockImplementation(() => {
+          return new Promise<ArtistDetail>((r) => {
+            resolvers.push(r);
+          });
+        }),
+      },
+    });
+
+    const fillerPromises: Promise<void>[] = [];
+    for (let i = 0; i < 200; i++) {
+      const req = makeReq({
+        params: { id: `evict-cap-artist-${i}` },
+        query: {},
+        headers: { authorization: `evict-cap-token-${i}` },
+      });
+      fillerPromises.push(fillerController.getArtistDetail(req, mockRes()));
+    }
+
+    // 201st request: should trigger eviction of the first entry so it can proceed
+    const capDetail = { id: "evict-cap-final" } as unknown as ArtistDetail;
+    const capExecute = vi.fn().mockResolvedValue(capDetail);
+    const capController = makeController({ getArtistDetailUseCase: { execute: capExecute } });
+    const capReq = makeReq({
+      params: { id: "evict-cap-final" },
+      query: {},
+      headers: { authorization: "evict-cap-final-token" },
+    });
+    const capRes = mockRes();
+    await capController.getArtistDetail(capReq, capRes);
+
+    expect(capRes.json).toHaveBeenCalledWith(capDetail);
+
+    // Resolve all hanging promises to clean up
+    const finalDetail = { id: "filler" } as unknown as ArtistDetail;
+    for (const r of resolvers) r(finalDetail);
+    await Promise.allSettled(fillerPromises);
+  });
+});
+
+// ─── getArtistAlbums ──────────────────────────────────────────────────────────
+
+describe("ArtistController.getArtistAlbums", () => {
+  let controller: ArtistController;
+
+  beforeEach(() => {
+    controller = makeController();
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when id param is missing", async () => {
+    const req = makeReq({ params: {}, query: {} });
+    const res = mockRes();
+
+    await controller.getArtistAlbums(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: "missing_artist_id" });
+  });
+
+  it("calls the use case and returns albums", async () => {
+    const albums = [{ id: "album-1" }];
+    const executeUseCase = vi.fn().mockResolvedValue(albums);
+    controller = makeController({
+      getArtistAlbumsUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: { limit: "10", offset: "5" } });
+    const res = mockRes();
+
+    await controller.getArtistAlbums(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 10, 5);
+    expect(res.json).toHaveBeenCalledWith(albums);
+  });
+
+  it("defaults limit to 25 and offset to 0 when query params are missing", async () => {
+    const executeUseCase = vi.fn().mockResolvedValue([]);
+    controller = makeController({
+      getArtistAlbumsUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: {} });
+    const res = mockRes();
+
+    await controller.getArtistAlbums(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 25, 0);
+  });
+
+  it("caps limit at 50 when the provided value exceeds it", async () => {
+    const executeUseCase = vi.fn().mockResolvedValue([]);
+    controller = makeController({
+      getArtistAlbumsUseCase: { execute: executeUseCase },
+    });
+
+    const req = makeReq({ params: { id: "artist-1" }, query: { limit: "100", offset: "0" } });
+    const res = mockRes();
+
+    await controller.getArtistAlbums(req, res);
+
+    expect(executeUseCase).toHaveBeenCalledWith("artist-1", 50, 0);
+  });
+});
+
+// ─── getAlbumTracks ───────────────────────────────────────────────────────────
 
 describe("ArtistController.getAlbumTracks", () => {
   let controller: ArtistController;
@@ -60,6 +359,51 @@ describe("ArtistController.getAlbumTracks", () => {
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({ error: "missing_params" });
+    });
+
+    it("returns 429 when the use case throws a spotify_rate_limited AppError", async () => {
+      const executeUseCase = vi.fn().mockRejectedValue(new AppError(429, "spotify_rate_limited"));
+      controller = makeController({
+        getAlbumTracksUseCase: { execute: executeUseCase },
+      });
+
+      const req = makeReq({ params: { id: "artist-1", albumId: "album-1" } });
+      const res = mockRes();
+
+      await controller.getAlbumTracks(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(429);
+      expect(res.json).toHaveBeenCalledWith({ error: "spotify_rate_limited" });
+    });
+
+    it("returns 404 when the use case throws an album_not_found AppError", async () => {
+      const executeUseCase = vi.fn().mockRejectedValue(new AppError(404, "album_not_found"));
+      controller = makeController({
+        getAlbumTracksUseCase: { execute: executeUseCase },
+      });
+
+      const req = makeReq({ params: { id: "artist-1", albumId: "album-1" } });
+      const res = mockRes();
+
+      await controller.getAlbumTracks(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({ error: "album_not_found" });
+    });
+
+    it("returns 500 when the use case throws an unexpected error", async () => {
+      const executeUseCase = vi.fn().mockRejectedValue(new Error("unexpected"));
+      controller = makeController({
+        getAlbumTracksUseCase: { execute: executeUseCase },
+      });
+
+      const req = makeReq({ params: { id: "artist-1", albumId: "album-1" } });
+      const res = mockRes();
+
+      await controller.getAlbumTracks(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ error: "internal_server_error" });
     });
   });
 });

--- a/apps/backend/src/presentation/controllers/artwork-backfill.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/artwork-backfill.controller.test.ts
@@ -1,6 +1,25 @@
 import type { Request, Response } from "express";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { GetArtworkBackfillStatusUseCase } from "@/application/use-cases/artwork-backfill/get-artwork-backfill-status.use-case";
+import type { PauseArtworkBackfillUseCase } from "@/application/use-cases/artwork-backfill/pause-artwork-backfill.use-case";
+import type { ResumeArtworkBackfillUseCase } from "@/application/use-cases/artwork-backfill/resume-artwork-backfill.use-case";
+import type { StartArtworkBackfillUseCase } from "@/application/use-cases/artwork-backfill/start-artwork-backfill.use-case";
 import { ArtworkBackfillController } from "./artwork-backfill.controller";
+
+const FAKE_STATUS = {
+  runId: "run-1",
+  status: "running",
+  phase: "artists",
+  totals: 10,
+  processed: 2,
+  skippedExisting: 1,
+  written: 1,
+  failed: 0,
+  externalCalls: 0,
+  lastCheckpoint: "artist:a1",
+  rateLimitUntil: null,
+  updatedAt: new Date().toISOString(),
+};
 
 function mockRes(): Response {
   return {
@@ -9,30 +28,43 @@ function mockRes(): Response {
   } as unknown as Response;
 }
 
-describe("ArtworkBackfillController", () => {
-  it("handles start -> status flow", async () => {
-    const controller = new ArtworkBackfillController(
-      { execute: vi.fn().mockResolvedValue({ runId: "run-1", status: "running" }) } as any,
-      { execute: vi.fn() } as any,
-      { execute: vi.fn() } as any,
-      {
-        execute: vi.fn().mockResolvedValue({
-          runId: "run-1",
-          status: "running",
-          phase: "artists",
-          totals: 10,
-          processed: 2,
-          skippedExisting: 1,
-          written: 1,
-          failed: 0,
-          externalCalls: 0,
-          lastCheckpoint: "artist:a1",
-          rateLimitUntil: null,
-          updatedAt: new Date().toISOString(),
-        }),
-      } as any,
-    );
+function makeController(
+  overrides: {
+    start?: Partial<StartArtworkBackfillUseCase>;
+    pause?: Partial<PauseArtworkBackfillUseCase>;
+    resume?: Partial<ResumeArtworkBackfillUseCase>;
+    status?: Partial<GetArtworkBackfillStatusUseCase>;
+  } = {},
+): ArtworkBackfillController {
+  return new ArtworkBackfillController(
+    {
+      execute: vi.fn().mockResolvedValue({ runId: "run-1", status: "running" }),
+      ...overrides.start,
+    } as unknown as StartArtworkBackfillUseCase,
+    {
+      execute: vi.fn().mockResolvedValue({ runId: "run-1", status: "paused" }),
+      ...overrides.pause,
+    } as unknown as PauseArtworkBackfillUseCase,
+    {
+      execute: vi.fn().mockResolvedValue({ runId: "run-1", status: "running" }),
+      ...overrides.resume,
+    } as unknown as ResumeArtworkBackfillUseCase,
+    {
+      execute: vi.fn().mockResolvedValue(FAKE_STATUS),
+      ...overrides.status,
+    } as unknown as GetArtworkBackfillStatusUseCase,
+  );
+}
 
+describe("ArtworkBackfillController", () => {
+  let controller: ArtworkBackfillController;
+
+  beforeEach(() => {
+    controller = makeController();
+    vi.clearAllMocks();
+  });
+
+  it("handles start -> status flow", async () => {
     const startRes = mockRes();
     await controller.start({} as Request, startRes);
     expect(startRes.status).toHaveBeenCalledWith(202);
@@ -44,5 +76,64 @@ describe("ArtworkBackfillController", () => {
         data: expect.objectContaining({ runId: "run-1", status: "running" }),
       }),
     );
+  });
+
+  describe("start", () => {
+    it("responds 202 with the data from the start use case", async () => {
+      const startData = { runId: "run-2", status: "running" };
+      const execute = vi.fn().mockResolvedValue(startData);
+      controller = makeController({ start: { execute } });
+
+      const res = mockRes();
+      await controller.start({} as Request, res);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({ data: startData });
+    });
+  });
+
+  describe("pause", () => {
+    it("responds 202 with the data from the pause use case", async () => {
+      const pauseData = { runId: "run-1", status: "paused" };
+      const execute = vi.fn().mockResolvedValue(pauseData);
+      controller = makeController({ pause: { execute } });
+
+      const res = mockRes();
+      await controller.pause({} as Request, res);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({ data: pauseData });
+    });
+  });
+
+  describe("resume", () => {
+    it("responds 202 with the data from the resume use case", async () => {
+      const resumeData = { runId: "run-1", status: "running" };
+      const execute = vi.fn().mockResolvedValue(resumeData);
+      controller = makeController({ resume: { execute } });
+
+      const res = mockRes();
+      await controller.resume({} as Request, res);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(202);
+      expect(res.json).toHaveBeenCalledWith({ data: resumeData });
+    });
+  });
+
+  describe("status", () => {
+    it("responds with the data from the status use case", async () => {
+      const statusData = { ...FAKE_STATUS, processed: 5 };
+      const execute = vi.fn().mockResolvedValue(statusData);
+      controller = makeController({ status: { execute } });
+
+      const res = mockRes();
+      await controller.status({} as Request, res);
+
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith({ data: statusData });
+    });
   });
 });

--- a/apps/backend/src/presentation/controllers/auth.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/auth.controller.test.ts
@@ -242,3 +242,172 @@ describe("AuthController.session", () => {
     expect(res.json).toHaveBeenCalledWith({ tokenRequired: true });
   });
 });
+
+// ─── login ────────────────────────────────────────────────────────────────────
+
+describe("AuthController.login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirects to the Spotify authorization URL", async () => {
+    const controller = makeController();
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.login(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    const redirectUrl = (res.redirect as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
+    expect(redirectUrl).toContain("https://accounts.spotify.com/authorize");
+    expect(redirectUrl).toContain("client_id=client-id");
+    expect(redirectUrl).toContain("response_type=code");
+  });
+});
+
+// ─── callback ─────────────────────────────────────────────────────────────────
+
+describe("AuthController.callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 400 when no code is in the query string", async () => {
+    const controller = makeController();
+    const req = { query: {} } as unknown as Request;
+    const res = mockRes();
+
+    await controller.callback(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "missing_code" }));
+  });
+
+  it("exchanges the code and redirects to / on success", async () => {
+    const spotifyAuth = makeSpotifyAuthService();
+    const controller = new AuthController(
+      spotifyAuth,
+      makeSettingsService(),
+      "client-id",
+      "http://localhost/callback",
+      VALID_TOKEN,
+      SESSION_TTL_HOURS,
+    );
+    const req = { query: { code: "spotify-auth-code" } } as unknown as Request;
+    const res = mockRes();
+
+    await controller.callback(req, res);
+
+    expect(spotifyAuth.exchangeCodeForToken).toHaveBeenCalledWith("spotify-auth-code");
+    expect(res.redirect).toHaveBeenCalledWith("/");
+  });
+});
+
+// ─── status ───────────────────────────────────────────────────────────────────
+
+describe("AuthController.status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns authenticated:true when access token exists", async () => {
+    const settings = makeSettingsService();
+    vi.mocked(settings.getString)
+      .mockResolvedValueOnce("access-token-value")
+      .mockResolvedValueOnce("refresh-token-value");
+
+    const controller = new AuthController(
+      makeSpotifyAuthService(),
+      settings,
+      "client-id",
+      "http://localhost/callback",
+      VALID_TOKEN,
+      SESSION_TTL_HOURS,
+    );
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.status(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      authenticated: true,
+      hasRefreshToken: true,
+    });
+  });
+
+  it("returns authenticated:false when access token is empty", async () => {
+    const settings = makeSettingsService();
+    vi.mocked(settings.getString).mockResolvedValueOnce("").mockResolvedValueOnce("");
+
+    const controller = new AuthController(
+      makeSpotifyAuthService(),
+      settings,
+      "client-id",
+      "http://localhost/callback",
+      VALID_TOKEN,
+      SESSION_TTL_HOURS,
+    );
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.status(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      authenticated: false,
+      hasRefreshToken: false,
+    });
+  });
+
+  it("returns authenticated:false when settings service throws", async () => {
+    const settings = makeSettingsService();
+    vi.mocked(settings.getString).mockRejectedValue(new Error("settings unavailable"));
+
+    const controller = new AuthController(
+      makeSpotifyAuthService(),
+      settings,
+      "client-id",
+      "http://localhost/callback",
+      VALID_TOKEN,
+      SESSION_TTL_HOURS,
+    );
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.status(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      authenticated: false,
+      hasRefreshToken: false,
+    });
+  });
+});
+
+// ─── logout ───────────────────────────────────────────────────────────────────
+
+describe("AuthController.logout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls spotifyAuthService.logout and responds with success", async () => {
+    const spotifyAuth = makeSpotifyAuthService();
+    const controller = new AuthController(
+      spotifyAuth,
+      makeSettingsService(),
+      "client-id",
+      "http://localhost/callback",
+      VALID_TOKEN,
+      SESSION_TTL_HOURS,
+    );
+    const req = {} as Request;
+    const res = mockRes();
+
+    await controller.logout(req, res);
+
+    expect(spotifyAuth.logout).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: "Successfully logged out from Spotify",
+    });
+  });
+});

--- a/apps/backend/src/presentation/controllers/events.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/events.controller.test.ts
@@ -5,23 +5,34 @@ import { EventsController } from "./events.controller";
 interface FakeResponse {
   headers: Record<string, string>;
   res: Response;
+  writeCalls: string[];
 }
 
 function createFakeResponse(): FakeResponse {
   const headers: Record<string, string> = {};
+  const writeCalls: string[] = [];
   const res = {
     setHeader: vi.fn((name: string, value: string) => {
       headers[name] = value;
     }),
-    write: vi.fn(),
+    write: vi.fn((data: string) => {
+      writeCalls.push(data);
+    }),
   } as unknown as Response;
-  return { headers, res };
+  return { headers, res, writeCalls };
 }
 
 function createFakeRequest(origin?: string): Request {
+  const listeners: Record<string, (() => void)[]> = {};
   return {
     headers: origin ? { origin } : {},
-    on: vi.fn(),
+    on: vi.fn((event: string, handler: () => void) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(handler);
+    }),
+    _trigger: (event: string) => {
+      for (const handler of listeners[event] ?? []) handler();
+    },
   } as unknown as Request;
 }
 
@@ -83,5 +94,100 @@ describe("EventsController SSE CORS", () => {
     new EventsController().connect(createFakeRequest("https://app.example.com"), res);
 
     expect(headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+
+  it("writes the initial SSE comment to keep the connection open", () => {
+    const { res, writeCalls } = createFakeResponse();
+
+    new EventsController().connect(createFakeRequest(), res);
+
+    expect(writeCalls[0]).toBe(": connected\n\n");
+  });
+
+  it("removes the client when the request closes", () => {
+    const controller = new EventsController();
+    const { res, writeCalls } = createFakeResponse();
+    const req = createFakeRequest();
+
+    controller.connect(req, res);
+
+    // Emit before close — should write
+    controller.emit("test-event", { x: 1 });
+    expect(writeCalls.length).toBe(2); // initial comment + event
+
+    // Trigger client disconnect
+    (req as unknown as { _trigger: (e: string) => void })._trigger("close");
+
+    // After disconnect, emit should not write to this client
+    controller.emit("test-event-2", { x: 2 });
+    expect(writeCalls.length).toBe(2); // still 2 — nothing new
+  });
+});
+
+// ─── emit ─────────────────────────────────────────────────────────────────────
+
+describe("EventsController.emit", () => {
+  it("is a no-op when there are no connected clients", () => {
+    const controller = new EventsController();
+    // No clients connected — should not throw
+    expect(() => controller.emit("test-event", {})).not.toThrow();
+  });
+
+  it("broadcasts the event payload to all connected clients", () => {
+    const controller = new EventsController();
+
+    const { res: res1, writeCalls: calls1 } = createFakeResponse();
+    const { res: res2, writeCalls: calls2 } = createFakeResponse();
+
+    controller.connect(createFakeRequest(), res1);
+    controller.connect(createFakeRequest(), res2);
+
+    const data = { value: 42 };
+    controller.emit("my-event", data);
+
+    const expected = `event: my-event\ndata: ${JSON.stringify(data)}\n\n`;
+    expect(calls1).toContain(expected);
+    expect(calls2).toContain(expected);
+  });
+
+  it("uses empty object as default data when no data argument is provided", () => {
+    const controller = new EventsController();
+    const { res, writeCalls } = createFakeResponse();
+
+    controller.connect(createFakeRequest(), res);
+    controller.emit("ping");
+
+    const expected = `event: ping\ndata: ${JSON.stringify({})}\n\n`;
+    expect(writeCalls).toContain(expected);
+  });
+
+  it("continues broadcasting to remaining clients when one write throws", () => {
+    const controller = new EventsController();
+
+    const { res: res1, writeCalls: calls1 } = createFakeResponse();
+    const { writeCalls: calls2 } = createFakeResponse();
+
+    // First client will throw on write
+    const throwingRes = {
+      setHeader: vi.fn(),
+      write: vi
+        .fn()
+        .mockImplementationOnce(() => {
+          // skip initial comment
+        })
+        .mockImplementationOnce(() => {
+          throw new Error("stream closed");
+        }),
+    } as unknown as Response;
+
+    controller.connect(createFakeRequest(), throwingRes);
+    controller.connect(createFakeRequest(), res1);
+
+    // Should not throw despite first client error
+    expect(() => controller.emit("safe-event", {})).not.toThrow();
+    // Second client should still receive the event
+    expect(calls1).toContain(`event: safe-event\ndata: ${JSON.stringify({})}\n\n`);
+    // First client's calls2 is from the original factory — just verify res1 got the event
+    expect(calls2.length).toBe(0);
   });
 });

--- a/apps/backend/src/presentation/controllers/feed.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/feed.controller.test.ts
@@ -88,4 +88,42 @@ describe("FeedController", () => {
       expect(res.json).toHaveBeenCalledWith([]);
     });
   });
+
+  describe("getArtists", () => {
+    it("returns cached artists from the repository when it has entries", async () => {
+      const cachedArtists = [makeFollowedArtist({ id: "a-cached" })];
+      vi.mocked(mocks.feedRepository.getArtists).mockResolvedValue(cachedArtists);
+
+      const res = mockRes();
+      await controller.getArtists(mockReq(), res);
+
+      expect(mocks.feedRepository.getArtists).toHaveBeenCalledTimes(1);
+      expect(mocks.spotifyUserLibraryService.getFollowedArtists).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith(cachedArtists);
+    });
+
+    it("falls back to Spotify when repository returns an empty array", async () => {
+      vi.mocked(mocks.feedRepository.getArtists).mockResolvedValue([]);
+      const spotifyArtists = [makeFollowedArtist({ id: "a-spotify" })];
+      vi.mocked(mocks.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue(
+        spotifyArtists,
+      );
+
+      const res = mockRes();
+      await controller.getArtists(mockReq(), res);
+
+      expect(mocks.spotifyUserLibraryService.getFollowedArtists).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith(spotifyArtists);
+    });
+
+    it("responds with an empty array when both repository and Spotify return nothing", async () => {
+      vi.mocked(mocks.feedRepository.getArtists).mockResolvedValue([]);
+      vi.mocked(mocks.spotifyUserLibraryService.getFollowedArtists).mockResolvedValue([]);
+
+      const res = mockRes();
+      await controller.getArtists(mockReq(), res);
+
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+  });
 });


### PR DESCRIPTION
## What

Wave-3 slice A: expand characterization tests for five Express controllers. **No source changes** — tests describe existing behavior.

| Controller | Before | After |
|---|---|---|
| artist | 28% | 98% |
| events | 60% | 100% |
| auth | 62% | 100% |
| feed | 67% | 100% |
| artwork-backfill | 75% | 100% |

Covered the previously-untested error paths: missing route params, cache TTL prune / size-cap eviction (artist), SSE client lifecycle (events), OAuth callback missing-code (auth), Spotify fallback (feed), and 429/404/500 branches.

## Evidence

- `pnpm --filter backend test:run src/presentation/controllers` → **15 files, 129 tests passed**.
- `pnpm --filter backend test:coverage` → gate exit 0. Controllers dir **80% -> 98%** lines; backend overall **92.2% -> 93.5%**.

## Notes

One defensive guard left uncovered: `artist.controller.ts` lines 26-27 (`if (!firstKey) break` inside `pruneActiveDetailRequests`) — logically unreachable given the `size >= 200` loop condition; not testable without a source change.