### PR TITLE
feat(frontend): resume queue, track and position after reload

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -967,3 +967,66 @@ describe("mobile now-playing trigger", () => {
     expect(document.activeElement).toBe(btn);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Resume playback position on reload
+// ---------------------------------------------------------------------------
+
+describe("resume playback position on reload", () => {
+  it("seeks audio to persisted currentTime on first loadedmetadata", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 42,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+
+    expect(audio.currentTime).toBe(42);
+  });
+
+  it("does NOT re-seek on subsequent loadedmetadata events (one-shot guard)", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 42,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+    expect(audio.currentTime).toBe(42);
+
+    audio.currentTime = 10;
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+    expect(audio.currentTime).toBe(10);
+  });
+
+  it("does NOT seek when persisted currentTime is 0", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 0,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    audio.currentTime = 0;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+
+    expect(audio.currentTime).toBe(0);
+  });
+});

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -96,6 +96,7 @@ export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
+  const seekRestoredRef = useRef(false);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
@@ -196,6 +197,26 @@ export const GlobalPlayerBar: FC = () => {
       el.removeEventListener("canplay", onCanPlay);
     };
   }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError, _onWaiting, _onCanPlay]);
+
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el || !currentItem) return;
+    const startAt = usePlayerStore.getState().currentTime;
+    if (startAt <= 0) return;
+
+    const onFirstMetadata = () => {
+      if (!seekRestoredRef.current) {
+        el.currentTime = startAt;
+        seekRestoredRef.current = true;
+      }
+      el.removeEventListener("loadedmetadata", onFirstMetadata);
+    };
+
+    el.addEventListener("loadedmetadata", onFirstMetadata);
+    return () => {
+      el.removeEventListener("loadedmetadata", onFirstMetadata);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -432,17 +432,15 @@ describe("persist partialize", () => {
     const persisted = partialize(state as unknown as Parameters<typeof partialize>[0]);
     const roundTripped = JSON.parse(JSON.stringify(persisted));
 
-    expect(roundTripped).toEqual({
-      volume: 0.6,
-      isMuted: true,
-      shuffleMode: true,
-      repeatMode: "one",
-    });
-    expect("queue" in roundTripped).toBe(false);
-    expect("currentTime" in roundTripped).toBe(false);
+    expect(roundTripped.volume).toBe(0.6);
+    expect(roundTripped.isMuted).toBe(true);
+    expect(roundTripped.shuffleMode).toBe(true);
+    expect(roundTripped.repeatMode).toBe("one");
+    expect("queue" in roundTripped).toBe(true);
+    expect("currentTime" in roundTripped).toBe(true);
     expect("isPlaying" in roundTripped).toBe(false);
-    expect("shuffleOrder" in roundTripped).toBe(false);
-    expect("shuffleOrderIndex" in roundTripped).toBe(false);
+    expect("shuffleOrder" in roundTripped).toBe(true);
+    expect("shuffleOrderIndex" in roundTripped).toBe(true);
   });
 });
 
@@ -490,7 +488,17 @@ describe("__partialize allowlist — persisted keys are exactly volume, isMuted,
     };
 
     const result = p(fullState as unknown as Parameters<typeof p>[0]);
-    expect(Object.keys(result).sort()).toEqual(["isMuted", "repeatMode", "shuffleMode", "volume"]);
+    expect(Object.keys(result).sort()).toEqual([
+      "currentIndex",
+      "currentTime",
+      "isMuted",
+      "queue",
+      "repeatMode",
+      "shuffleMode",
+      "shuffleOrder",
+      "shuffleOrderIndex",
+      "volume",
+    ]);
   });
 
   it("excluded fields are absent from result", async () => {
@@ -509,8 +517,8 @@ describe("__partialize allowlist — persisted keys are exactly volume, isMuted,
     const result = p(fullState);
     expect("isNowPlayingOpen" in result).toBe(false);
     expect("isQueuePanelOpen" in result).toBe(false);
-    expect("queue" in result).toBe(false);
-    expect("currentIndex" in result).toBe(false);
+    expect("queue" in result).toBe(true);
+    expect("currentIndex" in result).toBe(true);
   });
 });
 
@@ -620,7 +628,7 @@ describe("repeat state", () => {
 // ---------------------------------------------------------------------------
 
 describe("partialize S1-6", () => {
-  it("shuffleOrder and shuffleOrderIndex reset to defaults on rehydration", async () => {
+  it("shuffleOrder and shuffleOrderIndex ARE persisted on rehydration", async () => {
     const { __partialize: p } = await import("./usePlayerStore");
     const fakeState = {
       shuffleMode: true,
@@ -632,8 +640,10 @@ describe("partialize S1-6", () => {
     } as unknown as Parameters<typeof p>[0];
 
     const persisted = p(fakeState);
-    expect("shuffleOrder" in persisted).toBe(false);
-    expect("shuffleOrderIndex" in persisted).toBe(false);
+    expect("shuffleOrder" in persisted).toBe(true);
+    expect("shuffleOrderIndex" in persisted).toBe(true);
+    expect(persisted.shuffleOrder).toEqual([2, 0, 1]);
+    expect(persisted.shuffleOrderIndex).toBe(1);
     expect(persisted.shuffleMode).toBe(true);
     expect(persisted.repeatMode).toBe("one");
   });
@@ -1396,5 +1406,48 @@ describe("playQueue() with shuffle", () => {
     expect(state.currentIndex).toBe(1);
     expect(state.shuffleOrder).toEqual([]);
     expect(state.shuffleOrderIndex).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persist partialize — resume-where-left-off (queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex)
+// ---------------------------------------------------------------------------
+
+describe("persist partialize — resume fields", () => {
+  it("includes queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex in persisted shape", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      queue: [makeItem("a"), makeItem("b")],
+      currentIndex: 1,
+      isPlaying: true,
+      volume: 0.8,
+      isMuted: false,
+      currentTime: 42,
+      duration: 200,
+      error: "oops",
+      shuffleMode: true,
+      repeatMode: "all" as const,
+      shuffleOrder: [1, 0],
+      shuffleOrderIndex: 1,
+      consecutiveErrors: 2,
+      isBuffering: true,
+    } as unknown as Parameters<typeof p>[0];
+
+    const result = p(fakeState);
+
+    expect(result.queue).toEqual([makeItem("a"), makeItem("b")]);
+    expect(result.currentIndex).toBe(1);
+    expect(result.currentTime).toBe(42);
+    expect(result.shuffleOrder).toEqual([1, 0]);
+    expect(result.shuffleOrderIndex).toBe(1);
+    expect(result.volume).toBe(0.8);
+    expect(result.isMuted).toBe(false);
+    expect(result.shuffleMode).toBe(true);
+    expect(result.repeatMode).toBe("all");
+    expect("isPlaying" in result).toBe(false);
+    expect("error" in result).toBe(false);
+    expect("isBuffering" in result).toBe(false);
+    expect("consecutiveErrors" in result).toBe(false);
+    expect("duration" in result).toBe(false);
   });
 });

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -62,11 +62,27 @@ export interface PlayerState extends PlayerUISlice {
 
 export const __partialize = (
   state: PlayerState,
-): Pick<PlayerState, "volume" | "isMuted" | "shuffleMode" | "repeatMode"> => ({
+): Pick<
+  PlayerState,
+  | "volume"
+  | "isMuted"
+  | "shuffleMode"
+  | "repeatMode"
+  | "queue"
+  | "currentIndex"
+  | "currentTime"
+  | "shuffleOrder"
+  | "shuffleOrderIndex"
+> => ({
   volume: state.volume,
   isMuted: state.isMuted,
   shuffleMode: state.shuffleMode,
   repeatMode: state.repeatMode,
+  queue: state.queue,
+  currentIndex: state.currentIndex,
+  currentTime: state.currentTime,
+  shuffleOrder: state.shuffleOrder,
+  shuffleOrderIndex: state.shuffleOrderIndex,
 });
 
 let _audioElement: HTMLAudioElement | null = null;


### PR DESCRIPTION
## What

The player now resumes where you left off after a page reload — queue, current track, shuffle order, and playback position. **Targets the `feat/player-native-quality` tracker.**

## Why

Only `volume`/`mute`/`shuffle`/`repeat` were persisted, so a reload wiped the queue and current track and dropped you back to an empty bar. Every native player resumes.

## How

- Extended the store's persist allowlist (`__partialize`) with `queue`, `currentIndex`, `currentTime`, `shuffleOrder`, `shuffleOrderIndex`. Deliberately NOT persisted: `isPlaying` (boots paused — autoplay is blocked anyway), `error`, `isBuffering`, `consecutiveErrors`, `duration` (recomputed on load).
- On mount, a one-shot effect seeks the restored track to the saved position on its first `loadedmetadata`, then never re-applies.

## Testing

- New tests: persisted-shape assertions (store) + position-restore one-shot (GlobalPlayerBar). 3 existing persist-shape tests updated to the new shape.
- **Full frontend suite green: 1354 tests.** `tsc --noEmit` clean.

## Notes / follow-ups

- `currentTime` is persisted on each `timeupdate` during playback (small payload, only while playing). A debounced persist is a possible future optimization, deliberately out of scope here.
- Still pending: element→store play/pause bridge (interruptions), gapless preload, keyboard shortcuts, artwork sizes.