### PR TITLE
test(backend): cover application service branches (wave 3B)

### DIFF
--- a/apps/backend/src/application/services/artwork.service.test.ts
+++ b/apps/backend/src/application/services/artwork.service.test.ts
@@ -212,5 +212,280 @@ describe("ArtworkService", () => {
         "https://open.spotify.com/track/abc",
       );
     });
+
+    it("ATW-1d: swallows error when Deezer albumCoverUrl download fails", async () => {
+      artworkAssets.downloadImage.mockImplementation((url: string) => {
+        if (url === "https://cdn.deezer.com/failing.jpg") throw new Error("download failed");
+        return Promise.resolve(jpegBuffer);
+      });
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork({
+        ...track,
+        trackUrl: deezerTrackUrl,
+        albumCoverUrl: "https://cdn.deezer.com/failing.jpg",
+      });
+
+      // Error swallowed — trackCoverBuffer is null, falls back to playlistCoverBuffer
+      expect(artwork.tagCoverBuffer).toEqual(jpegBuffer);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resolveTrackArtwork — track with no playlist
+  // ---------------------------------------------------------------------------
+
+  describe("resolveTrackArtwork — no playlist", () => {
+    it("resolves without playlist cover when track has no playlistId", async () => {
+      playlistRepository.findOne.mockResolvedValue(null);
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork({ ...track, playlistId: undefined });
+
+      expect(playlistRepository.findOne).not.toHaveBeenCalled();
+      // Only trackCover download is called (spotifyService resolves a URL)
+      expect(artwork.tagCoverBuffer).toEqual(jpegBuffer);
+      expect(artwork.artistImageBuffer).toBeNull();
+    });
+
+    it("resolves without track cover when spotifyService returns empty string", async () => {
+      spotifyService.getCoverImage.mockResolvedValue("");
+      playlistRepository.findOne.mockResolvedValue(null);
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork({ ...track, playlistId: undefined });
+
+      expect(artwork.tagCoverBuffer).toBeNull();
+      expect(artwork.folderCoverBuffer).toBeNull();
+    });
+
+    it("swallows error when spotifyService.getCoverImage throws", async () => {
+      spotifyService.getCoverImage.mockRejectedValue(new Error("spotify error"));
+      playlistRepository.findOne.mockResolvedValue(null);
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork({ ...track, playlistId: undefined });
+
+      // Error swallowed — trackCoverBuffer is null
+      expect(artwork.tagCoverBuffer).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // resolveTrackArtwork — playlist type "playlist" (isPlaylistType = true)
+  // ---------------------------------------------------------------------------
+
+  describe("resolveTrackArtwork — playlist type variants", () => {
+    it("for playlist type: folderCoverBuffer prefers playlistCoverBuffer over trackCoverBuffer", async () => {
+      playlistRepository.findOne.mockResolvedValue(
+        new Playlist({
+          id: "playlist-1",
+          type: PlaylistTypeEnum.Playlist,
+          coverUrl: "https://image.test/playlist.jpg",
+        }),
+      );
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork(track);
+
+      // isPlaylistType=true → folderCoverBuffer = playlistCoverBuffer || trackCoverBuffer
+      expect(artwork.folderCoverBuffer).toEqual(jpegBuffer);
+      // No artistImageBuffer because type=playlist but artistImageUrl is missing
+      expect(artwork.artistImageBuffer).toBeNull();
+    });
+
+    it("for non-playlist type: folderCoverBuffer uses trackCoverBuffer first", async () => {
+      // Default beforeEach has type Album with both coverUrl and artistImageUrl
+      const trackBuffer = Buffer.from([0xff, 0xd8, 0xfe]);
+      const playlistBuffer = Buffer.from([0xff, 0xd8, 0xfd]);
+      artworkAssets.downloadImage.mockImplementation((url: string) => {
+        if (url === "https://image.test/playlist.jpg") return Promise.resolve(playlistBuffer);
+        if (url === "https://image.test/track.jpg") return Promise.resolve(trackBuffer);
+        return Promise.resolve(jpegBuffer);
+      });
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      const artwork = await service.resolveTrackArtwork(track);
+
+      // isPlaylistType=false (Album) → folderCoverBuffer = trackCoverBuffer || playlistCoverBuffer
+      expect(artwork.folderCoverBuffer).toEqual(trackBuffer);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveAlbumCover — no-op when folderCoverBuffer is null
+  // ---------------------------------------------------------------------------
+
+  describe("saveAlbumCover", () => {
+    it("does not call writeFileIfMissing when folderCoverBuffer is null", async () => {
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await service.saveAlbumCover("/music/Album", {
+        tagCoverBuffer: null,
+        folderCoverBuffer: null,
+        artistImageBuffer: null,
+      });
+
+      expect(artworkAssets.writeFileIfMissing).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // saveArtistImageIfNeeded — early-return conditions
+  // ---------------------------------------------------------------------------
+
+  describe("saveArtistImageIfNeeded", () => {
+    it("does not call writeFileIfMissing when artistImageBuffer is null", async () => {
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await service.saveArtistImageIfNeeded(track, {
+        tagCoverBuffer: null,
+        folderCoverBuffer: null,
+        artistImageBuffer: null,
+      });
+
+      expect(artworkAssets.writeFileIfMissing).not.toHaveBeenCalled();
+    });
+
+    it("does not call writeFileIfMissing when track has no playlistId", async () => {
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await service.saveArtistImageIfNeeded(
+        { ...track, playlistId: undefined },
+        {
+          tagCoverBuffer: null,
+          folderCoverBuffer: null,
+          artistImageBuffer: jpegBuffer,
+        },
+      );
+
+      expect(artworkAssets.writeFileIfMissing).not.toHaveBeenCalled();
+    });
+
+    it("swallows error when writeFileIfMissing throws while saving artist image", async () => {
+      artworkAssets.writeFileIfMissing.mockRejectedValue(new Error("disk full"));
+      pathService.getArtistFolderPath.mockReturnValue("/music/Artist");
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await expect(
+        service.saveArtistImageIfNeeded(track, {
+          tagCoverBuffer: null,
+          folderCoverBuffer: null,
+          artistImageBuffer: jpegBuffer,
+        }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("uses albumArtist over artist when determining the artist folder path", async () => {
+      pathService.getArtistFolderPath.mockReturnValue("/music/Album Artist");
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await service.saveArtistImageIfNeeded(track, {
+        tagCoverBuffer: null,
+        folderCoverBuffer: null,
+        artistImageBuffer: jpegBuffer,
+      });
+
+      expect(pathService.getArtistFolderPath).toHaveBeenCalledWith("Album Artist");
+    });
+
+    it("falls back to artist when albumArtist is absent", async () => {
+      pathService.getArtistFolderPath.mockReturnValue("/music/Track Artist");
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        artworkAssets as never,
+      );
+
+      await service.saveArtistImageIfNeeded(
+        { ...track, albumArtist: undefined },
+        {
+          tagCoverBuffer: null,
+          folderCoverBuffer: null,
+          artistImageBuffer: jpegBuffer,
+        },
+      );
+
+      expect(pathService.getArtistFolderPath).toHaveBeenCalledWith("Track Artist");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // clearCache — no-op when artworkAssets has no clearCache method
+  // ---------------------------------------------------------------------------
+
+  describe("clearCache", () => {
+    it("does nothing when artworkAssets does not have a clearCache method", () => {
+      const assetsWithoutCache = {
+        downloadImage: vi.fn(),
+        writeFileIfMissing: vi.fn(),
+        // no clearCache
+      };
+      const service = new ArtworkService(
+        playlistRepository as never,
+        spotifyService as never,
+        pathService as never,
+        assetsWithoutCache as never,
+      );
+
+      // Should not throw
+      expect(() => service.clearCache()).not.toThrow();
+    });
   });
 });

--- a/apps/backend/src/application/services/settings.service.test.ts
+++ b/apps/backend/src/application/services/settings.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { SettingsRepository } from "@/domain/repositories/settings.repository";
 import { SettingsService } from "./settings.service";
 
@@ -12,6 +12,14 @@ function makeUnseededService(): SettingsService {
     delete: async () => undefined,
   } as unknown as SettingsRepository;
   return new SettingsService(repo, () => undefined);
+}
+
+function makeRepo(value: string | undefined): SettingsRepository {
+  return {
+    get: vi.fn().mockResolvedValue(value),
+    set: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+  } as unknown as SettingsRepository;
 }
 
 describe("SettingsService.getNumber — recovery keys resolve to a default (regression guard)", () => {
@@ -32,5 +40,150 @@ describe("SettingsService.getNumber — recovery keys resolve to a default (regr
   it("still throws for a genuinely unknown numeric key with no default", async () => {
     const service = makeUnseededService();
     await expect(service.getNumber("DEFINITELY_NOT_A_SETTING")).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getString
+// ---------------------------------------------------------------------------
+
+describe("SettingsService.getString", () => {
+  it("returns the value from the repository when found", async () => {
+    const service = new SettingsService(makeRepo("custom-value"), () => undefined);
+    await expect(service.getString("UI_LANGUAGE")).resolves.toBe("custom-value");
+  });
+
+  it("returns the explicit fallback when repo returns undefined and no metadata default", async () => {
+    const service = new SettingsService(makeRepo(undefined), () => undefined);
+    await expect(service.getString("DEFINITELY_NOT_A_SETTING", "my-fallback")).resolves.toBe(
+      "my-fallback",
+    );
+  });
+
+  it("returns the metadata default when repo returns undefined and no explicit fallback", async () => {
+    // UI_LANGUAGE has defaultValue "en" in SETTINGS_METADATA
+    const service = makeUnseededService();
+    await expect(service.getString("UI_LANGUAGE")).resolves.toBe("en");
+  });
+
+  it("throws AppError when no repo value, no fallback, and no metadata default", async () => {
+    const service = makeUnseededService();
+    await expect(service.getString("DEFINITELY_NOT_A_SETTING")).rejects.toThrow(
+      "Setting DEFINITELY_NOT_A_SETTING not found and no valid default value available",
+    );
+  });
+
+  it("prefers repo value over metadata default", async () => {
+    const service = new SettingsService(makeRepo("custom-lang"), () => undefined);
+    // UI_LANGUAGE metadata default is "en", but repo returns "custom-lang"
+    await expect(service.getString("UI_LANGUAGE")).resolves.toBe("custom-lang");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getNumber — internalized numeric settings
+// ---------------------------------------------------------------------------
+
+describe("SettingsService.getNumber — internalized numeric settings", () => {
+  it("returns the internalized value when available, bypassing the repo", async () => {
+    const repo = makeRepo("999");
+    const service = new SettingsService(repo, (key) => {
+      if (key === "FEED_SYNC_INTERVAL_MINUTES") return 42;
+      return undefined;
+    });
+
+    await expect(service.getNumber("FEED_SYNC_INTERVAL_MINUTES")).resolves.toBe(42);
+    // repo.get should NOT be called when internalized value is present
+    expect(repo.get).not.toHaveBeenCalled();
+  });
+
+  it("falls through to repo when internalized value returns undefined for a non-internalized key", async () => {
+    const repo = makeRepo("15");
+    const service = new SettingsService(repo, () => undefined);
+
+    // PLAYLIST_CHECK_INTERVAL_MINUTES is in metadata but NOT in INTERNALIZED_NUMERIC_SETTINGS
+    await expect(service.getNumber("PLAYLIST_CHECK_INTERVAL_MINUTES")).resolves.toBe(15);
+    expect(repo.get).toHaveBeenCalled();
+  });
+
+  it("returns explicit fallback when repo value is not a valid number", async () => {
+    const repo = makeRepo("not-a-number");
+    const service = new SettingsService(repo, () => undefined);
+
+    await expect(service.getNumber("DEFINITELY_NOT_A_SETTING", 99)).resolves.toBe(99);
+  });
+
+  it("returns metadata default when repo returns undefined and no explicit fallback", async () => {
+    const service = makeUnseededService();
+    // DOWNLOAD_MAX_RETRIES has defaultValue "3"
+    await expect(service.getNumber("DOWNLOAD_MAX_RETRIES")).resolves.toBe(3);
+  });
+
+  it("returns repo numeric value parsed from string", async () => {
+    const repo = makeRepo("7");
+    const service = new SettingsService(repo, () => undefined);
+    // Using a key not in INTERNALIZED_NUMERIC_SETTINGS but in metadata
+    await expect(service.getNumber("PLAYLIST_CHECK_INTERVAL_MINUTES")).resolves.toBe(7);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBoolean
+// ---------------------------------------------------------------------------
+
+describe("SettingsService.getBoolean", () => {
+  it("returns true when repo value is 'true'", async () => {
+    const service = new SettingsService(makeRepo("true"), () => undefined);
+    await expect(service.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS")).resolves.toBe(true);
+  });
+
+  it("returns false when repo value is 'false'", async () => {
+    const service = new SettingsService(makeRepo("false"), () => undefined);
+    await expect(service.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS")).resolves.toBe(false);
+  });
+
+  it("returns explicit fallback when repo returns undefined", async () => {
+    const service = makeUnseededService();
+    await expect(service.getBoolean("DEFINITELY_NOT_A_SETTING", true)).resolves.toBe(true);
+  });
+
+  it("returns false from metadata default when no repo value and no explicit fallback", async () => {
+    // AUTO_SUBSCRIBE_NEW_PLAYLISTS has defaultValue "false"
+    const service = makeUnseededService();
+    await expect(service.getBoolean("AUTO_SUBSCRIBE_NEW_PLAYLISTS")).resolves.toBe(false);
+  });
+
+  it("returns true when metadata default is 'true' and no repo value or fallback", async () => {
+    // M3U_GENERATION_ENABLED has defaultValue "true"
+    const service = makeUnseededService();
+    await expect(service.getBoolean("M3U_GENERATION_ENABLED")).resolves.toBe(true);
+  });
+
+  it("returns false for an unknown key with no fallback (fallback undefined, metadata default undefined)", async () => {
+    const service = makeUnseededService();
+    // fallback ?? (undefined === "true") → false
+    await expect(service.getBoolean("DEFINITELY_NOT_A_SETTING")).resolves.toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setString / delete
+// ---------------------------------------------------------------------------
+
+describe("SettingsService.setString", () => {
+  it("delegates to repo.set with the given key and value", async () => {
+    const repo = makeRepo(undefined);
+    const service = new SettingsService(repo, () => undefined);
+    await service.setString("UI_LANGUAGE", "fr");
+    expect(repo.set).toHaveBeenCalledWith("UI_LANGUAGE", "fr");
+  });
+});
+
+describe("SettingsService.delete", () => {
+  it("delegates to repo.delete with the given key", async () => {
+    const repo = makeRepo(undefined);
+    const service = new SettingsService(repo, () => undefined);
+    await service.delete("UI_LANGUAGE");
+    expect(repo.delete).toHaveBeenCalledWith("UI_LANGUAGE");
   });
 });

--- a/apps/backend/src/application/services/spotify.service.test.ts
+++ b/apps/backend/src/application/services/spotify.service.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
 import { SpotifyService } from "./spotify.service";
 
 describe("SpotifyService", () => {
@@ -162,9 +163,7 @@ describe("SpotifyService", () => {
         userLibraryService: { getMyPlaylists: vi.fn() },
       });
 
-      const result = await service.getPlaylistMetadata(
-        "https://open.spotify.com/playlist/xyz",
-      );
+      const result = await service.getPlaylistMetadata("https://open.spotify.com/playlist/xyz");
 
       expect(result).toMatchObject({
         name: "Radio Alexander",
@@ -238,5 +237,654 @@ describe("SpotifyService", () => {
 
     expect(result.totalTracks).toBe(75);
     expect(result.tracks).toHaveLength(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPlaylistDetail — Artist URL (throws AppError 400)
+  // ---------------------------------------------------------------------------
+
+  describe("getPlaylistDetail — artist URL", () => {
+    it("throws AppError 400 for an artist URL", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      await expect(
+        service.getPlaylistDetail("https://open.spotify.com/artist/abc123"),
+      ).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("includes invalid_spotify_url error code for artist URL", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const err = await service
+        .getPlaylistDetail("https://open.spotify.com/artist/abc123")
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(AppError);
+      expect((err as AppError).statusCode).toBe(400);
+      expect((err as AppError).errorCode).toBe("invalid_spotify_url");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPlaylistDetail — error propagation
+  // ---------------------------------------------------------------------------
+
+  describe("getPlaylistDetail — error propagation", () => {
+    it("re-throws errors from trackClient", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: {
+          getTrackDetails: vi.fn().mockRejectedValue(new Error("track fetch failed")),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      await expect(
+        service.getPlaylistDetail("https://open.spotify.com/track/abc123"),
+      ).rejects.toThrow("track fetch failed");
+    });
+
+    it("re-throws errors from albumClient", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: {
+          getAlbumTracks: vi.fn().mockRejectedValue(new Error("album fetch failed")),
+          getAlbumDetails: vi.fn(),
+        },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      await expect(
+        service.getPlaylistDetail("https://open.spotify.com/album/abc123"),
+      ).rejects.toThrow("album fetch failed");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPlaylistDetail — album with no tracks (empty array edge-case)
+  // ---------------------------------------------------------------------------
+
+  it("returns 'Unknown Album' name when album has no tracks", async () => {
+    const service = new SpotifyService({
+      artistClient: { getArtistDetails: vi.fn() },
+      trackClient: { getTrackDetails: vi.fn() },
+      albumClient: {
+        getAlbumTracks: vi.fn().mockResolvedValue([]),
+        getAlbumDetails: vi.fn(),
+      },
+      playlistClient: {
+        getPlaylistMetadata: vi.fn(),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn(),
+      },
+      searchClient: { searchCatalog: vi.fn() },
+      userLibraryService: { getMyPlaylists: vi.fn() },
+    });
+
+    const result = await service.getPlaylistDetail("https://open.spotify.com/album/empty123");
+    expect(result.name).toBe("Unknown Album");
+    expect(result.tracks).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getCoverImage
+  // ---------------------------------------------------------------------------
+
+  describe("getCoverImage", () => {
+    it("returns track albumCoverUrl for a track URL", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/cover.jpg",
+            artists: [],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/track/abc123");
+      expect(url).toBe("https://image.test/cover.jpg");
+    });
+
+    it("returns empty string when track albumCoverUrl is null", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: null,
+            artists: [],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/track/abc123");
+      expect(url).toBe("");
+    });
+
+    it("returns first album image url for an album URL", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: {
+          getAlbumTracks: vi.fn(),
+          getAlbumDetails: vi.fn().mockResolvedValue({
+            images: [{ url: "https://image.test/album.jpg" }, { url: "https://image.test/sm.jpg" }],
+          }),
+        },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/album/abc123");
+      expect(url).toBe("https://image.test/album.jpg");
+    });
+
+    it("returns empty string when album has no images", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: {
+          getAlbumTracks: vi.fn(),
+          getAlbumDetails: vi.fn().mockResolvedValue({ images: [] }),
+        },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/album/abc123");
+      expect(url).toBe("");
+    });
+
+    it("returns playlist image for a playlist URL", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn().mockResolvedValue({
+            name: "My Playlist",
+            image: "https://image.test/playlist.jpg",
+          }),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/playlist/abc123");
+      expect(url).toBe("https://image.test/playlist.jpg");
+    });
+
+    it("returns empty string for an artist URL (no matching branch)", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/artist/abc123");
+      expect(url).toBe("");
+    });
+
+    it("returns empty string when client throws (swallows error)", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: {
+          getTrackDetails: vi.fn().mockRejectedValue(new Error("network error")),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = await service.getCoverImage("https://open.spotify.com/track/abc123");
+      expect(url).toBe("");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPlaylistTracks
+  // ---------------------------------------------------------------------------
+
+  describe("getPlaylistTracks", () => {
+    it("returns tracks from playlistClient.getAllPlaylistTracks", async () => {
+      const tracks = [{ name: "Track 1", artists: [] }];
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn().mockResolvedValue(tracks),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistTracks("https://open.spotify.com/playlist/abc123");
+      expect(result).toEqual(tracks);
+    });
+
+    it("returns empty array when playlistClient throws", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn().mockRejectedValue(new Error("network error")),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistTracks("https://open.spotify.com/playlist/abc123");
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPlaylistTracksPage
+  // ---------------------------------------------------------------------------
+
+  describe("getPlaylistTracksPage", () => {
+    it("delegates to playlistClient.getPlaylistTracksPage and returns result", async () => {
+      const pageResult = {
+        tracks: [{ name: "Track 1", artists: [] }],
+        total: 50,
+        hasMore: true,
+        nextOffset: 20,
+      };
+      const playlistClient = {
+        getPlaylistMetadata: vi.fn(),
+        getAllPlaylistTracks: vi.fn(),
+        getPlaylistTracksPage: vi.fn().mockResolvedValue(pageResult),
+      };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient,
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const url = "https://open.spotify.com/playlist/abc123";
+      const result = await service.getPlaylistTracksPage(url, 0, 20);
+
+      expect(playlistClient.getPlaylistTracksPage).toHaveBeenCalledWith(url, 0, 20);
+      expect(result).toEqual(pageResult);
+    });
+
+    it("re-throws errors from playlistClient.getPlaylistTracksPage", async () => {
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn().mockRejectedValue(new Error("paged fetch failed")),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      await expect(
+        service.getPlaylistTracksPage("https://open.spotify.com/playlist/abc123", 0, 20),
+      ).rejects.toThrow("paged fetch failed");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getMyPlaylists
+  // ---------------------------------------------------------------------------
+
+  describe("getMyPlaylists", () => {
+    it("delegates to userLibraryService.getMyPlaylists and returns result", async () => {
+      const playlists = [{ id: "p1", name: "My Playlist" }];
+      const userLibraryService = { getMyPlaylists: vi.fn().mockResolvedValue(playlists) };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService,
+      });
+
+      const result = await service.getMyPlaylists();
+      expect(result).toEqual(playlists);
+      expect(userLibraryService.getMyPlaylists).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // searchCatalog
+  // ---------------------------------------------------------------------------
+
+  describe("searchCatalog", () => {
+    it("delegates to searchClient.searchCatalog and returns result", async () => {
+      const searchResults = { tracks: [], albums: [], artists: [] };
+      const searchClient = { searchCatalog: vi.fn().mockResolvedValue(searchResults) };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient,
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.searchCatalog("rock", ["track"], { track: 10 });
+      expect(searchClient.searchCatalog).toHaveBeenCalledWith("rock", ["track"], { track: 10 });
+      expect(result).toEqual(searchResults);
+    });
+
+    it("works without optional types and limits args", async () => {
+      const searchResults = { tracks: [], albums: [], artists: [] };
+      const searchClient = { searchCatalog: vi.fn().mockResolvedValue(searchResults) };
+      const service = new SpotifyService({
+        artistClient: { getArtistDetails: vi.fn() },
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient,
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.searchCatalog("jazz");
+      expect(searchClient.searchCatalog).toHaveBeenCalledWith("jazz", undefined, undefined);
+      expect(result).toEqual(searchResults);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // populatePrimaryArtistImages — internal edge cases
+  // ---------------------------------------------------------------------------
+
+  describe("populatePrimaryArtistImages edge cases", () => {
+    it("returns track unchanged when primaryArtistImage is already set", async () => {
+      const artistClient = { getArtistDetails: vi.fn() };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/album.jpg",
+            primaryArtistImage: "https://existing.image/artist.jpg",
+            artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistDetail("https://open.spotify.com/track/abc123");
+      // Already has primaryArtistImage — should not call artistClient at all
+      expect(artistClient.getArtistDetails).not.toHaveBeenCalled();
+      expect(result.tracks[0]?.primaryArtistImage).toBe("https://existing.image/artist.jpg");
+    });
+
+    it("returns track unchanged when artists array is empty (no primaryArtistUrl)", async () => {
+      const artistClient = { getArtistDetails: vi.fn() };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/album.jpg",
+            primaryArtistImage: null,
+            artists: [],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistDetail("https://open.spotify.com/track/abc123");
+      expect(artistClient.getArtistDetails).not.toHaveBeenCalled();
+      expect(result.tracks[0]?.primaryArtistImage).toBeNull();
+    });
+
+    it("returns track unchanged when artistClient returns null image", async () => {
+      const artistClient = {
+        getArtistDetails: vi.fn().mockResolvedValue({
+          name: "Artist",
+          image: null,
+          spotifyUrl: null,
+          followers: null,
+          genres: [],
+        }),
+      };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/album.jpg",
+            primaryArtistImage: null,
+            artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistDetail("https://open.spotify.com/track/abc123");
+      // null image → returns track as-is, primaryArtistImage remains null
+      expect(result.tracks[0]?.primaryArtistImage).toBeNull();
+    });
+
+    it("returns track unchanged when artistClient throws (swallows error)", async () => {
+      const artistClient = {
+        getArtistDetails: vi.fn().mockRejectedValue(new Error("artist fetch failed")),
+      };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/album.jpg",
+            primaryArtistImage: null,
+            artists: [{ name: "Artist", url: "https://open.spotify.com/artist/abc123" }],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      // Should not throw — error is swallowed inside populatePrimaryArtistImages
+      const result = await service.getPlaylistDetail("https://open.spotify.com/track/abc123");
+      expect(result.tracks[0]?.primaryArtistImage).toBeNull();
+    });
+
+    it("returns track unchanged when SpotifyUrlHelper.extractId throws on invalid artist URL", async () => {
+      const artistClient = { getArtistDetails: vi.fn() };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: {
+          getTrackDetails: vi.fn().mockResolvedValue({
+            name: "Track",
+            albumCoverUrl: "https://image.test/album.jpg",
+            primaryArtistImage: null,
+            // artists[0].url is missing the expected path segment — extractId will throw
+            artists: [{ name: "Artist", url: "not-a-valid-spotify-url" }],
+          }),
+        },
+        albumClient: { getAlbumTracks: vi.fn(), getAlbumDetails: vi.fn() },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      // extractId throws for invalid URL → catch block returns track as-is
+      const result = await service.getPlaylistDetail("https://open.spotify.com/track/abc123");
+      expect(artistClient.getArtistDetails).not.toHaveBeenCalled();
+      expect(result.tracks[0]?.primaryArtistImage).toBeNull();
+    });
+
+    it("caches the artist lookup across multiple tracks with the same artist", async () => {
+      const artistClient = {
+        getArtistDetails: vi.fn().mockResolvedValue({
+          name: "Artist",
+          image: "https://image.test/artist.jpg",
+          spotifyUrl: null,
+          followers: null,
+          genres: [],
+        }),
+      };
+      const trackTemplate = {
+        primaryArtistImage: null,
+        album: "Album",
+        albumCoverUrl: "https://image.test/album.jpg",
+        artists: [{ name: "Artist", url: "https://open.spotify.com/artist/shared-id" }],
+      };
+      const service = new SpotifyService({
+        artistClient,
+        trackClient: { getTrackDetails: vi.fn() },
+        albumClient: {
+          getAlbumTracks: vi.fn().mockResolvedValue([
+            { ...trackTemplate, name: "Track 1" },
+            { ...trackTemplate, name: "Track 2" },
+            { ...trackTemplate, name: "Track 3" },
+          ]),
+          getAlbumDetails: vi.fn(),
+        },
+        playlistClient: {
+          getPlaylistMetadata: vi.fn(),
+          getAllPlaylistTracks: vi.fn(),
+          getPlaylistTracksPage: vi.fn(),
+        },
+        searchClient: { searchCatalog: vi.fn() },
+        userLibraryService: { getMyPlaylists: vi.fn() },
+      });
+
+      const result = await service.getPlaylistDetail("https://open.spotify.com/album/abc123");
+      // Cache means only 1 API call for 3 tracks sharing the same artist
+      expect(artistClient.getArtistDetails).toHaveBeenCalledTimes(1);
+      expect(result.tracks).toHaveLength(3);
+      result.tracks.forEach((t) => {
+        expect(t.primaryArtistImage).toBe("https://image.test/artist.jpg");
+      });
+    });
   });
 });

--- a/apps/backend/src/application/services/track-post-processing.service.test.ts
+++ b/apps/backend/src/application/services/track-post-processing.service.test.ts
@@ -93,4 +93,242 @@ describe("TrackPostProcessingService", () => {
       }),
     );
   });
+
+  // ---------------------------------------------------------------------------
+  // process — error branch: post-processing errors are swallowed
+  // ---------------------------------------------------------------------------
+
+  it("does not throw when artworkService.resolveTrackArtwork throws (error is swallowed)", async () => {
+    artworkService.resolveTrackArtwork.mockRejectedValue(new Error("artwork fetch failed"));
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await expect(
+      service.process(track, "/library/Album Artist/Album/01 - Track.mp3"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when metadataService.writeTags throws (error is swallowed)", async () => {
+    metadataService.writeTags.mockRejectedValue(new Error("writeTags failed"));
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await expect(
+      service.process(track, "/library/Album Artist/Album/01 - Track.mp3"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not throw when artworkService.saveAlbumCover throws (error is swallowed)", async () => {
+    artworkService.saveAlbumCover.mockRejectedValue(new Error("saveAlbumCover failed"));
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await expect(
+      service.process(track, "/library/Album Artist/Album/01 - Track.mp3"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes undefined coverBuffer when tagCoverBuffer is null", async () => {
+    resolvedArtwork.tagCoverBuffer = null;
+    artworkService.resolveTrackArtwork.mockResolvedValue(resolvedArtwork);
+    const service = new TrackPostProcessingService(
+      artworkService as never,
+      metadataService as never,
+      playlistRepository as never,
+      trackRepository as never,
+      trackPathService as never,
+      m3uService as never,
+    );
+
+    await service.process(track, "/library/Album Artist/Album/01 - Track.mp3");
+
+    expect(metadataService.writeTags).toHaveBeenCalledWith(
+      "/library/Album Artist/Album/01 - Track.mp3",
+      expect.objectContaining({ coverBuffer: undefined }),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // updatePlaylistM3u
+  // ---------------------------------------------------------------------------
+
+  describe("updatePlaylistM3u", () => {
+    it("returns early without calling repository when track has no playlistId", async () => {
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u({ ...track, playlistId: undefined });
+
+      expect(playlistRepository.findOne).not.toHaveBeenCalled();
+    });
+
+    it("returns early when playlist is not found (findOne returns null)", async () => {
+      playlistRepository.findOne.mockResolvedValue(null);
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u(track);
+
+      expect(trackRepository.findAllByPlaylist).not.toHaveBeenCalled();
+      expect(m3uService.generateM3uFile).not.toHaveBeenCalled();
+    });
+
+    it("returns early when playlist type is not 'playlist'", async () => {
+      const nonPlaylistEntity = {
+        name: "Some Album",
+        type: "album",
+        toPrimitive: vi.fn().mockReturnValue({ name: "Some Album", type: "album" }),
+      };
+      playlistRepository.findOne.mockResolvedValue(nonPlaylistEntity);
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u(track);
+
+      expect(trackRepository.findAllByPlaylist).not.toHaveBeenCalled();
+      expect(m3uService.generateM3uFile).not.toHaveBeenCalled();
+    });
+
+    it("returns early when playlist has no name", async () => {
+      const namelessEntity = {
+        name: undefined,
+        type: "playlist",
+        toPrimitive: vi.fn().mockReturnValue({ name: undefined, type: "playlist" }),
+      };
+      playlistRepository.findOne.mockResolvedValue(namelessEntity);
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u(track);
+
+      expect(trackRepository.findAllByPlaylist).not.toHaveBeenCalled();
+    });
+
+    it("generates M3U when playlist is of type 'playlist' with tracks", async () => {
+      const primitivePlaylist = { id: "playlist-1", name: "My Playlist", type: "playlist" };
+      const playlistEntity = {
+        name: "My Playlist",
+        type: "playlist",
+        toPrimitive: vi.fn().mockReturnValue(primitivePlaylist),
+      };
+      const primitiveTrack = { id: "t1", name: "Track", status: "completed" };
+      const trackEntity = { toPrimitive: vi.fn().mockReturnValue(primitiveTrack) };
+      playlistRepository.findOne.mockResolvedValue(playlistEntity);
+      trackRepository.findAllByPlaylist.mockResolvedValue([trackEntity]);
+      trackPathService.getPlaylistFolderPath.mockReturnValue("/music/My Playlist");
+      m3uService.generateM3uFile.mockResolvedValue(undefined);
+      m3uService.getCompletedTracksCount.mockReturnValue(1);
+
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u(track);
+
+      expect(trackRepository.findAllByPlaylist).toHaveBeenCalledWith("playlist-1");
+      expect(trackPathService.getPlaylistFolderPath).toHaveBeenCalledWith("My Playlist");
+      expect(m3uService.generateM3uFile).toHaveBeenCalledWith(
+        primitivePlaylist,
+        [primitiveTrack],
+        "/music/My Playlist",
+      );
+    });
+
+    it("skips M3U generation when playlist has no tracks", async () => {
+      const primitivePlaylist = { id: "playlist-1", name: "Empty Playlist", type: "playlist" };
+      const playlistEntity = {
+        name: "Empty Playlist",
+        type: "playlist",
+        toPrimitive: vi.fn().mockReturnValue(primitivePlaylist),
+      };
+      playlistRepository.findOne.mockResolvedValue(playlistEntity);
+      trackRepository.findAllByPlaylist.mockResolvedValue([]);
+
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await service.updatePlaylistM3u(track);
+
+      expect(m3uService.generateM3uFile).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors from m3uService.generateM3uFile without throwing", async () => {
+      const primitivePlaylist = { id: "playlist-1", name: "My Playlist", type: "playlist" };
+      const playlistEntity = {
+        name: "My Playlist",
+        type: "playlist",
+        toPrimitive: vi.fn().mockReturnValue(primitivePlaylist),
+      };
+      const primitiveTrack = { id: "t1", name: "Track" };
+      const trackEntity = { toPrimitive: vi.fn().mockReturnValue(primitiveTrack) };
+      playlistRepository.findOne.mockResolvedValue(playlistEntity);
+      trackRepository.findAllByPlaylist.mockResolvedValue([trackEntity]);
+      trackPathService.getPlaylistFolderPath.mockReturnValue("/music/My Playlist");
+      m3uService.generateM3uFile.mockRejectedValue(new Error("m3u write error"));
+
+      const service = new TrackPostProcessingService(
+        artworkService as never,
+        metadataService as never,
+        playlistRepository as never,
+        trackRepository as never,
+        trackPathService as never,
+        m3uService as never,
+      );
+
+      await expect(service.updatePlaylistM3u(track)).resolves.toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## What

Wave-3 slice B: expand characterization tests for four application services. **No source changes**.

| Service | Before | After |
|---|---|---|
| spotify.service | 55% | 99% |
| track-post-processing.service | 58% | 100% |
| settings.service | 64% | 100% |
| artwork.service | 82% | 100% |

Covered URL-type dispatch and resolve/search branches (spotify), tagging + move/cleanup paths (track-post-processing), get/update branches and defaults (settings), source selection and cache-clear guard (artwork).

## Evidence

- `pnpm --filter backend test:run src/application/services` → **9 files, 156 tests passed**.
- `pnpm --filter backend test:coverage` → gate exit 0. application/services **76% -> 99.8%** lines.

## Notes

Two uncoverable lines left, no source change: `spotify.service.ts:128` (dead fallback — `SpotifyUrlHelper.getUrlType()` throws first) and an artwork.service `&&` sub-branch that requires `clearCache` to be a non-function property.