### PR TITLE
chore(backend): ratchet coverage thresholds after wave-3 backfill

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -35,10 +35,10 @@ export default defineConfig({
       // Thresholds sit just under the currently measured coverage so the gate is
       // green on merge. Ratchet these up as coverage improves (issue #204).
       thresholds: {
-        lines: 91,
-        statements: 91,
-        functions: 92,
-        branches: 86,
+        lines: 96,
+        statements: 96,
+        functions: 97,
+        branches: 89,
       },
     },
   },


### PR DESCRIPTION
## What

Raise the backend coverage gate to match the levels reached by the wave-3 backfill (PRs #220-224).

| Metric | Before | After | Measured |
|---|---|---|---|
| lines | 91 | 96 | 97.51 |
| statements | 91 | 96 | 97.51 |
| functions | 92 | 97 | 98.25 |
| branches | 86 | 89 | 90.26 |

~1pt margin kept under measured for v8 coverage jitter.

## Evidence

- `pnpm --filter backend test:coverage` on merged main → gate exit 0 with the new thresholds.