### PR TITLE
fix(frontend): show working prev/next on iOS lock screen (#201)

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -5,7 +5,7 @@ import {
   faVolumeXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useEffect, useMemo, useRef } from "react";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
@@ -95,6 +95,11 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [audioEl, setAudioEl] = useState<HTMLAudioElement | null>(null);
+  const registerAudioEl = useCallback((el: HTMLAudioElement | null) => {
+    audioRef.current = el;
+    setAudioEl(el);
+  }, []);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
   const seekRestoredRef = useRef(false);
@@ -149,7 +154,7 @@ export const GlobalPlayerBar: FC = () => {
     }),
     [next, prev, seek],
   );
-  useMediaSession(currentItem, isPlaying, mediaSessionActions);
+  useMediaSession(currentItem, isPlaying, mediaSessionActions, audioEl);
   useGlobalPlayerShortcuts();
   useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
   useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
@@ -270,7 +275,12 @@ export const GlobalPlayerBar: FC = () => {
 
   return (
     <>
-      <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
+      <audio
+        ref={registerAudioEl}
+        aria-label="Audio player"
+        preload="metadata"
+        className="hidden"
+      />
       <QueueSidePanel />
       <NowPlayingFullscreen />
 

--- a/apps/frontend/src/hooks/useMediaSession.test.ts
+++ b/apps/frontend/src/hooks/useMediaSession.test.ts
@@ -302,3 +302,105 @@ describe("useMediaSession with stubbed navigator.mediaSession", () => {
     expect(stub.metadata).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// T3.9 — iOS skips the seekto handler to preserve lock-screen prev/next
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession on iOS (seekto suppression)", () => {
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+  let originalUA: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalUA = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+    Object.defineProperty(navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      configurable: true,
+    });
+    const result = setupMediaSessionStub();
+    setActionHandler = result.setActionHandler;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+    if (originalUA) {
+      Object.defineProperty(navigator, "userAgent", originalUA);
+    }
+  });
+
+  it("[T3.9] explicitly nulls seek actions on iOS so prev/next can surface", () => {
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), false, actions));
+
+    // null != "not registered" on WebKit: each seek action must be set to null.
+    const seekCalls = (setActionHandler.mock.calls as unknown[][]).filter((call) =>
+      ["seekbackward", "seekforward", "seekto"].includes(call[0] as string),
+    );
+    expect(seekCalls).toHaveLength(3);
+    seekCalls.forEach((call) => {
+      expect(call[1]).toBeNull();
+    });
+  });
+
+  it("[T3.9] still registers previoustrack and nexttrack on iOS", () => {
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), false, actions));
+
+    const registeredActions = (setActionHandler.mock.calls as unknown[][]).map((call) => call[0]);
+    expect(registeredActions).toContain("previoustrack");
+    expect(registeredActions).toContain("nexttrack");
+    expect(registeredActions).toContain("play");
+    expect(registeredActions).toContain("pause");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.10 — re-apply metadata + handlers on the audio "playing" event
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession re-applies on the audio playing event", () => {
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+
+  beforeEach(() => {
+    const result = setupMediaSessionStub();
+    setActionHandler = result.setActionHandler;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  it("[T3.10] re-registers action handlers when the element fires 'playing'", () => {
+    const actions = makeActions();
+    const el = document.createElement("audio");
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setActionHandler.mockClear();
+
+    // iOS clears handlers on playback start; the 'playing' event must re-apply them.
+    el.dispatchEvent(new Event("playing"));
+
+    const reRegistered = (setActionHandler.mock.calls as unknown[][]).map((call) => call[0]);
+    expect(reRegistered).toContain("previoustrack");
+    expect(reRegistered).toContain("nexttrack");
+    expect(reRegistered).toContain("play");
+    expect(reRegistered).toContain("pause");
+  });
+
+  it("[T3.10] does not attach a listener when audioEl is null", () => {
+    const actions = makeActions();
+
+    // No element provided → nothing to re-apply against, must not throw.
+    expect(() => {
+      renderHook(() => useMediaSession(makeItem(), true, actions, null));
+    }).not.toThrow();
+  });
+});

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -9,31 +9,91 @@ export interface MediaSessionActions {
   seek: (timeSec: number) => void;
 }
 
+const ALL_ACTIONS: MediaSessionAction[] = [
+  "play",
+  "pause",
+  "previoustrack",
+  "nexttrack",
+  "seekbackward",
+  "seekforward",
+  "seekto",
+];
+
 function isMediaSessionSupported(): boolean {
   return typeof navigator !== "undefined" && navigator.mediaSession != null;
+}
+
+/**
+ * iOS/iPadOS WebKit exposes only two transport slots next to play/pause and
+ * fills them with the <audio> element's native ±skip seek controls by default,
+ * which wins over prev/next. Explicitly nulling the seek actions (null !=
+ * "not registered" on WebKit) frees those slots so previoustrack/nexttrack
+ * surface on the lock screen.
+ * iPadOS 13+ reports a Macintosh UA, so we also treat touch-capable Macs as iOS.
+ */
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  return /iP(hone|ad|od)/.test(ua) || (ua.includes("Macintosh") && navigator.maxTouchPoints > 1);
+}
+
+function applyMetadata(currentItem: QueueItem | null): void {
+  if (!currentItem) {
+    navigator.mediaSession.metadata = null;
+    return;
+  }
+
+  const artwork = currentItem.artworkUrl ? [{ src: currentItem.artworkUrl }] : [];
+
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title: currentItem.name,
+    artist: currentItem.artist,
+    album: currentItem.album ?? "",
+    artwork,
+  });
+}
+
+function applyActionHandlers(actions: MediaSessionActions): void {
+  const handlers: [MediaSessionAction, MediaSessionActionHandler | null][] = [
+    ["play", () => actions.play()],
+    ["pause", () => actions.pause()],
+    ["previoustrack", () => actions.previous()],
+    ["nexttrack", () => actions.next()],
+  ];
+
+  if (isIOS()) {
+    handlers.push(["seekbackward", null], ["seekforward", null], ["seekto", null]);
+  } else {
+    handlers.push([
+      "seekto",
+      (details: MediaSessionActionDetails) => {
+        if (details.seekTime != null) {
+          actions.seek(details.seekTime);
+        }
+      },
+    ]);
+  }
+
+  handlers.forEach(([name, handler]) => {
+    try {
+      navigator.mediaSession.setActionHandler(name, handler);
+    } catch (e) {
+      if (import.meta.env.DEV) {
+        console.warn(`[useMediaSession] setActionHandler("${name}") failed:`, e);
+      }
+    }
+  });
 }
 
 export function useMediaSession(
   currentItem: QueueItem | null,
   isPlaying: boolean,
   actions: MediaSessionActions,
+  audioEl: HTMLAudioElement | null = null,
 ): void {
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
-
-    if (!currentItem) {
-      navigator.mediaSession.metadata = null;
-      return;
-    }
-
-    const artwork = currentItem.artworkUrl ? [{ src: currentItem.artworkUrl }] : [];
-
-    navigator.mediaSession.metadata = new MediaMetadata({
-      title: currentItem.name,
-      artist: currentItem.artist,
-      album: currentItem.album ?? "",
-      artwork,
-    });
+    applyMetadata(currentItem);
   }, [currentItem]);
 
   useEffect(() => {
@@ -49,34 +109,11 @@ export function useMediaSession(
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
 
-    const handlers: [MediaSessionAction, MediaSessionActionHandler | null][] = [
-      ["play", () => actions.play()],
-      ["pause", () => actions.pause()],
-      ["previoustrack", () => actions.previous()],
-      ["nexttrack", () => actions.next()],
-      [
-        "seekto",
-        (details: MediaSessionActionDetails) => {
-          if (details.seekTime != null) {
-            actions.seek(details.seekTime);
-          }
-        },
-      ],
-    ];
-
-    handlers.forEach(([name, handler]) => {
-      try {
-        navigator.mediaSession.setActionHandler(name, handler);
-      } catch (e) {
-        if (import.meta.env.DEV) {
-          console.warn(`[useMediaSession] setActionHandler("${name}") failed:`, e);
-        }
-      }
-    });
+    applyActionHandlers(actions);
 
     return () => {
       if (!isMediaSessionSupported()) return;
-      handlers.forEach(([name]) => {
+      ALL_ACTIONS.forEach((name) => {
         try {
           navigator.mediaSession.setActionHandler(name, null);
         } catch {
@@ -86,4 +123,22 @@ export function useMediaSession(
       navigator.mediaSession.metadata = null;
     };
   }, [actions]);
+
+  // iOS/WebKit clears MediaSession metadata and action handlers when playback
+  // starts, so handlers registered before the first play() are lost. Re-apply
+  // them on the audio element's "playing" event — it fires after WebKit has set
+  // up the Now Playing session, so the handlers stick.
+  useEffect(() => {
+    if (!isMediaSessionSupported() || !audioEl) return;
+
+    const reapply = (): void => {
+      applyMetadata(currentItem);
+      applyActionHandlers(actions);
+    };
+
+    audioEl.addEventListener("playing", reapply);
+    return () => {
+      audioEl.removeEventListener("playing", reapply);
+    };
+  }, [audioEl, currentItem, actions]);
 }


### PR DESCRIPTION
## What

Lock-screen / Control Center previous & next track controls now appear **and work** on iOS. Closes #201.

## Why it was broken

iOS/WebKit suppressed the `previoustrack`/`nexttrack` buttons for two compounding reasons:

1. **Slot competition.** iOS exposes only two transport slots beside play/pause and fills them with the `<audio>` element's native ±10s seek controls by default, which win over prev/next. Merely *omitting* a seek handler is not enough — on WebKit, `null` differs from "not registered". We now explicitly null `seekbackward`/`seekforward`/`seekto` on iOS to free the slots.
2. **Handler timing.** WebKit clears MediaSession metadata + action handlers when playback *starts*, so handlers registered before `play()` are lost. We now re-apply both on the audio element's `playing` event, which fires after WebKit sets up the Now Playing session.

Other platforms keep the real `seekto` handler for scrubber drag-to-seek.

## Changes

- `useMediaSession.ts`: extracted `applyMetadata`/`applyActionHandlers`; iOS nulls seek actions; re-applies on the `playing` event; accepts the audio element.
- `GlobalPlayerBar.tsx`: exposes the `<audio>` element reactively via a stable `useCallback` ref so the hook can bind the listener.

## Testing

- Unit: 16 `useMediaSession` tests (incl. T3.9 seek-null on iOS, T3.10 re-apply on `playing`) + 58 `GlobalPlayerBar` tests — 74/74 pass.
- `tsc --noEmit` clean.
- **Device-verified** on iPhone (iOS 17) over an HTTPS tunnel: prev/next appear on the lock screen and change tracks.