### PR TITLE
feat(frontend): reorganize mobile navigation IA

### DIFF
--- a/apps/frontend/src/components/layouts/AppHeader.test.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.test.tsx
@@ -70,6 +70,17 @@ describe("AppHeader", () => {
     expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("reserves no submit-button padding while the input is empty", () => {
+    renderHeader();
+    expect((screen.getByRole("textbox") as HTMLInputElement).className).toContain("pr-4");
+  });
+
+  it("reserves submit-button padding once the input has a value", () => {
+    mockController.url = "https://open.spotify.com/playlist/123";
+    renderHeader();
+    expect((screen.getByRole("textbox") as HTMLInputElement).className).toContain("pr-16");
+  });
+
   it("renders History and Settings as secondary destinations", () => {
     renderHeader();
     expect(screen.getByLabelText("History").getAttribute("href")).toBe(Path.HISTORY);

--- a/apps/frontend/src/components/layouts/AppHeader.test.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Path } from "@/routes/routes";
 import { AppHeader } from "./AppHeader";
 
 vi.mock("react-i18next", () => ({
@@ -67,5 +68,11 @@ describe("AppHeader", () => {
   it("renders at least one navigation link", () => {
     renderHeader();
     expect(screen.getAllByRole("link").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders History and Settings as secondary destinations", () => {
+    renderHeader();
+    expect(screen.getByLabelText("History").getAttribute("href")).toBe(Path.HISTORY);
+    expect(screen.getByLabelText("Settings").getAttribute("href")).toBe(Path.SETTINGS);
   });
 });

--- a/apps/frontend/src/components/layouts/AppHeader.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.tsx
@@ -1,15 +1,10 @@
-import {
-  faDownload,
-  faLink,
-  faMagnifyingGlass,
-  faSliders,
-} from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faLink, faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
+import { MOBILE_HEADER_ITEMS } from "@/config/navigation";
 import { useHeaderController } from "@/hooks/controllers/useHeaderController";
-import { Path } from "@/routes/routes";
 import { cn } from "@/utils/cn";
 
 export const AppHeader: FC = () => {
@@ -64,13 +59,19 @@ export const AppHeader: FC = () => {
           </div>
         </div>
 
-        {/* Settings: Mobile Only */}
-        <Link
-          to={Path.SETTINGS}
-          className="text-text-secondary hover:text-text-primary hover:bg-background-elevated flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-colors md:hidden"
-        >
-          <FontAwesomeIcon icon={faSliders} className="text-xl" />
-        </Link>
+        {/* Secondary destinations: Mobile Only */}
+        <nav className="flex shrink-0 items-center gap-1 md:hidden">
+          {MOBILE_HEADER_ITEMS.map((item) => (
+            <Link
+              key={item.to}
+              to={item.to}
+              aria-label={item.label}
+              className="text-text-secondary hover:text-text-primary hover:bg-background-elevated flex h-10 w-10 items-center justify-center rounded-full transition-colors"
+            >
+              <FontAwesomeIcon icon={item.icon} className="text-xl" />
+            </Link>
+          ))}
+        </nav>
       </div>
     </header>
   );

--- a/apps/frontend/src/components/layouts/AppHeader.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.tsx
@@ -31,8 +31,6 @@ export const AppHeader: FC = () => {
             <input
               className={cn(
                 "bg-background-elevated text-text-primary placeholder-text-secondary w-full rounded-full py-2 pl-9 text-sm transition focus:outline-none md:py-2.5 md:pl-10",
-                // Reserve right padding for the submit button only when it is shown,
-                // otherwise the placeholder clips early on narrow mobile widths.
                 url ? "pr-16 md:pr-36" : "pr-4",
                 "focus:bg-background-hover focus:ring-2 focus:ring-white/20",
               )}
@@ -62,7 +60,6 @@ export const AppHeader: FC = () => {
           </div>
         </div>
 
-        {/* Secondary destinations: Mobile Only */}
         <nav className="flex shrink-0 items-center gap-1 md:hidden">
           {MOBILE_HEADER_ITEMS.map((item) => (
             <Link

--- a/apps/frontend/src/components/layouts/AppHeader.tsx
+++ b/apps/frontend/src/components/layouts/AppHeader.tsx
@@ -30,7 +30,10 @@ export const AppHeader: FC = () => {
           <div className="relative">
             <input
               className={cn(
-                "bg-background-elevated text-text-primary placeholder-text-secondary w-full rounded-full py-2 pr-16 pl-9 text-sm transition focus:outline-none md:py-2.5 md:pr-36 md:pl-10",
+                "bg-background-elevated text-text-primary placeholder-text-secondary w-full rounded-full py-2 pl-9 text-sm transition focus:outline-none md:py-2.5 md:pl-10",
+                // Reserve right padding for the submit button only when it is shown,
+                // otherwise the placeholder clips early on narrow mobile widths.
+                url ? "pr-16 md:pr-36" : "pr-4",
                 "focus:bg-background-hover focus:ring-2 focus:ring-white/20",
               )}
               type="text"

--- a/apps/frontend/src/components/layouts/BottomNavigation.test.tsx
+++ b/apps/frontend/src/components/layouts/BottomNavigation.test.tsx
@@ -40,9 +40,9 @@ describe("BottomNavigation", () => {
 
   it("does not apply text-white to inactive route links", () => {
     renderNav(Path.HOME);
-    const historyItem = MOBILE_NAV_ITEMS.find((i) => i.to === Path.HISTORY)!;
-    const historyLink = screen.getByText(historyItem.label).closest("a")!;
-    expect(historyLink.className).not.toContain("text-white");
+    const releasesItem = MOBILE_NAV_ITEMS.find((i) => i.to === Path.RELEASES)!;
+    const releasesLink = screen.getByText(releasesItem.label).closest("a")!;
+    expect(releasesLink.className).not.toContain("text-white");
   });
 
   it("each link points to the correct path", () => {
@@ -51,5 +51,20 @@ describe("BottomNavigation", () => {
       const link = screen.getByText(item.label).closest("a")!;
       expect(link.getAttribute("href")).toBe(item.to);
     }
+  });
+
+  it("does not render History or Settings in the bottom bar", () => {
+    renderNav(Path.HOME);
+    expect(MOBILE_NAV_ITEMS.some((i) => i.to === Path.HISTORY)).toBe(false);
+    expect(MOBILE_NAV_ITEMS.some((i) => i.to === Path.SETTINGS)).toBe(false);
+    expect(screen.queryByText("History")).toBeNull();
+    expect(screen.queryByText("Settings")).toBeNull();
+  });
+
+  it("renders Home centered among five primary destinations", () => {
+    renderNav(Path.HOME);
+    expect(MOBILE_NAV_ITEMS.length).toBe(5);
+    const homeIndex = MOBILE_NAV_ITEMS.findIndex((i) => i.to === Path.HOME);
+    expect(homeIndex).toBe(2);
   });
 });

--- a/apps/frontend/src/config/navigation.ts
+++ b/apps/frontend/src/config/navigation.ts
@@ -26,4 +26,20 @@ export const NAV_ITEMS: NavItem[] = [
   { label: "Settings", icon: faSliders, to: Path.SETTINGS },
 ];
 
-export const MOBILE_NAV_ITEMS: NavItem[] = NAV_ITEMS.filter((item) => item.to !== Path.SETTINGS);
+const byPath = (path: Path): NavItem => {
+  const item = NAV_ITEMS.find((navItem) => navItem.to === path);
+  if (!item) throw new Error(`Missing nav item for path: ${path}`);
+  return item;
+};
+
+// Mobile bottom tab bar: primary destinations only, Home centered.
+export const MOBILE_NAV_ITEMS: NavItem[] = [
+  Path.RELEASES,
+  Path.MY_PLAYLISTS,
+  Path.HOME,
+  Path.ARTISTS,
+  Path.CHAT,
+].map(byPath);
+
+// Mobile top bar: secondary destinations rendered as icons next to search.
+export const MOBILE_HEADER_ITEMS: NavItem[] = [Path.HISTORY, Path.SETTINGS].map(byPath);

--- a/apps/frontend/src/config/navigation.ts
+++ b/apps/frontend/src/config/navigation.ts
@@ -32,7 +32,6 @@ const byPath = (path: Path): NavItem => {
   return item;
 };
 
-// Mobile bottom tab bar: primary destinations only, Home centered.
 export const MOBILE_NAV_ITEMS: NavItem[] = [
   Path.RELEASES,
   Path.MY_PLAYLISTS,
@@ -41,5 +40,4 @@ export const MOBILE_NAV_ITEMS: NavItem[] = [
   Path.CHAT,
 ].map(byPath);
 
-// Mobile top bar: secondary destinations rendered as icons next to search.
 export const MOBILE_HEADER_ITEMS: NavItem[] = [Path.HISTORY, Path.SETTINGS].map(byPath);


### PR DESCRIPTION
## What
Reorganize the mobile navigation information architecture (issue #197).

- **Bottom tab bar** reduced from 6 to **5 primary destinations**, with Home centered:
  `[Releases] [My Playlists] [Home] [Artists] [AI Chat]`
- **History** and **Settings** moved to the **mobile top bar** as icon links next to search.
- Desktop sidebar unchanged (still shows all 7 destinations via `NAV_ITEMS`).

## Why
The bottom bar packed 6 items, leaving items cramped and hard to tap/scan. Offloading the two secondary/utility destinations (History, Settings) to the top bar frees space, widens tap targets, and keeps Home as the central anchor.

## How
- `config/navigation.ts`: `MOBILE_NAV_ITEMS` now an explicit ordered list of 5; new `MOBILE_HEADER_ITEMS` for top-bar secondary destinations. Both derive from `NAV_ITEMS` via a `byPath` helper (single source of truth).
- `AppHeader.tsx`: the lone Settings icon now maps `MOBILE_HEADER_ITEMS` → History + Settings, each with `aria-label` (icon-only a11y).
- `BottomNavigation.tsx`: unchanged logic — data-driven, so it picks up the new 5-item set automatically.

## Verification
- `pnpm --filter frontend run lint` → exit 0 (only pre-existing warnings in unrelated files)
- `pnpm --filter frontend run test:run` → 1298 passed (added coverage: History/Settings absent from bottom bar, Home centered at index 2, History/Settings present in top bar with correct hrefs)
- `pnpm --filter frontend run build` → ok

## Notes
Nav labels stay hardcoded English, matching the existing `NAV_ITEMS` convention (no i18n on nav). Screenshots pending — change is a layout/IA reorg; happy to attach before/after captures if useful.

Closes #197
