### PR TITLE
feat(frontend): global keyboard shortcuts for the player

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -404,8 +404,8 @@ describe("keyboard space toggle", () => {
     const playBtn = screen.getByRole("button", { name: "Play" });
     fireEvent.keyDown(playBtn, { key: " " });
 
-    // The region onKeyDown should be a no-op when target is BUTTON
-    // so isPlaying remains unchanged from before the keyDown
+    // The global shortcut hook ignores BUTTON targets (native activation
+    // handles Space there), so the keydown does not toggle play.
     expect(usePlayerStore.getState().isPlaying).toBe(false);
   });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -9,6 +9,7 @@ import { FC, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
+import { useGlobalPlayerShortcuts } from "@/hooks/useGlobalPlayerShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
@@ -149,6 +150,7 @@ export const GlobalPlayerBar: FC = () => {
     [next, prev, seek],
   );
   useMediaSession(currentItem, isPlaying, mediaSessionActions);
+  useGlobalPlayerShortcuts();
   useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
   useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
 
@@ -266,14 +268,6 @@ export const GlobalPlayerBar: FC = () => {
     repeatMode !== "all" &&
     (currentIndex === null || currentIndex >= queue.length - 1);
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== " ") return;
-    const tag = (e.target as HTMLElement).tagName;
-    if (tag === "BUTTON" || tag === "INPUT") return;
-    e.preventDefault();
-    togglePlay();
-  };
-
   return (
     <>
       <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
@@ -284,7 +278,6 @@ export const GlobalPlayerBar: FC = () => {
         <section
           role="region"
           aria-label="Now playing"
-          onKeyDown={onKeyDown}
           className={cn(
             "bg-black",
             "fixed right-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 z-40 transition-[left] duration-300 md:bottom-0",

--- a/apps/frontend/src/hooks/useGlobalPlayerShortcuts.test.ts
+++ b/apps/frontend/src/hooks/useGlobalPlayerShortcuts.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { useGlobalPlayerShortcuts } from "./useGlobalPlayerShortcuts";
+
+const makeItem = () => ({
+  id: "t1",
+  name: "Track",
+  artist: "Artist",
+  audioUrl: "/audio/t1.mp3",
+});
+
+function dispatch(key: string, init: KeyboardEventInit = {}) {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }));
+}
+
+beforeEach(() => {
+  usePlayerStore.setState({
+    queue: [makeItem()],
+    currentIndex: 0,
+    isPlaying: false,
+    currentTime: 20,
+    duration: 60,
+    volume: 0.5,
+    isMuted: false,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  usePlayerStore.getState().clear();
+});
+
+describe("useGlobalPlayerShortcuts", () => {
+  it("Space toggles play when a track is active", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" "));
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("ArrowLeft seeks by -5 from currentTime", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowLeft"));
+    expect(usePlayerStore.getState().currentTime).toBe(15);
+  });
+
+  it("ArrowRight seeks by +5 from currentTime", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowRight"));
+    expect(usePlayerStore.getState().currentTime).toBe(25);
+  });
+
+  it("ArrowUp increases volume by 0.05", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowUp"));
+    expect(usePlayerStore.getState().volume).toBeCloseTo(0.55);
+  });
+
+  it("ArrowDown decreases volume by 0.05", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowDown"));
+    expect(usePlayerStore.getState().volume).toBeCloseTo(0.45);
+  });
+
+  it("m toggles mute", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("m"));
+    expect(usePlayerStore.getState().isMuted).toBe(true);
+  });
+
+  it("no-op when currentIndex is null", () => {
+    usePlayerStore.getState().clear();
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" "));
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("no-op when modifier key held (metaKey + Space)", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" ", { metaKey: true }));
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("no-op when event target is an INPUT element", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+    document.body.removeChild(input);
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/useGlobalPlayerShortcuts.ts
+++ b/apps/frontend/src/hooks/useGlobalPlayerShortcuts.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { usePlayerStore } from "@/store/usePlayerStore";
+
+const IGNORED_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "BUTTON", "A"]);
+
+export function useGlobalPlayerShortcuts(): void {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const target = e.target as HTMLElement;
+      if (IGNORED_TAGS.has(target.tagName) || target.isContentEditable) return;
+
+      const { currentIndex, currentTime, volume, togglePlay, seek, setVolume, toggleMute } =
+        usePlayerStore.getState();
+
+      if (currentIndex === null) return;
+
+      switch (e.key) {
+        case " ":
+          e.preventDefault();
+          togglePlay();
+          break;
+        case "ArrowLeft":
+          seek(currentTime - 5);
+          break;
+        case "ArrowRight":
+          seek(currentTime + 5);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setVolume(volume + 0.05);
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setVolume(volume - 0.05);
+          break;
+        case "m":
+        case "M":
+          toggleMute();
+          break;
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## What

Document-level keyboard shortcuts for the player (desktop native parity). **Targets the `feat/player-native-quality` tracker.**

| Key | Action |
|-----|--------|
| Space | play / pause |
| ← / → | seek −5s / +5s |
| ↑ / ↓ | volume +5% / −5% |
| m | mute toggle |

## How

- New `useGlobalPlayerShortcuts` hook: one `document` keydown listener, reads fresh state via `getState()` inside the handler (no stale closures, mounts once).
- Bails on: modifier keys (don't hijack browser shortcuts), text-entry targets (input/textarea/select/contenteditable), interactive controls (button/link — native Space activation owns those, avoids double-toggle), and when no track is active.
- Replaces the old region-scoped `onKeyDown` (worked only when focus was inside the bar).

## Testing

- 9 hook tests (each shortcut + the guards) + the existing player-bar Space tests retained and updated to the global behavior. 76 tests in the touched files green; `tsc --noEmit` clean.

## Note

The implementing agent ran in an isolated worktree based on pre-tracker `main`; its self-contained hook was brought onto the tracker branch and the small GlobalPlayerBar wiring re-applied by hand on top of the accumulated player changes, plus a fix to also ignore button/link targets (the agent's version only ignored form fields).