### PR TITLE
chore(frontend): make vite dev server allowed hosts env-driven

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig(({ mode }) => {
   const envDir = resolve(__dirname, "../../");
   // Load environment variables including those without VITE_ prefix
   const env = loadEnv(mode, envDir, "");
+  const allowedHosts = env.DEV_ALLOWED_HOSTS?.split(",")
+    .map((host) => host.trim())
+    .filter(Boolean);
 
   return {
     plugins: [
@@ -59,6 +62,7 @@ export default defineConfig(({ mode }) => {
     envDir,
     server: {
       host: env.PUBLIC_HOST || "localhost",
+      allowedHosts,
       proxy: {
         "/api": {
           target: `http://${env.PUBLIC_HOST || "localhost"}:3000`,


### PR DESCRIPTION
## What

Make the Vite dev server `allowedHosts` env-driven instead of hardcoding tunnel providers.

```ts
const allowedHosts = env.DEV_ALLOWED_HOSTS?.split(",").map((h) => h.trim()).filter(Boolean);
// ...
server: { host: ..., allowedHosts, ... }
```

## Why

Accessing `pnpm dev` through a public tunnel (Cloudflare, tunnelmole) requires the tunnel hostname in `server.allowedHosts`, or Vite blocks the request (DNS-rebinding protection). Previously this needed a local working-tree edit.

## Design

- **Dev-only**: `server.allowedHosts` affects `vite dev` exclusively. Zero impact on the production build (static `dist`, no dev server).
- **Secure by default**: when `DEV_ALLOWED_HOSTS` is unset, `allowedHosts` is `undefined` → Vite's default (localhost / configured host only). No third-party tunnel domains are baked into the repo for everyone.
- **Opt-in**: set `DEV_ALLOWED_HOSTS=.trycloudflare.com,.tunnelmole.net` (comma-separated; leading dot = wildcard subdomain) only when you tunnel.

## Follow-up (needs maintainer with .env write access)

Add to `.env.example`:
```
# Extra hostnames allowed to reach the Vite dev server (Optional, comma-separated).
# Only needed when exposing the dev server through a tunnel (Cloudflare, tunnelmole, etc.).
# A leading dot matches any subdomain. Unset = only localhost / the configured host.
# DEV_ALLOWED_HOSTS=.trycloudflare.com,.tunnelmole.net
```

## Verification
- `pnpm --filter frontend run test:run` green (config loads under vitest)
- oxlint clean
