### PR TITLE
feat(frontend): native-quality music playback

### DIFF
--- a/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.test.tsx
@@ -80,38 +80,40 @@ describe("PlaylistActions playback", () => {
 });
 
 describe("PlaylistActions shuffle button", () => {
-  it("renders shuffle button when onShufflePlay and hasPlayableTracks are provided", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+  it("renders shuffle button when onToggleShuffle and hasPlayableTracks are provided", () => {
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     expect(screen.getByRole("button", { name: "playlist.actions.shufflePlay" })).toBeTruthy();
   });
 
-  it("does not render shuffle button when onShufflePlay is not provided", () => {
+  it("does not render shuffle button when onToggleShuffle is not provided", () => {
     render(<PlaylistActions {...defaultProps} />);
     expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
   });
 
   it("does not render shuffle button when hasPlayableTracks is false", () => {
-    render(<PlaylistActions {...defaultProps} hasPlayableTracks={false} onShufflePlay={vi.fn()} />);
+    render(
+      <PlaylistActions {...defaultProps} hasPlayableTracks={false} onToggleShuffle={vi.fn()} />,
+    );
     expect(screen.queryByRole("button", { name: "playlist.actions.shufflePlay" })).toBeNull();
   });
 
   it("applies text-green-500 class when isShuffleActive is true", () => {
-    render(<PlaylistActions {...defaultProps} onShufflePlay={vi.fn()} isShuffleActive={true} />);
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={vi.fn()} isShuffleActive={true} />);
     const btn = screen.getByRole("button", { name: "playlist.actions.shufflePlay" });
     expect(btn.className).toContain("text-green-500");
   });
 
-  it("calls onShufflePlay when shuffle button is clicked", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+  it("calls onToggleShuffle when shuffle button is clicked", () => {
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     fireEvent.click(screen.getByRole("button", { name: "playlist.actions.shufflePlay" }));
-    expect(onShufflePlay).toHaveBeenCalledTimes(1);
+    expect(onToggleShuffle).toHaveBeenCalledTimes(1);
   });
 
   it("shuffle button appears after play button in DOM order", () => {
-    const onShufflePlay = vi.fn();
-    render(<PlaylistActions {...defaultProps} onShufflePlay={onShufflePlay} />);
+    const onToggleShuffle = vi.fn();
+    render(<PlaylistActions {...defaultProps} onToggleShuffle={onToggleShuffle} />);
     const buttons = screen.getAllByRole("button");
     const playIndex = buttons.findIndex(
       (b) => b.getAttribute("aria-label") === "library.album.playTrack",

--- a/apps/frontend/src/components/molecules/PlaylistActions.tsx
+++ b/apps/frontend/src/components/molecules/PlaylistActions.tsx
@@ -37,7 +37,7 @@ interface PlaylistActionsProps {
   onRetryFailed: () => void;
   onDelete: () => void;
   onDownload: () => void;
-  onShufflePlay?: () => void;
+  onToggleShuffle?: () => void;
   isShuffleActive?: boolean;
   mode?: PlaylistActionsMode;
 }
@@ -57,7 +57,7 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
   onRetryFailed,
   onDelete,
   onDownload,
-  onShufflePlay,
+  onToggleShuffle,
   isShuffleActive = false,
   spotifyUrl,
   playlistId,
@@ -87,11 +87,11 @@ export const PlaylistActions: FC<PlaylistActionsProps> = ({
         </Button>
       ) : null}
 
-      {hasPlayableTracks && onShufflePlay ? (
+      {hasPlayableTracks && onToggleShuffle ? (
         <Button
           variant="ghost"
           size="md"
-          onClick={onShufflePlay}
+          onClick={onToggleShuffle}
           title={t("playlist.actions.shufflePlay")}
           ariaLabel={t("playlist.actions.shufflePlay")}
           icon={faShuffle}

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -154,4 +154,16 @@ describe("TransportControls", () => {
     render(<TransportControls {...defaultProps} isBuffering={false} isPlaying={false} />);
     expect(screen.getByRole("button", { name: "player.transport.play" })).not.toBeNull();
   });
+
+  it("isBuffering=true: play/pause button has aria-busy='true'", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    const btn = screen.getByRole("button", { name: "player.transport.loading" });
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("isBuffering=false: play/pause button does not have aria-busy attribute", () => {
+    render(<TransportControls {...defaultProps} isBuffering={false} />);
+    const btn = screen.getByRole("button", { name: "player.transport.play" });
+    expect(btn.getAttribute("aria-busy")).toBeNull();
+  });
 });

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.test.tsx
@@ -131,4 +131,27 @@ describe("TransportControls", () => {
       true,
     );
   });
+
+  it("isBuffering=true: play/pause button shows spinner icon", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    const btn = screen.getByRole("button", { name: "player.transport.loading" });
+    const icon = btn.querySelector("[data-icon='spinner']");
+    expect(icon).not.toBeNull();
+  });
+
+  it("isBuffering=true: play/pause button has loading aria-label", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    expect(screen.getByRole("button", { name: "player.transport.loading" })).not.toBeNull();
+  });
+
+  it("isBuffering=true: play/pause button is still enabled (not disabled)", () => {
+    render(<TransportControls {...defaultProps} isBuffering={true} />);
+    const btn = screen.getByRole("button", { name: "player.transport.loading" });
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("isBuffering=false: shows play or pause as before", () => {
+    render(<TransportControls {...defaultProps} isBuffering={false} isPlaying={false} />);
+    expect(screen.getByRole("button", { name: "player.transport.play" })).not.toBeNull();
+  });
 });

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -5,6 +5,7 @@ import {
   faPlay,
   faRepeat,
   faShuffle,
+  faSpinner,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC } from "react";
@@ -25,6 +26,7 @@ export interface TransportControlsProps {
   onRepeatCycle: () => void;
   isPrevDisabled?: boolean;
   isNextDisabled?: boolean;
+  isBuffering?: boolean;
   size?: "default" | "large";
   className?: string;
 }
@@ -41,6 +43,7 @@ export const TransportControls: FC<TransportControlsProps> = ({
   onRepeatCycle,
   isPrevDisabled = false,
   isNextDisabled = false,
+  isBuffering = false,
   size,
   className,
 }) => {
@@ -101,7 +104,13 @@ export const TransportControls: FC<TransportControlsProps> = ({
 
       <button
         type="button"
-        aria-label={isPlaying ? t("player.transport.pause") : t("player.transport.play")}
+        aria-label={
+          isBuffering
+            ? t("player.transport.loading")
+            : isPlaying
+              ? t("player.transport.pause")
+              : t("player.transport.play")
+        }
         aria-pressed={isPlaying}
         disabled={allDisabled}
         aria-disabled={allDisabled || undefined}
@@ -112,7 +121,10 @@ export const TransportControls: FC<TransportControlsProps> = ({
           allDisabled && "cursor-not-allowed opacity-40",
         )}
       >
-        <FontAwesomeIcon icon={isPlaying ? faPause : faPlay} className={iconSize} />
+        <FontAwesomeIcon
+          icon={isBuffering ? faSpinner : isPlaying ? faPause : faPlay}
+          className={cn(iconSize, isBuffering && "animate-spin")}
+        />
       </button>
 
       <button

--- a/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
+++ b/apps/frontend/src/components/molecules/TransportControls/TransportControls.tsx
@@ -112,6 +112,7 @@ export const TransportControls: FC<TransportControlsProps> = ({
               : t("player.transport.play")
         }
         aria-pressed={isPlaying}
+        aria-busy={isBuffering || undefined}
         disabled={allDisabled}
         aria-disabled={allDisabled || undefined}
         onClick={onPlayPause}

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -805,6 +805,65 @@ describe("mobile chevron affordance", () => {
 });
 
 // ---------------------------------------------------------------------------
+// B3 — persisted volume/mute not applied to audio element on mount
+// ---------------------------------------------------------------------------
+
+describe("B3 — persisted volume/mute applied on mount", () => {
+  it("B3-1: audio element gets store volume and muted on mount", () => {
+    usePlayerStore.setState({ volume: 0.3, isMuted: true });
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    expect(audio.volume).toBe(0.3);
+    expect(audio.muted).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E4 — autoplay rejection swallowed, isPlaying lies
+// ---------------------------------------------------------------------------
+
+describe("E4 — autoplay NotAllowedError sets isPlaying false", () => {
+  it("E4-1: NotAllowedError rejection sets isPlaying to false", async () => {
+    const notAllowed = Object.assign(new Error("NotAllowedError"), { name: "NotAllowedError" });
+    const mockPlay = vi.fn().mockRejectedValue(notAllowed);
+    HTMLMediaElement.prototype.play = mockPlay;
+
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    await act(async () => {
+      render(<GlobalPlayerBar />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("E4-2: AbortError rejection leaves isPlaying true", async () => {
+    const abortError = Object.assign(new Error("AbortError"), { name: "AbortError" });
+    const mockPlay = vi.fn().mockRejectedValue(abortError);
+    HTMLMediaElement.prototype.play = mockPlay;
+
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+
+    await act(async () => {
+      render(<GlobalPlayerBar />);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // mobile now-playing trigger (Tasks 2 / S2 / S6)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -967,3 +967,66 @@ describe("mobile now-playing trigger", () => {
     expect(document.activeElement).toBe(btn);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Resume playback position on reload
+// ---------------------------------------------------------------------------
+
+describe("resume playback position on reload", () => {
+  it("seeks audio to persisted currentTime on first loadedmetadata", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 42,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+
+    expect(audio.currentTime).toBe(42);
+  });
+
+  it("does NOT re-seek on subsequent loadedmetadata events (one-shot guard)", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 42,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+    expect(audio.currentTime).toBe(42);
+
+    audio.currentTime = 10;
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+    expect(audio.currentTime).toBe(10);
+  });
+
+  it("does NOT seek when persisted currentTime is 0", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a")],
+      currentIndex: 0,
+      currentTime: 0,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    audio.currentTime = 0;
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+
+    expect(audio.currentTime).toBe(0);
+  });
+});

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -404,8 +404,8 @@ describe("keyboard space toggle", () => {
     const playBtn = screen.getByRole("button", { name: "Play" });
     fireEvent.keyDown(playBtn, { key: " " });
 
-    // The region onKeyDown should be a no-op when target is BUTTON
-    // so isPlaying remains unchanged from before the keyDown
+    // The global shortcut hook ignores BUTTON targets (native activation
+    // handles Space there), so the keydown does not toggle play.
     expect(usePlayerStore.getState().isPlaying).toBe(false);
   });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -969,6 +969,56 @@ describe("mobile now-playing trigger", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Element→store play/pause bridge
+// ---------------------------------------------------------------------------
+
+describe("element→store play/pause bridge", () => {
+  it("dispatching 'pause' event with el.ended=false sets store isPlaying to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    Object.defineProperty(audio, "ended", { value: false, configurable: true });
+
+    act(() => {
+      fireEvent(audio, new Event("pause"));
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("dispatching 'pause' event with el.ended=true does NOT change isPlaying (end-of-track guard)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    Object.defineProperty(audio, "ended", { value: true, configurable: true });
+
+    act(() => {
+      fireEvent(audio, new Event("pause"));
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("dispatching 'play' event sets store isPlaying to true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    act(() => {
+      fireEvent(audio, new Event("play"));
+    });
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Resume playback position on reload
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -1079,4 +1079,23 @@ describe("resume playback position on reload", () => {
 
     expect(audio.currentTime).toBe(0);
   });
+
+  it("does NOT seek when currentIndex changed before loadedmetadata fires", () => {
+    usePlayerStore.setState({
+      queue: [makeItem("a"), makeItem("b")],
+      currentIndex: 0,
+      currentTime: 42,
+    });
+
+    const { container } = render(<GlobalPlayerBar />);
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+
+    usePlayerStore.setState({ currentIndex: 1 });
+
+    act(() => {
+      fireEvent(audio, new Event("loadedmetadata"));
+    });
+
+    expect(audio.currentTime).not.toBe(42);
+  });
 });

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -782,6 +782,50 @@ describe("isAtFirst / isAtLast with modes", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Buffering audio events — waiting/playing/canplay
+// ---------------------------------------------------------------------------
+
+describe("buffering audio events", () => {
+  it("dispatching 'waiting' event on audio element sets store isBuffering to true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("waiting"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(true);
+  });
+
+  it("dispatching 'playing' event on audio element sets store isBuffering to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("playing"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("dispatching 'canplay' event on audio element sets store isBuffering to false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    const { container } = render(<GlobalPlayerBar />);
+
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("canplay"));
+    });
+
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // mobile chevron affordance (Item 3 / S3-chevron)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -5,7 +5,7 @@ import {
   faVolumeXmark,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useEffect, useMemo, useRef } from "react";
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
@@ -95,6 +95,11 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [audioEl, setAudioEl] = useState<HTMLAudioElement | null>(null);
+  const registerAudioEl = useCallback((el: HTMLAudioElement | null) => {
+    audioRef.current = el;
+    setAudioEl(el);
+  }, []);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
   const seekRestoredRef = useRef(false);
@@ -149,7 +154,7 @@ export const GlobalPlayerBar: FC = () => {
     }),
     [next, prev, seek],
   );
-  useMediaSession(currentItem, isPlaying, mediaSessionActions);
+  useMediaSession(currentItem, isPlaying, mediaSessionActions, audioEl);
   useGlobalPlayerShortcuts();
   useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
   useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
@@ -270,7 +275,12 @@ export const GlobalPlayerBar: FC = () => {
 
   return (
     <>
-      <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
+      <audio
+        ref={registerAudioEl}
+        aria-label="Audio player"
+        preload="metadata"
+        className="hidden"
+      />
       <QueueSidePanel />
       <NowPlayingFullscreen />
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -136,6 +136,8 @@ export const GlobalPlayerBar: FC = () => {
   const _onError = usePlayerStore((s) => s._onError);
   const _onWaiting = usePlayerStore((s) => s._onWaiting);
   const _onCanPlay = usePlayerStore((s) => s._onCanPlay);
+  const _onPlay = usePlayerStore((s) => s._onPlay);
+  const _onPause = usePlayerStore((s) => s._onPause);
   const isBuffering = usePlayerStore((s) => s.isBuffering);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
@@ -183,6 +185,10 @@ export const GlobalPlayerBar: FC = () => {
     const onStalled = () => _onWaiting();
     const onPlaying = () => _onCanPlay();
     const onCanPlay = () => _onCanPlay();
+    const onPlay = () => _onPlay();
+    const onPause = () => {
+      if (!el.ended) _onPause();
+    };
 
     el.addEventListener("timeupdate", onTimeUpdate);
     el.addEventListener("loadedmetadata", onLoadedMetadata);
@@ -192,6 +198,8 @@ export const GlobalPlayerBar: FC = () => {
     el.addEventListener("stalled", onStalled);
     el.addEventListener("playing", onPlaying);
     el.addEventListener("canplay", onCanPlay);
+    el.addEventListener("play", onPlay);
+    el.addEventListener("pause", onPause);
 
     return () => {
       el.removeEventListener("timeupdate", onTimeUpdate);
@@ -202,8 +210,19 @@ export const GlobalPlayerBar: FC = () => {
       el.removeEventListener("stalled", onStalled);
       el.removeEventListener("playing", onPlaying);
       el.removeEventListener("canplay", onCanPlay);
+      el.removeEventListener("play", onPlay);
+      el.removeEventListener("pause", onPause);
     };
-  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError, _onWaiting, _onCanPlay]);
+  }, [
+    _onTimeUpdate,
+    _onLoadedMetadata,
+    _onEnded,
+    _onError,
+    _onWaiting,
+    _onCanPlay,
+    _onPlay,
+    _onPause,
+  ]);
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -111,6 +111,9 @@ export const GlobalPlayerBar: FC = () => {
   const shuffleMode = usePlayerStore((s) => s.shuffleMode);
   const repeatMode = usePlayerStore((s) => s.repeatMode);
 
+  const volume = usePlayerStore((s) => s.volume);
+  const isMuted = usePlayerStore((s) => s.isMuted);
+
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
@@ -181,6 +184,13 @@ export const GlobalPlayerBar: FC = () => {
 
   useEffect(() => {
     const el = audioRef.current;
+    if (!el) return;
+    el.volume = volume;
+    el.muted = isMuted;
+  }, [volume, isMuted]);
+
+  useEffect(() => {
+    const el = audioRef.current;
     if (!el || !currentItem) return;
     if (el.src !== currentItem.audioUrl) {
       el.src = currentItem.audioUrl;
@@ -193,7 +203,11 @@ export const GlobalPlayerBar: FC = () => {
     if (isPlaying) {
       const playPromise = el.play();
       if (playPromise && typeof playPromise.catch === "function") {
-        void playPromise.catch(() => {});
+        void playPromise.catch((err: { name?: string } | null) => {
+          if (err?.name === "NotAllowedError") {
+            usePlayerStore.setState({ isPlaying: false });
+          }
+        });
       }
     } else {
       el.pause();

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -9,6 +9,7 @@ import { FC, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
+import { useGlobalPlayerShortcuts } from "@/hooks/useGlobalPlayerShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
 import { usePlayerStore } from "@/store/usePlayerStore";
 import type { QueueItem } from "@/store/usePlayerStore";
@@ -149,6 +150,7 @@ export const GlobalPlayerBar: FC = () => {
     [next, prev, seek],
   );
   useMediaSession(currentItem, isPlaying, mediaSessionActions);
+  useGlobalPlayerShortcuts();
   useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
   useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
 
@@ -266,14 +268,6 @@ export const GlobalPlayerBar: FC = () => {
     repeatMode !== "all" &&
     (currentIndex === null || currentIndex >= queue.length - 1);
 
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key !== " ") return;
-    const tag = (e.target as HTMLElement).tagName;
-    if (tag === "BUTTON" || tag === "INPUT") return;
-    e.preventDefault();
-    togglePlay();
-  };
-
   return (
     <>
       <audio ref={audioRef} aria-label="Audio player" preload="metadata" className="hidden" />
@@ -284,7 +278,6 @@ export const GlobalPlayerBar: FC = () => {
         <section
           role="region"
           aria-label="Now playing"
-          onKeyDown={onKeyDown}
           className={cn(
             "bg-black",
             "fixed right-0 bottom-[calc(4rem+env(safe-area-inset-bottom))] left-0 z-40 transition-[left] duration-300 md:bottom-0",

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -127,6 +127,9 @@ export const GlobalPlayerBar: FC = () => {
   const _onTimeUpdate = usePlayerStore((s) => s._onTimeUpdate);
   const _onEnded = usePlayerStore((s) => s._onEnded);
   const _onError = usePlayerStore((s) => s._onError);
+  const _onWaiting = usePlayerStore((s) => s._onWaiting);
+  const _onCanPlay = usePlayerStore((s) => s._onCanPlay);
+  const isBuffering = usePlayerStore((s) => s.isBuffering);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
@@ -168,19 +171,31 @@ export const GlobalPlayerBar: FC = () => {
       const msg = el.error?.message ?? "Playback error";
       _onError(msg);
     };
+    const onWaiting = () => _onWaiting();
+    const onStalled = () => _onWaiting();
+    const onPlaying = () => _onCanPlay();
+    const onCanPlay = () => _onCanPlay();
 
     el.addEventListener("timeupdate", onTimeUpdate);
     el.addEventListener("loadedmetadata", onLoadedMetadata);
     el.addEventListener("ended", onEnded);
     el.addEventListener("error", onError);
+    el.addEventListener("waiting", onWaiting);
+    el.addEventListener("stalled", onStalled);
+    el.addEventListener("playing", onPlaying);
+    el.addEventListener("canplay", onCanPlay);
 
     return () => {
       el.removeEventListener("timeupdate", onTimeUpdate);
       el.removeEventListener("loadedmetadata", onLoadedMetadata);
       el.removeEventListener("ended", onEnded);
       el.removeEventListener("error", onError);
+      el.removeEventListener("waiting", onWaiting);
+      el.removeEventListener("stalled", onStalled);
+      el.removeEventListener("playing", onPlaying);
+      el.removeEventListener("canplay", onCanPlay);
     };
-  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError]);
+  }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError, _onWaiting, _onCanPlay]);
 
   useEffect(() => {
     const el = audioRef.current;
@@ -313,6 +328,7 @@ export const GlobalPlayerBar: FC = () => {
                   onRepeatCycle={cycleRepeat}
                   isPrevDisabled={isAtFirst}
                   isNextDisabled={isAtLast}
+                  isBuffering={isBuffering}
                 />
 
                 <button

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -229,9 +229,15 @@ export const GlobalPlayerBar: FC = () => {
     if (!el || !currentItem) return;
     const startAt = usePlayerStore.getState().currentTime;
     if (startAt <= 0) return;
+    const restoreIndex = usePlayerStore.getState().currentIndex;
 
     const onFirstMetadata = () => {
       if (!seekRestoredRef.current) {
+        if (usePlayerStore.getState().currentIndex !== restoreIndex) {
+          seekRestoredRef.current = true;
+          el.removeEventListener("loadedmetadata", onFirstMetadata);
+          return;
+        }
         el.currentTime = startAt;
         seekRestoredRef.current = true;
       }
@@ -267,7 +273,7 @@ export const GlobalPlayerBar: FC = () => {
       if (playPromise && typeof playPromise.catch === "function") {
         void playPromise.catch((err: { name?: string } | null) => {
           if (err?.name === "NotAllowedError") {
-            usePlayerStore.setState({ isPlaying: false });
+            usePlayerStore.getState()._onPause();
           }
         });
       }

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -96,6 +96,7 @@ export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const nowPlayingTriggerRef = useRef<HTMLButtonElement>(null);
+  const seekRestoredRef = useRef(false);
   const navigate = useNavigate();
   const { t } = useTranslation();
   const isSidebarCollapsed = usePreferencesStore((s) => s.isSidebarCollapsed);
@@ -196,6 +197,26 @@ export const GlobalPlayerBar: FC = () => {
       el.removeEventListener("canplay", onCanPlay);
     };
   }, [_onTimeUpdate, _onLoadedMetadata, _onEnded, _onError, _onWaiting, _onCanPlay]);
+
+  useEffect(() => {
+    const el = audioRef.current;
+    if (!el || !currentItem) return;
+    const startAt = usePlayerStore.getState().currentTime;
+    if (startAt <= 0) return;
+
+    const onFirstMetadata = () => {
+      if (!seekRestoredRef.current) {
+        el.currentTime = startAt;
+        seekRestoredRef.current = true;
+      }
+      el.removeEventListener("loadedmetadata", onFirstMetadata);
+    };
+
+    el.addEventListener("loadedmetadata", onFirstMetadata);
+    return () => {
+      el.removeEventListener("loadedmetadata", onFirstMetadata);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
+++ b/apps/frontend/src/components/organisms/NowPlayingFullscreen.tsx
@@ -29,6 +29,7 @@ export const NowPlayingFullscreen: FC = () => {
   const reorderQueue = usePlayerStore((s) => s.reorderQueue);
   const currentTime = usePlayerStore((s) => s.currentTime);
   const duration = usePlayerStore((s) => s.duration);
+  const isBuffering = usePlayerStore((s) => s.isBuffering);
 
   const currentItem = currentIndex !== null ? (queue[currentIndex] ?? null) : null;
 
@@ -203,6 +204,7 @@ export const NowPlayingFullscreen: FC = () => {
           onNext={next}
           onShuffleToggle={toggleShuffle}
           onRepeatCycle={cycleRepeat}
+          isBuffering={isBuffering}
         />
       </div>
 

--- a/apps/frontend/src/components/organisms/Playlist.tsx
+++ b/apps/frontend/src/components/organisms/Playlist.tsx
@@ -38,7 +38,7 @@ interface PlaylistProps {
   onRetryFailed: () => void;
   onToggleSubscription: () => void;
   onDownloadOrRetry: () => void;
-  onShufflePlay?: () => void;
+  onToggleShuffle?: () => void;
   isShuffleActive?: boolean;
   mode?: PlaylistMode;
 }
@@ -70,7 +70,7 @@ export const Playlist: FC<PlaylistProps> = ({
   onRetryFailed,
   onToggleSubscription,
   onDownloadOrRetry,
-  onShufflePlay,
+  onToggleShuffle,
   isShuffleActive = false,
   mode = "managed",
 }) => {
@@ -135,7 +135,7 @@ export const Playlist: FC<PlaylistProps> = ({
               onRetryFailed={onRetryFailed}
               onDelete={handleDelete}
               onDownload={onDownloadOrRetry}
-              onShufflePlay={onShufflePlay}
+              onToggleShuffle={onToggleShuffle}
               isShuffleActive={isShuffleActive}
               spotifyUrl={
                 playlist?.spotifyUrl && !playlist.spotifyUrl.startsWith("spotiarr://")

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.test.tsx
@@ -5,14 +5,29 @@ import { describe, expect, it, vi } from "vitest";
 import { Path } from "@/routes/routes";
 import { useLibraryAlbumDetailController } from "./useLibraryAlbumDetailController";
 
-const { mockUseParams, mockUseLibraryArtistQuery, mockPlayQueue, mockSetState } = vi.hoisted(
-  () => ({
+const {
+  mockUseParams,
+  mockUseLibraryArtistQuery,
+  mockPlayQueue,
+  mockToggleShuffle,
+  mockTogglePlay,
+  mockStoreState,
+} = vi.hoisted(() => {
+  const storeState = {
+    isPlaying: false,
+    currentIndex: null as number | null,
+    queue: [] as Array<{ id: string; contextPath?: string }>,
+    shuffleMode: false,
+  };
+  return {
     mockUseParams: vi.fn(),
     mockUseLibraryArtistQuery: vi.fn(),
     mockPlayQueue: vi.fn(),
-    mockSetState: vi.fn(),
-  }),
-);
+    mockToggleShuffle: vi.fn(),
+    mockTogglePlay: vi.fn(),
+    mockStoreState: storeState,
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -34,14 +49,18 @@ vi.mock("@/store/usePlayerStore", () => ({
         selector: (state: {
           isPlaying: boolean;
           currentIndex: number | null;
-          queue: Array<{ id: string }>;
+          queue: Array<{ id: string; contextPath?: string }>;
           shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
+      ) => selector(mockStoreState),
     ),
     {
-      getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
-      setState: mockSetState,
+      getState: vi.fn(() => ({
+        playQueue: mockPlayQueue,
+        togglePlay: mockTogglePlay,
+        toggleShuffle: mockToggleShuffle,
+        shuffleMode: mockStoreState.shuffleMode,
+      })),
     },
   ),
 }));
@@ -92,18 +111,18 @@ const makeArtist = (): LibraryArtist => ({
   ],
 });
 
+const setupParams = () => {
+  mockUseParams.mockReturnValue({ name: "Sigur%20R%C3%B3s", albumName: "%28%20%29" });
+  mockUseLibraryArtistQuery.mockReturnValue({ data: makeArtist(), isLoading: false, error: null });
+  mockStoreState.isPlaying = false;
+  mockStoreState.currentIndex = null;
+  mockStoreState.queue = [];
+  mockStoreState.shuffleMode = false;
+};
+
 describe("useLibraryAlbumDetailController", () => {
   it("decodes params, resolves album and maps tracks to AlbumPageLayout shape", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
@@ -165,17 +184,7 @@ describe("useLibraryAlbumDetailController", () => {
   });
 
   it("dispatches playQueue to usePlayerStore with normalized QueueItems when onPlayTrack is called", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -194,7 +203,6 @@ describe("useLibraryAlbumDetailController", () => {
     expect(startIndex).toBe(1);
     expect(items).toHaveLength(2);
 
-    // audioUrl is normalized from track.trackUrl
     expect(items[0]!.audioUrl).toBe(
       `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent("/tmp/01.mp3")}`,
     );
@@ -202,23 +210,12 @@ describe("useLibraryAlbumDetailController", () => {
       `${ApiRoutes.BASE}${ApiRoutes.LIBRARY}/audio?path=${encodeURIComponent("/tmp/02.mp3")}`,
     );
 
-    // QueueItem fields
     expect(items[0]!.name).toBe("Vaka");
     expect(items[0]!.artist).toBe("Sigur Rós");
   });
 
   it("dispatches playQueue starting at index 0 when onPlayPlaylist is called with no current track", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -232,19 +229,54 @@ describe("useLibraryAlbumDetailController", () => {
     expect(startIndex).toBe(0);
   });
 
+  it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
+    setupParams();
+    const albumContextPath = generatePath(Path.LIBRARY_ALBUM, {
+      name: "Sigur Rós",
+      albumName: "( )",
+    });
+    mockStoreState.queue = [
+      { id: "Sigur Rós-( )-0", contextPath: albumContextPath },
+      { id: "Sigur Rós-( )-1", contextPath: albumContextPath },
+    ];
+    mockStoreState.isPlaying = true;
+    mockPlayQueue.mockClear();
+    mockTogglePlay.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockTogglePlay).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("onPlayPlaylist calls playQueue at random index when isActiveContext is false and shuffleMode is on", () => {
+    setupParams();
+    mockStoreState.shuffleMode = true;
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    // Math.floor(0.5 * 2) = 1 (2 tracks)
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(1);
+
+    vi.restoreAllMocks();
+    mockStoreState.shuffleMode = false;
+  });
+
   // T1.3 — artworkUrl regression: library album controller is unaffected
   it("[T1.3] dispatched QueueItems carry artworkUrl equal to coverUrl", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -260,7 +292,6 @@ describe("useLibraryAlbumDetailController", () => {
       number,
     ];
 
-    // All items should carry artworkUrl equal to the album's coverUrl
     const expectedCoverUrl = result.current.coverUrl;
     items.forEach((item) => {
       expect(item.artworkUrl).toBe(expectedCoverUrl);
@@ -269,17 +300,7 @@ describe("useLibraryAlbumDetailController", () => {
 
   // T2.4 — contextPath on library album queue items
   it("[T2.4] every dispatched QueueItem carries contextPath equal to the library album route", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
+    setupParams();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
@@ -305,108 +326,87 @@ describe("useLibraryAlbumDetailController", () => {
     });
   });
 
-  it("exposes onShufflePlay and isShuffleActive in return value", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+  it("exposes onToggleShuffle and isShuffleActive in return value", () => {
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
-    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.onToggleShuffle).toBe("function");
     expect(typeof result.current.isShuffleActive).toBe("boolean");
   });
 
-  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
-
-    mockSetState.mockClear();
+  it("onToggleShuffle calls toggleShuffle without starting playback", () => {
+    setupParams();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
-
-    const callOrder: string[] = [];
-    mockSetState.mockImplementation(() => {
-      callOrder.push("setState");
-    });
-    mockPlayQueue.mockImplementation(() => {
-      callOrder.push("playQueue");
-    });
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
-    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
-    expect(callOrder[0]).toBe("setState");
-    expect(callOrder[1]).toBe("playQueue");
+    expect(mockToggleShuffle).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
-  it("onShufflePlay is a no-op when hasPlayableTracks is false", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "missing",
-    });
+  it("onToggleShuffle is a no-op when hasPlayableTracks is false", () => {
+    mockUseParams.mockReturnValue({ name: "Sigur%20R%C3%B3s", albumName: "missing" });
     mockUseLibraryArtistQuery.mockReturnValue({
       data: makeArtist(),
       isLoading: false,
       error: null,
     });
-
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockToggleShuffle).not.toHaveBeenCalled();
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
   it("isShuffleActive is false when store shuffleMode is false", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
-    });
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 
     expect(result.current.isShuffleActive).toBe(false);
   });
 
-  it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
-    mockUseParams.mockReturnValue({
-      name: "Sigur%20R%C3%B3s",
-      albumName: "%28%20%29",
-    });
+  it("isPlaying exposed is false when isActiveContext is false even if store isPlaying is true", () => {
+    setupParams();
+    mockStoreState.isPlaying = true;
+    mockStoreState.queue = [];
 
-    mockUseLibraryArtistQuery.mockReturnValue({
-      data: makeArtist(),
-      isLoading: false,
-      error: null,
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
+    setupParams();
+    const albumContextPath = generatePath(Path.LIBRARY_ALBUM, {
+      name: "Sigur Rós",
+      albumName: "( )",
     });
+    mockStoreState.queue = [
+      { id: "Sigur Rós-( )-0", contextPath: albumContextPath },
+      { id: "Sigur Rós-( )-1", contextPath: albumContextPath },
+    ];
+    mockStoreState.isPlaying = true;
+
+    const { result } = renderHook(() => useLibraryAlbumDetailController());
+
+    expect(result.current.isPlaying).toBe(true);
+  });
+
+  it("does not expose audioRef, audioSrc, or playbackError in return shape", () => {
+    setupParams();
 
     const { result } = renderHook(() => useLibraryAlbumDetailController());
 

--- a/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/useLibraryAlbumDetailController.ts
@@ -71,9 +71,9 @@ export const useLibraryAlbumDetailController = () => {
   }, [album, artistName, coverUrl, selectedAlbumName]);
 
   const {
-    currentIndex,
     currentTrackId,
-    isPlaying,
+    isPlaying: globalIsPlaying,
+    isActiveContext,
     hasPlayableTracks,
     playFromIndex,
     onPlayTrack,
@@ -84,14 +84,20 @@ export const useLibraryAlbumDetailController = () => {
 
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
-    playFromIndex(currentIndex ?? 0);
-  }, [currentIndex, hasPlayableTracks, playFromIndex]);
+    if (isActiveContext) {
+      usePlayerStore.getState().togglePlay();
+      return;
+    }
+    const len = queueItems.length;
+    const startIndex =
+      usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
+    playFromIndex(startIndex);
+  }, [hasPlayableTracks, isActiveContext, queueItems, playFromIndex]);
 
-  const onShufflePlay = useCallback(() => {
+  const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;
-    usePlayerStore.setState({ shuffleMode: true });
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    usePlayerStore.getState().toggleShuffle();
+  }, [hasPlayableTracks]);
 
   const backToArtistPath = generatePath(Path.LIBRARY_ARTIST, {
     name: artistName,
@@ -109,13 +115,13 @@ export const useLibraryAlbumDetailController = () => {
     playlistType: PlaylistTypeEnum.Album,
     backToArtistPath,
     currentTrackId,
-    isPlaying,
+    isPlaying: isActiveContext && globalIsPlaying,
     onPlayTrack,
     onPauseTrack,
     hasPlayableTracks,
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
   };
 };

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.test.ts
@@ -12,16 +12,30 @@ const {
   mockUsePlaylistController,
   mockPlayQueue,
   mockSetState,
-} = vi.hoisted(() => ({
-  mockUseParams: vi.fn(),
-  mockUseSearchParams: vi.fn(),
-  mockUsePlaylistsQuery: vi.fn(),
-  mockUseTracksQuery: vi.fn(),
-  mockUseNavigationHelpers: vi.fn(),
-  mockUsePlaylistController: vi.fn(),
-  mockPlayQueue: vi.fn(),
-  mockSetState: vi.fn(),
-}));
+  mockToggleShuffle,
+  mockTogglePlay,
+  mockStoreState,
+} = vi.hoisted(() => {
+  const storeState = {
+    isPlaying: false,
+    currentIndex: null as number | null,
+    queue: [] as Array<{ id: string; contextPath?: string }>,
+    shuffleMode: false,
+  };
+  return {
+    mockUseParams: vi.fn(),
+    mockUseSearchParams: vi.fn(),
+    mockUsePlaylistsQuery: vi.fn(),
+    mockUseTracksQuery: vi.fn(),
+    mockUseNavigationHelpers: vi.fn(),
+    mockUsePlaylistController: vi.fn(),
+    mockPlayQueue: vi.fn(),
+    mockSetState: vi.fn(),
+    mockToggleShuffle: vi.fn(),
+    mockTogglePlay: vi.fn(),
+    mockStoreState: storeState,
+  };
+});
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -56,13 +70,18 @@ vi.mock("@/store/usePlayerStore", () => ({
         selector: (state: {
           isPlaying: boolean;
           currentIndex: number | null;
-          queue: Array<{ id: string }>;
+          queue: Array<{ id: string; contextPath?: string }>;
           shuffleMode: boolean;
         }) => unknown,
-      ) => selector({ isPlaying: false, currentIndex: null, queue: [], shuffleMode: false }),
+      ) => selector(mockStoreState),
     ),
     {
-      getState: vi.fn(() => ({ playQueue: mockPlayQueue, togglePlay: vi.fn() })),
+      getState: vi.fn(() => ({
+        playQueue: mockPlayQueue,
+        togglePlay: mockTogglePlay,
+        toggleShuffle: mockToggleShuffle,
+        shuffleMode: mockStoreState.shuffleMode,
+      })),
       setState: mockSetState,
     },
   ),
@@ -147,6 +166,10 @@ const setupDefaults = (mode = "managed") => {
   mockUsePlaylistsQuery.mockReturnValue({ data: [playlist], isLoading: false });
   mockUseTracksQuery.mockReturnValue({ data: tracks, isLoading: false });
   mockUsePlaylistController.mockReturnValue(defaultPlaylistController);
+  mockStoreState.isPlaying = false;
+  mockStoreState.currentIndex = null;
+  mockStoreState.queue = [];
+  mockStoreState.shuffleMode = false;
 };
 
 describe("usePlaylistDetailController", () => {
@@ -273,6 +296,86 @@ describe("usePlaylistDetailController", () => {
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
+  it("onPlayPlaylist calls togglePlay when isActiveContext is true", () => {
+    setupDefaults("library");
+    mockStoreState.queue = [
+      { id: "track-2", contextPath: "/playlist/playlist-1?mode=library" },
+      { id: "track-3", contextPath: "/playlist/playlist-1?mode=library" },
+    ];
+    mockStoreState.isPlaying = true;
+    mockPlayQueue.mockClear();
+    mockTogglePlay.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockTogglePlay).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
+  });
+
+  it("onPlayPlaylist calls playQueue at index 0 when isActiveContext is false and shuffleMode is off", () => {
+    setupDefaults("library");
+    mockStoreState.shuffleMode = false;
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(0);
+  });
+
+  it("onPlayPlaylist calls playQueue at random index when isActiveContext is false and shuffleMode is on", () => {
+    setupDefaults("library");
+    mockStoreState.shuffleMode = true;
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    mockPlayQueue.mockClear();
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    act(() => {
+      result.current.onPlayPlaylist();
+    });
+
+    // Math.floor(0.5 * 2) = 1 (2 playable tracks)
+    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
+    const [, startIndex] = mockPlayQueue.mock.calls[0] as [unknown[], number];
+    expect(startIndex).toBe(1);
+
+    vi.restoreAllMocks();
+    mockStoreState.shuffleMode = false;
+  });
+
+  it("isPlaying exposed is false when isActiveContext is false even if store isPlaying is true", () => {
+    setupDefaults("library");
+    mockStoreState.isPlaying = true;
+    mockStoreState.queue = []; // different queue → isActiveContext false
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(result.current.isPlaying).toBe(false);
+  });
+
+  it("isPlaying exposed is true when isActiveContext is true and store isPlaying is true", () => {
+    setupDefaults("library");
+    mockStoreState.queue = [
+      { id: "track-2", contextPath: "/playlist/playlist-1?mode=library" },
+      { id: "track-3", contextPath: "/playlist/playlist-1?mode=library" },
+    ];
+    mockStoreState.isPlaying = true;
+
+    const { result } = renderHook(() => usePlaylistDetailController());
+
+    expect(result.current.isPlaying).toBe(true);
+  });
+
   // T1.1 — artworkUrl resolution
   it("[T1.1-A] uses track.albumCoverUrl when present", () => {
     setupDefaults("library");
@@ -339,52 +442,42 @@ describe("usePlaylistDetailController", () => {
   });
 
   // T2.2 — contextPath on playlist queue items
-  it("exposes onShufflePlay and isShuffleActive in return value", () => {
+  it("exposes onToggleShuffle and isShuffleActive in return value", () => {
     setupDefaults("library");
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
-    expect(typeof result.current.onShufflePlay).toBe("function");
+    expect(typeof result.current.onToggleShuffle).toBe("function");
     expect(typeof result.current.isShuffleActive).toBe("boolean");
   });
 
-  it("onShufflePlay calls setState({shuffleMode:true}) BEFORE playFromIndex(0)", () => {
+  it("onToggleShuffle calls toggleShuffle without starting playback", () => {
     setupDefaults("library");
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
-
-    const callOrder: string[] = [];
-    mockSetState.mockImplementation(() => {
-      callOrder.push("setState");
-    });
-    mockPlayQueue.mockImplementation(() => {
-      callOrder.push("playQueue");
-    });
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).toHaveBeenCalledWith({ shuffleMode: true });
-    expect(mockPlayQueue).toHaveBeenCalledTimes(1);
-    expect(callOrder[0]).toBe("setState");
-    expect(callOrder[1]).toBe("playQueue");
+    expect(mockToggleShuffle).toHaveBeenCalledTimes(1);
+    expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 
-  it("onShufflePlay is a no-op when !hasPlayableTracks (managed mode)", () => {
+  it("onToggleShuffle is a no-op when hasPlayableTracks is false", () => {
     setupDefaults("managed");
-    mockSetState.mockClear();
+    mockToggleShuffle.mockClear();
     mockPlayQueue.mockClear();
 
     const { result } = renderHook(() => usePlaylistDetailController());
 
     act(() => {
-      result.current.onShufflePlay();
+      result.current.onToggleShuffle();
     });
 
-    expect(mockSetState).not.toHaveBeenCalled();
+    expect(mockToggleShuffle).not.toHaveBeenCalled();
     expect(mockPlayQueue).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
+++ b/apps/frontend/src/hooks/controllers/usePlaylistDetailController.ts
@@ -37,21 +37,34 @@ export const usePlaylistDetailController = () => {
       }));
   }, [mode, tracks, playlist, id]);
 
-  const { currentTrackId, isPlaying, hasPlayableTracks, playFromIndex, onPlayTrack, onPauseTrack } =
-    usePlayerQueueBinding(queueItems);
+  const {
+    currentTrackId,
+    isPlaying: globalIsPlaying,
+    isActiveContext,
+    hasPlayableTracks,
+    playFromIndex,
+    onPlayTrack,
+    onPauseTrack,
+  } = usePlayerQueueBinding(queueItems);
 
   const isShuffleActive = usePlayerStore((s) => s.shuffleMode);
 
   const onPlayPlaylist = useCallback(() => {
     if (!hasPlayableTracks) return;
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    if (isActiveContext) {
+      usePlayerStore.getState().togglePlay();
+      return;
+    }
+    const len = queueItems.length;
+    const startIndex =
+      usePlayerStore.getState().shuffleMode && len > 0 ? Math.floor(Math.random() * len) : 0;
+    playFromIndex(startIndex);
+  }, [hasPlayableTracks, isActiveContext, queueItems, playFromIndex]);
 
-  const onShufflePlay = useCallback(() => {
+  const onToggleShuffle = useCallback(() => {
     if (!hasPlayableTracks) return;
-    usePlayerStore.setState({ shuffleMode: true });
-    playFromIndex(0);
-  }, [hasPlayableTracks, playFromIndex]);
+    usePlayerStore.getState().toggleShuffle();
+  }, [hasPlayableTracks]);
 
   const {
     isDownloading,
@@ -89,14 +102,14 @@ export const usePlaylistDetailController = () => {
     handleRetryTrack,
     handleGoHome,
     currentTrackId,
-    isPlaying,
+    isPlaying: isActiveContext && globalIsPlaying,
     onPlayTrack,
     onPauseTrack,
     onPlayPlaylist,
     onPausePlaylist: onPauseTrack,
     hasPlayableTracks,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
     mode,
   };
 };

--- a/apps/frontend/src/hooks/useGlobalPlayerShortcuts.test.ts
+++ b/apps/frontend/src/hooks/useGlobalPlayerShortcuts.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { useGlobalPlayerShortcuts } from "./useGlobalPlayerShortcuts";
+
+const makeItem = () => ({
+  id: "t1",
+  name: "Track",
+  artist: "Artist",
+  audioUrl: "/audio/t1.mp3",
+});
+
+function dispatch(key: string, init: KeyboardEventInit = {}) {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }));
+}
+
+beforeEach(() => {
+  usePlayerStore.setState({
+    queue: [makeItem()],
+    currentIndex: 0,
+    isPlaying: false,
+    currentTime: 20,
+    duration: 60,
+    volume: 0.5,
+    isMuted: false,
+    error: null,
+  });
+});
+
+afterEach(() => {
+  usePlayerStore.getState().clear();
+});
+
+describe("useGlobalPlayerShortcuts", () => {
+  it("Space toggles play when a track is active", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" "));
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("ArrowLeft seeks by -5 from currentTime", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowLeft"));
+    expect(usePlayerStore.getState().currentTime).toBe(15);
+  });
+
+  it("ArrowRight seeks by +5 from currentTime", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowRight"));
+    expect(usePlayerStore.getState().currentTime).toBe(25);
+  });
+
+  it("ArrowUp increases volume by 0.05", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowUp"));
+    expect(usePlayerStore.getState().volume).toBeCloseTo(0.55);
+  });
+
+  it("ArrowDown decreases volume by 0.05", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("ArrowDown"));
+    expect(usePlayerStore.getState().volume).toBeCloseTo(0.45);
+  });
+
+  it("m toggles mute", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch("m"));
+    expect(usePlayerStore.getState().isMuted).toBe(true);
+  });
+
+  it("no-op when currentIndex is null", () => {
+    usePlayerStore.getState().clear();
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" "));
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("no-op when modifier key held (metaKey + Space)", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    act(() => dispatch(" ", { metaKey: true }));
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("no-op when event target is an INPUT element", () => {
+    renderHook(() => useGlobalPlayerShortcuts());
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+    document.body.removeChild(input);
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});

--- a/apps/frontend/src/hooks/useGlobalPlayerShortcuts.ts
+++ b/apps/frontend/src/hooks/useGlobalPlayerShortcuts.ts
@@ -1,0 +1,48 @@
+import { useEffect } from "react";
+import { usePlayerStore } from "@/store/usePlayerStore";
+
+const IGNORED_TAGS = new Set(["INPUT", "TEXTAREA", "SELECT", "BUTTON", "A"]);
+
+export function useGlobalPlayerShortcuts(): void {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent): void {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      const target = e.target as HTMLElement;
+      if (IGNORED_TAGS.has(target.tagName) || target.isContentEditable) return;
+
+      const { currentIndex, currentTime, volume, togglePlay, seek, setVolume, toggleMute } =
+        usePlayerStore.getState();
+
+      if (currentIndex === null) return;
+
+      switch (e.key) {
+        case " ":
+          e.preventDefault();
+          togglePlay();
+          break;
+        case "ArrowLeft":
+          seek(currentTime - 5);
+          break;
+        case "ArrowRight":
+          seek(currentTime + 5);
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setVolume(volume + 0.05);
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setVolume(volume - 0.05);
+          break;
+        case "m":
+        case "M":
+          toggleMute();
+          break;
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+}

--- a/apps/frontend/src/hooks/useMediaSession.test.ts
+++ b/apps/frontend/src/hooks/useMediaSession.test.ts
@@ -48,10 +48,12 @@ const makeActions = (): MediaSessionActions & {
 
 function setupMediaSessionStub() {
   const setActionHandler = vi.fn();
+  const setPositionState = vi.fn();
   const stub = {
     metadata: null as unknown,
     playbackState: "none" as string,
     setActionHandler,
+    setPositionState,
   };
 
   Object.defineProperty(navigator, "mediaSession", {
@@ -85,7 +87,7 @@ function setupMediaSessionStub() {
     vi.unstubAllGlobals();
   }
 
-  return { stub, setActionHandler, restore };
+  return { stub, setActionHandler, setPositionState, restore };
 }
 
 // ---------------------------------------------------------------------------
@@ -401,6 +403,112 @@ describe("useMediaSession re-applies on the audio playing event", () => {
     // No element provided → nothing to re-apply against, must not throw.
     expect(() => {
       renderHook(() => useMediaSession(makeItem(), true, actions, null));
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.11 — applyPositionState via audio element events
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession setPositionState", () => {
+  let setPositionState: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+
+  beforeEach(() => {
+    const result = setupMediaSessionStub();
+    setPositionState = result.setPositionState;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  function makeAudioEl(duration: number, currentTime: number, playbackRate = 1): HTMLAudioElement {
+    const el = document.createElement("audio");
+    Object.defineProperty(el, "duration", { get: () => duration, configurable: true });
+    Object.defineProperty(el, "currentTime", { get: () => currentTime, configurable: true });
+    Object.defineProperty(el, "playbackRate", { get: () => playbackRate, configurable: true });
+    return el;
+  }
+
+  it("[T3.11] calls setPositionState with correct values on loadedmetadata", () => {
+    const el = makeAudioEl(300, 42, 1);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).toHaveBeenCalledOnce();
+    expect(setPositionState).toHaveBeenCalledWith({ duration: 300, playbackRate: 1, position: 42 });
+  });
+
+  it("[T3.11] does NOT call setPositionState when duration is NaN", () => {
+    const el = makeAudioEl(NaN, 0);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).not.toHaveBeenCalled();
+  });
+
+  it("[T3.11] does NOT call setPositionState when duration is Infinity", () => {
+    const el = makeAudioEl(Infinity, 0);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("loadedmetadata"));
+
+    expect(setPositionState).not.toHaveBeenCalled();
+  });
+
+  it("[T3.11] clamps position to duration when currentTime > duration", () => {
+    const el = makeAudioEl(100, 150);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("seeked"));
+
+    expect(setPositionState).toHaveBeenCalledWith({
+      duration: 100,
+      playbackRate: 1,
+      position: 100,
+    });
+  });
+
+  it("[T3.11] re-pushes position state on the playing event", () => {
+    const el = makeAudioEl(200, 60);
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setPositionState.mockClear();
+    el.dispatchEvent(new Event("playing"));
+
+    expect(setPositionState).toHaveBeenCalledWith({ duration: 200, playbackRate: 1, position: 60 });
+  });
+
+  it("[T3.11] no-op when setPositionState is absent from navigator.mediaSession", () => {
+    const el = makeAudioEl(300, 42);
+    const actions = makeActions();
+
+    // Simulate older browser: remove setPositionState from the stub
+    const ms = navigator.mediaSession as unknown as Record<string, unknown>;
+    delete ms.setPositionState;
+
+    expect(() => {
+      renderHook(() => useMediaSession(makeItem(), true, actions, el));
+      el.dispatchEvent(new Event("loadedmetadata"));
     }).not.toThrow();
   });
 });

--- a/apps/frontend/src/hooks/useMediaSession.test.ts
+++ b/apps/frontend/src/hooks/useMediaSession.test.ts
@@ -302,3 +302,105 @@ describe("useMediaSession with stubbed navigator.mediaSession", () => {
     expect(stub.metadata).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// T3.9 — iOS skips the seekto handler to preserve lock-screen prev/next
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession on iOS (seekto suppression)", () => {
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+  let originalUA: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalUA = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+    Object.defineProperty(navigator, "userAgent", {
+      value:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+      configurable: true,
+    });
+    const result = setupMediaSessionStub();
+    setActionHandler = result.setActionHandler;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+    if (originalUA) {
+      Object.defineProperty(navigator, "userAgent", originalUA);
+    }
+  });
+
+  it("[T3.9] explicitly nulls seek actions on iOS so prev/next can surface", () => {
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), false, actions));
+
+    // null != "not registered" on WebKit: each seek action must be set to null.
+    const seekCalls = (setActionHandler.mock.calls as unknown[][]).filter((call) =>
+      ["seekbackward", "seekforward", "seekto"].includes(call[0] as string),
+    );
+    expect(seekCalls).toHaveLength(3);
+    seekCalls.forEach((call) => {
+      expect(call[1]).toBeNull();
+    });
+  });
+
+  it("[T3.9] still registers previoustrack and nexttrack on iOS", () => {
+    const actions = makeActions();
+
+    renderHook(() => useMediaSession(makeItem(), false, actions));
+
+    const registeredActions = (setActionHandler.mock.calls as unknown[][]).map((call) => call[0]);
+    expect(registeredActions).toContain("previoustrack");
+    expect(registeredActions).toContain("nexttrack");
+    expect(registeredActions).toContain("play");
+    expect(registeredActions).toContain("pause");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T3.10 — re-apply metadata + handlers on the audio "playing" event
+// ---------------------------------------------------------------------------
+
+describe("useMediaSession re-applies on the audio playing event", () => {
+  let setActionHandler: ReturnType<typeof vi.fn>;
+  let restore: () => void;
+
+  beforeEach(() => {
+    const result = setupMediaSessionStub();
+    setActionHandler = result.setActionHandler;
+    restore = result.restore;
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  it("[T3.10] re-registers action handlers when the element fires 'playing'", () => {
+    const actions = makeActions();
+    const el = document.createElement("audio");
+
+    renderHook(() => useMediaSession(makeItem(), true, actions, el));
+
+    setActionHandler.mockClear();
+
+    // iOS clears handlers on playback start; the 'playing' event must re-apply them.
+    el.dispatchEvent(new Event("playing"));
+
+    const reRegistered = (setActionHandler.mock.calls as unknown[][]).map((call) => call[0]);
+    expect(reRegistered).toContain("previoustrack");
+    expect(reRegistered).toContain("nexttrack");
+    expect(reRegistered).toContain("play");
+    expect(reRegistered).toContain("pause");
+  });
+
+  it("[T3.10] does not attach a listener when audioEl is null", () => {
+    const actions = makeActions();
+
+    // No element provided → nothing to re-apply against, must not throw.
+    expect(() => {
+      renderHook(() => useMediaSession(makeItem(), true, actions, null));
+    }).not.toThrow();
+  });
+});

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -56,6 +56,7 @@ function applyPositionState(el: HTMLAudioElement): void {
 }
 
 function applyMetadata(currentItem: QueueItem | null): void {
+  if (!isMediaSessionSupported()) return;
   if (!currentItem) {
     navigator.mediaSession.metadata = null;
     return;

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -37,6 +37,24 @@ function isIOS(): boolean {
   return /iP(hone|ad|od)/.test(ua) || (ua.includes("Macintosh") && navigator.maxTouchPoints > 1);
 }
 
+const POSITION_STATE_EVENTS = [
+  "loadedmetadata",
+  "durationchange",
+  "seeked",
+  "play",
+  "pause",
+  "ratechange",
+] as const;
+
+function applyPositionState(el: HTMLAudioElement): void {
+  if (!isMediaSessionSupported()) return;
+  if (!("setPositionState" in navigator.mediaSession)) return;
+  const { duration, currentTime, playbackRate } = el;
+  if (!Number.isFinite(duration) || duration <= 0) return;
+  const position = Math.min(Math.max(currentTime, 0), duration);
+  navigator.mediaSession.setPositionState({ duration, playbackRate: playbackRate || 1, position });
+}
+
 function applyMetadata(currentItem: QueueItem | null): void {
   if (!currentItem) {
     navigator.mediaSession.metadata = null;
@@ -134,6 +152,7 @@ export function useMediaSession(
     const reapply = (): void => {
       applyMetadata(currentItem);
       applyActionHandlers(actions);
+      applyPositionState(audioEl);
     };
 
     audioEl.addEventListener("playing", reapply);
@@ -141,4 +160,14 @@ export function useMediaSession(
       audioEl.removeEventListener("playing", reapply);
     };
   }, [audioEl, currentItem, actions]);
+
+  useEffect(() => {
+    if (!isMediaSessionSupported() || !audioEl) return;
+
+    const handler = (): void => applyPositionState(audioEl);
+    POSITION_STATE_EVENTS.forEach((ev) => audioEl.addEventListener(ev, handler));
+    return () => {
+      POSITION_STATE_EVENTS.forEach((ev) => audioEl.removeEventListener(ev, handler));
+    };
+  }, [audioEl]);
 }

--- a/apps/frontend/src/hooks/useMediaSession.ts
+++ b/apps/frontend/src/hooks/useMediaSession.ts
@@ -9,31 +9,91 @@ export interface MediaSessionActions {
   seek: (timeSec: number) => void;
 }
 
+const ALL_ACTIONS: MediaSessionAction[] = [
+  "play",
+  "pause",
+  "previoustrack",
+  "nexttrack",
+  "seekbackward",
+  "seekforward",
+  "seekto",
+];
+
 function isMediaSessionSupported(): boolean {
   return typeof navigator !== "undefined" && navigator.mediaSession != null;
+}
+
+/**
+ * iOS/iPadOS WebKit exposes only two transport slots next to play/pause and
+ * fills them with the <audio> element's native ±skip seek controls by default,
+ * which wins over prev/next. Explicitly nulling the seek actions (null !=
+ * "not registered" on WebKit) frees those slots so previoustrack/nexttrack
+ * surface on the lock screen.
+ * iPadOS 13+ reports a Macintosh UA, so we also treat touch-capable Macs as iOS.
+ */
+function isIOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  return /iP(hone|ad|od)/.test(ua) || (ua.includes("Macintosh") && navigator.maxTouchPoints > 1);
+}
+
+function applyMetadata(currentItem: QueueItem | null): void {
+  if (!currentItem) {
+    navigator.mediaSession.metadata = null;
+    return;
+  }
+
+  const artwork = currentItem.artworkUrl ? [{ src: currentItem.artworkUrl }] : [];
+
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title: currentItem.name,
+    artist: currentItem.artist,
+    album: currentItem.album ?? "",
+    artwork,
+  });
+}
+
+function applyActionHandlers(actions: MediaSessionActions): void {
+  const handlers: [MediaSessionAction, MediaSessionActionHandler | null][] = [
+    ["play", () => actions.play()],
+    ["pause", () => actions.pause()],
+    ["previoustrack", () => actions.previous()],
+    ["nexttrack", () => actions.next()],
+  ];
+
+  if (isIOS()) {
+    handlers.push(["seekbackward", null], ["seekforward", null], ["seekto", null]);
+  } else {
+    handlers.push([
+      "seekto",
+      (details: MediaSessionActionDetails) => {
+        if (details.seekTime != null) {
+          actions.seek(details.seekTime);
+        }
+      },
+    ]);
+  }
+
+  handlers.forEach(([name, handler]) => {
+    try {
+      navigator.mediaSession.setActionHandler(name, handler);
+    } catch (e) {
+      if (import.meta.env.DEV) {
+        console.warn(`[useMediaSession] setActionHandler("${name}") failed:`, e);
+      }
+    }
+  });
 }
 
 export function useMediaSession(
   currentItem: QueueItem | null,
   isPlaying: boolean,
   actions: MediaSessionActions,
+  audioEl: HTMLAudioElement | null = null,
 ): void {
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
-
-    if (!currentItem) {
-      navigator.mediaSession.metadata = null;
-      return;
-    }
-
-    const artwork = currentItem.artworkUrl ? [{ src: currentItem.artworkUrl }] : [];
-
-    navigator.mediaSession.metadata = new MediaMetadata({
-      title: currentItem.name,
-      artist: currentItem.artist,
-      album: currentItem.album ?? "",
-      artwork,
-    });
+    applyMetadata(currentItem);
   }, [currentItem]);
 
   useEffect(() => {
@@ -49,34 +109,11 @@ export function useMediaSession(
   useEffect(() => {
     if (!isMediaSessionSupported()) return;
 
-    const handlers: [MediaSessionAction, MediaSessionActionHandler | null][] = [
-      ["play", () => actions.play()],
-      ["pause", () => actions.pause()],
-      ["previoustrack", () => actions.previous()],
-      ["nexttrack", () => actions.next()],
-      [
-        "seekto",
-        (details: MediaSessionActionDetails) => {
-          if (details.seekTime != null) {
-            actions.seek(details.seekTime);
-          }
-        },
-      ],
-    ];
-
-    handlers.forEach(([name, handler]) => {
-      try {
-        navigator.mediaSession.setActionHandler(name, handler);
-      } catch (e) {
-        if (import.meta.env.DEV) {
-          console.warn(`[useMediaSession] setActionHandler("${name}") failed:`, e);
-        }
-      }
-    });
+    applyActionHandlers(actions);
 
     return () => {
       if (!isMediaSessionSupported()) return;
-      handlers.forEach(([name]) => {
+      ALL_ACTIONS.forEach((name) => {
         try {
           navigator.mediaSession.setActionHandler(name, null);
         } catch {
@@ -86,4 +123,22 @@ export function useMediaSession(
       navigator.mediaSession.metadata = null;
     };
   }, [actions]);
+
+  // iOS/WebKit clears MediaSession metadata and action handlers when playback
+  // starts, so handlers registered before the first play() are lost. Re-apply
+  // them on the audio element's "playing" event — it fires after WebKit has set
+  // up the Now Playing session, so the handlers stick.
+  useEffect(() => {
+    if (!isMediaSessionSupported() || !audioEl) return;
+
+    const reapply = (): void => {
+      applyMetadata(currentItem);
+      applyActionHandlers(actions);
+    };
+
+    audioEl.addEventListener("playing", reapply);
+    return () => {
+      audioEl.removeEventListener("playing", reapply);
+    };
+  }, [audioEl, currentItem, actions]);
 }

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.test.ts
@@ -104,4 +104,56 @@ describe("usePlayerQueueBinding", () => {
 
     expect(playQueue).not.toHaveBeenCalled();
   });
+
+  const ctx = "/playlist/p1?mode=library";
+  const makeCtxItem = (id: string, contextPath = ctx) => makeItem(id, { contextPath });
+
+  it("isActiveContext is false when store queue is empty", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
+
+  it("isActiveContext is true when the store queue belongs to this context", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
+    usePlayerStore.setState({ queue: items, currentIndex: 0, isPlaying: true });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(true);
+  });
+
+  it("isActiveContext stays true when the active queue is reordered (order-independent)", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b"), makeCtxItem("c")];
+    usePlayerStore.setState({
+      queue: [makeCtxItem("c"), makeCtxItem("a"), makeCtxItem("b")],
+      currentIndex: 0,
+      isPlaying: true,
+    });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(true);
+  });
+
+  it("isActiveContext is false when another context plays the same track ids", () => {
+    const items = [makeCtxItem("a"), makeCtxItem("b")];
+    usePlayerStore.setState({
+      queue: [
+        makeCtxItem("a", "/playlist/p2?mode=library"),
+        makeCtxItem("b", "/playlist/p2?mode=library"),
+      ],
+      currentIndex: 0,
+      isPlaying: true,
+    });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
+
+  it("isActiveContext is false when queue items have no contextPath", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.setState({ queue: items, currentIndex: 0, isPlaying: true });
+
+    const { result } = renderHook(() => usePlayerQueueBinding(items));
+    expect(result.current.isActiveContext).toBe(false);
+  });
 });

--- a/apps/frontend/src/hooks/usePlayerQueueBinding.ts
+++ b/apps/frontend/src/hooks/usePlayerQueueBinding.ts
@@ -1,9 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { usePlayerStore, type QueueItem } from "@/store/usePlayerStore";
 
 export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
   const currentIndex = usePlayerStore((state) => state.currentIndex);
   const isPlaying = usePlayerStore((state) => state.isPlaying);
+  const queue = usePlayerStore((state) => state.queue);
 
   const currentTrackId = usePlayerStore((state) => {
     if (state.currentIndex === null) return null;
@@ -11,6 +12,13 @@ export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
   });
 
   const hasPlayableTracks = queueItems.length > 0;
+
+  const isActiveContext = useMemo(() => {
+    if (queueItems.length === 0 || queue.length === 0) return false;
+    const contextPath = queueItems[0]?.contextPath;
+    if (contextPath == null) return false;
+    return queue.every((item) => item.contextPath === contextPath);
+  }, [queue, queueItems]);
 
   const playFromIndex = useCallback(
     (index: number) => {
@@ -37,6 +45,7 @@ export const usePlayerQueueBinding = (queueItems: QueueItem[]) => {
     currentIndex,
     currentTrackId,
     isPlaying,
+    isActiveContext,
     hasPlayableTracks,
     playFromIndex,
     onPlayTrack,

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -456,7 +456,8 @@
       "seek": "Seek",
       "repeatEnable": "Enable repeat",
       "repeatAll": "Repeat all",
-      "repeatOne": "Repeat one"
+      "repeatOne": "Repeat one",
+      "loading": "Loading"
     }
   },
   "aiChat": {

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -456,7 +456,8 @@
       "seek": "Avanzar",
       "repeatEnable": "Activar repetición",
       "repeatAll": "Repetir todo",
-      "repeatOne": "Repetir una"
+      "repeatOne": "Repetir una",
+      "loading": "Cargando"
     }
   },
   "aiChat": {

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1410,6 +1410,50 @@ describe("playQueue() with shuffle", () => {
 });
 
 // ---------------------------------------------------------------------------
+// _onPlay / _onPause — element→store bridge
+// ---------------------------------------------------------------------------
+
+describe("_onPlay", () => {
+  it("sets isPlaying to true when currently false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    usePlayerStore.getState()._onPlay();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+
+  it("is a no-op when isPlaying is already true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: true });
+
+    usePlayerStore.getState()._onPlay();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+describe("_onPause", () => {
+  it("sets isPlaying to false when currently true", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: true });
+
+    usePlayerStore.getState()._onPause();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+
+  it("is a no-op when isPlaying is already false", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isPlaying: false });
+
+    usePlayerStore.getState()._onPause();
+
+    expect(usePlayerStore.getState().isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // persist partialize — resume-where-left-off (queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1229,6 +1229,148 @@ describe("playFromIndex — M5 stale error clear", () => {
 });
 
 // ---------------------------------------------------------------------------
+// _onError auto-skip (E1-1 through E1-8)
+// ---------------------------------------------------------------------------
+
+describe("_onError auto-skip", () => {
+  it("E1-1: error mid-queue advances to next track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.getState()._onError("x");
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+    expect(state.consecutiveErrors).toBe(1);
+    expect(state.error).toBe("x");
+  });
+
+  it("E1-2: every track fails stops queue with sticky error", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    // 3 errors for a 3-track queue: each advances, last one hits the ceiling
+    usePlayerStore.getState()._onError("e1");
+    usePlayerStore.getState()._onError("e2");
+    usePlayerStore.getState()._onError("e3");
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.error).toBe("e3");
+    expect(state.consecutiveErrors).toBe(0);
+  });
+
+  it("E1-3: single-track queue error is sticky", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState()._onError("fail");
+
+    const state = usePlayerStore.getState();
+    expect(state.isPlaying).toBe(false);
+    expect(state.error).toBe("fail");
+    expect(state.currentIndex).toBe(0);
+    expect(state.consecutiveErrors).toBe(0);
+  });
+
+  it("E1-4: repeatMode one + error moves to next track", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ repeatMode: "one" });
+    usePlayerStore.getState()._onError("err");
+
+    const state = usePlayerStore.getState();
+    expect(state.currentIndex).toBe(1);
+    expect(state.isPlaying).toBe(true);
+  });
+
+  it("E1-5: _onLoadedMetadata resets consecutiveErrors", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState()._onLoadedMetadata(180);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-6: playFromIndex resets consecutiveErrors", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState().playFromIndex(1);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-7: playQueue resets consecutiveErrors", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ consecutiveErrors: 2 });
+    usePlayerStore.getState().playQueue([makeItem("b"), makeItem("c")], 0);
+
+    expect(usePlayerStore.getState().consecutiveErrors).toBe(0);
+  });
+
+  it("E1-8: null currentIndex error sets error and stops without throw", () => {
+    usePlayerStore.getState()._onError("no-track");
+
+    const state = usePlayerStore.getState();
+    expect(state.error).toBe("no-track");
+    expect(state.isPlaying).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isBuffering — _onWaiting, _onCanPlay, clear, _onError, __partialize
+// ---------------------------------------------------------------------------
+
+describe("isBuffering", () => {
+  it("initial value is false", () => {
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onWaiting sets isBuffering to true", () => {
+    usePlayerStore.getState()._onWaiting();
+    expect(usePlayerStore.getState().isBuffering).toBe(true);
+  });
+
+  it("_onCanPlay sets isBuffering to false", () => {
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onCanPlay();
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("clear() resets isBuffering to false", () => {
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState().clear();
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onError leaves isBuffering false (sticky-stop path)", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onError("fail");
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("_onError leaves isBuffering false (skip path)", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isBuffering: true });
+    usePlayerStore.getState()._onError("skip-error");
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("isBuffering is NOT in persisted state (__partialize does not include it)", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      isBuffering: true,
+      volume: 1,
+      isMuted: false,
+      shuffleMode: false,
+      repeatMode: "off" as const,
+    } as unknown as Parameters<typeof p>[0];
+    const result = p(fakeState);
+    expect("isBuffering" in result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1144,6 +1144,91 @@ describe("isNowPlayingOpen", () => {
 });
 
 // ---------------------------------------------------------------------------
+// B4 — seek clamps to duration=0 before metadata loads
+// ---------------------------------------------------------------------------
+
+describe("seek — B4 pre-metadata clamp fix", () => {
+  it("B4-1: seek(42) with duration=0 keeps requested value 42", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(42);
+
+    expect(usePlayerStore.getState().currentTime).toBe(42);
+  });
+
+  it("B4-2: seek(500) with duration=200 clamps to 200", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 200 });
+    usePlayerStore.getState().seek(500);
+
+    expect(usePlayerStore.getState().currentTime).toBe(200);
+  });
+
+  it("B4-3: seek(-5) clamps to 0 regardless of duration", () => {
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(-5);
+
+    expect(usePlayerStore.getState().currentTime).toBe(0);
+  });
+
+  it("B4-4: seek(42) with duration=0 sets _audioElement.currentTime to 42", () => {
+    const mockAudio = { currentTime: 0 };
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    usePlayerStore.getState().setAudioElement(mockAudio as unknown as HTMLAudioElement);
+    usePlayerStore.setState({ duration: 0 });
+    usePlayerStore.getState().seek(42);
+
+    expect(mockAudio.currentTime).toBe(42);
+    usePlayerStore.getState().setAudioElement(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// B6 — invalid duration stored verbatim
+// ---------------------------------------------------------------------------
+
+describe("_onLoadedMetadata — B6 invalid duration guard", () => {
+  it("B6-1: NaN duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(NaN);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+
+  it("B6-2: Infinity duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(Infinity);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+
+  it("B6-3: valid duration 180 is stored as-is", () => {
+    usePlayerStore.getState()._onLoadedMetadata(180);
+    expect(usePlayerStore.getState().duration).toBe(180);
+  });
+
+  it("B6-4: zero duration is stored as 0", () => {
+    usePlayerStore.getState()._onLoadedMetadata(0);
+    expect(usePlayerStore.getState().duration).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// M5 — playFromIndex does not clear stale error
+// ---------------------------------------------------------------------------
+
+describe("playFromIndex — M5 stale error clear", () => {
+  it("M5-1: playFromIndex clears a stale error", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ error: "previous error" });
+
+    usePlayerStore.getState().playFromIndex(1);
+
+    expect(usePlayerStore.getState().error).toBeNull();
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+    expect(usePlayerStore.getState().isPlaying).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // playQueue() with shuffle (S3-1, S3-2)
 // ---------------------------------------------------------------------------
 

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -391,11 +391,11 @@ describe("_onError", () => {
 });
 
 // ---------------------------------------------------------------------------
-// persist partialize: only volume, isMuted, shuffleMode, repeatMode survive
+// persist partialize: 9 approved keys survive (volume, isMuted, shuffleMode, repeatMode, queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex)
 // ---------------------------------------------------------------------------
 
 describe("persist partialize", () => {
-  it("serializes volume, isMuted, shuffleMode, repeatMode", async () => {
+  it("serializes volume, isMuted, shuffleMode, repeatMode, queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex", async () => {
     const mod = await import("./usePlayerStore");
     const partialize = mod.__partialize;
 
@@ -448,8 +448,8 @@ describe("persist partialize", () => {
 // __partialize allowlist regression (REQ-5)
 // ---------------------------------------------------------------------------
 
-describe("__partialize allowlist — persisted keys are exactly volume, isMuted, shuffleMode, repeatMode", () => {
-  it("result keys are exactly the 4 approved keys", async () => {
+describe("__partialize allowlist — persisted keys are exactly volume, isMuted, shuffleMode, repeatMode, queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex", () => {
+  it("result keys are exactly the 9 approved keys", async () => {
     const { __partialize: p } = await import("./usePlayerStore");
     const fullState = {
       queue: [makeItem("a")],
@@ -1377,6 +1377,47 @@ describe("isBuffering", () => {
     } as unknown as Parameters<typeof p>[0];
     const result = p(fakeState);
     expect("isBuffering" in result).toBe(false);
+  });
+
+  it("next() resets isBuffering to false when advancing to a different track", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isBuffering: true });
+
+    usePlayerStore.getState().next();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(1);
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("prev() resets isBuffering to false when changing track", () => {
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ isBuffering: true, currentTime: 0 });
+
+    usePlayerStore.getState().prev();
+
+    expect(usePlayerStore.getState().currentIndex).toBe(0);
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("playFromIndex() resets isBuffering to false", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ isBuffering: true });
+
+    usePlayerStore.getState().playFromIndex(2);
+
+    expect(usePlayerStore.getState().currentIndex).toBe(2);
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
+  });
+
+  it("playQueue() resets isBuffering to false when starting a new queue", () => {
+    usePlayerStore.setState({ isBuffering: true });
+
+    usePlayerStore.getState().playQueue([makeItem("a"), makeItem("b")], 0);
+
+    expect(usePlayerStore.getState().isBuffering).toBe(false);
   });
 });
 

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -432,17 +432,15 @@ describe("persist partialize", () => {
     const persisted = partialize(state as unknown as Parameters<typeof partialize>[0]);
     const roundTripped = JSON.parse(JSON.stringify(persisted));
 
-    expect(roundTripped).toEqual({
-      volume: 0.6,
-      isMuted: true,
-      shuffleMode: true,
-      repeatMode: "one",
-    });
-    expect("queue" in roundTripped).toBe(false);
-    expect("currentTime" in roundTripped).toBe(false);
+    expect(roundTripped.volume).toBe(0.6);
+    expect(roundTripped.isMuted).toBe(true);
+    expect(roundTripped.shuffleMode).toBe(true);
+    expect(roundTripped.repeatMode).toBe("one");
+    expect("queue" in roundTripped).toBe(true);
+    expect("currentTime" in roundTripped).toBe(true);
     expect("isPlaying" in roundTripped).toBe(false);
-    expect("shuffleOrder" in roundTripped).toBe(false);
-    expect("shuffleOrderIndex" in roundTripped).toBe(false);
+    expect("shuffleOrder" in roundTripped).toBe(true);
+    expect("shuffleOrderIndex" in roundTripped).toBe(true);
   });
 });
 
@@ -490,7 +488,17 @@ describe("__partialize allowlist — persisted keys are exactly volume, isMuted,
     };
 
     const result = p(fullState as unknown as Parameters<typeof p>[0]);
-    expect(Object.keys(result).sort()).toEqual(["isMuted", "repeatMode", "shuffleMode", "volume"]);
+    expect(Object.keys(result).sort()).toEqual([
+      "currentIndex",
+      "currentTime",
+      "isMuted",
+      "queue",
+      "repeatMode",
+      "shuffleMode",
+      "shuffleOrder",
+      "shuffleOrderIndex",
+      "volume",
+    ]);
   });
 
   it("excluded fields are absent from result", async () => {
@@ -509,8 +517,8 @@ describe("__partialize allowlist — persisted keys are exactly volume, isMuted,
     const result = p(fullState);
     expect("isNowPlayingOpen" in result).toBe(false);
     expect("isQueuePanelOpen" in result).toBe(false);
-    expect("queue" in result).toBe(false);
-    expect("currentIndex" in result).toBe(false);
+    expect("queue" in result).toBe(true);
+    expect("currentIndex" in result).toBe(true);
   });
 });
 
@@ -620,7 +628,7 @@ describe("repeat state", () => {
 // ---------------------------------------------------------------------------
 
 describe("partialize S1-6", () => {
-  it("shuffleOrder and shuffleOrderIndex reset to defaults on rehydration", async () => {
+  it("shuffleOrder and shuffleOrderIndex ARE persisted on rehydration", async () => {
     const { __partialize: p } = await import("./usePlayerStore");
     const fakeState = {
       shuffleMode: true,
@@ -632,8 +640,10 @@ describe("partialize S1-6", () => {
     } as unknown as Parameters<typeof p>[0];
 
     const persisted = p(fakeState);
-    expect("shuffleOrder" in persisted).toBe(false);
-    expect("shuffleOrderIndex" in persisted).toBe(false);
+    expect("shuffleOrder" in persisted).toBe(true);
+    expect("shuffleOrderIndex" in persisted).toBe(true);
+    expect(persisted.shuffleOrder).toEqual([2, 0, 1]);
+    expect(persisted.shuffleOrderIndex).toBe(1);
     expect(persisted.shuffleMode).toBe(true);
     expect(persisted.repeatMode).toBe("one");
   });
@@ -1396,5 +1406,48 @@ describe("playQueue() with shuffle", () => {
     expect(state.currentIndex).toBe(1);
     expect(state.shuffleOrder).toEqual([]);
     expect(state.shuffleOrderIndex).toBe(-1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persist partialize — resume-where-left-off (queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex)
+// ---------------------------------------------------------------------------
+
+describe("persist partialize — resume fields", () => {
+  it("includes queue, currentIndex, currentTime, shuffleOrder, shuffleOrderIndex in persisted shape", async () => {
+    const { __partialize: p } = await import("./usePlayerStore");
+    const fakeState = {
+      queue: [makeItem("a"), makeItem("b")],
+      currentIndex: 1,
+      isPlaying: true,
+      volume: 0.8,
+      isMuted: false,
+      currentTime: 42,
+      duration: 200,
+      error: "oops",
+      shuffleMode: true,
+      repeatMode: "all" as const,
+      shuffleOrder: [1, 0],
+      shuffleOrderIndex: 1,
+      consecutiveErrors: 2,
+      isBuffering: true,
+    } as unknown as Parameters<typeof p>[0];
+
+    const result = p(fakeState);
+
+    expect(result.queue).toEqual([makeItem("a"), makeItem("b")]);
+    expect(result.currentIndex).toBe(1);
+    expect(result.currentTime).toBe(42);
+    expect(result.shuffleOrder).toEqual([1, 0]);
+    expect(result.shuffleOrderIndex).toBe(1);
+    expect(result.volume).toBe(0.8);
+    expect(result.isMuted).toBe(false);
+    expect(result.shuffleMode).toBe(true);
+    expect(result.repeatMode).toBe("all");
+    expect("isPlaying" in result).toBe(false);
+    expect("error" in result).toBe(false);
+    expect("isBuffering" in result).toBe(false);
+    expect("consecutiveErrors" in result).toBe(false);
+    expect("duration" in result).toBe(false);
   });
 });

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -34,6 +34,8 @@ export interface PlayerState extends PlayerUISlice {
   repeatMode: RepeatMode;
   shuffleOrder: number[];
   shuffleOrderIndex: number;
+  consecutiveErrors: number;
+  isBuffering: boolean;
 
   playQueue: (items: QueueItem[], startIndex: number) => void;
   togglePlay: () => void;
@@ -54,6 +56,8 @@ export interface PlayerState extends PlayerUISlice {
   _onTimeUpdate: (currentTime: number) => void;
   _onEnded: () => void;
   _onError: (message: string) => void;
+  _onWaiting: () => void;
+  _onCanPlay: () => void;
 }
 
 export const __partialize = (
@@ -99,9 +103,11 @@ const INITIAL_STATE = {
   repeatMode: "off" as RepeatMode,
   shuffleOrder: [] as number[],
   shuffleOrderIndex: -1,
+  consecutiveErrors: 0,
+  isBuffering: false,
 };
 
-type AdvanceSource = "user" | "ended";
+type AdvanceSource = "user" | "ended" | "error";
 
 export const usePlayerStore = create<PlayerState>()(
   persist(
@@ -160,6 +166,7 @@ export const usePlayerStore = create<PlayerState>()(
             isPlaying: true,
             currentTime: 0,
             error: null,
+            consecutiveErrors: 0,
           });
           if (get().shuffleMode && items.length > 0) {
             const order = shuffleIndices(items.length, startIndex);
@@ -263,6 +270,7 @@ export const usePlayerStore = create<PlayerState>()(
             error: null,
             isQueuePanelOpen: false,
             isNowPlayingOpen: false,
+            isBuffering: false,
           });
         },
 
@@ -271,7 +279,10 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onLoadedMetadata(duration) {
-          set({ duration: Number.isFinite(duration) && duration > 0 ? duration : 0 });
+          set({
+            duration: Number.isFinite(duration) && duration > 0 ? duration : 0,
+            consecutiveErrors: 0,
+          });
         },
 
         _onTimeUpdate(currentTime) {
@@ -302,13 +313,38 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onError(message) {
-          set({ error: message, isPlaying: false });
+          const { currentIndex, queue, consecutiveErrors } = get();
+          if (currentIndex === null) {
+            set({ error: message, isPlaying: false, isBuffering: false });
+            return;
+          }
+          const errs = consecutiveErrors + 1;
+          if (errs >= queue.length) {
+            set({ error: message, isPlaying: false, consecutiveErrors: 0, isBuffering: false });
+            return;
+          }
+          set({ consecutiveErrors: errs, error: message, isBuffering: false });
+          advance("error");
+        },
+
+        _onWaiting() {
+          set({ isBuffering: true });
+        },
+
+        _onCanPlay() {
+          set({ isBuffering: false });
         },
 
         playFromIndex(index) {
           const { queue, shuffleMode } = get();
           if (index < 0 || index >= queue.length) return;
-          set({ currentIndex: index, isPlaying: true, currentTime: 0, error: null });
+          set({
+            currentIndex: index,
+            isPlaying: true,
+            currentTime: 0,
+            error: null,
+            consecutiveErrors: 0,
+          });
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {
             const order = shuffleIndices(queue.length, index);

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -228,7 +228,8 @@ export const usePlayerStore = create<PlayerState>()(
 
         seek(seconds) {
           const { duration } = get();
-          const clamped = Math.max(0, Math.min(seconds, duration));
+          const clamped =
+            duration > 0 ? Math.max(0, Math.min(seconds, duration)) : Math.max(0, seconds);
           set({ currentTime: clamped });
           if (_audioElement) {
             _audioElement.currentTime = clamped;
@@ -270,7 +271,7 @@ export const usePlayerStore = create<PlayerState>()(
         },
 
         _onLoadedMetadata(duration) {
-          set({ duration });
+          set({ duration: Number.isFinite(duration) && duration > 0 ? duration : 0 });
         },
 
         _onTimeUpdate(currentTime) {
@@ -307,7 +308,7 @@ export const usePlayerStore = create<PlayerState>()(
         playFromIndex(index) {
           const { queue, shuffleMode } = get();
           if (index < 0 || index >= queue.length) return;
-          set({ currentIndex: index, isPlaying: true, currentTime: 0 });
+          set({ currentIndex: index, isPlaying: true, currentTime: 0, error: null });
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {
             const order = shuffleIndices(queue.length, index);

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -58,6 +58,8 @@ export interface PlayerState extends PlayerUISlice {
   _onError: (message: string) => void;
   _onWaiting: () => void;
   _onCanPlay: () => void;
+  _onPlay: () => void;
+  _onPause: () => void;
 }
 
 export const __partialize = (
@@ -349,6 +351,14 @@ export const usePlayerStore = create<PlayerState>()(
 
         _onCanPlay() {
           set({ isBuffering: false });
+        },
+
+        _onPlay() {
+          if (!get().isPlaying) set({ isPlaying: true });
+        },
+
+        _onPause() {
+          if (get().isPlaying) set({ isPlaying: false });
         },
 
         playFromIndex(index) {

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -62,11 +62,27 @@ export interface PlayerState extends PlayerUISlice {
 
 export const __partialize = (
   state: PlayerState,
-): Pick<PlayerState, "volume" | "isMuted" | "shuffleMode" | "repeatMode"> => ({
+): Pick<
+  PlayerState,
+  | "volume"
+  | "isMuted"
+  | "shuffleMode"
+  | "repeatMode"
+  | "queue"
+  | "currentIndex"
+  | "currentTime"
+  | "shuffleOrder"
+  | "shuffleOrderIndex"
+> => ({
   volume: state.volume,
   isMuted: state.isMuted,
   shuffleMode: state.shuffleMode,
   repeatMode: state.repeatMode,
+  queue: state.queue,
+  currentIndex: state.currentIndex,
+  currentTime: state.currentTime,
+  shuffleOrder: state.shuffleOrder,
+  shuffleOrderIndex: state.shuffleOrderIndex,
 });
 
 let _audioElement: HTMLAudioElement | null = null;

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -144,7 +144,12 @@ export const usePlayerStore = create<PlayerState>()(
         if (shuffleMode) {
           if (shuffleOrderIndex >= shuffleOrder.length - 1) {
             if (repeatMode === "all") {
-              set({ shuffleOrderIndex: 0, currentIndex: shuffleOrder[0]!, currentTime: 0 });
+              set({
+                shuffleOrderIndex: 0,
+                currentIndex: shuffleOrder[0]!,
+                currentTime: 0,
+                isBuffering: false,
+              });
             } else {
               set({ isPlaying: false });
             }
@@ -155,18 +160,19 @@ export const usePlayerStore = create<PlayerState>()(
             shuffleOrderIndex: nextOrderIndex,
             currentIndex: shuffleOrder[nextOrderIndex]!,
             currentTime: 0,
+            isBuffering: false,
           });
           return;
         }
         if (currentIndex >= queue.length - 1) {
           if (repeatMode === "all") {
-            set({ currentIndex: 0, currentTime: 0 });
+            set({ currentIndex: 0, currentTime: 0, isBuffering: false });
           } else {
             set({ isPlaying: false });
           }
           return;
         }
-        set({ currentIndex: currentIndex + 1, currentTime: 0 });
+        set({ currentIndex: currentIndex + 1, currentTime: 0, isBuffering: false });
       }
 
       return {
@@ -185,6 +191,7 @@ export const usePlayerStore = create<PlayerState>()(
             currentTime: 0,
             error: null,
             consecutiveErrors: 0,
+            isBuffering: false,
           });
           if (get().shuffleMode && items.length > 0) {
             const order = shuffleIndices(items.length, startIndex);
@@ -229,6 +236,7 @@ export const usePlayerStore = create<PlayerState>()(
                 shuffleOrderIndex: nextOrderIndex,
                 currentIndex: shuffleOrder[nextOrderIndex]!,
                 currentTime: 0,
+                isBuffering: false,
               });
               return;
             }
@@ -238,16 +246,17 @@ export const usePlayerStore = create<PlayerState>()(
                 shuffleOrderIndex: nextOrderIndex,
                 currentIndex: shuffleOrder[nextOrderIndex]!,
                 currentTime: 0,
+                isBuffering: false,
               });
             }
             return;
           }
           if (currentIndex > 0) {
-            set({ currentIndex: currentIndex - 1, currentTime: 0 });
+            set({ currentIndex: currentIndex - 1, currentTime: 0, isBuffering: false });
             return;
           }
           if (repeatMode === "all") {
-            set({ currentIndex: queue.length - 1, currentTime: 0 });
+            set({ currentIndex: queue.length - 1, currentTime: 0, isBuffering: false });
           }
         },
 
@@ -370,6 +379,7 @@ export const usePlayerStore = create<PlayerState>()(
             currentTime: 0,
             error: null,
             consecutiveErrors: 0,
+            isBuffering: false,
           });
           if (_audioElement) _audioElement.currentTime = 0;
           if (shuffleMode) {

--- a/apps/frontend/src/views/LibraryAlbumDetail.tsx
+++ b/apps/frontend/src/views/LibraryAlbumDetail.tsx
@@ -30,7 +30,7 @@ export const LibraryAlbumDetail: FC = () => {
     onPlayPlaylist,
     onPausePlaylist,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
   } = useLibraryAlbumDetailController();
 
   if (isLoading) {
@@ -119,11 +119,11 @@ export const LibraryAlbumDetail: FC = () => {
                   </span>
                 </Button>
               ) : null}
-              {hasPlayableTracks && onShufflePlay ? (
+              {hasPlayableTracks && onToggleShuffle ? (
                 <Button
                   variant="ghost"
                   size="md"
-                  onClick={onShufflePlay}
+                  onClick={onToggleShuffle}
                   title={t("playlist.actions.shufflePlay")}
                   ariaLabel={t("playlist.actions.shufflePlay")}
                   icon={faShuffle}

--- a/apps/frontend/src/views/PlaylistDetail.tsx
+++ b/apps/frontend/src/views/PlaylistDetail.tsx
@@ -31,7 +31,7 @@ export const PlaylistDetail: FC = () => {
     isPlaying,
     hasPlayableTracks,
     isShuffleActive,
-    onShufflePlay,
+    onToggleShuffle,
     mode,
   } = usePlaylistDetailController();
 
@@ -70,7 +70,7 @@ export const PlaylistDetail: FC = () => {
         currentTrackId={currentTrackId}
         isPlaying={isPlaying}
         hasPlayableTracks={hasPlayableTracks}
-        onShufflePlay={onShufflePlay}
+        onToggleShuffle={onToggleShuffle}
         isShuffleActive={isShuffleActive}
         mode={mode}
       />


### PR DESCRIPTION
## Summary

Integration branch for the playback "native quality" initiative. Brings the player to native-app parity across desktop and mobile. Device-verified (desktop + iPhone lock screen) and passed a dual-judge adversarial review.

## What's included (9 commits)

- **Reliability** (#232): seek-before-metadata, NaN/Infinity duration, stale error banner, volume/mute applied on reload, autoplay-rejection state.
- **Resilience** (#235): auto-skip failed tracks (queue no longer stalls), buffering spinner.
- **Resume** (#236): queue, track and position survive reload; boots paused.
- **Global keyboard shortcuts** (#238): space / arrows / m, document-level with input guards.
- **iOS lock screen prev/next** (#231): nulls seek actions and re-applies handlers on `playing` so WebKit shows working previous/next. Closes #201.
- **MediaSession position state**: lock-screen scrubber accurate (setPositionState).
- **Interruption bridge** (#237): native play/pause events sync the store (phone call pauses, UI no longer lies).
- **Judgment-day hardening**: applyMetadata guard, isBuffering reset on every track change, aria-busy.
- **Playlist/album controls** (#244): shuffle is a pure toggle, header play is context-aware (resume not restart), shuffle starts on a random track.

## Testing

Full frontend suite green (1401 tests), `tsc --noEmit` clean. Two judgment-day rounds (APPROVED). Device-tested on desktop and iPhone.