### PR TITLE
test(backend): cover application use-case branches (wave 3C)

### DIFF
--- a/apps/backend/src/application/use-cases/artists/get-album-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/artists/get-album-tracks.use-case.test.ts
@@ -476,3 +476,147 @@ describe("GetAlbumTracksUseCase — AlbumTracksCachePort", () => {
     });
   });
 });
+
+describe("GetAlbumTracksUseCase — release-cache fallback and album backfill", () => {
+  let repo: FeedRepositoryPort;
+  let deezerClient: DeezerAlbumPort;
+  let musicBrainzClient: MusicBrainzReleasePort;
+
+  beforeEach(() => {
+    repo = mockRepo();
+    deezerClient = mockDeezerClient();
+    musicBrainzClient = mockMusicBrainzClient();
+  });
+
+  it("falls back to getArtistReleaseWithArtist when getArtistAlbumWithArtist returns null", async () => {
+    const deezerTracks = [makeNormalizedTrack({ name: "Release Track" })];
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue(null);
+    vi.mocked(repo.getArtistReleaseWithArtist).mockResolvedValue({
+      id: "rel-1",
+      albumId: "album-1",
+      albumName: "Release Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: null,
+      spotifyUrl: null,
+      artistName: "Release Artist",
+    } as any);
+    vi.mocked(deezerClient.searchAlbum).mockResolvedValue({ id: 789 });
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue(deezerTracks);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "album-1");
+
+    expect(result).toEqual(deezerTracks);
+    expect(deezerClient.searchAlbum).toHaveBeenCalledWith("Release Artist", "Release Album");
+  });
+
+  it("uses deezerAlbumId when albumId is a numeric Deezer ID in release-cache fallback", async () => {
+    const deezerTracks = [makeNormalizedTrack({ name: "Deezer Track" })];
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue(null);
+    vi.mocked(repo.getArtistReleaseWithArtist).mockResolvedValue({
+      id: "rel-2",
+      albumId: "123456789",
+      albumName: "Numeric Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: null,
+      spotifyUrl: null,
+      artistName: "Numeric Artist",
+    } as any);
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue(deezerTracks);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "123456789");
+
+    // isDeezerAlbumId("123456789") = true → deezerAlbumId set → getAlbumTracks called directly
+    expect(deezerClient.getAlbumTracks).toHaveBeenCalledWith("123456789");
+    expect(result).toEqual(deezerTracks);
+  });
+
+  it("backfills empty album on track with albumName from cache", async () => {
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue({
+      id: "sp-artist-1:album-1",
+      spotifyArtistId: "sp-artist-1",
+      albumId: "album-1",
+      albumName: "Great Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: null,
+      spotifyUrl: null,
+      totalTracks: 10,
+      deezerAlbumId: "dz-42",
+      mbAlbumId: null,
+      artistName: "Great Artist",
+    });
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue([makeNormalizedTrack({ album: "" })]);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "album-1");
+
+    expect(result[0].album).toBe("Great Album");
+  });
+
+  it("backfills whitespace-only album on track with albumName from cache", async () => {
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue({
+      id: "sp-artist-1:album-1",
+      spotifyArtistId: "sp-artist-1",
+      albumId: "album-1",
+      albumName: "Great Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: null,
+      spotifyUrl: null,
+      totalTracks: 10,
+      deezerAlbumId: "dz-42",
+      mbAlbumId: null,
+      artistName: "Great Artist",
+    });
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue([
+      makeNormalizedTrack({ album: "   " }),
+    ]);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "album-1");
+
+    expect(result[0].album).toBe("Great Album");
+  });
+
+  it("does NOT replace album when track already has a populated album name", async () => {
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue({
+      id: "sp-artist-1:album-1",
+      spotifyArtistId: "sp-artist-1",
+      albumId: "album-1",
+      albumName: "Great Album",
+      albumType: "album",
+      releaseDate: "2024-01-01",
+      coverUrl: null,
+      spotifyUrl: null,
+      totalTracks: 10,
+      deezerAlbumId: "dz-42",
+      mbAlbumId: null,
+      artistName: "Great Artist",
+    });
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue([
+      makeNormalizedTrack({ album: "Original Album" }),
+    ]);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "album-1");
+
+    expect(result[0].album).toBe("Original Album");
+  });
+
+  it("skips album backfill when albumName is empty (both caches miss)", async () => {
+    vi.mocked(repo.getArtistAlbumWithArtist).mockResolvedValue(null);
+    vi.mocked(repo.getArtistReleaseWithArtist).mockResolvedValue(null);
+    vi.mocked(deezerClient.searchAlbum).mockResolvedValue({ id: 999 });
+    vi.mocked(deezerClient.getAlbumTracks).mockResolvedValue([makeNormalizedTrack({ album: "" })]);
+
+    const useCase = new GetAlbumTracksUseCase(repo, deezerClient, musicBrainzClient);
+    const result = await useCase.execute("sp-artist-1", "album-1");
+
+    // albumName is "" so backfill map is skipped — track's album stays as-is
+    expect(result[0].album).toBe("");
+  });
+});

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.test.ts
@@ -792,3 +792,546 @@ describe("CreatePlaylistUseCase — SettingsPort seam", () => {
     expect(savedArg.toPrimitive().subscribed).toBe(true);
   });
 });
+
+describe("CreatePlaylistUseCase — executeSpotifyUrl branch", () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  it("saves playlist and processes tracks on happy path", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "My Song",
+          artist: "Band",
+          primaryArtist: "Band",
+          artists: [{ name: "Band", url: undefined }],
+          album: "My Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/abc",
+        },
+      ],
+      name: "My Album",
+      image: "img.jpg",
+      type: "album",
+      owner: "user",
+      ownerUrl: "http://u",
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/album/abc123",
+    });
+
+    expect(stubs.playlistRepository.save).toHaveBeenCalled();
+    expect(stubs.trackService.create).toHaveBeenCalledTimes(1);
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("displayName for album type: prepends primaryArtist to name", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "OK Computer",
+          artist: "Radiohead",
+          primaryArtist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "OK Computer",
+      image: "",
+      type: "album",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/album/abc" });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().name).toBe("Radiohead - OK Computer");
+  });
+
+  it("displayName for track type: prepends artist to name", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Karma Police",
+          artist: "Radiohead",
+          primaryArtist: "Radiohead",
+          artists: [{ name: "Radiohead", url: undefined }],
+          album: "OK Computer",
+          trackNumber: 3,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "Karma Police",
+      image: "",
+      type: "track",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/track/abc" });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().name).toBe("Radiohead - Karma Police");
+  });
+
+  it("displayName for artist type: uses plain name", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [],
+      name: "Radiohead",
+      image: "http://artist-image.jpg",
+      type: "artist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/artist/abc",
+    });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().name).toBe("Radiohead");
+  });
+
+  it("artistImageUrl from artist type uses image field", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [],
+      name: "Radiohead",
+      image: "http://artist-image.jpg",
+      type: "artist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/artist/abc",
+    });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().artistImageUrl).toBe("http://artist-image.jpg");
+  });
+
+  it("artistImageUrl from non-artist type uses first track primaryArtistImage", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Track 1",
+          artist: "Artist",
+          primaryArtistImage: "http://track-artist.jpg",
+          artists: [{ name: "Artist", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "My Playlist",
+      image: "http://playlist-cover.jpg",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().artistImageUrl).toBe("http://track-artist.jpg");
+  });
+
+  it("autoSubscribe: marks playlist subscribed when setting is true", async () => {
+    stubs.settingsService.getBoolean.mockResolvedValue(true);
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    const savedPlaylist = stubs.playlistRepository.save.mock.calls[0]?.[0] as Playlist;
+    expect(savedPlaylist.toPrimitive().subscribed).toBe(true);
+  });
+
+  it("error in getPlaylistDetail: still saves and emits, does not process tracks", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockRejectedValue(new Error("Spotify down"));
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/album/abc" });
+
+    expect(stubs.playlistRepository.save).toHaveBeenCalled();
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+    expect(stubs.trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("no tracks in detail: save happens but trackService.create is not called", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [],
+      name: "Empty Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    expect(stubs.playlistRepository.save).toHaveBeenCalled();
+    expect(stubs.trackService.create).not.toHaveBeenCalled();
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+
+  it("duplicate spotifyUrl throws 409 with playlist_already_exists", async () => {
+    const existingEntity = makePlaylistEntity({ spotifyUrl: "https://open.spotify.com/album/abc" });
+    stubs.playlistRepository.findAll.mockResolvedValue([existingEntity]);
+
+    const useCase = makeUseCase(stubs);
+    const thrown = await useCase
+      .execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/album/abc" })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).errorCode).toBe("playlist_already_exists");
+  });
+});
+
+describe("CreatePlaylistUseCase — missing optional deps (500 guards)", () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  it("executeAlbumRef throws 500 when getAlbumTracksUseCase not provided", async () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const useCase = new CreatePlaylistUseCase(
+      stubs.playlistRepository as any,
+      stubs.spotifyService as any,
+      stubs.trackService as any,
+      stubs.settingsService as any,
+      stubs.eventBus as any,
+      undefined, // no getAlbumTracksUseCase
+      undefined, // no feedRepository
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const thrown = await useCase
+      .execute({ kind: "album", artistId: "artist-1", albumId: "album-1" })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(500);
+  });
+
+  it("executeAlbumTrackRef throws 500 when deps not configured", async () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const useCase = new CreatePlaylistUseCase(
+      stubs.playlistRepository as any,
+      stubs.spotifyService as any,
+      stubs.trackService as any,
+      stubs.settingsService as any,
+      stubs.eventBus as any,
+      undefined,
+      undefined,
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const thrown = await useCase
+      .execute({ kind: "albumTrack", artistId: "artist-1", albumId: "album-1", trackIndex: 0 })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(500);
+  });
+
+  it("executeDeezerTrack throws 500 when deezerClient not provided", async () => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const useCase = new CreatePlaylistUseCase(
+      stubs.playlistRepository as any,
+      stubs.spotifyService as any,
+      stubs.trackService as any,
+      stubs.settingsService as any,
+      stubs.eventBus as any,
+      stubs.getAlbumTracksUseCase as any,
+      stubs.feedRepository as any,
+      undefined, // no deezerClient
+    );
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+
+    const thrown = await useCase
+      .execute({ kind: "deezerTrack", deezerTrackId: "123", deezerAlbumId: "456" })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(AppError);
+    expect((thrown as AppError).statusCode).toBe(500);
+  });
+});
+
+describe("CreatePlaylistUseCase — executePlaylistTrack non-P2002 error", () => {
+  it("non-P2002 error on parent save re-throws without swallowing", async () => {
+    const stubs = makeStubs();
+    const PARENT_URL = "https://open.spotify.com/playlist/parent-id";
+    const TRACK_URL = "https://open.spotify.com/track/track-id";
+
+    stubs.playlistRepository.findAll.mockResolvedValue([]);
+    stubs.spotifyService.getPlaylistMetadata.mockResolvedValue({
+      name: "Parent Playlist",
+      image: "",
+      owner: "user1",
+      ownerUrl: undefined,
+    });
+    // Non-P2002 error (no .code property)
+    stubs.playlistRepository.save.mockRejectedValue(new Error("DB down"));
+
+    const useCase = makeUseCase(stubs);
+    const thrown = await useCase
+      .execute({ kind: "playlistTrack", parentSpotifyUrl: PARENT_URL, trackUrl: TRACK_URL })
+      .catch((e) => e);
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("DB down");
+  });
+});
+
+describe("CreatePlaylistUseCase — processTrack edge cases", () => {
+  let stubs: ReturnType<typeof makeStubs>;
+
+  beforeEach(() => {
+    stubs = makeStubs();
+  });
+
+  it("skips track when artist is missing", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Track Without Artist",
+          artist: "",
+          artists: [],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    expect(stubs.trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("skips track when name is missing", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    expect(stubs.trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("skips unavailable track", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Unavailable Track",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+          unavailable: true,
+        },
+      ],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({
+      kind: "spotifyUrl",
+      spotifyUrl: "https://open.spotify.com/playlist/abc",
+    });
+
+    expect(stubs.trackService.create).not.toHaveBeenCalled();
+  });
+
+  it("uses primaryArtist for album-type playlist when primaryArtist is set", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Song",
+          artist: "Secondary",
+          primaryArtist: "Primary",
+          artists: [{ name: "Primary", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "Album",
+      image: "",
+      type: "album",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/album/abc" });
+
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ artist: "Primary" }),
+    );
+  });
+
+  it("uses artist fallback when primaryArtist is absent for album type", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Song",
+          artist: "Secondary",
+          primaryArtist: undefined,
+          artists: [{ name: "Secondary", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "Album",
+      image: "",
+      type: "album",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/album/abc" });
+
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ artist: "Secondary" }),
+    );
+  });
+
+  it("album defaults to Singles when track has no album and context is track type", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Single Song",
+          artist: "Artist",
+          primaryArtist: "Artist",
+          artists: [{ name: "Artist", url: undefined }],
+          album: undefined,
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "Single Song",
+      image: "",
+      type: "track",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+
+    const useCase = makeUseCase(stubs);
+    await useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/track/abc" });
+
+    expect(stubs.trackService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ album: "Singles" }),
+    );
+  });
+
+  it("trackService.create error does not throw from execute — eventBus still emits", async () => {
+    stubs.spotifyService.getPlaylistDetail.mockResolvedValue({
+      tracks: [
+        {
+          name: "Failing Track",
+          artist: "Artist",
+          artists: [{ name: "Artist", url: undefined }],
+          album: "Album",
+          trackNumber: 1,
+          durationMs: 200000,
+          trackUrl: "https://open.spotify.com/track/t1",
+        },
+      ],
+      name: "My Playlist",
+      image: "",
+      type: "playlist",
+      owner: "user",
+      ownerUrl: undefined,
+    });
+    stubs.trackService.create.mockRejectedValue(new Error("DB constraint"));
+
+    const useCase = makeUseCase(stubs);
+    await expect(
+      useCase.execute({ kind: "spotifyUrl", spotifyUrl: "https://open.spotify.com/playlist/abc" }),
+    ).resolves.toBeDefined();
+
+    expect(stubs.eventBus.emit).toHaveBeenCalledWith("playlists-updated");
+  });
+});

--- a/apps/backend/src/application/use-cases/settings/update-setting.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/settings/update-setting.use-case.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fsMock from "fs";
+import * as pathMock from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MASKED_SENTINEL } from "./get-settings.use-case";
 import { UpdateSettingUseCase } from "./update-setting.use-case";
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("path", () => ({
+  join: vi.fn(),
+}));
 
 function makeStubs() {
   const repository = {
@@ -61,5 +73,97 @@ describe("UpdateSettingUseCase — masked sentinel guard", () => {
       key: "AI_API_KEY",
       value: "sk-new-key",
     });
+  });
+});
+
+describe("UpdateSettingUseCase — YT_COOKIES branch", () => {
+  beforeEach(() => {
+    vi.mocked(pathMock.join)
+      .mockReturnValueOnce("/fake/config") // configDir = path.join(cwd, "config")
+      .mockReturnValueOnce("/fake/config/cookies.txt"); // cookiePath = path.join(configDir, "cookies.txt")
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("writes cookies file when value contains newline and sets repository value to file path", async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(true);
+    const { repository, spotifyUserLibraryService, eventBus } = makeStubs();
+    const useCase = new UpdateSettingUseCase(repository, spotifyUserLibraryService, eventBus);
+    const cookieContent = "# Netscape HTTP Cookie File\nfoo=bar\nbaz=qux";
+
+    await useCase.execute("YT_COOKIES", cookieContent);
+
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      "/fake/config/cookies.txt",
+      cookieContent,
+      "utf-8",
+    );
+    expect(repository.set).toHaveBeenCalledWith("YT_COOKIES", "/fake/config/cookies.txt");
+    expect(eventBus.emit).toHaveBeenCalledWith("settings:updated", {
+      key: "YT_COOKIES",
+      value: "/fake/config/cookies.txt",
+    });
+  });
+
+  it("writes cookies file when value starts with hash (# comment) and sets repository value to file path", async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(true);
+    vi.mocked(pathMock.join)
+      .mockReset()
+      .mockReturnValueOnce("/fake/config")
+      .mockReturnValueOnce("/fake/config/cookies.txt");
+    const { repository, spotifyUserLibraryService, eventBus } = makeStubs();
+    const useCase = new UpdateSettingUseCase(repository, spotifyUserLibraryService, eventBus);
+    const cookieContent = "# Netscape HTTP Cookie File\nfoo=bar";
+
+    await useCase.execute("YT_COOKIES", cookieContent);
+
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      "/fake/config/cookies.txt",
+      cookieContent,
+      "utf-8",
+    );
+    expect(repository.set).toHaveBeenCalledWith("YT_COOKIES", "/fake/config/cookies.txt");
+  });
+
+  it("does NOT write file and passes raw path through when value is a plain path", async () => {
+    const { repository, spotifyUserLibraryService, eventBus } = makeStubs();
+    const useCase = new UpdateSettingUseCase(repository, spotifyUserLibraryService, eventBus);
+
+    await useCase.execute("YT_COOKIES", "/etc/cookies.txt");
+
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+    expect(repository.set).toHaveBeenCalledWith("YT_COOKIES", "/etc/cookies.txt");
+  });
+
+  it("does NOT call mkdirSync when configDir already exists", async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(true);
+    vi.mocked(pathMock.join)
+      .mockReset()
+      .mockReturnValueOnce("/fake/config")
+      .mockReturnValueOnce("/fake/config/cookies.txt");
+    const { repository, spotifyUserLibraryService, eventBus } = makeStubs();
+    const useCase = new UpdateSettingUseCase(repository, spotifyUserLibraryService, eventBus);
+
+    await useCase.execute("YT_COOKIES", "line1\nline2");
+
+    expect(fsMock.mkdirSync).not.toHaveBeenCalled();
+    expect(fsMock.writeFileSync).toHaveBeenCalled();
+  });
+
+  it("calls mkdirSync with recursive:true when configDir does not exist", async () => {
+    vi.mocked(fsMock.existsSync).mockReturnValue(false);
+    vi.mocked(pathMock.join)
+      .mockReset()
+      .mockReturnValueOnce("/fake/config")
+      .mockReturnValueOnce("/fake/config/cookies.txt");
+    const { repository, spotifyUserLibraryService, eventBus } = makeStubs();
+    const useCase = new UpdateSettingUseCase(repository, spotifyUserLibraryService, eventBus);
+
+    await useCase.execute("YT_COOKIES", "line1\nline2");
+
+    expect(fsMock.mkdirSync).toHaveBeenCalledWith("/fake/config", { recursive: true });
+    expect(fsMock.writeFileSync).toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/get-tracks.use-case.test.ts
@@ -114,4 +114,87 @@ describe("GetTracksUseCase", () => {
     expect(result[0]).toMatchObject({ id: "track-1" });
     expect(result[0]).not.toHaveProperty("audioUrl");
   });
+
+  it("getAll returns all tracks mapped to primitives", async () => {
+    trackRepository.findAll.mockResolvedValue([makeTrack({ id: "t-1" }), makeTrack({ id: "t-2" })]);
+
+    const result = await useCase.getAll();
+
+    expect(trackRepository.findAll).toHaveBeenCalledWith(undefined);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ id: "t-1" });
+    expect(result[1]).toMatchObject({ id: "t-2" });
+  });
+
+  it("getAll passes where filter to repository", async () => {
+    trackRepository.findAll.mockResolvedValue([]);
+
+    await useCase.getAll({ status: TrackStatusEnum.Completed });
+
+    expect(trackRepository.findAll).toHaveBeenCalledWith({ status: TrackStatusEnum.Completed });
+  });
+
+  it("get returns a single track as primitive when found", async () => {
+    trackRepository.findOne.mockResolvedValue(makeTrack({ id: "track-99" }));
+
+    const result = await useCase.get("track-99");
+
+    expect(trackRepository.findOne).toHaveBeenCalledWith("track-99");
+    expect(result).toMatchObject({ id: "track-99" });
+  });
+
+  it("get returns null when track is not found", async () => {
+    trackRepository.findOne.mockResolvedValue(null);
+
+    const result = await useCase.get("missing");
+
+    expect(result).toBeNull();
+  });
+
+  it("findStuckTracks delegates to repository and maps to primitives", async () => {
+    trackRepository.findStuckTracks.mockResolvedValue([
+      makeTrack({ id: "stuck-1", status: TrackStatusEnum.Downloading }),
+    ]);
+
+    const result = await useCase.findStuckTracks([TrackStatusEnum.Downloading], 1000);
+
+    expect(trackRepository.findStuckTracks).toHaveBeenCalledWith(
+      [TrackStatusEnum.Downloading],
+      1000,
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "stuck-1" });
+  });
+
+  it("getAllByPlaylist returns items early when playlist row has no name", async () => {
+    trackRepository.findAllByPlaylist.mockResolvedValue([makeTrack()]);
+    // Playlist entity without a name set — name will be undefined/null → !playlistName is true
+    playlistRepository.findOne.mockResolvedValue(new Playlist({ id: "playlist-1" }));
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(trackPathService.getTrackFileName).not.toHaveBeenCalled();
+    expect(result[0]).not.toHaveProperty("audioUrl");
+  });
+
+  it("getAllByPlaylist skips audioUrl for non-completed tracks in a mixed playlist", async () => {
+    // Mixed scenario: one Completed + one Downloading. Completed triggers the Promise.all map;
+    // the non-completed item hits the `return track` branch (line 37).
+    trackRepository.findAllByPlaylist.mockResolvedValue([
+      makeTrack({ id: "track-completed", status: TrackStatusEnum.Completed }),
+      makeTrack({ id: "track-downloading", status: TrackStatusEnum.Downloading }),
+    ]);
+    playlistRepository.findOne.mockResolvedValue(
+      new Playlist({ id: "playlist-1", name: "Road Trip" }),
+    );
+    trackPathService.getTrackFileName.mockResolvedValue(
+      "/tmp/Playlists/Road Trip/01 - Artist - Track 01.mp3",
+    );
+
+    const result = await useCase.getAllByPlaylist("playlist-1");
+
+    expect(result).toHaveLength(2);
+    expect(result.find((t) => t.id === "track-completed")).toHaveProperty("audioUrl");
+    expect(result.find((t) => t.id === "track-downloading")).not.toHaveProperty("audioUrl");
+  });
 });

--- a/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.test.ts
@@ -91,4 +91,55 @@ describe("RescueStuckTracksUseCase", () => {
 
     expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
   });
+
+  it("skips tracks without id", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      { id: undefined, status: TrackStatusEnum.New, name: "T", artist: "A" } as any,
+    ]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("skips tracks without status", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      { id: "track-no-status", status: undefined, name: "T", artist: "A" } as any,
+    ]);
+
+    await useCase.execute();
+
+    expect(retryTrackDownloadUseCase.execute).not.toHaveBeenCalled();
+  });
+
+  it("continues to next track when retryTrackDownloadUseCase throws and does not rethrow", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      makeTrack({ id: "track-fail", status: TrackStatusEnum.New }),
+      makeTrack({ id: "track-ok", status: TrackStatusEnum.New }),
+    ]);
+    retryTrackDownloadUseCase.execute
+      .mockRejectedValueOnce(new Error("download failed"))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(useCase.execute()).resolves.toBeUndefined();
+
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledTimes(2);
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-fail");
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledWith("track-ok");
+  });
+
+  it("rescues only tracks that succeed when one errors", async () => {
+    trackRepository.findAllByStatuses.mockResolvedValue([
+      makeTrack({ id: "track-fail", status: TrackStatusEnum.New }),
+      makeTrack({ id: "track-ok", status: TrackStatusEnum.New }),
+    ]);
+    retryTrackDownloadUseCase.execute
+      .mockRejectedValueOnce(new Error("download failed"))
+      .mockResolvedValueOnce(undefined);
+
+    // Should resolve (not throw) even with partial failure
+    await expect(useCase.execute()).resolves.toBeUndefined();
+    // Both tracks were attempted
+    expect(retryTrackDownloadUseCase.execute).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## What

Wave-3 slice C: expand characterization tests for five application use-cases. **No source changes**.

| Use-case | Before | After |
|---|---|---|
| settings/update-setting | 56% | 100% |
| tracks/get-tracks | 76% | 100% |
| tracks/rescue-stuck-tracks | 86% | 100% |
| artists/get-album-tracks | 84% | 100% |
| playlists/create-playlist | 85% | 97% |

42 tests added. Covered YT_COOKIES disk-write path (update-setting), mixed-playlist completed/non-completed mapping (get-tracks), malformed-track guard (rescue-stuck-tracks), and the Spotify-URL flow + Singles album fallback (create-playlist).

## Evidence

- `pnpm --filter backend test:run src/application/use-cases` → **41 files, 358 tests passed**.
- `pnpm --filter backend test:coverage` → gate exit 0; all targets >=90% lines.

## Notes

create-playlist left at 97% — remaining lines are deep private-branch combinations exercised only by specific Spotify detail shapes; covered the high-value paths without source changes.