### PR TITLE
feat(frontend): MediaSession position state for lock-screen scrubber

### DIFF
--- a/apps/frontend/src/hooks/useMediaSession.test.ts
+++ b/apps/frontend/src/hooks/useMediaSession.test.ts
@@ -48,10 +48,12 @@ const makeActions = (): MediaSessionActions & {
 
 function setupMediaSessionStub() {
   const setActionHandler = vi.fn();
+  const setPositionState = vi.fn();
   const stub = {
     metadata: null as unknown,
     playbackState: "none" as string,
     setActionHandler,
+    setPositionState,
   };
 
   Object.defineProperty(navigator, "mediaSession", {
@@ -85,7 +87,7 @@ function setupMediaSessionStub() {
     vi.unstubAllGlobals();
   }
 
-  return { stub, setActionHandler, restore };
+  return { stub, setActionHandler, setPositionState, restore };
 }
 
 // ---------------------------------------------------------------------------
@@ -401,6 +403,112 @@ describe("useMediaSession re-applies on the audio playing event", () => {
     // No element provided → nothing to re-apply against, must not throw.
     expect(() => {
       renderHook(() => useMediaSession(makeItem(), true, actions, null));
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.11 — applyPositionState via audio element events
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession setPositionState", () => {
+  let setPositionState: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+
+  beforeEach(() => {
+    const result = setupMediaSessionStub();
+    setPositionState = result.setPositionState;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  function makeAudioEl(duration: number, currentTime: number, playbackRate = 1): HTMLAudioElement {
+    const el = document.createElement("audio");
+    Object.defineProperty(el, "duration", { get: () => duration, configurable: true });
+    Object.defineProperty(el, "currentTime", { get: () => currentTime, configurable: true });
+    Object.defineProperty(el, "playbackRate", { get: () => playbackRate, configurable: true });
+    return el;
+  }
+
+  it("[T3.11] calls setPositionState with correct values on loadedmetadata", () => {
+    const el = makeAudioEl(300, 42, 1);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).toHaveBeenCalledOnce();
+    expect(setPositionState).toHaveBeenCalledWith({ duration: 300, playbackRate: 1, position: 42 });
+  });
+
+  it("[T3.11] does NOT call setPositionState when duration is NaN", () => {
+    const el = makeAudioEl(NaN, 0);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).not.toHaveBeenCalled();
+  });
+
+  it("[T3.11] does NOT call setPositionState when duration is Infinity", () => {
+    const el = makeAudioEl(Infinity, 0);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).not.toHaveBeenCalled();
+  });
+
+  it("[T3.11] clamps position to duration when currentTime > duration", () => {
+    const el = makeAudioEl(100, 150);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("seeked"));
+
+    expect(setPositionState).toHaveBeenCalledWith({
+      duration: 100,
+      playbackRate: 1,
+      position: 100,
+    });
+  });
+
+  it("[T3.11] re-pushes position state on the playing event", () => {
+    const el = makeAudioEl(200, 60);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("playing"));
+
+    expect(setPositionState).toHaveBeenCalledWith({ duration: 200, playbackRate: 1, position: 60 });
+  });
+
+  it("[T3.11] no-op when setPositionState is absent from navigator.mediaSession", () => {
+    const el = makeAudioEl(300, 42);
+    const actions = makeActions();
+
+    // Simulate older browser: remove setPositionState from the stub
+    const ms = navigator.mediaSession as unknown as Record<string, unknown>;
+    delete ms.setPositionState;
+
+    expect(() => {
+      renderHook(() => useMediaSession(makeItem(), true, actions, el));
+      el.dispatchEvent(new Event("loadedmetadata"));
     }).not.toThrow();
   });
 });

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -37,6 +37,24 @@ function isIOS(): boolean {
   return /iP(hone|ad|od)/.test(ua) || (ua.includes("Macintosh") && navigator.maxTouchPoints > 1);
 }
 
+const POSITION_STATE_EVENTS = [
+  "loadedmetadata",
+  "durationchange",
+  "seeked",
+  "play",
+  "pause",
+  "ratechange",
+] as const;
+
+function applyPositionState(el: HTMLAudioElement): void {
+  if (!isMediaSessionSupported()) return;
+  if (!("setPositionState" in navigator.mediaSession)) return;
+  const { duration, currentTime, playbackRate } = el;
+  if (!Number.isFinite(duration) || duration <= 0) return;
+  const position = Math.min(Math.max(currentTime, 0), duration);
+  navigator.mediaSession.setPositionState({ duration, playbackRate: playbackRate || 1, position });
+}
+
 function applyMetadata(currentItem: QueueItem | null): void {
   if (!currentItem) {
     navigator.mediaSession.metadata = null;
@@ -134,6 +152,7 @@ export function useMediaSession(
     const reapply = (): void => {
       applyMetadata(currentItem);
       applyActionHandlers(actions);
+      applyPositionState(audioEl);
     };
 
     audioEl.addEventListener("playing", reapply);
@@ -141,4 +160,14 @@ export function useMediaSession(
       audioEl.removeEventListener("playing", reapply);
     };
   }, [audioEl, currentItem, actions]);
+
+  useEffect(() => {
+    if (!isMediaSessionSupported() || !audioEl) return;
+
+    const handler = (): void => applyPositionState(audioEl);
+    POSITION_STATE_EVENTS.forEach((ev) => audioEl.addEventListener(ev, handler));
+    return () => {
+      POSITION_STATE_EVENTS.forEach((ev) => audioEl.removeEventListener(ev, handler));
+    };
+  }, [audioEl]);
 }


### PR DESCRIPTION
## What

Reports `navigator.mediaSession.setPositionState()` so the OS lock-screen / notification scrubber shows accurate position and duration.

**Stacked on #231** (builds on its `useMediaSession` restructure). Review/merge #231 first.

## Why

The hook set metadata, playback state, and action handlers but never reported position. Without `setPositionState` the OS scrubber is frozen/absent on Android & desktop and drifts elsewhere — the single biggest "not native" tell on the lock screen.

## How

- New `applyPositionState(el)` pushes `{ duration, position, playbackRate }`, clamping position into `[0, duration]` and skipping when duration is not finite/positive (pre-metadata, live streams).
- Bound to the meaningful audio transitions — `loadedmetadata`, `durationchange`, `seeked`, `play`, `pause`, `ratechange` — not `timeupdate` (the OS extrapolates between updates from `playbackRate`).
- Also re-pushed on the iOS `playing` re-apply, since WebKit clears session state when playback starts.
- Double-guarded: no-op when MediaSession or `setPositionState` is unavailable (older browsers).

## Testing

- 6 new tests (T3.11): correct values on metadata, skip on NaN/Infinity, position clamp, re-push on `playing`, no-op when unsupported. 22 hook tests pass.
- `tsc --noEmit` clean.

## Not in scope (separate PRs)

Element→store play/pause bridge for interruptions (needs careful handling of the `ended → advance` flow), error auto-skip, queue persistence, gapless.