### PR TITLE
style(frontend): left-align track title and artist in player bar (mobile + desktop)

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -62,7 +62,7 @@ const TrackMetaContent: FC<{ item: QueueItem }> = ({ item }) => (
     <div className="h-10 w-10 shrink-0 overflow-hidden rounded shadow-sm">
       <Image src={item.artworkUrl} alt={item.name} className="rounded" />
     </div>
-    <div className="flex min-w-0 flex-col">
+    <div className="flex min-w-0 flex-col text-left">
       <span className="truncate text-sm font-semibold text-white">{item.name}</span>
       <span className="text-text-secondary truncate text-xs">{item.artist}</span>
     </div>

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -341,7 +341,7 @@ export const GlobalPlayerBar: FC = () => {
                         className="rounded"
                       />
                     </div>
-                    <div className="flex min-w-0 flex-1 flex-col items-center text-center">
+                    <div className="flex min-w-0 flex-1 flex-col items-start text-left">
                       <span className="w-full truncate text-sm font-semibold text-white">
                         {currentItem.name}
                       </span>


### PR DESCRIPTION
## Why

Track title and artist were not consistently left-aligned in the player bar:

- **Mobile** trigger used `items-center text-center`, inconsistent with the desktop `TrackMeta` layout.
- **Desktop**: when a track has a `contextPath`, `TrackMeta` renders a `<button>` whose browser-default `text-align: center` centered the shorter artist line.

## What

- Mobile trigger: `items-center text-center` → `items-start text-left` (kept `w-full truncate`).
- `TrackMetaContent`: added `text-left` so title and artist stay left-aligned in both the button and non-button branches.

## Acceptance

- [x] Title and artist left-aligned on mobile
- [x] Title and artist left-aligned on desktop (including context-link button)
- [x] No regression to truncation / min-width
- [x] Build passes

Closes #257