### PR TITLE
fix(frontend): context-aware play and toggle-only shuffle in playlist/album header

### DIFF
--- a/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
@@ -80,38 +80,40 @@ describe("PlaylistActions playback", () => {
 });
 
 describe("PlaylistActions shuffle button", () => {
-  it("renders shuffle button when onShufflePlay and hasPlayableTracks are provided", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+  it("renders shuffle button when onToggleShuffle and hasPlayableTracks are provided", () => {
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     expect(screen.getByRole("button", { name: "playlist.actions.shufflePlay" })).toBeTruthy();
   });
 
-  it("does not render shuffle button when onShufflePlay is not provided", () => {
+  it("does not render shuffle button when onToggleShuffle is not provided", () => {
     render(<PlaylistActions {...defaultProps} />);
     expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
   });
 
   it("does not render shuffle button when hasPlayableTracks is false", () => {
-    render(<PlaylistActions {...defaultProps} hasPlayableTracks={false} onShufflePlay={vi.fn()} />);
+    render(
+      <PlaylistActions {...defaultProps} hasPlayableTracks={false} onToggleShuffle={vi.fn()} />,
+    );
     expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
   });
 
   it("applies text-green-500 class when isShuffleActive is true", () => {
-    render(<PlaylistActions {...defaultProps} onShufflePlay={vi.fn()} isShuffleActive={true} />);
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={vi.fn()} isShuffleActive={true} />);
     const btn = screen.getByRole("button", { name: "playlist.actions.shufflePlay" });
     expect(btn.className).toContain("text-green-500");
   });
 
-  it("calls onShufflePlay when shuffle button is clicked", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+  it("calls onToggleShuffle when shuffle button is clicked", () => {
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     fireEvent.click(screen.getByRole("button", { name: "playlist.actions.shufflePlay" }));
-    expect(onShufflePlay).toHaveBeenCalledTimes(1);
+    expect(onToggleShuffle).toHaveBeenCalledTimes(1);
   });
 
   it("shuffle button appears after play button in DOM order", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     const buttons = screen.getAllByRole("button");
     const playIndex = buttons.findIndex(
       (b) => b.getAttribute("aria-label") === "library.album.playTrack",

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -37,7 +37,7 @@ interface PlaylistActionsProps {
   onRetryFailed: () => void;
   onDelete: () => void;
   onDownload: () => void;
-  onShufflePlay?: () => void;
+  onToggleShuffle?: () => void;
   isShuffleActive?: boolean;
   mode?: PlaylistActionsMode;
 }
@@ -57,7 +57,7 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   onRetryFailed,
   onDelete,
   onDownload,
-  onShufflePlay,
+  onToggleShuffle,
   isShuffleActive = false,
   spotifyUrl,
   playlistId,
@@ -87,11 +87,11 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </Button>
       ) : null}
 
-      {hasPlayableTracks && onShufflePlay ? (
+      {hasPlayableTracks && onToggleShuffle ? (
         <Button
           variant="ghost"
           size="md"
-          onClick={onShufflePlay}
+          onClick={onToggleShuffle}
           title={t("playlist.actions.shufflePlay")}
           ariaLabel={t("playlist.actions.shufflePlay")}
           icon={faShuffle}

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -38,7 +38,7 @@ interface PlaylistProps {
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
   onDownloadOrRetry: () => void;
-  onShufflePlay?: () => void;
+  onToggleShuffle?: () => void;
   isShuffleActive?: boolean;
   mode?: PlaylistMode;
 }
@@ -70,7 +70,7 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryFailed,
   onToggleSubscription,
   onDownloadOrRetry,
-  onShufflePlay,
+  onToggleShuffle,
   isShuffleActive = false,
   mode = "managed",
 }) => {
@@ -135,7 +135,7 @@ export const Playlist: FC<PlaylistProps> = ({
               onRetryFailed={onRetryFailed}
               onDelete={handleDelete}
               onDownload={onDownloadOrRetry}
-              onShufflePlay={onShufflePlay}
+              onToggleShuffle={onToggleShuffle}
               isShuffleActive={isShuffleActive}
               spotifyUrl={
                 playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -16,7 +16,7 @@ const {
   const storeState = {
     isPlaying: false,
     currentIndex: null as number | null,
-    queue: [] as Array<{ id: string }>,
+    queue: [] as Array<{ id: string; contextPath?: string }>,
     shuffleMode: false,
   };
   return {
@@ -49,7 +49,7 @@ vi.mock("@/store/usePlayerStore", () => ({
         selector: (state: {
           isPlaying: boolean;
           currentIndex: number | null;
-          queue: Array<{ id: string }>;
+          queue: Array<{ id: string; contextPath?: string }>;
           shuffleMode: boolean;
         }) => unknown,
       ) => selector(mockStoreState),
@@ -231,7 +231,14 @@ describe("useLibraryAlbumDetailController", () => {
 
   it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
     setupParams();
-    mockStoreState.queue = [{ id: "Sigur Rós-( )-0" }, { id: "Sigur Rós-( )-1" }];
+    const albumContextPath = generatePath(Path.LIBRARY_ALBUM, {
+      name: "Sigur Rós",
+      albumName: "( )",
+    });
+    mockStoreState.queue = [
+      { id: "Sigur Rós-( )-0", contextPath: albumContextPath },
+      { id: "Sigur Rós-( )-1", contextPath: albumContextPath },
+    ];
     mockStoreState.isPlaying = true;
     mockPlayQueue.mockClear();
     mockTogglePlay.mockClear();
@@ -383,7 +390,14 @@ describe("useLibraryAlbumDetailController", () => {
 
   it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
     setupParams();
-    mockStoreState.queue = [{ id: "Sigur Rós-( )-0" }, { id: "Sigur Rós-( )-1" }];
+    const albumContextPath = generatePath(Path.LIBRARY_ALBUM, {
+      name: "Sigur Rós",
+      albumName: "( )",
+    });
+    mockStoreState.queue = [
+      { id: "Sigur Rós-( )-0", contextPath: albumContextPath },
+      { id: "Sigur Rós-( )-1", contextPath: albumContextPath },
+    ];
     mockStoreState.isPlaying = true;
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -5,14 +5,29 @@ import { describe, expect, it, vi } from "vitest";
 import { Path } from "@/routes/routes";
 import { useLibraryAlbumDetailController } from "./useLibraryAlbumDetailController";
 
-const { mockUseParams, mockUseLibraryArtistQuery, mockPlayQueue, mockSetState } = vi.hoisted(
-  () => ({
+const {
+  mockUseParams,
+  mockUseLibraryArtistQuery,
+  mockPlayQueue,
+  mockToggleShuffle,
+  mockTogglePlay,
+  mockStoreState,
+} = vi.hoisted(() => {
+  const storeState = {
+    isPlaying: false,
+    currentIndex: null as number | null,
+    queue: [] as Array<{ id: string }>,
+    shuffleMode: false,
+  };
+  return {
     mockUseParams: vi.fn(),
     mockUseLibraryArtistQuery: vi.fn(),
     mockPlayQueue: vi.fn(),
-    mockSetState: vi.fn(),
-  }),
-);
+    mockToggleShuffle: vi.fn(),
+    mockTogglePlay: vi.fn(),
+    mockStoreState: storeState,
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -37,11 +52,15 @@ vi.mock("@/store/usePlayerStore", () => ({
           queue: Array<{ id: string }>;
           shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
+      ) => selector(mockStoreState),
     ),
     {
-      getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
-      setState: mockSetState,
+      getState: vi.fn(() => ({
+        playQueue: mockPlayQueue,
+        togglePlay: mockTogglePlay,
+        toggleShuffle: mockToggleShuffle,
+        shuffleMode: mockStoreState.shuffleMode,
+      })),
     },
   ),
 }));
@@ -92,18 +111,18 @@ const makeArtist = (): LibraryArtist => ({
   ],
 });
 
+const setupParams = () => {
+  mockUseParams.mockReturnValue({ name: "Sigur%20R%C3%B3s", albumName: "%28%20%29" });
+  mockUseLibraryArtistQuery.mockReturnValue({ data: makeArtist(), isLoading: false, error: null });
+  mockStoreState.isPlaying = false;
+  mockStoreState.currentIndex = null;
+  mockStoreState.queue = [];
+  mockStoreState.shuffleMode = false;
+};
+
 describe("useLibraryAlbumDetailController", () => {
   it("decodes params, resolves album and maps tracks to AlbumPageLayout shape", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
@@ -165,17 +184,7 @@ describe("useLibraryAlbumDetailController", () => {
   });
 
   it("dispatches playQueue to usePlayerStore with normalized QueueItems when onPlayTrack is called", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -194,7 +203,6 @@ describe("useLibraryAlbumDetailController", () => {
     expect(startIndex).toBe(1);
     expect(items).toHaveLength(2);
 
-    // audioUrl is normalized from track.trackUrl
     expect(items[0]!.audioUrl).toBe(
       `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent("/tmp/01.mp3")}`,
     );
@@ -202,23 +210,12 @@ describe("useLibraryAlbumDetailController", () => {
       `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent("/tmp/02.mp3")}`,
     );
 
-    // QueueItem fields
     expect(items[0]!.name).toBe("Vaka");
     expect(items[0]!.artist).toBe("Sigur Rós");
   });
 
   it("dispatches playQueue starting at index 0 when onPlayPlaylist is called with no current track", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -232,19 +229,47 @@ describe("useLibraryAlbumDetailController", () => {
     expect(startIndex).toBe(0);
   });
 
+  it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
+    setupParams();
+    mockStoreState.queue = [{ id: "Sigur Rós-( )-0" }, { id: "Sigur Rós-( )-1" }];
+    mockStoreState.isPlaying = true;
+    mockPlayQueue.mockClear();
+    mockTogglePlay.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockTogglePlay).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("onPlayPlaylist calls playQueue at random index when isActiveContext is false and shuffleMode is on", () => {
+    setupParams();
+    mockStoreState.shuffleMode = true;
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    // Math.floor(0.5 * 2) = 1 (2 tracks)
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(1);
+
+    vi.restoreAllMocks();
+    mockStoreState.shuffleMode = false;
+  });
+
   // T1.3 — artworkUrl regression: library album controller is unaffected
   it("[T1.3] dispatched QueueItems carry artworkUrl equal to coverUrl", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -260,7 +285,6 @@ describe("useLibraryAlbumDetailController", () => {
       number,
     ];
 
-    // All items should carry artworkUrl equal to the album's coverUrl
     const expectedCoverUrl = result.current.coverUrl;
     items.forEach((item) => {
       expect(item.artworkUrl).toBe(expectedCoverUrl);
@@ -269,17 +293,7 @@ describe("useLibraryAlbumDetailController", () => {
 
   // T2.4 — contextPath on library album queue items
   it("[T2.4] every dispatched QueueItem carries contextPath equal to the library album route", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -305,108 +319,80 @@ describe("useLibraryAlbumDetailController", () => {
     });
   });
 
-  it("exposes onShufflePlay and isShuffleActive in return value", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+  it("exposes onToggleShuffle and isShuffleActive in return value", () => {
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
-    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.onToggleShuffle).toBe("function");
     expect(typeof result.current.isShuffleActive).toBe("boolean");
   });
 
-  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
-    mockSetState.mockClear();
+  it("onToggleShuffle calls toggleShuffle without starting playback", () => {
+    setupParams();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
-
-    const callOrder: string[] = [];
-    mockSetState.mockImplementation(() => {
-      callOrder.push("setState");
-    });
-    mockPlayQueue.mockImplementation(() => {
-      callOrder.push("playQueue");
-    });
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
-    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
-    expect(callOrder[0]).toBe("setState");
-    expect(callOrder[1]).toBe("playQueue");
+    expect(mockToggleShuffle).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
-  it("onShufflePlay is a no-op when hasPlayableTracks is false", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "missing",
-    });
+  it("onToggleShuffle is a no-op when hasPlayableTracks is false", () => {
+    mockUseParams.mockReturnValue({ name: "Sigur%20R%C3%B3s", albumName: "missing" });
     mockUseLibraryArtistQuery.mockReturnValue({
       data: makeArtist(),
       isLoading: false,
       error: null,
     });
-
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockToggleShuffle).not.toHaveBeenCalled();
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
   it("isShuffleActive is false when store shuffleMode is false", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     expect(result.current.isShuffleActive).toBe(false);
   });
 
-  it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
+  it("isPlaying exposed is false when isActiveContext is false even if store isPlaying is true", () => {
+    setupParams();
+    mockStoreState.isPlaying = true;
+    mockStoreState.queue = [];
 
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
+    setupParams();
+    mockStoreState.queue = [{ id: "Sigur Rós-( )-0" }, { id: "Sigur Rós-( )-1" }];
+    mockStoreState.isPlaying = true;
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.isPlaying).toBe(true);
+  });
+
+  it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -71,9 +71,9 @@ export const useLibraryAlbumDetailController = () => {
   }, [album, artistName, coverUrl, selectedAlbumName]);
 
   const {
-    currentIndex,
     currentTrackId,
-    isPlaying,
+    isPlaying: globalIsPlaying,
+    isActiveContext,
     hasPlayableTracks,
     playFromIndex,
     onPlayTrack,
@@ -84,14 +84,20 @@ export const useLibraryAlbumDetailController = () => {
 
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
-    playFromIndex(currentIndex ?? 0);
-  }, [currentIndex, hasPlayableTracks, playFromIndex]);
+    if (isActiveContext) {
+      usePlayerStore.getState().togglePlay();
+      return;
+    }
+    const len = queueItems.length;
+    const startIndex =
+      usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
+    playFromIndex(startIndex);
+  }, [hasPlayableTracks, isActiveContext, queueItems.length, playFromIndex]);
 
-  const onShufflePlay = useCallback(() => {
+  const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;
-    usePlayerStore.setState({ shuffleMode: true });
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    usePlayerStore.getState().toggleShuffle();
+  }, [hasPlayableTracks]);
 
   const backToArtistPath = generatePath(Path.LIBRARY_ARTIST, {
     name: artistName,
@@ -109,13 +115,13 @@ export const useLibraryAlbumDetailController = () => {
     playlistType: PlaylistTypeEnum.Album,
     backToArtistPath,
     currentTrackId,
-    isPlaying,
+    isPlaying: isActiveContext && globalIsPlaying,
     onPlayTrack,
     onPauseTrack,
     hasPlayableTracks,
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
   };
 };

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -92,7 +92,7 @@ export const useLibraryAlbumDetailController = () => {
     const startIndex =
       usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
     playFromIndex(startIndex);
-  }, [hasPlayableTracks, isActiveContext, queueItems.length, playFromIndex]);
+  }, [hasPlayableTracks, isActiveContext, queueItems, playFromIndex]);
 
   const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -12,16 +12,30 @@ const {
   mockUsePlaylistController,
   mockPlayQueue,
   mockSetState,
-} = vi.hoisted(() => ({
-  mockUseParams: vi.fn(),
-  mockUseSearchParams: vi.fn(),
-  mockUsePlaylistsQuery: vi.fn(),
-  mockUseTracksQuery: vi.fn(),
-  mockUseNavigationHelpers: vi.fn(),
-  mockUsePlaylistController: vi.fn(),
-  mockPlayQueue: vi.fn(),
-  mockSetState: vi.fn(),
-}));
+  mockToggleShuffle,
+  mockTogglePlay,
+  mockStoreState,
+} = vi.hoisted(() => {
+  const storeState = {
+    isPlaying: false,
+    currentIndex: null as number | null,
+    queue: [] as Array<{ id: string }>,
+    shuffleMode: false,
+  };
+  return {
+    mockUseParams: vi.fn(),
+    mockUseSearchParams: vi.fn(),
+    mockUsePlaylistsQuery: vi.fn(),
+    mockUseTracksQuery: vi.fn(),
+    mockUseNavigationHelpers: vi.fn(),
+    mockUsePlaylistController: vi.fn(),
+    mockPlayQueue: vi.fn(),
+    mockSetState: vi.fn(),
+    mockToggleShuffle: vi.fn(),
+    mockTogglePlay: vi.fn(),
+    mockStoreState: storeState,
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -59,10 +73,15 @@ vi.mock("@/store/usePlayerStore", () => ({
           queue: Array<{ id: string }>;
           shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
+      ) => selector(mockStoreState),
     ),
     {
-      getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
+      getState: vi.fn(() => ({
+        playQueue: mockPlayQueue,
+        togglePlay: mockTogglePlay,
+        toggleShuffle: mockToggleShuffle,
+        shuffleMode: mockStoreState.shuffleMode,
+      })),
       setState: mockSetState,
     },
   ),
@@ -147,6 +166,10 @@ const setupDefaults = (mode = "managed") => {
   mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
   mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
   mockUsePlaylistController.mockReturnValue(defaultPlaylistController);
+  mockStoreState.isPlaying = false;
+  mockStoreState.currentIndex = null;
+  mockStoreState.queue = [];
+  mockStoreState.shuffleMode = false;
 };
 
 describe("usePlaylistDetailController", () => {
@@ -273,6 +296,80 @@ describe("usePlaylistDetailController", () => {
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
+  it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
+    setupDefaults("library");
+    mockStoreState.queue = [{ id: "track-2" }, { id: "track-3" }];
+    mockStoreState.isPlaying = true;
+    mockPlayQueue.mockClear();
+    mockTogglePlay.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockTogglePlay).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("onPlayPlaylist calls playQueue at index 0 when isActiveContext is false and shuffleMode is off", () => {
+    setupDefaults("library");
+    mockStoreState.shuffleMode = false;
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(0);
+  });
+
+  it("onPlayPlaylist calls playQueue at random index when isActiveContext is false and shuffleMode is on", () => {
+    setupDefaults("library");
+    mockStoreState.shuffleMode = true;
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    // Math.floor(0.5 * 2) = 1 (2 playable tracks)
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(1);
+
+    vi.restoreAllMocks();
+    mockStoreState.shuffleMode = false;
+  });
+
+  it("isPlaying exposed is false when isActiveContext is false even if store isPlaying is true", () => {
+    setupDefaults("library");
+    mockStoreState.isPlaying = true;
+    mockStoreState.queue = []; // different queue → isActiveContext false
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
+    setupDefaults("library");
+    mockStoreState.queue = [{ id: "track-2" }, { id: "track-3" }];
+    mockStoreState.isPlaying = true;
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(result.current.isPlaying).toBe(true);
+  });
+
   // T1.1 — artworkUrl resolution
   it("[T1.1-A] uses track.albumCoverUrl when present", () => {
     setupDefaults("library");
@@ -339,52 +436,42 @@ describe("usePlaylistDetailController", () => {
   });
 
   // T2.2 — contextPath on playlist queue items
-  it("exposes onShufflePlay and isShuffleActive in return value", () => {
+  it("exposes onToggleShuffle and isShuffleActive in return value", () => {
     setupDefaults("library");
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
-    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.onToggleShuffle).toBe("function");
     expect(typeof result.current.isShuffleActive).toBe("boolean");
   });
 
-  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
+  it("onToggleShuffle calls toggleShuffle without starting playback", () => {
     setupDefaults("library");
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
-
-    const callOrder: string[] = [];
-    mockSetState.mockImplementation(() => {
-      callOrder.push("setState");
-    });
-    mockPlayQueue.mockImplementation(() => {
-      callOrder.push("playQueue");
-    });
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
-    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
-    expect(callOrder[0]).toBe("setState");
-    expect(callOrder[1]).toBe("playQueue");
+    expect(mockToggleShuffle).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
-  it("onShufflePlay is a no-op when !hasPlayableTracks (managed mode)", () => {
+  it("onToggleShuffle is a no-op when hasPlayableTracks is false", () => {
     setupDefaults("managed");
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockToggleShuffle).not.toHaveBeenCalled();
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -19,7 +19,7 @@ const {
   const storeState = {
     isPlaying: false,
     currentIndex: null as number | null,
-    queue: [] as Array<{ id: string }>,
+    queue: [] as Array<{ id: string; contextPath?: string }>,
     shuffleMode: false,
   };
   return {
@@ -70,7 +70,7 @@ vi.mock("@/store/usePlayerStore", () => ({
         selector: (state: {
           isPlaying: boolean;
           currentIndex: number | null;
-          queue: Array<{ id: string }>;
+          queue: Array<{ id: string; contextPath?: string }>;
           shuffleMode: boolean;
         }) => unknown,
       ) => selector(mockStoreState),
@@ -298,7 +298,10 @@ describe("usePlaylistDetailController", () => {
 
   it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
     setupDefaults("library");
-    mockStoreState.queue = [{ id: "track-2" }, { id: "track-3" }];
+    mockStoreState.queue = [
+      { id: "track-2", contextPath: "/playlist/playlist-1?mode=library" },
+      { id: "track-3", contextPath: "/playlist/playlist-1?mode=library" },
+    ];
     mockStoreState.isPlaying = true;
     mockPlayQueue.mockClear();
     mockTogglePlay.mockClear();
@@ -362,7 +365,10 @@ describe("usePlaylistDetailController", () => {
 
   it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
     setupDefaults("library");
-    mockStoreState.queue = [{ id: "track-2" }, { id: "track-3" }];
+    mockStoreState.queue = [
+      { id: "track-2", contextPath: "/playlist/playlist-1?mode=library" },
+      { id: "track-3", contextPath: "/playlist/playlist-1?mode=library" },
+    ];
     mockStoreState.isPlaying = true;
 
     const { result } = renderHook(() => usePlaylistDetailController());

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -59,7 +59,7 @@ export const usePlaylistDetailController = () => {
     const startIndex =
       usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
     playFromIndex(startIndex);
-  }, [hasPlayableTracks, isActiveContext, queueItems.length, playFromIndex]);
+  }, [hasPlayableTracks, isActiveContext, queueItems, playFromIndex]);
 
   const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -37,21 +37,34 @@ export const usePlaylistDetailController = () => {
       }));
   }, [mode, tracks, playlist, id]);
 
-  const { currentTrackId, isPlaying, hasPlayableTracks, playFromIndex, onPlayTrack, onPauseTrack } =
-    usePlayerQueueBinding(queueItems);
+  const {
+    currentTrackId,
+    isPlaying: globalIsPlaying,
+    isActiveContext,
+    hasPlayableTracks,
+    playFromIndex,
+    onPlayTrack,
+    onPauseTrack,
+  } = usePlayerQueueBinding(queueItems);
 
   const isShuffleActive = usePlayerStore((s) => s.shuffleMode);
 
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    if (isActiveContext) {
+      usePlayerStore.getState().togglePlay();
+      return;
+    }
+    const len = queueItems.length;
+    const startIndex =
+      usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
+    playFromIndex(startIndex);
+  }, [hasPlayableTracks, isActiveContext, queueItems.length, playFromIndex]);
 
-  const onShufflePlay = useCallback(() => {
+  const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;
-    usePlayerStore.setState({ shuffleMode: true });
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    usePlayerStore.getState().toggleShuffle();
+  }, [hasPlayableTracks]);
 
   const {
     isDownloading,
@@ -89,14 +102,14 @@ export const usePlaylistDetailController = () => {
     handleRetryTrack,
     handleGoHome,
     currentTrackId,
-    isPlaying,
+    isPlaying: isActiveContext && globalIsPlaying,
     onPlayTrack,
     onPauseTrack,
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
     hasPlayableTracks,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
     mode,
   };
 };

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
@@ -104,4 +104,38 @@ describe("usePlayerQueueBinding", () => {
 
     expect(playQueue).not.toHaveBeenCalled();
   });
+
+  it("isActiveContext is false when store queue is empty", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
+
+  it("isActiveContext is true when store queue matches queueItems exactly", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.setState({ queue: items, currentIndex: 0, isPlaying: true });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(true);
+  });
+
+  it("isActiveContext is false when store queue has same length but different ids", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.setState({
+      queue: [makeItem("a"), makeItem("x")],
+      currentIndex: 0,
+      isPlaying: true,
+    });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
+
+  it("isActiveContext is false when store queue has different length", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.setState({ queue: [makeItem("a")], currentIndex: 0, isPlaying: true });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
 });

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
@@ -105,24 +105,42 @@ describe("usePlayerQueueBinding", () => {
     expect(playQueue).not.toHaveBeenCalled();
   });
 
+  const ctx = "/playlist/p1?mode=library";
+  const makeCtxItem = (id: string, contextPath = ctx) => makeItem(id, { contextPath });
+
   it("isActiveContext is false when store queue is empty", () => {
-    const items = [makeItem("a"), makeItem("b")];
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
     const { result } = renderHook(() => usePlayerQueueBinding(items));
     expect(result.current.isActiveContext).toBe(false);
   });
 
-  it("isActiveContext is true when store queue matches queueItems exactly", () => {
-    const items = [makeItem("a"), makeItem("b")];
+  it("isActiveContext is true when the store queue belongs to this context", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
     usePlayerStore.setState({ queue: items, currentIndex: 0, isPlaying: true });
 
     const { result } = renderHook(() => usePlayerQueueBinding(items));
     expect(result.current.isActiveContext).toBe(true);
   });
 
-  it("isActiveContext is false when store queue has same length but different ids", () => {
-    const items = [makeItem("a"), makeItem("b")];
+  it("isActiveContext stays true when the active queue is reordered (order-independent)", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b"), makeCtxItem("c")];
     usePlayerStore.setState({
-      queue: [makeItem("a"), makeItem("x")],
+      queue: [makeCtxItem("c"), makeCtxItem("a"), makeCtxItem("b")],
+      currentIndex: 0,
+      isPlaying: true,
+    });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(true);
+  });
+
+  it("isActiveContext is false when another context plays the same track ids", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
+    usePlayerStore.setState({
+      queue: [
+        makeCtxItem("a", "/playlist/p2?mode=library"),
+        makeCtxItem("b", "/playlist/p2?mode=library"),
+      ],
       currentIndex: 0,
       isPlaying: true,
     });
@@ -131,9 +149,9 @@ describe("usePlayerQueueBinding", () => {
     expect(result.current.isActiveContext).toBe(false);
   });
 
-  it("isActiveContext is false when store queue has different length", () => {
+  it("isActiveContext is false when queue items have no contextPath", () => {
     const items = [makeItem("a"), makeItem("b")];
-    usePlayerStore.setState({ queue: [makeItem("a")], currentIndex: 0, isPlaying: true });
+    usePlayerStore.setState({ queue: items, currentIndex: 0, isPlaying: true });
 
     const { result } = renderHook(() => usePlayerQueueBinding(items));
     expect(result.current.isActiveContext).toBe(false);

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.ts
@@ -14,8 +14,10 @@ export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
   const hasPlayableTracks = queueItems.length > 0;
 
   const isActiveContext = useMemo(() => {
-    if (queueItems.length === 0 || queue.length !== queueItems.length) return false;
-    return queueItems.every((item, i) => item.id === queue[i]?.id);
+    if (queueItems.length === 0 || queue.length === 0) return false;
+    const contextPath = queueItems[0]?.contextPath;
+    if (contextPath == null) return false;
+    return queue.every((item) => item.contextPath === contextPath);
   }, [queue, queueItems]);
 
   const playFromIndex = useCallback(

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.ts
@@ -1,9 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { usePlayerStore, type QueueItem } from "@/store/usePlayerStore";
 
 export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
   const currentIndex = usePlayerStore((state) => state.currentIndex);
   const isPlaying = usePlayerStore((state) => state.isPlaying);
+  const queue = usePlayerStore((state) => state.queue);
 
   const currentTrackId = usePlayerStore((state) => {
     if (state.currentIndex === null) return null;
@@ -11,6 +12,11 @@ export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
   });
 
   const hasPlayableTracks = queueItems.length > 0;
+
+  const isActiveContext = useMemo(() => {
+    if (queueItems.length === 0 || queue.length !== queueItems.length) return false;
+    return queueItems.every((item, i) => item.id === queue[i]?.id);
+  }, [queue, queueItems]);
 
   const playFromIndex = useCallback(
     (index: number) => {
@@ -37,6 +43,7 @@ export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
     currentIndex,
     currentTrackId,
     isPlaying,
+    isActiveContext,
     hasPlayableTracks,
     playFromIndex,
     onPlayTrack,

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -30,7 +30,7 @@ export const LibraryAlbumDetail: FC = () => {
     onPlayPlaylist,
     onPausePlaylist,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
   } = useLibraryAlbumDetailController();
 
   if (isLoading) {
@@ -119,11 +119,11 @@ export const LibraryAlbumDetail: FC = () => {
                   </span>
                 </Button>
               ) : null}
-              {hasPlayableTracks && onShufflePlay ? (
+              {hasPlayableTracks && onToggleShuffle ? (
                 <Button
                   variant="ghost"
                   size="md"
-                  onClick={onShufflePlay}
+                  onClick={onToggleShuffle}
                   title={t("playlist.actions.shufflePlay")}
                   ariaLabel={t("playlist.actions.shufflePlay")}
                   icon={faShuffle}

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -31,7 +31,7 @@ export const PlaylistDetail: FC = () => {
     isPlaying,
     hasPlayableTracks,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
     mode,
   } = usePlaylistDetailController();
 
@@ -70,7 +70,7 @@ export const PlaylistDetail: FC = () => {
         currentTrackId={currentTrackId}
         isPlaying={isPlaying}
         hasPlayableTracks={hasPlayableTracks}
-        onShufflePlay={onShufflePlay}
+        onToggleShuffle={onToggleShuffle}
         isShuffleActive={isShuffleActive}
         mode={mode}
       />


### PR DESCRIPTION
## What

Fixes 3 playback-control UX bugs in the playlist/album detail header. **Targets the `feat/player-native-quality` tracker.**

1. **Shuffle is now a pure toggle** (like the global player bar) — flips `shuffleMode` without starting playback; the green highlight reflects state. Previously every click forced shuffle on and restarted from track 0.
2. **Header play/pause is context-aware** (Spotify model). Shows pause only when *this* playlist/album is the active, playing context, and pauses/resumes the current track instead of restarting from 0. Starts the context fresh only when a different context (or nothing) is playing.
3. **Shuffle starts on a random track**, not always the first.

## How

- `usePlayerQueueBinding` derives `isActiveContext` by matching the store queue against the view's `queueItems` (length + ordered ids), reactively.
- Both detail controllers route the header play button through `togglePlay()` when active, else a fresh start (random index when shuffle on, else 0). Exposed `isPlaying` is `isActiveContext && globalIsPlaying`.
- `onShufflePlay` → `onToggleShuffle`; prop renamed across PlaylistActions, both controllers, and consuming views.

## Note on Bug 2

Playing a track from a playlist *does* light the header button — intentional, matches Spotify (the playlist is the active context). The actual bug was restarting from track 0; it now pauses/resumes. Say so if you'd prefer "always restart from the beginning" instead.

## Testing

New/updated tests across binding, both controllers, and PlaylistActions (random start stubbed). Full suite green: **1400 tests**. `tsc --noEmit` clean.