### PR TITLE
test(e2e): stabilize flaky player flow and harden E2E gate

### DIFF
--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -42,6 +42,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
+  // Give visibility/state assertions headroom over the cold-CI render chain
+  // (route fulfil -> store update -> React re-render) instead of racing the 5s default.
+  expect: { timeout: 10_000 },
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     trace: "on-first-retry",

--- a/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/ai-chat.spec.ts
@@ -128,7 +128,7 @@ test.describe("Mocked AI Chat flows", () => {
 
     await expect(page.getByText("jazz for a rainy afternoon").first()).toBeVisible();
 
-    await expect(page.getByText(/tracks added/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/tracks added/i)).toBeVisible();
   });
 
   test("error path: provider-misconfig shows settings redirect message", async ({ page }) => {
@@ -161,7 +161,7 @@ test.describe("Mocked AI Chat flows", () => {
     const sendBtn = page.getByRole("button", { name: /Generate/i });
     await sendBtn.click();
 
-    await expect(page.getByText(/Settings/i)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/Settings/i)).toBeVisible();
   });
 
   test("empty prompt guard: send button is disabled when textarea is empty", async ({ page }) => {
@@ -255,6 +255,7 @@ test.describe("Mocked AI Chat flows", () => {
     await expect(page.getByText(/Created playlist with 7 tracks/i)).toBeVisible();
 
     // User bubbles must render in chronological order (oldest first).
+    await expect(page.getByText(/prompt$/)).toHaveCount(2); // settle before the snapshot below
     const promptTexts = await page.getByText(/prompt$/).allTextContents();
     expect(promptTexts).toEqual(["first prompt", "second prompt"]);
   });
@@ -292,7 +293,10 @@ test.describe("Mocked AI Chat flows", () => {
 
     // Confirming the destructive action clears the transcript.
     await page.getByRole("button", { name: /Clear conversation/i }).click();
-    await page.getByRole("dialog").getByRole("button", { name: /^Delete$/ }).click();
+    await page
+      .getByRole("dialog")
+      .getByRole("button", { name: /^Delete$/ })
+      .click();
 
     await expect(page.getByText("drum and bass set")).toBeHidden();
     await expect(page.getByText(/No conversation yet/i)).toBeVisible();

--- a/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/instance-auth.spec.ts
@@ -108,9 +108,7 @@ test.describe("SESSION EXPIRED re-lock", () => {
     await installPlaylistMocks(page, { playlists: [] });
 
     await page.goto("/", { waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible({
-      timeout: 5_000,
-    });
+    await expect(page.getByRole("heading", { name: "Library", exact: true })).toBeVisible();
 
     loadPhase = "reload";
     await page.reload({ waitUntil: "domcontentloaded" });

--- a/apps/frontend/tests/e2e/mocked/player.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/player.spec.ts
@@ -171,6 +171,7 @@ test.describe("player — queue reorder @smoke", () => {
 
     await awake.dragTo(dayvanCowboy);
 
+    await expect(queueItems).toHaveCount(2);
     await expect(queueItems.first()).toContainText("Awake");
     await expect(queueItems.nth(1)).toContainText("Dayvan Cowboy");
   });
@@ -237,7 +238,8 @@ test.describe("Mocked global player flows", () => {
       playerBar.getByRole("button", { name: /Open Dayvan Cowboy by Boards of Canada/ }),
     ).toBeVisible();
 
-    await page.getByRole("button", { name: "Play track" }).nth(1).click();
+    // Advance via transport, not the row button: non-current rows reveal play on hover (#226).
+    await playerBar.getByRole("button", { name: "Next track" }).click();
 
     await expect(playerBar.getByRole("button", { name: /Open Awake by Tycho/ })).toBeVisible();
   });

--- a/apps/frontend/tests/e2e/mocked/playlists.spec.ts
+++ b/apps/frontend/tests/e2e/mocked/playlists.spec.ts
@@ -179,7 +179,10 @@ test.describe("Mocked my playlists flows", () => {
       });
     });
     await page.route("**/api/playlist/created-playlist-2", async (route) => {
-      updatedPayload = route.request().postDataJSON();
+      // Skip GET: a refetch has no body and would clobber updatedPayload with null.
+      if (route.request().method() !== "GET") {
+        updatedPayload = route.request().postDataJSON();
+      }
       await route.fulfill({
         status: 200,
         contentType: "application/json",

--- a/apps/frontend/tests/helpers/api-mocks.ts
+++ b/apps/frontend/tests/helpers/api-mocks.ts
@@ -134,11 +134,33 @@ const DEFAULT_TIMESTAMP = new Date(0).toISOString();
 
 const DEFAULT_COMPLETED_AT = 1_700_000_000_000;
 
-const SILENT_WAV_BUFFER = Buffer.from([
-  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45, 0x66, 0x6d, 0x74, 0x20,
-  0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x44, 0xac, 0x00, 0x00, 0x88, 0x58, 0x01, 0x00,
-  0x02, 0x00, 0x10, 0x00, 0x64, 0x61, 0x74, 0x61, 0x00, 0x00, 0x00, 0x00,
-]);
+function buildSilentWav(seconds: number): Buffer {
+  const sampleRate = 44_100;
+  const channels = 1;
+  const bitsPerSample = 16;
+  const blockAlign = (channels * bitsPerSample) / 8;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = byteRate * seconds;
+
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0, "ascii");
+  header.writeUInt32LE(36 + dataSize, 4);
+  header.write("WAVE", 8, "ascii");
+  header.write("fmt ", 12, "ascii");
+  header.writeUInt32LE(16, 16);
+  header.writeUInt16LE(1, 20);
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write("data", 36, "ascii");
+  header.writeUInt32LE(dataSize, 40);
+
+  return Buffer.concat([header, Buffer.alloc(dataSize)]);
+}
+
+const SILENT_WAV_BUFFER = buildSilentWav(10);
 
 const SETTINGS_PAYLOAD = {
   data: [
@@ -516,6 +538,16 @@ export async function installTrackMocks(
 }
 
 export async function installLibraryAudioMocks(page: Page): Promise<void> {
+  // No-op playback so `ended` never fires: real playback auto-advances the queue
+  // non-deterministically and races "current track" assertions (#226).
+  await page.addInitScript(() => {
+    const proto = HTMLMediaElement.prototype;
+    proto.play = function play() {
+      return Promise.resolve();
+    };
+    proto.pause = function pause() {};
+  });
+
   await page.route(`**${buildApiUrl(`${ApiRoutes.LIBRARY}/audio**`)}`, async (route) => {
     await route.fulfill({
       status: 200,

--- a/apps/frontend/tests/runtime/api-mocks.test.ts
+++ b/apps/frontend/tests/runtime/api-mocks.test.ts
@@ -48,14 +48,18 @@ const TESTS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".
 
 function createRouteRecorder() {
   const routes: RegisteredRoute[] = [];
+  const initScripts: unknown[] = [];
 
   const page = {
     route: async (pattern: RoutePattern, handler: RouteHandler) => {
       routes.push({ pattern, handler });
     },
+    addInitScript: async (script: unknown) => {
+      initScripts.push(script);
+    },
   } as unknown as Page;
 
-  return { page, routes };
+  return { page, routes, initScripts };
 }
 
 async function invokeJsonRoute(handler: RouteHandler, url: string) {
@@ -319,12 +323,13 @@ describe("api mock installers", () => {
   });
 
   test("installs a hermetic library audio route for playback-capable specs", async () => {
-    const { page, routes } = createRouteRecorder();
+    const { page, routes, initScripts } = createRouteRecorder();
 
     await installLibraryAudioMocks(page);
 
     expect(routes).toHaveLength(1);
     expect(String(routes[0]!.pattern)).toBe("**/api/library/audio**");
+    expect(initScripts).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## What

Fixes the recurrent flaky E2E test from #226: `tests/e2e/mocked/player.spec.ts › updates the GlobalPlayerBar while playing a library-backed playlist queue` is now deterministic.

## Why

The E2E job is a required check on every PR (including backend-only ones). This flaky test produced false-reds that had to be cleared with admin overrides while merging the backend coverage waves (#218–#225), eroding trust in the gate. Fixing the test removes the false-reds at the source, so E2E keeps running in full on every PR.

## Root cause (not what the issue first guessed)

The issue suspected `HTMLMediaElement.play()` latency. The real mechanism:

- The player bar visibility is **store-driven** (`GlobalPlayerBar.tsx`: `isVisible = currentIndex !== null`), independent of audio.
- The mock `SILENT_WAV` had a **zero-length data chunk**, so playback reached `ended` instantly and `_onEnded` **auto-advanced** the queue. The "which track is current" assertion raced that advance.
- Selecting the second track by **ordinal** also raced track 1's button relabel (`Play track` → `Pause track`), and a non-current row **hides its play button behind hover**, while the header play-all button shares the same i18n labels as the rows.

## Changes

- Make mocked audio deterministic: no-op `HTMLMediaElement` `play`/`pause` via `addInitScript` so `ended` never fires; emit a valid real-duration silent WAV.
- Drive the second track change through the always-visible **"Next track"** transport instead of an ordinal/hover-hidden row button.
- Global `expect` timeout 5s → 10s for cold-CI headroom; drop redundant per-assertion 5s overrides.
- Settle the prompt list before the `allTextContents` snapshot in `ai-chat`.
- Method-guard a playlist route handler so a refetch `GET` cannot clobber the captured mutation body.

## Verification

- `player.spec.ts` stress: **50/50** (`--repeat-each=10`).
- Full mocked suite: **45/45**, and **135/135** under `--repeat-each=3`.
- `pnpm --filter frontend run lint`: clean.

Closes #226
