### PR TITLE
fix(frontend): harden player reliability edge cases

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -805,6 +805,65 @@ describe("mobile chevron affordance", () => {
 });
 
 // ---------------------------------------------------------------------------
+// B3 — persisted volume/mute not applied to audio element on mount
+// ---------------------------------------------------------------------------
+
+describe("B3 — persisted volume/mute applied on mount", () => {
+  it("B3-1: audio element gets store volume and muted on mount", () => {
+    usePlayerStore.setState({ volume: 0.3, isMuted: true });
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    expect(audio.volume).toBe(0.3);
+    expect(audio.muted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E4 — autoplay rejection swallowed, isPlaying lies
+// ---------------------------------------------------------------------------
+
+describe("E4 — autoplay NotAllowedError sets isPlaying false", () => {
+  it("E4-1: NotAllowedError rejection sets isPlaying to false", async () => {
+    const notAllowed = Object.assign(new Error("NotAllowedError"), { name: "NotAllowedError" });
+    const mockPlay = vi.fn().mockRejectedValue(notAllowed);
+    HTMLMediaElement.prototype.play = mockPlay;
+
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    await act(async () => {
+      render(<GlobalPlayerBar />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("E4-2: AbortError rejection leaves isPlaying true", async () => {
+    const abortError = Object.assign(new Error("AbortError"), { name: "AbortError" });
+    const mockPlay = vi.fn().mockRejectedValue(abortError);
+    HTMLMediaElement.prototype.play = mockPlay;
+
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    await act(async () => {
+      render(<GlobalPlayerBar />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // mobile now-playing trigger (Tasks 2 / S2 / S6)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -111,6 +111,9 @@ export const GlobalPlayerBar: FC = () => {
   const shuffleMode = usePlayerStore((s) => s.shuffleMode);
   const repeatMode = usePlayerStore((s) => s.repeatMode);
 
+  const volume = usePlayerStore((s) => s.volume);
+  const isMuted = usePlayerStore((s) => s.isMuted);
+
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
@@ -181,6 +184,13 @@ export const GlobalPlayerBar: FC = () => {
 
   useEffect(() => {
     const el = audioRef.current;
+    if (!el) return;
+    el.volume = volume;
+    el.muted = isMuted;
+  }, [volume, isMuted]);
+
+  useEffect(() => {
+    const el = audioRef.current;
     if (!el || !currentItem) return;
     if (el.src !== currentItem.audioUrl) {
       el.src = currentItem.audioUrl;
@@ -193,7 +203,11 @@ export const GlobalPlayerBar: FC = () => {
     if (isPlaying) {
       const playPromise = el.play();
       if (playPromise && typeof playPromise.catch === "function") {
-        void playPromise.catch(() => {});
+        void playPromise.catch((err: { name?: string } | null) => {
+          if (err?.name === "NotAllowedError") {
+            usePlayerStore.setState({ isPlaying: false });
+          }
+        });
       }
     } else {
       el.pause();

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1144,6 +1144,91 @@ describe("isNowPlayingOpen", () => {
 });
 
 // ---------------------------------------------------------------------------
+// B4 — seek clamps to duration=0 before metadata loads
+// ---------------------------------------------------------------------------
+
+describe("seek — B4 pre-metadata clamp fix", () => {
+  it("B4-1: seek(42) with duration=0 keeps requested value 42", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(42);
+
+    expect(usePlayerStore.getState().currentTime).toBe(42);
+  });
+
+  it("B4-2: seek(500) with duration=200 clamps to 200", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 200 });
+    usePlayerStore.getState().seek(500);
+
+    expect(usePlayerStore.getState().currentTime).toBe(200);
+  });
+
+  it("B4-3: seek(-5) clamps to 0 regardless of duration", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(-5);
+
+    expect(usePlayerStore.getState().currentTime).toBe(0);
+  });
+
+  it("B4-4: seek(42) with duration=0 sets _audioElement.currentTime to 42", () => {
+    const mockAudio = { currentTime: 0 };
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState().setAudioElement(mockAudio as unknown as HTMLAudioElement);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(42);
+
+    expect(mockAudio.currentTime).toBe(42);
+    usePlayerStore.getState().setAudioElement(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B6 — invalid duration stored verbatim
+// ---------------------------------------------------------------------------
+
+describe("_onLoadedMetadata — B6 invalid duration guard", () => {
+  it("B6-1: NaN duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(NaN);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+
+  it("B6-2: Infinity duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(Infinity);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+
+  it("B6-3: valid duration 180 is stored as-is", () => {
+    usePlayerStore.getState()._onLoadedMetadata(180);
+    expect(usePlayerStore.getState().duration).toBe(180);
+  });
+
+  it("B6-4: zero duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(0);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M5 — playFromIndex does not clear stale error
+// ---------------------------------------------------------------------------
+
+describe("playFromIndex — M5 stale error clear", () => {
+  it("M5-1: playFromIndex clears a stale error", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ error: "previous error" });
+
+    usePlayerStore.getState().playFromIndex(1);
+
+    expect(usePlayerStore.getState().error).toBeNull();
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -228,7 +228,8 @@ export const usePlayerStore = create<PlayerState>()(
 
         seek(seconds) {
           const { duration } = get();
-          const clamped = Math.max(0, Math.min(seconds, duration));
+          const clamped =
+            duration > 0 ? Math.max(0, Math.min(seconds, duration)) : Math.max(0, seconds);
           set({ currentTime: clamped });
           if (_audioElement) {
             _audioElement.currentTime = clamped;
@@ -270,7 +271,7 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onLoadedMetadata(duration) {
-          set({ duration });
+          set({ duration: Number.isFinite(duration) && duration > 0 ? duration : 0 });
         },
 
         _onTimeUpdate(currentTime) {
@@ -307,7 +308,7 @@ export const usePlayerStore = create<PlayerState>()(
         playFromIndex(index) {
           const { queue, shuffleMode } = get();
           if (index < 0 || index >= queue.length) return;
-          set({ currentIndex: index, isPlaying: true, currentTime: 0 });
+          set({ currentIndex: index, isPlaying: true, currentTime: 0, error: null });
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {
             const order = shuffleIndices(queue.length, index);


### PR DESCRIPTION
## What

Five verified playback bugs in the player store and global bar, found during a deep audit of the playback subsystem. Frontend-only, low risk, fully tested.

| Fix | Problem | Resolution |
|-----|---------|------------|
| **seek before metadata** | `seek()` clamped to `duration` which is `0` until `loadedmetadata`, forcing every early seek to 0:00 | Apply the upper bound only when `duration > 0` |
| **invalid duration** | `_onLoadedMetadata` stored `NaN`/`Infinity` (streams, missing metadata) verbatim, poisoning seek clamping and the progress bar | Validate to a finite positive value or `0` |
| **stale error banner** | `playFromIndex` did not clear `error` (unlike `playQueue`), so a previous error lingered over a freshly started track | Clear `error` on `playFromIndex` |
| **volume/mute not applied** | Persisted volume/mute were never pushed to the `<audio>` element on mount/reload — audio played at full volume while the UI showed the saved level | Effect reconciles the element to store `volume`/`isMuted` |
| **autoplay lie** | A blocked `play()` rejection was swallowed, leaving `isPlaying: true` with no sound | `NotAllowedError` flips `isPlaying` to `false`; `AbortError` stays ignored |

## Testing

- New unit tests per fix (B4, B6, M5, B3, E4 groups). 163 frontend tests pass.
- `tsc --noEmit` clean.

## Notes

Part of a larger playback-quality initiative. Follow-ups (separate PRs): MediaSession `setPositionState` + element→store play/pause bridge, error auto-skip/retry, queue+position persistence, gapless preloading.