### PR TITLE
feat(frontend): player resilience — auto-skip failed tracks + buffering indicator

### DIFF
--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -131,4 +131,27 @@ describe("TransportControls", () => {
       true,
     );
   });
+
+  it("isBuffering=true: play/pause button shows spinner icon", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    const btn = screen.getByRole("button", { name: "player.transport.loading" });
+    const icon = btn.querySelector("[data-icon='spinner']");
+    expect(icon).not.toBeNull();
+  });
+
+  it("isBuffering=true: play/pause button has loading aria-label", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.loading" })).not.toBeNull();
+  });
+
+  it("isBuffering=true: play/pause button is still enabled (not disabled)", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    const btn = screen.getByRole("button", { name: "player.transport.loading" });
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("isBuffering=false: shows play or pause as before", () => {
+    render(<TransportControls {...defaultProps} isBuffering={false} isPlaying={false} />);
+    expect(screen.getByRole("button", { name: "player.transport.play" })).not.toBeNull();
+  });
 });

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -5,6 +5,7 @@ import {
   faPlay,
   faRepeat,
   faShuffle,
+  faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
@@ -25,6 +26,7 @@ export interface TransportControlsProps {
   onRepeatCycle: () => void;
   isPrevDisabled?: boolean;
   isNextDisabled?: boolean;
+  isBuffering?: boolean;
   size?: "default" | "large";
   className?: string;
 }
@@ -41,6 +43,7 @@ export const TransportControls: FC<TransportControlsProps> = ({
   onRepeatCycle,
   isPrevDisabled = false,
   isNextDisabled = false,
+  isBuffering = false,
   size,
   className,
 }) => {
@@ -101,7 +104,13 @@ export const TransportControls: FC<TransportControlsProps> = ({
 
       <button
         type="button"
-        aria-label={isPlaying ? t("player.transport.pause") : t("player.transport.play")}
+        aria-label={
+          isBuffering
+            ? t("player.transport.loading")
+            : isPlaying
+              ? t("player.transport.pause")
+              : t("player.transport.play")
+        }
         aria-pressed={isPlaying}
         disabled={allDisabled}
         aria-disabled={allDisabled || undefined}
@@ -112,7 +121,10 @@ export const TransportControls: FC<TransportControlsProps> = ({
           allDisabled && "cursor-not-allowed opacity-40",
         )}
       >
-        <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className={iconSize} />
+        <FontAwesomeIcon
+          icon={isBuffering ? faSpinner : isPlaying ? faPause : faPlay}
+          className={cn(iconSize, isBuffering && "animate-spin")}
+        />
       </button>
 
       <button

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -782,6 +782,50 @@ describe("isAtFirst / isAtLast with modes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Buffering audio events — waiting/playing/canplay
+// ---------------------------------------------------------------------------
+
+describe("buffering audio events", () => {
+  it("dispatching 'waiting' event on audio element sets store isBuffering to true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("waiting"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(true);
+  });
+
+  it("dispatching 'playing' event on audio element sets store isBuffering to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("playing"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("dispatching 'canplay' event on audio element sets store isBuffering to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("canplay"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // mobile chevron affordance (Item 3 / S3-chevron)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -127,6 +127,9 @@ export const GlobalPlayerBar: FC = () => {
   const _onTimeUpdate = usePlayerStore((s) => s._onTimeUpdate);
   const _onEnded = usePlayerStore((s) => s._onEnded);
   const _onError = usePlayerStore((s) => s._onError);
+  const _onWaiting = usePlayerStore((s) => s._onWaiting);
+  const _onCanPlay = usePlayerStore((s) => s._onCanPlay);
+  const isBuffering = usePlayerStore((s) => s.isBuffering);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
@@ -168,19 +171,31 @@ export const GlobalPlayerBar: FC = () => {
       const msg = el.error?.message ?? "Playback error";
       _onError(msg);
     };
+    const onWaiting = () => _onWaiting();
+    const onStalled = () => _onWaiting();
+    const onPlaying = () => _onCanPlay();
+    const onCanPlay = () => _onCanPlay();
 
     el.addEventListener("timeupdate", onTimeUpdate);
     el.addEventListener("loadedmetadata", onLoadedMetadata);
     el.addEventListener("ended", onEnded);
     el.addEventListener("error", onError);
+    el.addEventListener("waiting", onWaiting);
+    el.addEventListener("stalled", onStalled);
+    el.addEventListener("playing", onPlaying);
+    el.addEventListener("canplay", onCanPlay);
 
     return () => {
       el.removeEventListener("timeupdate", onTimeUpdate);
       el.removeEventListener("loadedmetadata", onLoadedMetadata);
       el.removeEventListener("ended", onEnded);
       el.removeEventListener("error", onError);
+      el.removeEventListener("waiting", onWaiting);
+      el.removeEventListener("stalled", onStalled);
+      el.removeEventListener("playing", onPlaying);
+      el.removeEventListener("canplay", onCanPlay);
     };
-  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError]);
+  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError, _onWaiting, _onCanPlay]);
 
   useEffect(() => {
     const el = audioRef.current;
@@ -313,6 +328,7 @@ export const GlobalPlayerBar: FC = () => {
                   onRepeatCycle={cycleRepeat}
                   isPrevDisabled={isAtFirst}
                   isNextDisabled={isAtLast}
+                  isBuffering={isBuffering}
                 />
 
                 <button

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -29,6 +29,7 @@ export const NowPlayingFullscreen: FC = () => {
   const reorderQueue = usePlayerStore((s) => s.reorderQueue);
   const currentTime = usePlayerStore((s) => s.currentTime);
   const duration = usePlayerStore((s) => s.duration);
+  const isBuffering = usePlayerStore((s) => s.isBuffering);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
@@ -203,6 +204,7 @@ export const NowPlayingFullscreen: FC = () => {
           onNext={next}
           onShuffleToggle={toggleShuffle}
           onRepeatCycle={cycleRepeat}
+          isBuffering={isBuffering}
         />
       </div>
 

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -456,7 +456,8 @@
       "seek": "Seek",
       "repeatEnable": "Enable repeat",
       "repeatAll": "Repeat all",
-      "repeatOne": "Repeat one"
+      "repeatOne": "Repeat one",
+      "loading": "Loading"
     }
   },
   "aiChat": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -456,7 +456,8 @@
       "seek": "Avanzar",
       "repeatEnable": "Activar repetición",
       "repeatAll": "Repetir todo",
-      "repeatOne": "Repetir una"
+      "repeatOne": "Repetir una",
+      "loading": "Cargando"
     }
   },
   "aiChat": {

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1316,6 +1316,61 @@ describe("_onError auto-skip", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isBuffering — _onWaiting, _onCanPlay, clear, _onError, __partialize
+// ---------------------------------------------------------------------------
+
+describe("isBuffering", () => {
+  it("initial value is false", () => {
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onWaiting sets isBuffering to true", () => {
+    usePlayerStore.getState()._onWaiting();
+    expect(usePlayerStore.getState().isBuffering).toBe(true);
+  });
+
+  it("_onCanPlay sets isBuffering to false", () => {
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onCanPlay();
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("clear() resets isBuffering to false", () => {
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState().clear();
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onError leaves isBuffering false (sticky-stop path)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onError("fail");
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onError leaves isBuffering false (skip path)", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onError("skip-error");
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("isBuffering is NOT in persisted state (__partialize does not include it)", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      isBuffering: true,
+      volume: 1,
+      isMuted: false,
+      shuffleMode: false,
+      repeatMode: "off" as const,
+    } as unknown as Parameters<typeof p>[0];
+    const result = p(fakeState);
+    expect("isBuffering" in result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1229,6 +1229,93 @@ describe("playFromIndex — M5 stale error clear", () => {
 });
 
 // ---------------------------------------------------------------------------
+// _onError auto-skip (E1-1 through E1-8)
+// ---------------------------------------------------------------------------
+
+describe("_onError auto-skip", () => {
+  it("E1-1: error mid-queue advances to next track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState()._onError("x");
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+    expect(state.consecutiveErrors).toBe(1);
+    expect(state.error).toBe("x");
+  });
+
+  it("E1-2: every track fails stops queue with sticky error", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    // 3 errors for a 3-track queue: each advances, last one hits the ceiling
+    usePlayerStore.getState()._onError("e1");
+    usePlayerStore.getState()._onError("e2");
+    usePlayerStore.getState()._onError("e3");
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.error).toBe("e3");
+    expect(state.consecutiveErrors).toBe(0);
+  });
+
+  it("E1-3: single-track queue error is sticky", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState()._onError("fail");
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.error).toBe("fail");
+    expect(state.currentIndex).toBe(0);
+    expect(state.consecutiveErrors).toBe(0);
+  });
+
+  it("E1-4: repeatMode one + error moves to next track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ repeatMode: "one" });
+    usePlayerStore.getState()._onError("err");
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+  });
+
+  it("E1-5: _onLoadedMetadata resets consecutiveErrors", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState()._onLoadedMetadata(180);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-6: playFromIndex resets consecutiveErrors", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState().playFromIndex(1);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-7: playQueue resets consecutiveErrors", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState().playQueue([makeItem("b"), makeItem("c")], 0);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-8: null currentIndex error sets error and stops without throw", () => {
+    usePlayerStore.getState()._onError("no-track");
+
+    const state = usePlayerStore.getState();
+    expect(state.error).toBe("no-track");
+    expect(state.isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -35,6 +35,7 @@ export interface PlayerState extends PlayerUISlice {
   shuffleOrder: number[];
   shuffleOrderIndex: number;
   consecutiveErrors: number;
+  isBuffering: boolean;
 
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
@@ -55,6 +56,8 @@ export interface PlayerState extends PlayerUISlice {
   _onTimeUpdate: (currentTime: number) => void;
   _onEnded: () => void;
   _onError: (message: string) => void;
+  _onWaiting: () => void;
+  _onCanPlay: () => void;
 }
 
 export const __partialize = (
@@ -101,6 +104,7 @@ const INITIAL_STATE = {
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
   consecutiveErrors: 0,
+  isBuffering: false,
 };
 
 type AdvanceSource = "user" | "ended" | "error";
@@ -266,6 +270,7 @@ export const usePlayerStore = create<PlayerState>()(
             error: null,
             isQueuePanelOpen: false,
             isNowPlayingOpen: false,
+            isBuffering: false,
           });
         },
 
@@ -310,16 +315,24 @@ export const usePlayerStore = create<PlayerState>()(
         _onError(message) {
           const { currentIndex, queue, consecutiveErrors } = get();
           if (currentIndex === null) {
-            set({ error: message, isPlaying: false });
+            set({ error: message, isPlaying: false, isBuffering: false });
             return;
           }
           const errs = consecutiveErrors + 1;
           if (errs >= queue.length) {
-            set({ error: message, isPlaying: false, consecutiveErrors: 0 });
+            set({ error: message, isPlaying: false, consecutiveErrors: 0, isBuffering: false });
             return;
           }
-          set({ consecutiveErrors: errs, error: message });
+          set({ consecutiveErrors: errs, error: message, isBuffering: false });
           advance("error");
+        },
+
+        _onWaiting() {
+          set({ isBuffering: true });
+        },
+
+        _onCanPlay() {
+          set({ isBuffering: false });
         },
 
         playFromIndex(index) {

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -34,6 +34,7 @@ export interface PlayerState extends PlayerUISlice {
   repeatMode: RepeatMode;
   shuffleOrder: number[];
   shuffleOrderIndex: number;
+  consecutiveErrors: number;
 
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
@@ -99,9 +100,10 @@ const INITIAL_STATE = {
   repeatMode: "off" as RepeatMode,
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
+  consecutiveErrors: 0,
 };
 
-type AdvanceSource = "user" | "ended";
+type AdvanceSource = "user" | "ended" | "error";
 
 export const usePlayerStore = create<PlayerState>()(
   persist(
@@ -160,6 +162,7 @@ export const usePlayerStore = create<PlayerState>()(
             isPlaying: true,
             currentTime: 0,
             error: null,
+            consecutiveErrors: 0,
           });
           if (get().shuffleMode && items.length > 0) {
             const order = shuffleIndices(items.length, startIndex);
@@ -271,7 +274,10 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onLoadedMetadata(duration) {
-          set({ duration: Number.isFinite(duration) && duration > 0 ? duration : 0 });
+          set({
+            duration: Number.isFinite(duration) && duration > 0 ? duration : 0,
+            consecutiveErrors: 0,
+          });
         },
 
         _onTimeUpdate(currentTime) {
@@ -302,13 +308,30 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onError(message) {
-          set({ error: message, isPlaying: false });
+          const { currentIndex, queue, consecutiveErrors } = get();
+          if (currentIndex === null) {
+            set({ error: message, isPlaying: false });
+            return;
+          }
+          const errs = consecutiveErrors + 1;
+          if (errs >= queue.length) {
+            set({ error: message, isPlaying: false, consecutiveErrors: 0 });
+            return;
+          }
+          set({ consecutiveErrors: errs, error: message });
+          advance("error");
         },
 
         playFromIndex(index) {
           const { queue, shuffleMode } = get();
           if (index < 0 || index >= queue.length) return;
-          set({ currentIndex: index, isPlaying: true, currentTime: 0, error: null });
+          set({
+            currentIndex: index,
+            isPlaying: true,
+            currentTime: 0,
+            error: null,
+            consecutiveErrors: 0,
+          });
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {
             const order = shuffleIndices(queue.length, index);


### PR DESCRIPTION
## What

Two resilience improvements toward native-grade playback. **Targets the `feat/player-native-quality` tracker.** Two work-unit commits.

### 1. Auto-skip failed tracks
A single broken/unavailable track used to stop playback entirely (3s error flash, queue stalled until manual next). Now `_onError` advances to the next track and keeps playing, counting consecutive failures; only when the whole queue fails in a row does it surface a sticky error and stop — so one bad file can't break the session and an all-broken queue can't infinite-loop. The counter resets on any successful metadata load or fresh play intent.

### 2. Buffering indicator
Tapping play on a cold track flipped to "pause" instantly with no sound — read as broken. The play/pause button now shows a spinner while the audio element buffers (`waiting`/`stalled` → on, `playing`/`canplay` → off), with a localized label, in both the global bar and the now-playing view.

## Testing

- New unit tests: 8 (auto-skip) + 12 (buffering) across store, TransportControls, and GlobalPlayerBar. Full suite green (203 frontend tests in the touched files).
- `tsc --noEmit` clean.
- i18n `player.transport.loading` added to `en` + `es` (the only locales).

## Not in scope (separate PRs)

Element→store play/pause bridge for interruptions, queue+position persistence, gapless preloading.