### PR TITLE
refactor(backend): migrate application layer to pino logger (slice 3/4)

### DIFF
--- a/apps/backend/src/__tests__/architecture.test.ts
+++ b/apps/backend/src/__tests__/architecture.test.ts
@@ -87,7 +87,18 @@ describe("architecture boundaries (baseline before cleanup)", () => {
       ...walkSrcExcludingTests(join(SRC_ROOT, "application", "use-cases")),
       ...walkSrcExcludingTests(join(SRC_ROOT, "application", "services")),
     ];
-    const violations = findMatches(appFiles, /from\s+"@\/infrastructure/);
+
+    // infrastructure/logging/logger is the documented cross-cutting exception:
+    // the logger is a shared module any layer may import directly (see design ADR-1).
+    // All other infrastructure imports from application are still forbidden.
+    const violations = appFiles.filter((file) => {
+      const content = readFileSync(file, "utf8");
+      const allInfraImports = [...content.matchAll(/from\s+"(@\/infrastructure[^"]+)"/g)].map(
+        (m) => m[1],
+      );
+      return allInfraImports.some((spec) => spec !== "@/infrastructure/logging/logger");
+    });
+
     expect(violations.length).toBe(0);
   });
 

--- a/apps/backend/src/application/services/artwork.service.ts
+++ b/apps/backend/src/application/services/artwork.service.ts
@@ -4,8 +4,10 @@ import * as path from "path";
 import type { ArtworkAssetsPort } from "@/application/ports/artwork-assets.port";
 import type { FileSystemTrackPathPort } from "@/application/ports/file-system.port";
 import type { SpotifyService } from "@/application/services/spotify.service";
-import { getErrorMessage } from "@/application/utils/error.utils";
 import { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { logger } from "@/infrastructure/logging/logger";
+
+const log = logger.child({ component: "artwork-service" });
 
 export interface ResolvedArtwork {
   tagCoverBuffer: Buffer | null;
@@ -47,9 +49,7 @@ export class ArtworkService {
           try {
             trackCoverBuffer = await this.artworkAssets.downloadImage(track.albumCoverUrl);
           } catch (error) {
-            console.warn(
-              `Failed to download Deezer album cover for ${track.name}: ${getErrorMessage(error)}`,
-            );
+            log.warn({ err: error, name: track.name }, "Failed to download Deezer album cover");
           }
         }
         // If albumCoverUrl is absent, fall through — trackCoverBuffer stays null and
@@ -61,9 +61,7 @@ export class ArtworkService {
             trackCoverBuffer = await this.artworkAssets.downloadImage(resolvedTrackCoverUrl);
           }
         } catch (error) {
-          console.warn(
-            `Failed to resolve track cover for ${track.name}: ${getErrorMessage(error)}`,
-          );
+          log.warn({ err: error, name: track.name }, "Failed to resolve track cover");
         }
       }
     }
@@ -109,7 +107,7 @@ export class ArtworkService {
         artwork.artistImageBuffer,
       );
     } catch (error) {
-      console.warn(`Failed to save artist image for ${track.name}: ${getErrorMessage(error)}`);
+      log.warn({ err: error, name: track.name }, "Failed to save artist image");
     }
   }
 

--- a/apps/backend/src/application/services/spotify.service.ts
+++ b/apps/backend/src/application/services/spotify.service.ts
@@ -1,7 +1,9 @@
 import { NormalizedTrack, SpotifyPlaylist, SpotifySearchResults } from "@spotiarr/shared";
-import { getErrorMessage } from "@/application/utils/error.utils";
 import { AppError } from "@/domain/errors/app-error";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
+import { logger } from "@/infrastructure/logging/logger";
+
+const log = logger.child({ component: "spotify-service" });
 
 type SpotifyArtistClientLike = {
   getArtistDetails(id: string): Promise<{
@@ -127,7 +129,7 @@ export class SpotifyService {
 
       throw new AppError(400, "invalid_spotify_url", "Unhandled URL type");
     } catch (error) {
-      console.error(`Error getting playlist details: ${getErrorMessage(error)}`);
+      log.error({ err: error, spotifyUrl }, "Error getting playlist details");
       throw error;
     }
   }
@@ -197,7 +199,7 @@ export class SpotifyService {
     try {
       return await this.deps.playlistClient.getAllPlaylistTracks(spotifyUrl);
     } catch (error) {
-      console.error(`Error getting playlist tracks: ${getErrorMessage(error)}`);
+      log.error({ err: error, spotifyUrl }, "Error getting playlist tracks");
       return [];
     }
   }
@@ -210,7 +212,7 @@ export class SpotifyService {
     try {
       return await this.deps.playlistClient.getPlaylistTracksPage(spotifyUrl, offset, limit);
     } catch (error) {
-      console.error(`Error getting playlist tracks page: ${getErrorMessage(error)}`);
+      log.error({ err: error, spotifyUrl }, "Error getting playlist tracks page");
       throw error;
     }
   }

--- a/apps/backend/src/application/services/track-post-processing.service.ts
+++ b/apps/backend/src/application/services/track-post-processing.service.ts
@@ -6,9 +6,11 @@ import type {
   MetadataPort,
 } from "@/application/ports/file-system.port";
 import { ArtworkService } from "@/application/services/artwork.service";
-import { getErrorMessage } from "@/application/utils/error.utils";
 import { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackRepository } from "@/domain/repositories/track.repository";
+import { logger } from "@/infrastructure/logging/logger";
+
+const log = logger.child({ component: "track-post-processing" });
 
 export class TrackPostProcessingService {
   constructor(
@@ -48,9 +50,7 @@ export class TrackPostProcessingService {
       // 3. Save Artist Image (if applicable)
       await this.artworkService.saveArtistImageIfNeeded(track, artwork);
     } catch (error) {
-      console.error(
-        `Error during post-processing for track ${track.name}: ${getErrorMessage(error)}`,
-      );
+      log.error({ err: error, name: track.name }, "Error during post-processing for track");
       // We don't throw here to avoid failing the whole download if just metadata fails
     }
   }
@@ -75,10 +75,10 @@ export class TrackPostProcessingService {
         await this.m3uService.generateM3uFile(playlist, playlistTracks, playlistFolderPath);
 
         const completedCount = this.m3uService.getCompletedTracksCount(playlistTracks);
-        console.debug(`Playlist M3U updated: ${completedCount}/${playlistTracks.length} tracks`);
+        log.debug({ completedCount, totalTracks: playlistTracks.length }, "Playlist M3U updated");
       }
     } catch (err) {
-      console.error(`Failed to generate M3U file: ${getErrorMessage(err)}`);
+      log.error({ err }, "Failed to generate M3U file");
     }
   }
 }

--- a/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/ai/generate-ai-playlist.use-case.ts
@@ -8,11 +8,14 @@ import { Playlist } from "@/domain/entities/playlist.entity";
 import { AiChatError } from "@/domain/errors/ai-chat.error";
 import type { EventBus } from "@/domain/events/event-bus";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import type { TrackService } from "../../services/track.service";
 import type {
   AppendChatMessageInput,
   AppendChatMessageUseCase,
 } from "./append-chat-message.use-case";
+
+const log = logger.child({ component: "generate-ai-playlist" });
 
 const MAX_TRACKS = 50;
 const AI_PLAYLIST_OWNER = "SpotiArr AI";
@@ -83,10 +86,7 @@ export class GenerateAiPlaylistUseCase {
         contentKey: "aiChat.userPrompt",
         contentParams: { prompt },
       }).catch((err) => {
-        console.error(
-          "[GenerateAiPlaylistUseCase] appendChatMessage(user) failed",
-          err instanceof Error ? err.message : err,
-        );
+        log.error({ err }, "appendChatMessage(user) failed");
       });
 
       emit("llm", { progress: 0 });
@@ -115,10 +115,7 @@ export class GenerateAiPlaylistUseCase {
           contentParams: { code: "zero-resolved" },
           errorCode: "zero-resolved",
         }).catch((err) => {
-          console.error(
-            "[GenerateAiPlaylistUseCase] appendChatMessage(zero-resolved) failed",
-            err instanceof Error ? err.message : err,
-          );
+          log.error({ err }, "appendChatMessage(zero-resolved) failed");
         });
 
         return;
@@ -168,16 +165,10 @@ export class GenerateAiPlaylistUseCase {
         contentParams: { count: deduped.length },
         playlistId,
       }).catch((err) => {
-        console.error(
-          "[GenerateAiPlaylistUseCase] appendChatMessage(done) failed",
-          err instanceof Error ? err.message : err,
-        );
+        log.error({ err }, "appendChatMessage(done) failed");
       });
     } catch (err) {
-      console.error(
-        "[GenerateAiPlaylistUseCase] generateTracks failed",
-        err instanceof Error ? err.message : err,
-      );
+      log.error({ err }, "generateTracks failed");
       const code =
         err instanceof AiChatError ? (err.code as AiPlaylistErrorCode) : "provider-unreachable";
       const message = err instanceof Error ? err.message : String(err);
@@ -193,10 +184,7 @@ export class GenerateAiPlaylistUseCase {
         contentParams: { code },
         errorCode: code,
       }).catch((appendErr) => {
-        console.error(
-          "[GenerateAiPlaylistUseCase] appendChatMessage(error) failed",
-          appendErr instanceof Error ? appendErr.message : appendErr,
-        );
+        log.error({ err: appendErr }, "appendChatMessage(error) failed");
       });
     }
   }

--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.test.ts
@@ -6,6 +6,14 @@ import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import { GetRecentReleasesUseCase } from "./get-recent-releases.use-case";
 
+const loggerMock = vi.hoisted(() => {
+  const mock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+  mock.child.mockReturnValue(mock);
+  return mock;
+});
+
+vi.mock("../../../infrastructure/logging/logger", () => ({ logger: loggerMock }));
+
 function makeArtist(overrides: Partial<FollowedArtist> = {}): FollowedArtist {
   return {
     id: "a1",
@@ -64,8 +72,8 @@ describe("GetRecentReleasesUseCase", () => {
       deps.releaseFeedService,
       deps.settingsService,
     );
-    vi.spyOn(console, "log").mockImplementation(() => {});
-    vi.spyOn(console, "warn").mockImplementation(() => {});
+    loggerMock.info.mockClear();
+    loggerMock.warn.mockClear();
   });
 
   it("returns cached releases without triggering warm when cache is fresh", async () => {

--- a/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
+++ b/apps/backend/src/application/use-cases/feed/get-recent-releases.use-case.ts
@@ -3,6 +3,9 @@ import type { FeedRepositoryPort } from "@/application/ports/feed-repository.por
 import type { ReleaseFeedPort } from "@/application/ports/release-feed.port";
 import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
+import { logger } from "@/infrastructure/logging/logger";
+
+const log = logger.child({ component: "get-recent-releases" });
 
 export class GetRecentReleasesUseCase {
   constructor(
@@ -17,7 +20,7 @@ export class GetRecentReleasesUseCase {
     let releases = await this.feedRepository.getReleases(lookbackDays);
 
     if (releases.length === 0) {
-      console.log("[GetRecentReleasesUseCase] Empty release cache — running Deezer-first fallback");
+      log.info("Empty release cache — running Deezer-first fallback");
 
       const artists = await this.spotifyUserLibraryService.getFollowedArtists();
       const catalogArtists = artists.map((a) => ({
@@ -35,13 +38,12 @@ export class GetRecentReleasesUseCase {
 
       if (fallbackReleases.length > 0) {
         await this.feedRepository.upsertReleases(fallbackReleases);
-        console.log(
-          `[GetRecentReleasesUseCase] Fallback warmed cache with ${fallbackReleases.length} releases for ${artists.length} artists`,
+        log.info(
+          { releaseCount: fallbackReleases.length, artistCount: artists.length },
+          "Fallback warmed cache",
         );
       } else {
-        console.warn(
-          "[GetRecentReleasesUseCase] Fallback resolved 0 releases — DB warming skipped",
-        );
+        log.warn("Fallback resolved 0 releases — DB warming skipped");
       }
 
       releases = fallbackReleases;

--- a/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
+++ b/apps/backend/src/application/use-cases/library/scan-library.use-case.ts
@@ -6,7 +6,10 @@ import type {
 import type { SettingsPort } from "@/application/ports/settings.port";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import type { RetryTrackDownloadUseCase } from "../tracks/retry-track-download.use-case";
+
+const log = logger.child({ component: "scan-library" });
 
 const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
 
@@ -24,7 +27,7 @@ export class ScanLibraryUseCase {
     const startTime = Date.now();
     const libraryPath = this.pathService.getMusicLibraryPath();
 
-    console.log(`🔍 Scanning music library at: ${libraryPath}`);
+    log.info({ libraryPath }, "Scanning music library");
 
     const artists = await this.scannerService.scanMusicLibrary(libraryPath);
 
@@ -105,12 +108,12 @@ export class ScanLibraryUseCase {
                 await this.retryTrackDownloadUseCase.execute(track.id);
               }
             } catch (err) {
-              console.warn(`[ScanLibrary] Reconciliation failed for track ${track.id}:`, err);
+              log.warn({ err, trackId: track.id }, "Reconciliation failed for track");
             }
           }
         }
       } catch (err) {
-        console.warn("Failed to attach track durations from database:", err);
+        log.warn({ err }, "Failed to attach track durations from database");
       }
     }
 
@@ -121,9 +124,16 @@ export class ScanLibraryUseCase {
 
     const scanDuration = Date.now() - startTime;
 
-    console.log(`✅ Library scan completed in ${scanDuration}ms`);
-    console.log(`   Found: ${totalArtists} artists, ${totalAlbums} albums, ${totalTracks} tracks`);
-    console.log(`   Total size: ${(totalSize / 1024 / 1024).toFixed(2)} MB`);
+    log.info(
+      {
+        scanDuration,
+        totalArtists,
+        totalAlbums,
+        totalTracks,
+        totalSizeMb: (totalSize / 1024 / 1024).toFixed(2),
+      },
+      "Library scan completed",
+    );
 
     return {
       artists,

--- a/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/create-playlist.use-case.ts
@@ -14,8 +14,11 @@ import { AppError } from "@/domain/errors/app-error";
 import type { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import type { TrackService } from "../../services/track.service";
 import type { GetAlbumTracksUseCase } from "../artists/get-album-tracks.use-case";
+
+const log = logger.child({ component: "create-playlist" });
 
 interface DeezerAlbumTracksPort {
   getAlbumTracks(deezerAlbumId: string | number): Promise<NormalizedTrack[]>;
@@ -77,7 +80,7 @@ export class CreatePlaylistUseCase {
 
     try {
       detail = await this.spotifyService.getPlaylistDetail(spotifyUrl);
-      console.debug(`Playlist detail retrieved with ${detail.tracks?.length || 0} tracks`);
+      log.debug({ trackCount: detail.tracks?.length || 0 }, "Playlist detail retrieved");
 
       let displayName = detail.name;
       if ((detail.type === "track" || detail.type === "album") && detail.tracks?.length > 0) {
@@ -110,10 +113,7 @@ export class CreatePlaylistUseCase {
         playlist.markAsSubscribed();
       }
     } catch (error) {
-      console.error(
-        `Error getting playlist details: ${spotifyUrl}`,
-        error instanceof Error ? error.stack : String(error),
-      );
+      log.error({ err: error, spotifyUrl }, "Error getting playlist details");
       playlist.markAsError(error instanceof Error ? error.message : String(error));
     }
 
@@ -125,7 +125,10 @@ export class CreatePlaylistUseCase {
       const playlistType = this.urlTypeToPlaylistType(urlType);
       await this.processTracks(savedPlaylist, detail.tracks, playlistType);
     } else {
-      console.warn(`No tracks found for playlist ${savedPlaylist.name}`);
+      log.warn(
+        { playlistId: savedPlaylist.id, name: savedPlaylist.name },
+        "No tracks found for playlist",
+      );
     }
 
     this.eventBus.emit("playlists-updated");
@@ -194,7 +197,7 @@ export class CreatePlaylistUseCase {
     if (tracks.length > 0) {
       await this.processTracks(savedPlaylist, tracks, PlaylistTypeEnum.Album);
     } else {
-      console.warn(`No tracks found for album ${albumName}`);
+      log.warn({ albumName }, "No tracks found for album");
     }
 
     this.eventBus.emit("playlists-updated");
@@ -429,7 +432,10 @@ export class CreatePlaylistUseCase {
     tracks: NormalizedTrack[],
     type: PlaylistTypeEnum,
   ): Promise<void> {
-    console.debug(`Starting to process ${tracks.length} tracks for playlist ${playlist.name}`);
+    log.debug(
+      { trackCount: tracks.length, playlistId: playlist.id, name: playlist.name },
+      "Starting to process tracks for playlist",
+    );
 
     let processedCount = 0;
     let skippedCount = 0;
@@ -457,12 +463,13 @@ export class CreatePlaylistUseCase {
       }
 
       if (processedCount % 50 === 0 && processedCount > 0) {
-        console.debug(`Processed ${processedCount} tracks so far for playlist ${playlist.name}`);
+        log.debug({ processedCount, playlistId: playlist.id }, "Processed tracks so far");
       }
     }
 
-    console.debug(
-      `Finished processing playlist ${playlist.name}: ${processedCount} tracks processed, ${skippedCount} skipped, ${errorCount} errors`,
+    log.debug(
+      { playlistId: playlist.id, name: playlist.name, processedCount, skippedCount, errorCount },
+      "Finished processing playlist",
     );
   }
 
@@ -479,12 +486,15 @@ export class CreatePlaylistUseCase {
   ): Promise<"ok" | "skipped" | "error"> {
     try {
       if (!track.artist || !track.name) {
-        console.warn(`Skipping track ${index + 1}: Missing artist or name information`);
+        log.warn({ trackIndex: index + 1 }, "Skipping track: missing artist or name information");
         return "skipped";
       }
 
       if (track.unavailable === true) {
-        console.warn(`Skipping unavailable track ${index + 1}: ${track.artist} - ${track.name}`);
+        log.warn(
+          { trackIndex: index + 1, artist: track.artist, name: track.name },
+          "Skipping unavailable track",
+        );
         return "skipped";
       }
 
@@ -514,9 +524,7 @@ export class CreatePlaylistUseCase {
 
       return "ok";
     } catch (error) {
-      console.error(
-        `Error creating track "${track?.artist || "Unknown"} - ${track?.name || "Unknown"}": ${error instanceof Error ? error.message : String(error)}`,
-      );
+      log.error({ err: error, artist: track?.artist, name: track?.name }, "Error creating track");
       return "error";
     }
   }

--- a/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-my-playlists.use-case.test.ts
@@ -26,7 +26,6 @@ const freshPlaylists = [
 describe("GetMyPlaylistsUseCase", () => {
   it("calls Spotify and returns the remote playlists", async () => {
     const { spotifyService } = makeDeps();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     spotifyService.getMyPlaylists.mockResolvedValue(freshPlaylists);
     const useCase = makeUseCase(spotifyService);
 
@@ -34,8 +33,6 @@ describe("GetMyPlaylistsUseCase", () => {
 
     expect(spotifyService.getMyPlaylists).toHaveBeenCalledOnce();
     expect(result).toEqual(freshPlaylists);
-    expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
   });
 
   it("does not swallow Spotify errors behind cache fallbacks", async () => {

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview-tracks-page.use-case.test.ts
@@ -18,7 +18,6 @@ const makeUseCase = (spotifyService: Pick<SpotifyService, "getPlaylistTracksPage
 describe("GetPlaylistPreviewTracksPageUseCase", () => {
   it("calls Spotify and maps the tracks page response", async () => {
     const { spotifyService } = makeDeps();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     spotifyService.getPlaylistTracksPage.mockResolvedValue({
       tracks: [
         {
@@ -55,8 +54,6 @@ describe("GetPlaylistPreviewTracksPageUseCase", () => {
       hasMore: true,
       nextOffset: 50,
     });
-    expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
   });
 
   it("returns the latest Spotify page across consecutive executions", async () => {

--- a/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/playlists/get-playlist-preview.use-case.test.ts
@@ -17,14 +17,12 @@ const makePreviewUseCase = (
   spotifyService: Pick<SpotifyService, "getPlaylistDetail" | "getPlaylistTracksPage">,
 ) => new GetPlaylistPreviewUseCase(spotifyService as unknown as SpotifyService);
 
-const makeTracksPageUseCase = (
-  spotifyService: Pick<SpotifyService, "getPlaylistTracksPage">,
-) => new GetPlaylistPreviewTracksPageUseCase(spotifyService as unknown as SpotifyService);
+const makeTracksPageUseCase = (spotifyService: Pick<SpotifyService, "getPlaylistTracksPage">) =>
+  new GetPlaylistPreviewTracksPageUseCase(spotifyService as unknown as SpotifyService);
 
 describe("GetPlaylistPreviewUseCase", () => {
   it("calls Spotify and returns the preview payload directly", async () => {
     const { spotifyService } = makeDeps();
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     spotifyService.getPlaylistDetail.mockResolvedValue({
       name: "Fresh Playlist",
       type: "playlist",
@@ -45,8 +43,6 @@ describe("GetPlaylistPreviewUseCase", () => {
         totalTracks: 0,
       }),
     );
-    expect(errorSpy).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
   });
 
   it("uses the live Spotify payload instead of relying on cache-key versioning", async () => {

--- a/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
+++ b/apps/backend/src/application/use-cases/playlists/sync-subscribed-playlists.use-case.ts
@@ -5,7 +5,10 @@ import { AppError } from "@/domain/errors/app-error";
 import { EventBus } from "@/domain/events/event-bus";
 import { SpotifyUrlHelper, SpotifyUrlType } from "@/domain/helpers/spotify-url.helper";
 import type { PlaylistRepository } from "@/domain/repositories/playlist.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import { TrackService } from "../../services/track.service";
+
+const log = logger.child({ component: "sync-subscribed-playlists" });
 
 const PERMANENTLY_UNAVAILABLE_ERROR_CODES = new Set([
   "playlist_not_accessible",
@@ -27,9 +30,7 @@ export class SyncSubscribedPlaylistsUseCase {
 
   async execute(): Promise<void> {
     if (this.spotifyCircuitBreaker.isOpen()) {
-      console.warn(
-        "[SyncSubscribedPlaylists] Skipping run — Spotify circuit breaker is open. Will retry on next scheduled tick.",
-      );
+      log.warn("Skipping run — Spotify circuit breaker is open. Will retry on next scheduled tick");
       return;
     }
 
@@ -67,8 +68,9 @@ export class SyncSubscribedPlaylistsUseCase {
           playlist.markAsUnsubscribed();
           playlist.markAsError(message);
           await this.playlistRepository.update(playlist.id, playlist);
-          console.warn(
-            `[SyncSubscribedPlaylists] Unsubscribed permanently-unavailable playlist ${playlist.id}: ${errorCode}`,
+          log.warn(
+            { playlistId: playlist.id, errorCode },
+            "Unsubscribed permanently-unavailable playlist",
           );
           continue;
         }
@@ -76,9 +78,7 @@ export class SyncSubscribedPlaylistsUseCase {
         if (errorCode === "circuit_open" || errorCode === "spotify_rate_limited") {
           // Transient: stop the loop entirely — every other playlist will fail
           // for the same reason and we'll just spam writes.
-          console.warn(
-            "[SyncSubscribedPlaylists] Aborting run — Spotify rate limited. Will retry on next scheduled tick.",
-          );
+          log.warn("Aborting run — Spotify rate limited. Will retry on next scheduled tick");
           return;
         }
 

--- a/apps/backend/src/application/use-cases/settings/update-setting.use-case.ts
+++ b/apps/backend/src/application/use-cases/settings/update-setting.use-case.ts
@@ -1,7 +1,10 @@
 import type { SpotifyUserLibraryPort } from "@/application/ports/spotify-user-library.port";
 import type { EventBus } from "@/domain/events/event-bus";
 import type { SettingsRepository } from "@/domain/repositories/settings.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import { MASKED_SENTINEL } from "./get-settings.use-case";
+
+const log = logger.child({ component: "update-setting" });
 
 export class UpdateSettingUseCase {
   constructor(
@@ -32,7 +35,7 @@ export class UpdateSettingUseCase {
 
         fs.writeFileSync(cookiePath, value, "utf-8");
         finalValue = cookiePath;
-        console.log(`Saved YouTube cookies to ${cookiePath}`);
+        log.info({ cookiePath }, "Saved YouTube cookies");
       }
     }
 

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Track } from "@/domain/entities/track.entity";
 import { DownloadTrackUseCase } from "./download-track.use-case";
 
+const loggerMock = vi.hoisted(() => {
+  const mock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+  mock.child.mockReturnValue(mock);
+  return mock;
+});
+
+vi.mock("../../../infrastructure/logging/logger", () => ({ logger: loggerMock }));
+
 function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
   return {
     id: "track-1",
@@ -37,8 +45,6 @@ describe("DownloadTrackUseCase", () => {
   let useCase: DownloadTrackUseCase;
 
   beforeEach(() => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
     trackRepository = {
       findOne: vi.fn(),
       update: vi.fn().mockResolvedValue(undefined),

--- a/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/download-track.use-case.ts
@@ -6,8 +6,11 @@ import { EventBus } from "@/domain/events/event-bus";
 import { HistoryRepository } from "@/domain/repositories/history.repository";
 import { PlaylistRepository } from "@/domain/repositories/playlist.repository";
 import { TrackRepository } from "@/domain/repositories/track.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import { TrackPostProcessingService } from "../../services/track-post-processing.service";
 import { getErrorMessage } from "../../utils/error.utils";
+
+const log = logger.child({ component: "download-track" });
 
 export class DownloadTrackUseCase {
   constructor(
@@ -45,9 +48,9 @@ export class DownloadTrackUseCase {
     try {
       ({ durationMs } = await this.downloadAndProcessTrack(track.toPrimitive()));
     } catch (err) {
-      console.error(
-        `Failed to download track: ${track.artist} - ${track.name}`,
-        getErrorMessage(err),
+      log.error(
+        { err, trackId: track.id, artist: track.artist, name: track.name },
+        "Failed to download track",
       );
       error = getErrorMessage(err);
     }
@@ -95,7 +98,7 @@ export class DownloadTrackUseCase {
   private validateTrack(track: ITrack): void {
     if (!track.name || !track.artist) {
       const errorMsg = `Track field is null or undefined: name=${track.name}, artist=${track.artist}`;
-      console.error(errorMsg);
+      log.error({ trackId: track.id }, errorMsg);
       throw new AppError(400, "internal_server_error", errorMsg);
     }
   }

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Track } from "@/domain/entities/track.entity";
 import { RecoverErroredTracksUseCase } from "./recover-errored-tracks.use-case";
 
+const loggerMock = vi.hoisted(() => {
+  const mock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+  mock.child.mockReturnValue(mock);
+  return mock;
+});
+
+vi.mock("../../../infrastructure/logging/logger", () => ({ logger: loggerMock }));
+
 function makeErrorTrack(overrides: Partial<ITrack> = {}): Track {
   return new Track({
     id: "track-err-1",
@@ -145,7 +153,6 @@ describe("RecoverErroredTracksUseCase", () => {
     retryTrackDownloadUseCase.execute.mockImplementation((id: string) =>
       id === "track-fail" ? Promise.reject(new Error("redis down")) : Promise.resolve(undefined),
     );
-    vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(useCase.execute()).resolves.not.toThrow();
 

--- a/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/recover-errored-tracks.use-case.ts
@@ -3,7 +3,10 @@ import type { SettingsPort } from "@/application/ports/settings.port";
 import type { SpotifyCircuitBreakerPort } from "@/application/ports/spotify-circuit-breaker.port";
 import { EventBus } from "@/domain/events/event-bus";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import type { RetryTrackDownloadUseCase } from "./retry-track-download.use-case";
+
+const log = logger.child({ component: "recover-errored-tracks" });
 
 const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
 
@@ -18,8 +21,8 @@ export class RecoverErroredTracksUseCase {
 
   async execute(): Promise<void> {
     if (this.spotifyCircuitBreaker.isOpen()) {
-      console.warn(
-        "[RecoverErroredTracks] Skipping run — Spotify circuit breaker is open. Tracks remain in Error and will be retried on next tick.",
+      log.warn(
+        "Skipping run — Spotify circuit breaker is open. Tracks remain in Error and will be retried on next tick",
       );
       return;
     }
@@ -44,10 +47,7 @@ export class RecoverErroredTracksUseCase {
         await this.retryTrackDownloadUseCase.execute(track.id);
         recovered++;
       } catch (error) {
-        console.error(
-          `[RecoverErroredTracks] Failed to re-drive track ${track.id}:`,
-          error instanceof Error ? error.message : String(error),
-        );
+        log.error({ err: error, trackId: track.id }, "Failed to re-drive track");
       }
     }
 

--- a/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/rescue-stuck-tracks.use-case.ts
@@ -1,6 +1,9 @@
 import { TrackStatusEnum } from "@spotiarr/shared";
 import type { TrackRepository } from "@/domain/repositories/track.repository";
+import { logger } from "@/infrastructure/logging/logger";
 import type { RetryTrackDownloadUseCase } from "./retry-track-download.use-case";
+
+const log = logger.child({ component: "rescue-stuck-tracks" });
 
 export class RescueStuckTracksUseCase {
   constructor(
@@ -9,7 +12,7 @@ export class RescueStuckTracksUseCase {
   ) {}
 
   async execute(): Promise<void> {
-    console.log("🚑 Checking for stuck tracks...");
+    log.info("Checking for stuck tracks");
 
     const stuckStatuses = [
       TrackStatusEnum.New,
@@ -21,28 +24,28 @@ export class RescueStuckTracksUseCase {
     const stuckTracks = await this.trackRepository.findAllByStatuses(stuckStatuses);
 
     if (stuckTracks.length === 0) {
-      console.log("✅ No stuck tracks found.");
+      log.info("No stuck tracks found");
       return;
     }
 
-    console.log(`⚠️ Found ${stuckTracks.length} stuck tracks. Rescuing...`);
+    log.info({ count: stuckTracks.length }, "Found stuck tracks, rescuing");
 
     let rescuedCount = 0;
     for (const track of stuckTracks) {
       if (!track.id || !track.status) continue;
 
       try {
-        console.log(`🔄 Rescuing track: ${track.artist} - ${track.name} [${track.status}]`);
+        log.info(
+          { trackId: track.id, artist: track.artist, name: track.name, status: track.status },
+          "Rescuing stuck track",
+        );
         await this.retryTrackDownloadUseCase.execute(track.id);
         rescuedCount++;
       } catch (error) {
-        console.error(
-          `❌ Failed to rescue track ${track.id}:`,
-          error instanceof Error ? error.message : String(error),
-        );
+        log.error({ err: error, trackId: track.id }, "Failed to rescue track");
       }
     }
 
-    console.log(`✅ Rescued ${rescuedCount}/${stuckTracks.length} tracks.`);
+    log.info({ rescued: rescuedCount, total: stuckTracks.length }, "Rescue complete");
   }
 }

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.test.ts
@@ -3,6 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Track } from "@/domain/entities/track.entity";
 import { SearchTrackOnYoutubeUseCase } from "./search-track-on-youtube.use-case";
 
+const loggerMock = vi.hoisted(() => {
+  const mock = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+  mock.child.mockReturnValue(mock);
+  return mock;
+});
+
+vi.mock("../../../infrastructure/logging/logger", () => ({ logger: loggerMock }));
+
 function makeTrack(overrides: Partial<ITrack> = {}): ITrack {
   return {
     id: "track-1",
@@ -25,8 +33,6 @@ describe("SearchTrackOnYoutubeUseCase", () => {
   let useCase: SearchTrackOnYoutubeUseCase;
 
   beforeEach(() => {
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
     trackRepository = {
       findOneWithPlaylist: vi.fn(),
       update: vi.fn().mockResolvedValue(undefined),

--- a/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
+++ b/apps/backend/src/application/use-cases/tracks/search-track-on-youtube.use-case.ts
@@ -4,6 +4,9 @@ import type { YoutubeSearchPort } from "@/application/ports/youtube.port";
 import { EventBus } from "@/domain/events/event-bus";
 import { TrackRepository } from "@/domain/repositories/track.repository";
 import type { TrackQueueService } from "@/domain/services/track-queue.service";
+import { logger } from "@/infrastructure/logging/logger";
+
+const log = logger.child({ component: "search-track-on-youtube" });
 
 const DEFAULT_SEARCH_MAX_ATTEMPTS = 5;
 
@@ -67,9 +70,9 @@ export class SearchTrackOnYoutubeUseCase {
           existingTrack.markAsError("youtube_not_found");
         }
       } catch (error) {
-        console.error(
-          `Failed to find track on YouTube: ${existingTrack.artist} - ${existingTrack.name}`,
-          error instanceof Error ? error.stack : String(error),
+        log.error(
+          { err: error, artist: existingTrack.artist, name: existingTrack.name },
+          "Failed to find track on YouTube",
         );
         existingTrack.markAsError(error instanceof Error ? error.message : String(error));
       }


### PR DESCRIPTION
## Chain context

This is **slice 3 of 4** in the feature-branch chain for issue #150.

```
refactor/backend-structured-logging (tracker, no-merge)
  └── slice 1 — PR #246 (logger infra + bootstrap)
        └── slice 2 — PR #247 (BullMQ workers + jobs)
              └── slice 3 — this PR 📍
                    └── slice 4 — presentation + remaining infra (upcoming)
```

## Summary

- Migrates all `console.log/warn/error/debug` calls in `application/use-cases/**` and `application/services/**` to `logger.child({ component })` structured calls (10 use-case files + 3 service files — 0 console.* calls remain in the application layer).
- Updates test files that previously spied on `console.*` to use the `vi.mock("@/infrastructure/logging/logger")` pattern via `vi.hoisted`.
- Extends the architecture guard (R2) to allowlist `@/infrastructure/logging/logger` imports from the application layer, per design ADR-1 (logger is a documented cross-cutting exception — not a regular infrastructure dependency).

## Changes

| File | Change |
|------|--------|
| `application/use-cases/tracks/rescue-stuck-tracks.use-case.ts` | 5 console.* → logger.child |
| `application/use-cases/tracks/download-track.use-case.ts` | 2 console.* → logger.child |
| `application/use-cases/tracks/recover-errored-tracks.use-case.ts` | 2 console.* → logger.child |
| `application/use-cases/tracks/search-track-on-youtube.use-case.ts` | 1 console.* → logger.child |
| `application/use-cases/library/scan-library.use-case.ts` | 5 console.* → logger.child |
| `application/use-cases/feed/get-recent-releases.use-case.ts` | 3 console.* → logger.child |
| `application/use-cases/playlists/sync-subscribed-playlists.use-case.ts` | 3 console.* → logger.child |
| `application/use-cases/playlists/create-playlist.use-case.ts` | 10 console.* → logger.child |
| `application/use-cases/ai/generate-ai-playlist.use-case.ts` | 5 console.* → logger.child |
| `application/use-cases/settings/update-setting.use-case.ts` | 1 console.* → logger.child |
| `application/services/artwork.service.ts` | 3 console.* → logger.child |
| `application/services/spotify.service.ts` | 3 console.* → logger.child |
| `application/services/track-post-processing.service.ts` | 3 console.* → logger.child |
| Test files (7) | Removed console spies, added logger mock |
| `__tests__/architecture.test.ts` | Extended R2 to allowlist logger cross-cut import |

## Verification

- `pnpm --filter backend test:run`: **171 files, 1842 tests passing** (matches baseline)
- `pnpm --filter backend run lint`: exit 0 (warnings only, pre-existing)
- `pnpm --filter backend run build`: exit 0

Closes #150 (partial — slice 3 of 4)