### PR TITLE
refactor(backend): migrate BullMQ workers and jobs to structured pino logger (slice 2)

### DIFF
--- a/apps/backend/src/infrastructure/jobs/catalog-sync.job.ts
+++ b/apps/backend/src/infrastructure/jobs/catalog-sync.job.ts
@@ -1,7 +1,10 @@
 import cron from "node-cron";
 import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
 import { getContainer } from "@/container";
+import { logger } from "../logging/logger";
 import { getCatalogSyncQueue } from "../setup/queues";
+
+const log = logger.child({ job: "catalog-sync-job" });
 
 let lastCatalogSyncCheckTimestamp = 0;
 
@@ -33,7 +36,7 @@ export const catalogSyncJob = cron.createTask("* * * * *", async () => {
 
     lastCatalogSyncCheckTimestamp = now;
   } catch (error) {
-    console.error("[ScheduledJob] Error enqueuing catalog sync job:", error);
+    log.error({ err: error }, "Error enqueuing catalog sync job");
   }
 });
 

--- a/apps/backend/src/infrastructure/jobs/feed-sync.job.ts
+++ b/apps/backend/src/infrastructure/jobs/feed-sync.job.ts
@@ -1,7 +1,10 @@
 import cron from "node-cron";
 import { SYNC_STATUS } from "@/application/ports/feed-repository.port";
 import { getContainer } from "@/container";
+import { logger } from "../logging/logger";
 import { getFeedSyncQueue } from "../setup/queues";
+
+const log = logger.child({ job: "feed-sync-job" });
 
 let lastFeedSyncCheckTimestamp = 0;
 
@@ -32,7 +35,7 @@ export const feedSyncJob = cron.createTask("* * * * *", async () => {
 
     lastFeedSyncCheckTimestamp = now;
   } catch (error) {
-    console.error("[ScheduledJob] Error enqueuing feed sync job:", error);
+    log.error({ err: error }, "Error enqueuing feed sync job");
   }
 });
 

--- a/apps/backend/src/infrastructure/jobs/index.ts
+++ b/apps/backend/src/infrastructure/jobs/index.ts
@@ -1,8 +1,11 @@
 import { TrackStatusEnum } from "@spotiarr/shared";
 import cron from "node-cron";
 import { getContainer } from "../../container";
+import { logger } from "../logging/logger";
 import { startCatalogSyncJob } from "./catalog-sync.job";
 import { startFeedSyncJob } from "./feed-sync.job";
+
+const log = logger.child({ component: "scheduled-jobs" });
 
 let lastPlaylistCheckTimestamp = 0;
 let lastStuckTracksCleanupTimestamp = 0;
@@ -25,11 +28,11 @@ export const recoverErroredTracksJob = cron.createTask("* * * * *", async () => 
     }
 
     lastRecoveryTimestamp = now;
-    console.log("[ScheduledJob] Running errored-tracks recovery...");
+    log.info("Running errored-tracks recovery...");
     await recoverErroredTracksUseCase.execute();
-    console.log("[ScheduledJob] Errored-tracks recovery completed");
+    log.info("Errored-tracks recovery completed");
   } catch (error) {
-    console.error("[ScheduledJob] Error recovering errored tracks:", error);
+    log.error({ err: error }, "Error recovering errored tracks");
   }
 });
 
@@ -44,12 +47,12 @@ export const checkPlaylistsJob = cron.createTask("* * * * *", async () => {
       return;
     }
 
-    console.log("[ScheduledJob] Running playlist check...");
+    log.info("Running playlist check...");
     await playlistService.checkSubscribedPlaylists();
     lastPlaylistCheckTimestamp = now;
-    console.log("[ScheduledJob] Playlist check completed");
+    log.info("Playlist check completed");
   } catch (error) {
-    console.error("[ScheduledJob] Error checking playlists:", error);
+    log.error({ err: error }, "Error checking playlists");
   }
 });
 
@@ -80,7 +83,7 @@ export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
     );
 
     if (stuckTracks.length > 0) {
-      console.log(`[ScheduledJob] Found ${stuckTracks.length} stuck tracks, marking as error`);
+      log.info({ count: stuckTracks.length }, "Found stuck tracks, marking as error");
       for (const track of stuckTracks) {
         if (track.id && track.status) {
           // CAS: only mark Error if the track is STILL in the stuck status we
@@ -100,7 +103,7 @@ export const cleanStuckTracksJob = cron.createTask("* * * * *", async () => {
 
     lastStuckTracksCleanupTimestamp = now;
   } catch (error) {
-    console.error("[ScheduledJob] Error cleaning stuck tracks:", error);
+    log.error({ err: error }, "Error cleaning stuck tracks");
   }
 });
 
@@ -110,5 +113,5 @@ export function startScheduledJobs(): void {
   cleanStuckTracksJob.start();
   startFeedSyncJob();
   startCatalogSyncJob();
-  console.log("✅ Scheduled jobs started (intervals configurable in Settings)");
+  log.info("Scheduled jobs started (intervals configurable in Settings)");
 }

--- a/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/ai-playlist.worker.test.ts
@@ -14,6 +14,16 @@ const WorkerMock = vi.fn(() => ({
 const executeUseCase = vi.fn();
 const emitEventBus = vi.fn();
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({
   Worker: WorkerMock,
 }));
@@ -49,15 +59,15 @@ vi.mock("@/application/use-cases/ai/generate-ai-playlist.use-case", () => ({
   })),
 }));
 
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
+
 describe("createAiPlaylistWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.keys(workerListeners).forEach((key) => {
       delete workerListeners[key];
     });
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
   it("creates a Worker with the AI_PLAYLIST_QUEUE and concurrency 1", async () => {
@@ -122,7 +132,7 @@ describe("createAiPlaylistWorker", () => {
     expect(emitEventBus).toHaveBeenCalledWith("ai-playlist-progress", event);
   });
 
-  it("failed handler logs the error", async () => {
+  it("failed handler logs the error via structured logger", async () => {
     const { createAiPlaylistWorker } = await import("./ai-playlist.worker");
     createAiPlaylistWorker();
 
@@ -131,6 +141,6 @@ describe("createAiPlaylistWorker", () => {
 
     failedHandler?.({ id: "job-1" }, new Error("job failed"));
 
-    expect(console.error).toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/infrastructure/workers/ai-playlist.worker.ts
+++ b/apps/backend/src/infrastructure/workers/ai-playlist.worker.ts
@@ -3,8 +3,11 @@ import { Worker } from "bullmq";
 import { GenerateAiPlaylistUseCase } from "@/application/use-cases/ai/generate-ai-playlist.use-case";
 import { getContainer } from "@/container";
 import { createAiChatPort } from "../external/providers/ai/openai-compatible.adapter";
+import { logger } from "../logging/logger";
 import { getEnv } from "../setup/environment";
 import { AI_PLAYLIST_QUEUE } from "../setup/queues";
+
+const log = logger.child({ worker: "ai-playlist-worker" });
 
 export function createAiPlaylistWorker(): Worker {
   const {
@@ -50,13 +53,13 @@ export function createAiPlaylistWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[AiPlaylistWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("failed", (job, error) => {
-    console.error(`[AiPlaylistWorker] Job ${job?.id} failed`, error);
+    log.error({ jobId: job?.id, err: error }, "Job failed");
   });
 
-  console.log("✅ AI playlist worker initialized");
+  log.info("AI playlist worker initialized");
   return worker;
 }

--- a/apps/backend/src/infrastructure/workers/artwork-backfill.worker.create.test.ts
+++ b/apps/backend/src/infrastructure/workers/artwork-backfill.worker.create.test.ts
@@ -8,6 +8,16 @@ const workerOn = vi.fn((event: string, cb: (...args: unknown[]) => unknown) => {
 
 const WorkerMock = vi.fn(() => ({ on: workerOn }));
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({ Worker: WorkerMock }));
 
 vi.mock("@/container", () => ({
@@ -32,13 +42,13 @@ vi.mock("../setup/queues", () => ({
   ARTWORK_BACKFILL_QUEUE: "artwork-backfill-processor",
 }));
 
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
+
 describe("createArtworkBackfillWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.keys(workerListeners).forEach((key) => delete workerListeners[key]);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
   it("creates a BullMQ Worker with the artwork-backfill queue name", async () => {
@@ -60,23 +70,29 @@ describe("createArtworkBackfillWorker", () => {
     expect(workerOn).toHaveBeenCalledWith("failed", expect.any(Function));
   });
 
-  it("completed listener logs the finished job id", async () => {
+  it("completed listener logs the finished job id via structured logger", async () => {
     const { createArtworkBackfillWorker } = await import("./artwork-backfill.worker");
     createArtworkBackfillWorker();
 
     workerListeners.completed?.({ id: "job-99" });
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("job-99"));
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-99" }),
+      expect.any(String),
+    );
   });
 
-  it("failed listener logs the job id and error", async () => {
+  it("failed listener logs the job id and error via structured logger", async () => {
     const { createArtworkBackfillWorker } = await import("./artwork-backfill.worker");
     createArtworkBackfillWorker();
 
     const err = new Error("backfill crash");
     workerListeners.failed?.({ id: "job-1" }, err);
 
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("job-1"), err);
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-1", err }),
+      expect.any(String),
+    );
   });
 
   it("failed listener handles a null job without throwing", async () => {

--- a/apps/backend/src/infrastructure/workers/artwork-backfill.worker.ts
+++ b/apps/backend/src/infrastructure/workers/artwork-backfill.worker.ts
@@ -4,6 +4,7 @@ import { ProcessArtworkBackfillBatchUseCase } from "@/application/use-cases/artw
 import { getContainer, type Container } from "@/container";
 import { ARTWORK_BACKFILL_STATUS } from "@/domain/artwork-backfill.types";
 import { AppError } from "@/domain/errors/app-error";
+import { logger } from "../logging/logger";
 import { getEnv } from "../setup/environment";
 import { ARTWORK_BACKFILL_QUEUE } from "../setup/queues";
 
@@ -113,6 +114,8 @@ function isRateLimited(error: unknown): boolean {
 }
 
 export function createArtworkBackfillWorker(): Worker {
+  const log = logger.child({ worker: "artwork-backfill-worker" });
+
   const {
     artworkBackfillRepository,
     processArtworkBackfillBatchUseCase,
@@ -147,11 +150,11 @@ export function createArtworkBackfillWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[ArtworkBackfillWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("failed", (job, error) => {
-    console.error(`[ArtworkBackfillWorker] Job ${job?.id} failed`, error);
+    log.error({ jobId: job?.id, err: error }, "Job failed");
   });
 
   return worker;

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.create.test.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.create.test.ts
@@ -11,6 +11,16 @@ const WorkerMock = vi.fn(() => ({ on: workerOn }));
 const getCatalogSyncState = vi.fn();
 const setCatalogSyncState = vi.fn();
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({ Worker: WorkerMock }));
 
 vi.mock("@/container", () => ({
@@ -38,15 +48,15 @@ vi.mock("../setup/queues", () => ({
   CATALOG_SYNC_QUEUE: "catalog-sync-queue",
 }));
 
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
+
 describe("createCatalogSyncWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     Object.keys(workerListeners).forEach((key) => delete workerListeners[key]);
     getCatalogSyncState.mockResolvedValue({ status: "idle" });
     setCatalogSyncState.mockResolvedValue(undefined);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
   it("creates a BullMQ Worker with the catalog-sync queue name", async () => {
@@ -68,13 +78,16 @@ describe("createCatalogSyncWorker", () => {
     expect(workerOn).toHaveBeenCalledWith("failed", expect.any(Function));
   });
 
-  it("completed listener logs the finished job id", async () => {
+  it("completed listener logs the finished job id via structured logger", async () => {
     const { createCatalogSyncWorker } = await import("./catalog-sync.worker");
     createCatalogSyncWorker();
 
     workerListeners.completed?.({ id: "job-42" });
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("job-42"));
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-42" }),
+      expect.any(String),
+    );
   });
 
   it("resets catalog sync state to Idle when stuck in Running on startup", async () => {
@@ -103,7 +116,7 @@ describe("createCatalogSyncWorker", () => {
     expect(setCatalogSyncState).not.toHaveBeenCalled();
   });
 
-  it("logs an error when the startup state check rejects", async () => {
+  it("logs an error via structured logger when the startup state check rejects", async () => {
     getCatalogSyncState.mockRejectedValueOnce(new Error("db down"));
 
     const { createCatalogSyncWorker } = await import("./catalog-sync.worker");
@@ -112,17 +125,20 @@ describe("createCatalogSyncWorker", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(console.error).toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalled();
   });
 
-  it("failed listener logs the job id and error", async () => {
+  it("failed listener logs the job id and error via structured logger", async () => {
     const { createCatalogSyncWorker } = await import("./catalog-sync.worker");
     createCatalogSyncWorker();
 
     const err = new Error("sync crash");
     workerListeners.failed?.({ id: "job-1" }, err);
 
-    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("job-1"), err);
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-1", err }),
+      expect.any(String),
+    );
   });
 
   it("failed listener resets state to Error when sync state is still Running", async () => {

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.test.ts
@@ -60,9 +60,6 @@ describe("CatalogSyncWorker — runCatalogSyncJob", () => {
 
   beforeEach(() => {
     deps = makeMockDeps();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
   describe("REQ-1: Artist list sourced from DB cache", () => {

--- a/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/catalog-sync.worker.ts
@@ -3,9 +3,12 @@ import { SYNC_STATUS, type FeedRepositoryPort } from "@/application/ports/feed-r
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
 import type { SettingsPort } from "@/application/ports/settings.port";
 import { getContainer } from "@/container";
+import { logger } from "../logging/logger";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { CATALOG_SYNC_QUEUE } from "../setup/queues";
+
+const log = logger.child({ worker: "catalog-sync-worker" });
 
 export interface CatalogSyncJobDependencies {
   feedRepository: FeedRepositoryPort;
@@ -25,7 +28,7 @@ export async function runCatalogSyncJob(deps: CatalogSyncJobDependencies): Promi
     const artists = await feedRepository.getArtists();
 
     if (artists.length === 0) {
-      console.log("[CatalogSyncWorker] No artists in DB cache — skipping catalog cycle");
+      log.info("No artists in DB cache — skipping catalog cycle");
       await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
       eventBus.emit("catalog-updated", { artists: 0, albums: 0 });
       return;
@@ -40,12 +43,12 @@ export async function runCatalogSyncJob(deps: CatalogSyncJobDependencies): Promi
     );
 
     if (artistIds.length === 0) {
-      console.log("[CatalogSyncWorker] No artists need catalog sync");
+      log.info("No artists need catalog sync");
       await feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
       return;
     }
 
-    console.log(`[CatalogSyncWorker] Processing catalog for ${artistIds.length} artists`);
+    log.info({ artistCount: artistIds.length }, "Processing catalog for artists");
 
     const artistMap = new Map(artists.map((a) => [a.id, a]));
     const artistsToSync = artistIds
@@ -71,13 +74,14 @@ export async function runCatalogSyncJob(deps: CatalogSyncJobDependencies): Promi
         successCount++;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.warn(`[CatalogSyncWorker] Failed to sync artist ${artist.id}:`, message);
+        log.warn({ artistId: artist.id, message }, "Failed to sync artist");
         failedArtistIds.push(artist.id);
       }
     }
 
-    console.log(
-      `[CatalogSyncWorker] Synced ${successCount}/${artistsToSync.length} artists (${failedArtistIds.length} failed)`,
+    log.info(
+      { success: successCount, total: artistsToSync.length, failed: failedArtistIds.length },
+      "Catalog sync cycle complete",
     );
 
     if (successCount === 0) {
@@ -110,14 +114,12 @@ export function createCatalogSyncWorker(): Worker {
     .getCatalogSyncState()
     .then((state) => {
       if (state.status === SYNC_STATUS.Running) {
-        console.warn(
-          "[CatalogSyncWorker] Sync was stuck in 'running' on startup — resetting to idle",
-        );
+        log.warn("Sync was stuck in 'running' on startup — resetting to idle");
         return feedRepository.setCatalogSyncState(SYNC_STATUS.Idle);
       }
     })
     .catch((err) => {
-      console.error("[CatalogSyncWorker] Failed to check/reset sync state on startup", err);
+      log.error({ err }, "Failed to check/reset sync state on startup");
     });
 
   const worker = new Worker(
@@ -137,11 +139,11 @@ export function createCatalogSyncWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[CatalogSyncWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("failed", (job, error) => {
-    console.error(`[CatalogSyncWorker] Job ${job?.id} failed`, error);
+    log.error({ jobId: job?.id, err: error }, "Job failed");
     feedRepository
       .getCatalogSyncState()
       .then((state) => {
@@ -155,6 +157,6 @@ export function createCatalogSyncWorker(): Worker {
       .catch(() => {});
   });
 
-  console.log("✅ Catalog sync worker initialized");
+  log.info("Catalog sync worker initialized");
   return worker;
 }

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.create.test.ts
@@ -13,6 +13,16 @@ const WorkerMock = vi.fn(() => ({
 const getSyncState = vi.fn();
 const setSyncState = vi.fn();
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({
   Worker: WorkerMock,
 }));
@@ -48,6 +58,8 @@ vi.mock("../setup/queues", () => ({
   FEED_SYNC_QUEUE: "feed-sync",
 }));
 
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
+
 describe("createFeedSyncWorker", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -56,12 +68,10 @@ describe("createFeedSyncWorker", () => {
     });
     getSyncState.mockResolvedValue({ status: "idle" });
     setSyncState.mockResolvedValue(undefined);
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    vi.spyOn(console, "log").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
-  it("logs non-fatal warning when failed-state sync check rejects", async () => {
+  it("logs non-fatal warning via structured logger when failed-state sync check rejects", async () => {
     const { createFeedSyncWorker } = await import("./feed-sync.worker");
 
     createFeedSyncWorker();
@@ -73,7 +83,7 @@ describe("createFeedSyncWorker", () => {
     await failedHandler?.({ id: "job-1" }, new Error("job failed"));
     await Promise.resolve();
 
-    expect(console.warn).toHaveBeenCalled();
+    expect(loggerMock.warn).toHaveBeenCalled();
   });
 
   it("resets feed sync state to Idle when stuck in Running on startup", async () => {
@@ -89,7 +99,7 @@ describe("createFeedSyncWorker", () => {
     expect(setSyncState).toHaveBeenCalledWith(SYNC_STATUS.Idle);
   });
 
-  it("logs an error when the startup state check rejects", async () => {
+  it("logs an error via structured logger when the startup state check rejects", async () => {
     getSyncState.mockRejectedValueOnce(new Error("startup db error"));
 
     const { createFeedSyncWorker } = await import("./feed-sync.worker");
@@ -98,10 +108,10 @@ describe("createFeedSyncWorker", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(console.error).toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalled();
   });
 
-  it("completed listener logs the finished job id", async () => {
+  it("completed listener logs the finished job id via structured logger", async () => {
     const { createFeedSyncWorker } = await import("./feed-sync.worker");
     createFeedSyncWorker();
 
@@ -110,7 +120,10 @@ describe("createFeedSyncWorker", () => {
 
     completedHandler?.({ id: "job-77" });
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("job-77"));
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-77" }),
+      expect.any(String),
+    );
   });
 
   it("failed listener resets state to Error when sync state is Running", async () => {

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.test.ts
@@ -71,8 +71,6 @@ describe("FeedSyncWorker — runFeedSyncJob", () => {
 
   beforeEach(() => {
     deps = makeMockDeps();
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   describe("Scenario: User follow-source preservation", () => {

--- a/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
+++ b/apps/backend/src/infrastructure/workers/feed-sync.worker.ts
@@ -4,9 +4,12 @@ import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import { getContainer } from "@/container";
 import type { ReleaseFeedService } from "../external/release-feed.service";
+import { logger } from "../logging/logger";
 import type { AppEventBus } from "../messaging/app-event-bus";
 import { getEnv } from "../setup/environment";
 import { FEED_SYNC_QUEUE } from "../setup/queues";
+
+const log = logger.child({ worker: "feed-sync-worker" });
 
 const RELEASES_SYNC_TTL_HOURS = 24;
 const RELEASES_ACTIVITY_WINDOW_DAYS = 90;
@@ -60,12 +63,12 @@ export async function runFeedSyncJob(deps: FeedSyncJobDependencies): Promise<voi
     );
 
     if (artistIds.length === 0) {
-      console.log("[FeedSyncWorker] No active artists need releases sync");
+      log.info("No active artists need releases sync");
       await feedRepository.setSyncState(SYNC_STATUS.Idle);
       return;
     }
 
-    console.log(`[FeedSyncWorker] Processing releases for ${artistIds.length} active artists`);
+    log.info({ artistCount: artistIds.length }, "Processing releases for active artists");
 
     const artistMap = new Map(artists.map((a) => [a.id, a]));
     const artistsToSync = artistIds
@@ -97,7 +100,7 @@ export async function runFeedSyncJob(deps: FeedSyncJobDependencies): Promise<voi
       "errorCode" in error &&
       (error as { errorCode: string }).errorCode === "circuit_open"
     ) {
-      console.warn("[FeedSyncWorker] Circuit breaker open — skipping cycle");
+      log.warn("Circuit breaker open — skipping cycle");
       await feedRepository.setSyncState(SYNC_STATUS.Idle);
       return;
     }
@@ -122,12 +125,12 @@ export function createFeedSyncWorker(): Worker {
     .getSyncState()
     .then((state) => {
       if (state.status === SYNC_STATUS.Running) {
-        console.warn("[FeedSyncWorker] Sync was stuck in 'running' on startup — resetting to idle");
+        log.warn("Sync was stuck in 'running' on startup — resetting to idle");
         return feedRepository.setSyncState(SYNC_STATUS.Idle);
       }
     })
     .catch((err) => {
-      console.error("[FeedSyncWorker] Failed to check/reset sync state on startup", err);
+      log.error({ err }, "Failed to check/reset sync state on startup");
     });
 
   const worker = new Worker(
@@ -154,11 +157,11 @@ export function createFeedSyncWorker(): Worker {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[FeedSyncWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("failed", (job, error) => {
-    console.error(`[FeedSyncWorker] Job ${job?.id} failed`, error);
+    log.error({ jobId: job?.id, err: error }, "Job failed");
     // Ensure sync state is never left as "running" if BullMQ marks the job failed
     // (e.g. stalled job after process restart, or unhandled rejection)
     feedRepository
@@ -172,12 +175,13 @@ export function createFeedSyncWorker(): Worker {
         }
       })
       .catch((err) => {
-        console.warn("[feed-sync.worker] non-fatal error", {
-          err: err instanceof Error ? err.message : String(err),
-        });
+        log.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          "Non-fatal error in failed handler",
+        );
       });
   });
 
-  console.log("✅ Feed sync worker initialized");
+  log.info("Feed sync worker initialized");
   return worker;
 }

--- a/apps/backend/src/infrastructure/workers/track-download.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/track-download.worker.test.ts
@@ -17,6 +17,16 @@ const settingsService = { getNumber: vi.fn() };
 const libraryService = { scan: vi.fn() };
 const eventsController = { emit: vi.fn() };
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({ Worker: WorkerMock }));
 
 vi.mock("../../container", () => ({
@@ -26,6 +36,8 @@ vi.mock("../../container", () => ({
 vi.mock("../setup/environment", () => ({
   getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
 }));
+
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
 
 function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
   return { id: "track-1", name: "Song", artist: "Artist", ...overrides };
@@ -38,8 +50,7 @@ describe("createTrackDownloadWorker", () => {
     settingsService.getNumber.mockResolvedValue(10);
     libraryService.scan.mockResolvedValue(undefined);
     trackService.update.mockResolvedValue(undefined);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
   it("configures the BullMQ limiter from the per-minute setting", async () => {
@@ -71,7 +82,7 @@ describe("createTrackDownloadWorker", () => {
 
     await expect(workerListeners.drained?.()).resolves.toBeUndefined();
     expect(eventsController.emit).not.toHaveBeenCalledWith("library-updated");
-    expect(console.error).toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalled();
   });
 
   it("marks the track as Error and emits playlists-updated on a failed job", async () => {
@@ -112,13 +123,16 @@ describe("createTrackDownloadWorker", () => {
     expect(trackService.downloadFromYoutube).toHaveBeenCalledWith(track);
   });
 
-  it("logs the job id in the completed listener", async () => {
+  it("logs the job id in the completed listener via structured logger", async () => {
     const { createTrackDownloadWorker } = await import("./track-download.worker");
     await createTrackDownloadWorker();
 
     workerListeners.completed?.({ id: "job-completed-1" });
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("job-completed-1"));
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-completed-1" }),
+      expect.any(String),
+    );
   });
 
   it("logs but does not throw when trackService.update fails in the failed handler", async () => {
@@ -131,9 +145,9 @@ describe("createTrackDownloadWorker", () => {
       workerListeners.failed?.({ id: "job-3", data: makeTrack() }, new Error("download failed")),
     ).resolves.toBeUndefined();
 
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("track-1"),
-      expect.any(Error),
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ trackId: "track-1" }),
+      expect.any(String),
     );
   });
 });

--- a/apps/backend/src/infrastructure/workers/track-download.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-download.worker.ts
@@ -1,7 +1,10 @@
 import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { Worker } from "bullmq";
 import { getContainer } from "../../container";
+import { logger } from "../logging/logger";
 import { getEnv } from "../setup/environment";
+
+const log = logger.child({ worker: "track-download-worker" });
 
 export async function createTrackDownloadWorker() {
   const { trackService, settingsService, libraryService, eventsController } = getContainer();
@@ -27,29 +30,29 @@ export async function createTrackDownloadWorker() {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[TrackDownloadWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("drained", async () => {
-    console.log(`[TrackDownloadWorker] Queue drained, triggering library scan...`);
+    log.info("Queue drained, triggering library scan...");
     try {
       await libraryService.scan();
       eventsController.emit("library-updated");
-      console.log(`[TrackDownloadWorker] Library scan completed successfully.`);
+      log.info("Library scan completed successfully.");
     } catch (err) {
-      console.error(`[TrackDownloadWorker] Failed to scan library after queue drain:`, err);
+      log.error({ err }, "Failed to scan library after queue drain");
     }
   });
 
   worker.on("failed", async (job, err) => {
-    console.error(`[TrackDownloadWorker] Job ${job?.id} failed:`, err);
+    log.error({ jobId: job?.id, err }, "Job failed");
 
     if (job?.data?.id) {
       const track: ITrack = job.data;
       const trackId = track.id;
 
       if (!trackId) {
-        console.error("Cannot update track status: track.id is undefined");
+        log.error("Cannot update track status: track.id is undefined");
         return;
       }
 
@@ -61,11 +64,11 @@ export async function createTrackDownloadWorker() {
         });
         eventsController.emit("playlists-updated");
       } catch (updateError) {
-        console.error(`Failed to update track ${trackId} status after job failure:`, updateError);
+        log.error({ trackId, err: updateError }, "Failed to update track status after job failure");
       }
     }
   });
 
-  console.log(`✅ Track download worker initialized (Rate limit: ${maxPerMinute}/min)`);
+  log.info({ rateLimit: maxPerMinute || 10 }, "Track download worker initialized");
   return worker;
 }

--- a/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.test.ts
@@ -16,6 +16,16 @@ const trackService = {
 const settingsService = { getNumber: vi.fn() };
 const eventsController = { emit: vi.fn() };
 
+// Logger mock — child logger returned for the worker scope
+const loggerMock = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+loggerMock.child.mockReturnValue(loggerMock);
+
 vi.mock("bullmq", () => ({ Worker: WorkerMock }));
 
 vi.mock("../../container", () => ({
@@ -25,6 +35,8 @@ vi.mock("../../container", () => ({
 vi.mock("../setup/environment", () => ({
   getEnv: () => ({ REDIS_HOST: "localhost", REDIS_PORT: 6379 }),
 }));
+
+vi.mock("../logging/logger", () => ({ logger: loggerMock }));
 
 function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
   return { id: "track-1", name: "Song", artist: "Artist", ...overrides };
@@ -36,8 +48,7 @@ describe("createTrackSearchWorker", () => {
     Object.keys(workerListeners).forEach((key) => delete workerListeners[key]);
     settingsService.getNumber.mockResolvedValue(3);
     trackService.update.mockResolvedValue(undefined);
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
+    loggerMock.child.mockReturnValue(loggerMock);
   });
 
   it("configures the BullMQ worker with the search concurrency setting", async () => {
@@ -158,13 +169,16 @@ describe("createTrackSearchWorker", () => {
     expect(trackService.findOnYoutube).toHaveBeenCalledWith(track);
   });
 
-  it("logs the job id in the completed listener", async () => {
+  it("logs the job id in the completed listener via structured logger", async () => {
     const { createTrackSearchWorker } = await import("./track-search.worker");
     await createTrackSearchWorker();
 
     workerListeners.completed?.({ id: "job-completed-search" });
 
-    expect(console.log).toHaveBeenCalledWith(expect.stringContaining("job-completed-search"));
+    expect(loggerMock.info).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-completed-search" }),
+      expect.any(String),
+    );
   });
 
   it("logs but does not throw when trackService.update fails in the failed handler", async () => {
@@ -177,9 +191,9 @@ describe("createTrackSearchWorker", () => {
       workerListeners.failed?.({ id: "job-err", data: makeTrack() }, new Error("search failed")),
     ).resolves.toBeUndefined();
 
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("track-1"),
-      expect.any(Error),
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      expect.objectContaining({ trackId: "track-1" }),
+      expect.any(String),
     );
   });
 });

--- a/apps/backend/src/infrastructure/workers/track-search.worker.ts
+++ b/apps/backend/src/infrastructure/workers/track-search.worker.ts
@@ -1,7 +1,10 @@
 import { TrackStatusEnum, type ITrack } from "@spotiarr/shared";
 import { Worker } from "bullmq";
 import { getContainer } from "../../container";
+import { logger } from "../logging/logger";
 import { getEnv } from "../setup/environment";
+
+const log = logger.child({ worker: "track-search-worker" });
 
 export async function createTrackSearchWorker() {
   const { trackService, settingsService, eventsController } = getContainer();
@@ -23,18 +26,18 @@ export async function createTrackSearchWorker() {
   );
 
   worker.on("completed", (job) => {
-    console.log(`[TrackSearchWorker] Job ${job.id} completed`);
+    log.info({ jobId: job.id }, "Job completed");
   });
 
   worker.on("failed", async (job, err) => {
-    console.error(`[TrackSearchWorker] Job ${job?.id} failed:`, err);
+    log.error({ jobId: job?.id, err }, "Job failed");
 
     if (job?.data?.id) {
       const track: ITrack = job.data;
       const trackId = track.id;
 
       if (!trackId) {
-        console.error("Cannot update track status: track.id is undefined");
+        log.error("Cannot update track status: track.id is undefined");
         return;
       }
 
@@ -47,11 +50,11 @@ export async function createTrackSearchWorker() {
         });
         eventsController.emit("playlists-updated");
       } catch (updateError) {
-        console.error(`Failed to update track ${trackId} status after job failure:`, updateError);
+        log.error({ trackId, err: updateError }, "Failed to update track status after job failure");
       }
     }
   });
 
-  console.log(`✅ Track search worker initialized (Concurrency: ${concurrency || 3})`);
+  log.info({ concurrency: concurrency || 3 }, "Track search worker initialized");
   return worker;
 }


### PR DESCRIPTION
## Chain Context

**Chain**: feature-branch-chain — `backend-structured-logging` (issue #150)
**Chain diagram**:
```
main
 └── refactor/backend-structured-logging (tracker)
      └── refactor/backend-structured-logging-slice1 (PR #246, merged into tracker)
           └── refactor/backend-structured-logging-slice2 📍 ← this PR
                └── slice3 (application use-cases + services)
                     └── slice4 (presentation + remaining infra)
```

**Targets**: `refactor/backend-structured-logging-slice1` (not main)
**Slice**: 2 of 4 — BullMQ workers + cron jobs
**Depends on**: PR #246 (logger module, LOG_LEVEL env wiring)

---

Closes #150

## Summary

- Replace all `console.*` calls in `infrastructure/workers/*` (6 workers) with child loggers derived from the centralized `infrastructure/logging/logger` module (TASK-2.1 + TASK-2.2)
- Replace all `console.*` calls in `infrastructure/jobs/index.ts`, `feed-sync.job.ts`, and `catalog-sync.job.ts` with structured logger (TASK-2.3)
- Update 8 worker test files: remove `vi.spyOn(console.*)` and add logger mock (`vi.mock('../logging/logger')`); tests that asserted on console behavior now assert on `loggerMock.info/error` with expected structured fields
- Gate: lint + test + build green for slice 2 (TASK-2.4)

## Changes

| File | Change |
|------|--------|
| `infrastructure/workers/track-download.worker.ts` | Replaced 6 console calls with `log.*`; child logger `{ worker: "track-download-worker" }` |
| `infrastructure/workers/catalog-sync.worker.ts` | Replaced 10 console calls with `log.*`; child logger `{ worker: "catalog-sync-worker" }` |
| `infrastructure/workers/feed-sync.worker.ts` | Replaced 9 console calls with `log.*`; child logger `{ worker: "feed-sync-worker" }` |
| `infrastructure/workers/track-search.worker.ts` | Replaced 5 console calls with `log.*`; child logger `{ worker: "track-search-worker" }` |
| `infrastructure/workers/ai-playlist.worker.ts` | Replaced 3 console calls with `log.*`; child logger `{ worker: "ai-playlist-worker" }` |
| `infrastructure/workers/artwork-backfill.worker.ts` | Replaced 2 console calls with `log.*`; child logger `{ worker: "artwork-backfill-worker" }` |
| `infrastructure/jobs/index.ts` | Replaced 9 console calls; child logger `{ component: "scheduled-jobs" }` |
| `infrastructure/jobs/feed-sync.job.ts` | Replaced 1 console.error; child logger `{ job: "feed-sync-job" }` |
| `infrastructure/jobs/catalog-sync.job.ts` | Replaced 1 console.error; child logger `{ job: "catalog-sync-job" }` |
| `workers/*.worker.test.ts` (8 files) | Removed console spies; added logger mock; updated assertions to structured fields |

## Level mapping (REQ-6)

- `console.error` → `logger.error` (never downgraded)
- `console.warn` → `logger.warn`
- `console.log` → `logger.info`
- Error objects passed as `{ err }` field per pino serializer convention (REQ-6.3)

## Test Plan

- [x] `pnpm --filter backend test:run` — 171 files, 1842 tests passing
- [x] `pnpm --filter backend run lint` — exit 0 (only pre-existing any warnings)
- [x] `pnpm --filter backend run build` — exit 0
- [x] No console.* calls remain in migrated source files (grep confirmed)
- [x] Worker tests use logger mock; no console spies in the updated test files