### PR TITLE
feat(frontend): Artists section heading + consistent library grid sizing

### DIFF
--- a/apps/frontend/src/components/molecules/HomePlaylistCard.test.tsx
+++ b/apps/frontend/src/components/molecules/HomePlaylistCard.test.tsx
@@ -1,7 +1,7 @@
+import { TrackStatusEnum } from "@spotiarr/shared";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { PlaylistWithStats } from "@/types";
-import { TrackStatusEnum } from "@spotiarr/shared";
 import { HomePlaylistCard } from "./HomePlaylistCard";
 
 vi.mock("react-i18next", () => ({
@@ -80,6 +80,19 @@ describe("HomePlaylistCard", () => {
     expect(screen.getByText("12/187")).not.toBeNull();
   });
 
+  it("hides the count badge when the playlist is fully downloaded", () => {
+    const playlist = makePlaylist();
+    render(
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={50}
+        totalCount={50}
+        onClick={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("50/50")).toBeNull();
+  });
+
   it("renders cover image when coverUrl is provided", () => {
     const playlist = makePlaylist({ coverUrl: "https://example.com/img.jpg" });
     render(
@@ -98,7 +111,12 @@ describe("HomePlaylistCard", () => {
     const onClick = vi.fn();
     const playlist = makePlaylist({ id: "my-id" });
     render(
-      <HomePlaylistCard playlist={playlist} downloadedCount={1} totalCount={10} onClick={onClick} />,
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={1}
+        totalCount={10}
+        onClick={onClick}
+      />,
     );
     const button = screen.getByRole("button");
     fireEvent.click(button);

--- a/apps/frontend/src/components/molecules/HomePlaylistCard.tsx
+++ b/apps/frontend/src/components/molecules/HomePlaylistCard.tsx
@@ -49,9 +49,11 @@ export const HomePlaylistCard: FC<HomePlaylistCardProps> = memo(
         <p className="text-text-secondary truncate text-sm">
           {t("common.by", "By")} {playlist.owner ?? ""}
         </p>
-        <span className="bg-background-hover text-text-secondary mt-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
-          {downloadedCount}/{totalCount}
-        </span>
+        {downloadedCount < totalCount && (
+          <span className="bg-background-hover text-text-secondary mt-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
+            {downloadedCount}/{totalCount}
+          </span>
+        )}
       </button>
     );
   },

--- a/apps/frontend/src/components/organisms/HomePlaylistList.test.tsx
+++ b/apps/frontend/src/components/organisms/HomePlaylistList.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
 import { TrackStatusEnum } from "@spotiarr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
 import { PlaylistWithStats } from "@/types";
 import { HomePlaylistList } from "./HomePlaylistList";
 
@@ -10,8 +11,28 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-// HomePlaylistList uses a simple grid, not VirtualGrid, so we don't need to mock Virtuoso
-const makeItem = (id: string, name: string): { playlist: PlaylistWithStats; downloadedCount: number; totalCount: number } => ({
+vi.mock("../molecules/VirtualGrid", () => ({
+  VirtualGrid: <T,>({
+    items,
+    itemKey,
+    renderItem,
+  }: {
+    items: T[];
+    itemKey: (item: T) => string;
+    renderItem: (item: T) => ReactNode;
+  }) => (
+    <div>
+      {items.map((item) => (
+        <div key={itemKey(item)}>{renderItem(item)}</div>
+      ))}
+    </div>
+  ),
+}));
+
+const makeItem = (
+  id: string,
+  name: string,
+): { playlist: PlaylistWithStats; downloadedCount: number; totalCount: number } => ({
   playlist: {
     id,
     name,

--- a/apps/frontend/src/components/organisms/HomePlaylistList.tsx
+++ b/apps/frontend/src/components/organisms/HomePlaylistList.tsx
@@ -1,6 +1,7 @@
 import { FC, memo, useCallback } from "react";
-import { HomePlaylistCard } from "../molecules/HomePlaylistCard";
 import { PlaylistWithStats } from "@/types";
+import { HomePlaylistCard } from "../molecules/HomePlaylistCard";
+import { VirtualGrid } from "../molecules/VirtualGrid";
 
 interface HomePlaylistListItem {
   playlist: PlaylistWithStats;
@@ -21,20 +22,22 @@ export const HomePlaylistList: FC<HomePlaylistListProps> = memo(({ items, onPlay
     [onPlaylistClick],
   );
 
+  const renderItem = useCallback(
+    ({ playlist, downloadedCount, totalCount }: HomePlaylistListItem) => (
+      <HomePlaylistCard
+        playlist={playlist}
+        downloadedCount={downloadedCount}
+        totalCount={totalCount}
+        onClick={handleClick}
+      />
+    ),
+    [handleClick],
+  );
+
   if (items.length === 0) return null;
 
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-      {items.map(({ playlist, downloadedCount, totalCount }) => (
-        <HomePlaylistCard
-          key={playlist.id}
-          playlist={playlist}
-          downloadedCount={downloadedCount}
-          totalCount={totalCount}
-          onClick={handleClick}
-        />
-      ))}
-    </div>
+    <VirtualGrid items={items} itemKey={({ playlist }) => playlist.id} renderItem={renderItem} />
   );
 });
 

--- a/apps/frontend/src/locales/en.json
+++ b/apps/frontend/src/locales/en.json
@@ -140,6 +140,7 @@
     "albumSearchNoResults": "No albums found",
     "albumSearchNoResultsDescription": "No albums match your search.",
     "playlistsSection": "Playlists",
+    "artistsSection": "Artists",
     "artistNotFound": "Artist not found",
     "artistNotFoundDescription": "Could not load artist details.",
     "artistCardAriaLabel": "Artist {{name}}, {{albums}} albums, {{tracks}} tracks",

--- a/apps/frontend/src/locales/es.json
+++ b/apps/frontend/src/locales/es.json
@@ -140,6 +140,7 @@
     "albumSearchNoResults": "No se encontraron álbumes",
     "albumSearchNoResultsDescription": "Ningún álbum coincide con tu búsqueda.",
     "playlistsSection": "Listas",
+    "artistsSection": "Artistas",
     "artistNotFound": "Artista no encontrado",
     "artistNotFoundDescription": "No se pudieron cargar los detalles del artista.",
     "artistCardAriaLabel": "Artista {{name}}, {{albums}} álbumes, {{tracks}} canciones",

--- a/apps/frontend/src/views/Home.test.tsx
+++ b/apps/frontend/src/views/Home.test.tsx
@@ -183,6 +183,39 @@ describe("Home", () => {
     expect(artistList.getAttribute("data-count")).toBe("1");
   });
 
+  it("renders the artists section heading above the artist list when artists are present", () => {
+    const artist = {
+      name: "Rock Band",
+      path: "/rb",
+      albumCount: 2,
+      trackCount: 20,
+      totalSize: 0,
+      albums: [],
+    };
+    mockUseHomeController.mockReturnValue({
+      ...defaultController,
+      artists: [artist],
+      filteredArtists: [artist],
+    });
+
+    render(<Home />);
+
+    const heading = screen.getByRole("heading", { name: "Artists" });
+    const artistList = screen.getByTestId("artist-list");
+    expect(heading).not.toBeNull();
+    expect(heading.compareDocumentPosition(artistList) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+  });
+
+  it("hides the artists section heading when no artists are present", () => {
+    mockUseHomeController.mockReturnValue(defaultController);
+
+    render(<Home />);
+
+    expect(screen.queryByRole("heading", { name: "Artists" })).toBeNull();
+  });
+
   it("does not render library stat cards (stats block moved to Dashboard)", () => {
     mockUseHomeController.mockReturnValue({
       ...defaultController,

--- a/apps/frontend/src/views/Home.tsx
+++ b/apps/frontend/src/views/Home.tsx
@@ -89,7 +89,12 @@ export const Home: FC = () => {
                 }
               />
             ) : filteredArtists.length > 0 ? (
-              <LibraryArtistList artists={filteredArtists} onArtistClick={handleArtistClick} />
+              <div className="mb-8">
+                <h2 className="text-text-primary mb-4 text-lg font-semibold">
+                  {t("library.artistsSection", "Artists")}
+                </h2>
+                <LibraryArtistList artists={filteredArtists} onArtistClick={handleArtistClick} />
+              </div>
             ) : null}
           </>
         )}


### PR DESCRIPTION
## Why

Two related Home/Library UI inconsistencies:

1. The Playlists section had a heading but the Artists list did not — visually inconsistent (closes #256).
2. Playlist cards and artist cards rendered at different sizes on desktop because the two grids used different column systems: `HomePlaylistList` used static Tailwind classes (`grid-cols-2 sm:3 md:4 lg:5 xl:6`) while every other library grid used `VirtualGrid` + `APP_CONFIG.GRID`. They diverged at most breakpoints (e.g. 5 vs 4 columns at 1024–1279px).

## What

- **Artists heading**: added `library.artistsSection` i18n key (en: "Artists", es: "Artistas") and rendered an `<h2>` above `LibraryArtistList`, matching the Playlists section markup. Only shown when artists exist.
- **Grid consistency**: migrated `HomePlaylistList` from a static Tailwind grid to `VirtualGrid`. All 8 library grids now read column count from a single source (`APP_CONFIG.GRID` via `useGridColumns`), so playlist and artist cards share the same size at every breakpoint and gain the same virtualization.

## Acceptance (#256)

- "Artists" heading shows above the artist list ✅
- Translated via i18n ✅
- Hidden when no artists ✅

## Validation

- `pnpm --filter frontend run lint` — no errors (pre-existing `any` warnings only)
- `pnpm --filter frontend run test:run` — 1430 passed (added Home heading tests; `HomePlaylistList` test now mocks `VirtualGrid`)
- `pnpm --filter frontend run build` — OK

Closes #256

## Update: playlist count badge

The `X/Y` badge on playlist cards now only shows when the playlist is **partially** downloaded (`downloaded < total`). When fully downloaded it is hidden — a bare `5/5` on every complete playlist was redundant noise. Incomplete playlists (`3/5`) now stand out, since that is the actionable state.
