### PR TITLE
fix(frontend): highlight active track in album and playlist lists

### DIFF
--- a/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.test.tsx
@@ -160,4 +160,35 @@ describe("PlaylistTracksList playback", () => {
 
     expect(screen.getByRole("button", { name: "library.album.playTrack" })).toBeTruthy();
   });
+
+  it("highlights the current track title in green", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId="track-1"
+        isPlaying={true}
+        onPlayTrack={vi.fn()}
+        onPauseTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    expect(screen.getByText("Track 1").closest("div")?.className).toContain("text-green-400");
+  });
+
+  it("does not highlight a non-current track title", () => {
+    render(
+      <PlaylistTracksList
+        tracks={tracks}
+        currentTrackId={null}
+        isPlaying={false}
+        onPlayTrack={vi.fn()}
+        canPlayTrack={(track) => Boolean(track.audioUrl)}
+      />,
+    );
+
+    const title = screen.getByText("Track 1").closest("div");
+    expect(title?.className).toContain("text-text-primary");
+    expect(title?.className).not.toContain("text-green-400");
+  });
 });

--- a/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
+++ b/apps/frontend/src/components/organisms/PlaylistTracksList.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom";
 import { useBulkTrackStatus } from "@/hooks/queries/useDownloadStatus";
 import { Path } from "@/routes/routes";
 import { Track } from "@/types";
+import { cn } from "@/utils/cn";
 import { formatDuration } from "@/utils/date";
 import { isSpotifyUrl } from "@/utils/spotify";
 import { ArtistLinks } from "../molecules/ArtistLinks";
@@ -107,7 +108,12 @@ const PlaylistTrackItem: FC<PlaylistTrackItemProps> = memo(
 
         {/* Title & Artist */}
         <div className="flex min-w-0 flex-col">
-          <div className="text-text-primary truncate font-medium">
+          <div
+            className={cn(
+              "truncate font-medium",
+              isCurrent ? "text-green-400" : "text-text-primary",
+            )}
+          >
             {isSpotifyUrl(track.trackUrl) ? (
               <Link
                 to={`${Path.PLAYLIST_PREVIEW}?url=${encodeURIComponent(track.trackUrl!)}`}


### PR DESCRIPTION
## What
The currently playing track now shows its title in green (`text-green-400`) inside album and playlist views, matching the queue's active-row styling.

## Why
The queue side panel highlighted the playing track green, but the track rows in album/playlist views did not — only the index cell swapped to a play/pause icon. The active track was indistinguishable from the rest of the list.

## How
- `PlaylistTracksList` (shared by `AlbumPageLayout` and `Playlist`): the title color is now conditional on `isCurrent` via `cn()` — `text-green-400` when current, `text-text-primary` otherwise. `isCurrent` was already computed; only the title styling changed.
- One fix covers both album and playlist views since they reuse the same row component.

## Verification
- `pnpm --filter frontend run lint` — pass.
- `pnpm --filter frontend run test:run` — 1316 passed. Added tests asserting the current track title gets `text-green-400` and a non-current title does not.
- `pnpm --filter frontend run build` — pass (`tsc` clean).

## Notes
UI-only change; no behavior or state changes.