### PR TITLE
feat(history): backend aggregation for listening history (2/5, #205)

### DIFF
--- a/apps/backend/src/application/use-cases/history/history.use-cases.test.ts
+++ b/apps/backend/src/application/use-cases/history/history.use-cases.test.ts
@@ -1,4 +1,10 @@
-import type { DownloadHistoryItem, RecordPlayInput } from "@spotiarr/shared";
+import type {
+  DownloadHistoryItem,
+  RecordPlayInput,
+  TopTrackItem,
+  TopArtistItem,
+  RecentPlayItem,
+} from "@spotiarr/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { HistoryUseCases } from "./history.use-cases";
 
@@ -202,5 +208,185 @@ describe("HistoryUseCases.recordPlay", () => {
   it("returns void on success", async () => {
     const result = await useCases.recordPlay(makePlayInput());
     expect(result).toBeUndefined();
+  });
+});
+
+// ── Aggregation use-cases — limit clamping (REQ-LH-010, REQ-LH-014, REQ-LH-018) ────────
+
+function makeTopTrackItem(overrides: Partial<TopTrackItem> = {}): TopTrackItem {
+  return {
+    trackUrl: "https://open.spotify.com/track/x",
+    trackName: "Song",
+    artist: "Artist",
+    album: null,
+    albumCoverUrl: null,
+    playCount: 3,
+    lastPlayedAt: 1_000,
+    ...overrides,
+  };
+}
+
+function makeTopArtistItem(overrides: Partial<TopArtistItem> = {}): TopArtistItem {
+  return {
+    artist: "Artist",
+    playCount: 5,
+    lastPlayedAt: 2_000,
+    ...overrides,
+  };
+}
+
+function makeRecentPlayItem(overrides: Partial<RecentPlayItem> = {}): RecentPlayItem {
+  return {
+    trackId: null,
+    trackUrl: null,
+    trackName: "Track",
+    artist: "Artist",
+    album: null,
+    playedAt: 3_000,
+    ...overrides,
+  };
+}
+
+describe("HistoryUseCases.getTopTracks", () => {
+  let repository: {
+    findAll: ReturnType<typeof vi.fn>;
+    createFromTrack: ReturnType<typeof vi.fn>;
+    recordPlay: ReturnType<typeof vi.fn>;
+    getTopTracks: ReturnType<typeof vi.fn>;
+    getTopArtists: ReturnType<typeof vi.fn>;
+    getRecentPlays: ReturnType<typeof vi.fn>;
+  };
+  let useCases: HistoryUseCases;
+
+  beforeEach(() => {
+    repository = {
+      findAll: vi.fn(),
+      createFromTrack: vi.fn(),
+      recordPlay: vi.fn().mockResolvedValue(undefined),
+      getTopTracks: vi.fn().mockResolvedValue([]),
+      getTopArtists: vi.fn().mockResolvedValue([]),
+      getRecentPlays: vi.fn().mockResolvedValue([]),
+    };
+    useCases = new HistoryUseCases({ repository: repository as never });
+  });
+
+  it("uses default N=10 when called without arguments", async () => {
+    await useCases.getTopTracks();
+    expect(repository.getTopTracks).toHaveBeenCalledWith(10);
+  });
+
+  it("passes the provided limit to the repository", async () => {
+    await useCases.getTopTracks(25);
+    expect(repository.getTopTracks).toHaveBeenCalledWith(25);
+  });
+
+  it("clamps N to max 50 (REQ-LH-010)", async () => {
+    await useCases.getTopTracks(200);
+    expect(repository.getTopTracks).toHaveBeenCalledWith(50);
+  });
+
+  it("returns the array from the repository", async () => {
+    const items = [makeTopTrackItem()];
+    repository.getTopTracks.mockResolvedValue(items);
+
+    const result = await useCases.getTopTracks(10);
+
+    expect(result).toBe(items);
+  });
+});
+
+describe("HistoryUseCases.getTopArtists", () => {
+  let repository: {
+    findAll: ReturnType<typeof vi.fn>;
+    createFromTrack: ReturnType<typeof vi.fn>;
+    recordPlay: ReturnType<typeof vi.fn>;
+    getTopTracks: ReturnType<typeof vi.fn>;
+    getTopArtists: ReturnType<typeof vi.fn>;
+    getRecentPlays: ReturnType<typeof vi.fn>;
+  };
+  let useCases: HistoryUseCases;
+
+  beforeEach(() => {
+    repository = {
+      findAll: vi.fn(),
+      createFromTrack: vi.fn(),
+      recordPlay: vi.fn().mockResolvedValue(undefined),
+      getTopTracks: vi.fn().mockResolvedValue([]),
+      getTopArtists: vi.fn().mockResolvedValue([]),
+      getRecentPlays: vi.fn().mockResolvedValue([]),
+    };
+    useCases = new HistoryUseCases({ repository: repository as never });
+  });
+
+  it("uses default N=10 when called without arguments", async () => {
+    await useCases.getTopArtists();
+    expect(repository.getTopArtists).toHaveBeenCalledWith(10);
+  });
+
+  it("passes the provided limit to the repository", async () => {
+    await useCases.getTopArtists(20);
+    expect(repository.getTopArtists).toHaveBeenCalledWith(20);
+  });
+
+  it("clamps N to max 50 (REQ-LH-014)", async () => {
+    await useCases.getTopArtists(99);
+    expect(repository.getTopArtists).toHaveBeenCalledWith(50);
+  });
+
+  it("returns the array from the repository", async () => {
+    const items = [makeTopArtistItem()];
+    repository.getTopArtists.mockResolvedValue(items);
+
+    const result = await useCases.getTopArtists(10);
+
+    expect(result).toBe(items);
+  });
+});
+
+describe("HistoryUseCases.getRecentPlays", () => {
+  let repository: {
+    findAll: ReturnType<typeof vi.fn>;
+    createFromTrack: ReturnType<typeof vi.fn>;
+    recordPlay: ReturnType<typeof vi.fn>;
+    getTopTracks: ReturnType<typeof vi.fn>;
+    getTopArtists: ReturnType<typeof vi.fn>;
+    getRecentPlays: ReturnType<typeof vi.fn>;
+  };
+  let useCases: HistoryUseCases;
+
+  beforeEach(() => {
+    repository = {
+      findAll: vi.fn(),
+      createFromTrack: vi.fn(),
+      recordPlay: vi.fn().mockResolvedValue(undefined),
+      getTopTracks: vi.fn().mockResolvedValue([]),
+      getTopArtists: vi.fn().mockResolvedValue([]),
+      getRecentPlays: vi.fn().mockResolvedValue([]),
+    };
+    useCases = new HistoryUseCases({ repository: repository as never });
+  });
+
+  it("uses default N=20 when called without arguments", async () => {
+    await useCases.getRecentPlays();
+    expect(repository.getRecentPlays).toHaveBeenCalledWith(20);
+  });
+
+  it("passes the provided limit to the repository", async () => {
+    await useCases.getRecentPlays(50);
+    expect(repository.getRecentPlays).toHaveBeenCalledWith(50);
+  });
+
+  it("clamps N to max 100 (REQ-LH-018)", async () => {
+    await useCases.getRecentPlays(500);
+    expect(repository.getRecentPlays).toHaveBeenCalledWith(100);
+  });
+
+  it("returns the array from the repository", async () => {
+    const items = [makeRecentPlayItem()];
+    repository.getRecentPlays.mockResolvedValue(items);
+
+    const result = await useCases.getRecentPlays(20);
+
+    expect(result).toBe(items);
   });
 });

--- a/apps/backend/src/application/use-cases/history/history.use-cases.ts
+++ b/apps/backend/src/application/use-cases/history/history.use-cases.ts
@@ -1,4 +1,11 @@
-import type { PlaylistHistory, DownloadHistoryItem, RecordPlayInput } from "@spotiarr/shared";
+import type {
+  PlaylistHistory,
+  DownloadHistoryItem,
+  RecordPlayInput,
+  TopTrackItem,
+  TopArtistItem,
+  RecentPlayItem,
+} from "@spotiarr/shared";
 import type { SettingsPort } from "@/application/ports/settings.port";
 import type { HistoryRepository } from "@/domain/repositories/history.repository";
 
@@ -47,6 +54,27 @@ export class HistoryUseCases {
     if (!enabled) return;
 
     await this.deps.repository.recordPlay(input);
+  }
+
+  async getTopTracks(limit?: number): Promise<TopTrackItem[]> {
+    const DEFAULT_TOP_TRACKS = 10;
+    const MAX_TOP_TRACKS = 50;
+    const clamped = Math.min(limit ?? DEFAULT_TOP_TRACKS, MAX_TOP_TRACKS);
+    return this.deps.repository.getTopTracks(clamped);
+  }
+
+  async getTopArtists(limit?: number): Promise<TopArtistItem[]> {
+    const DEFAULT_TOP_ARTISTS = 10;
+    const MAX_TOP_ARTISTS = 50;
+    const clamped = Math.min(limit ?? DEFAULT_TOP_ARTISTS, MAX_TOP_ARTISTS);
+    return this.deps.repository.getTopArtists(clamped);
+  }
+
+  async getRecentPlays(limit?: number): Promise<RecentPlayItem[]> {
+    const DEFAULT_RECENT_PLAYS = 20;
+    const MAX_RECENT_PLAYS = 100;
+    const clamped = Math.min(limit ?? DEFAULT_RECENT_PLAYS, MAX_RECENT_PLAYS);
+    return this.deps.repository.getRecentPlays(clamped);
   }
 
   private initializeDeduplicationMaps(): DeduplicationMaps {

--- a/apps/backend/src/domain/repositories/history.repository.ts
+++ b/apps/backend/src/domain/repositories/history.repository.ts
@@ -1,4 +1,11 @@
-import type { DownloadHistoryItem, ITrack, RecordPlayInput } from "@spotiarr/shared";
+import type {
+  DownloadHistoryItem,
+  ITrack,
+  RecordPlayInput,
+  TopTrackItem,
+  TopArtistItem,
+  RecentPlayItem,
+} from "@spotiarr/shared";
 
 export interface HistoryRepository {
   findAll(limit?: number): Promise<DownloadHistoryItem[]>;
@@ -6,4 +13,10 @@ export interface HistoryRepository {
   createFromTrack(track: ITrack): Promise<void>;
 
   recordPlay(input: RecordPlayInput): Promise<void>;
+
+  getTopTracks(limit: number): Promise<TopTrackItem[]>;
+
+  getTopArtists(limit: number): Promise<TopArtistItem[]>;
+
+  getRecentPlays(limit: number): Promise<RecentPlayItem[]>;
 }

--- a/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
@@ -41,28 +41,22 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
           trackUrl: "https://open.spotify.com/track/a",
           trackName: "Track A",
           artist: "Artist A",
-          album: "Album A",
-          albumCoverUrl: null,
-          _count: { trackUrl: 5 },
-          _max: { playedAt: BigInt(2000) },
+          _count: { id: 5 },
+          _max: { playedAt: BigInt(2000), album: "Album A", albumCoverUrl: null },
         },
         {
           trackUrl: "https://open.spotify.com/track/c",
           trackName: "Track C",
           artist: "Artist C",
-          album: null,
-          albumCoverUrl: null,
-          _count: { trackUrl: 5 },
-          _max: { playedAt: BigInt(1000) },
+          _count: { id: 5 },
+          _max: { playedAt: BigInt(1000), album: null, albumCoverUrl: null },
         },
         {
           trackUrl: "https://open.spotify.com/track/b",
           trackName: "Track B",
           artist: "Artist B",
-          album: null,
-          albumCoverUrl: null,
-          _count: { trackUrl: 3 },
-          _max: { playedAt: BigInt(1500) },
+          _count: { id: 3 },
+          _max: { playedAt: BigInt(1500), album: null, albumCoverUrl: null },
         },
       ];
       vi.mocked(prisma.playHistory.groupBy).mockResolvedValue(groupByRows as never);
@@ -76,6 +70,12 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       expect(result[1].playCount).toBe(5);
       expect(result[2].trackUrl).toBe("https://open.spotify.com/track/b");
       expect(result[2].playCount).toBe(3);
+
+      // Fix F: assert the exact orderBy argument passed to Prisma so a broken sort still fails
+      const call = vi.mocked(prisma.playHistory.groupBy).mock.calls[0][0] as {
+        orderBy?: unknown;
+      };
+      expect(call.orderBy).toEqual([{ _count: { id: "desc" } }, { _max: { playedAt: "desc" } }]);
     });
 
     it("maps BigInt lastPlayedAt to Number at the JSON boundary", async () => {
@@ -84,10 +84,8 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
           trackUrl: "https://open.spotify.com/track/x",
           trackName: "Test",
           artist: "Artist",
-          album: null,
-          albumCoverUrl: null,
-          _count: { trackUrl: 2 },
-          _max: { playedAt: BigInt(1_700_000_000_000) },
+          _count: { id: 2 },
+          _max: { playedAt: BigInt(1_700_000_000_000), album: null, albumCoverUrl: null },
         },
       ] as never);
 
@@ -103,10 +101,12 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
           trackUrl: "https://open.spotify.com/track/x",
           trackName: "My Song",
           artist: "My Artist",
-          album: "My Album",
-          albumCoverUrl: "https://example.com/cover.jpg",
-          _count: { trackUrl: 7 },
-          _max: { playedAt: BigInt(9_000) },
+          _count: { id: 7 },
+          _max: {
+            playedAt: BigInt(9_000),
+            album: "My Album",
+            albumCoverUrl: "https://example.com/cover.jpg",
+          },
         },
       ] as never);
 
@@ -127,10 +127,8 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
           trackUrl: null,
           trackName: "Null URL Track",
           artist: "Some Artist",
-          album: null,
-          albumCoverUrl: null,
-          _count: { trackUrl: 3 },
-          _max: { playedAt: BigInt(5_000) },
+          _count: { id: 3 },
+          _max: { playedAt: BigInt(5_000), album: null, albumCoverUrl: null },
         },
       ] as never);
 
@@ -139,6 +137,7 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       expect(result).toHaveLength(1);
       expect(result[0].trackUrl).toBeNull();
       expect(result[0].trackName).toBe("Null URL Track");
+      // playCount must come from _count.id, not _count.trackUrl (which would be 0 for null trackUrl rows)
       expect(result[0].playCount).toBe(3);
     });
 
@@ -167,15 +166,13 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
         {
           artist: "Artist A",
-          _count: { artist: 10 },
+          _count: { id: 10 },
           _max: { playedAt: BigInt(3000) },
-          _countDistinct: undefined,
         },
         {
           artist: "Artist B",
-          _count: { artist: 4 },
+          _count: { id: 4 },
           _max: { playedAt: BigInt(1000) },
-          _countDistinct: undefined,
         },
       ] as never);
 
@@ -185,13 +182,19 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       expect(result[0].playCount).toBe(10);
       expect(result[1].artist).toBe("Artist B");
       expect(result[1].playCount).toBe(4);
+
+      // Fix F: assert the exact orderBy argument passed to Prisma so a broken sort still fails
+      const call = vi.mocked(prisma.playHistory.groupBy).mock.calls[0][0] as {
+        orderBy?: unknown;
+      };
+      expect(call.orderBy).toEqual([{ _count: { id: "desc" } }, { _max: { playedAt: "desc" } }]);
     });
 
     it("maps TopArtistItem shape correctly (REQ-LH-015)", async () => {
       vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
         {
           artist: "Cool Band",
-          _count: { artist: 6 },
+          _count: { id: 6 },
           _max: { playedAt: BigInt(7_000) },
         },
       ] as never);

--- a/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { AppError } from "@/domain/errors/app-error";
+import { prisma } from "../../setup/prisma";
+import { PrismaPlayHistoryRepository } from "../prisma-play-history.repository";
+
+vi.mock("../../setup/prisma", () => ({
+  prisma: {
+    playHistory: {
+      create: vi.fn(),
+      groupBy: vi.fn(),
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+describe("PrismaPlayHistoryRepository — aggregation", () => {
+  let repo: PrismaPlayHistoryRepository;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repo = new PrismaPlayHistoryRepository();
+  });
+
+  // ── getTopTracks ──────────────────────────────────────────────────────────
+
+  describe("getTopTracks", () => {
+    it("returns empty array when no rows exist (S-08)", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+
+      const result = await repo.getTopTracks(10);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns tracks ordered by playCount desc, then lastPlayedAt desc as tiebreaker (S-09)", async () => {
+      // Track A: 5 plays, lastPlayedAt = 2000 (most recent)
+      // Track C: 5 plays, lastPlayedAt = 1000 (older)
+      // Track B: 3 plays
+      const groupByRows = [
+        {
+          trackUrl: "https://open.spotify.com/track/a",
+          trackName: "Track A",
+          artist: "Artist A",
+          album: "Album A",
+          albumCoverUrl: null,
+          _count: { trackUrl: 5 },
+          _max: { playedAt: BigInt(2000) },
+        },
+        {
+          trackUrl: "https://open.spotify.com/track/c",
+          trackName: "Track C",
+          artist: "Artist C",
+          album: null,
+          albumCoverUrl: null,
+          _count: { trackUrl: 5 },
+          _max: { playedAt: BigInt(1000) },
+        },
+        {
+          trackUrl: "https://open.spotify.com/track/b",
+          trackName: "Track B",
+          artist: "Artist B",
+          album: null,
+          albumCoverUrl: null,
+          _count: { trackUrl: 3 },
+          _max: { playedAt: BigInt(1500) },
+        },
+      ];
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue(groupByRows as never);
+
+      const result = await repo.getTopTracks(10);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].trackUrl).toBe("https://open.spotify.com/track/a");
+      expect(result[0].playCount).toBe(5);
+      expect(result[1].trackUrl).toBe("https://open.spotify.com/track/c");
+      expect(result[1].playCount).toBe(5);
+      expect(result[2].trackUrl).toBe("https://open.spotify.com/track/b");
+      expect(result[2].playCount).toBe(3);
+    });
+
+    it("maps BigInt lastPlayedAt to Number at the JSON boundary", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
+        {
+          trackUrl: "https://open.spotify.com/track/x",
+          trackName: "Test",
+          artist: "Artist",
+          album: null,
+          albumCoverUrl: null,
+          _count: { trackUrl: 2 },
+          _max: { playedAt: BigInt(1_700_000_000_000) },
+        },
+      ] as never);
+
+      const result = await repo.getTopTracks(10);
+
+      expect(typeof result[0].lastPlayedAt).toBe("number");
+      expect(result[0].lastPlayedAt).toBe(1_700_000_000_000);
+    });
+
+    it("maps TopTrackItem shape correctly (REQ-LH-011)", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
+        {
+          trackUrl: "https://open.spotify.com/track/x",
+          trackName: "My Song",
+          artist: "My Artist",
+          album: "My Album",
+          albumCoverUrl: "https://example.com/cover.jpg",
+          _count: { trackUrl: 7 },
+          _max: { playedAt: BigInt(9_000) },
+        },
+      ] as never);
+
+      const [item] = await repo.getTopTracks(10);
+
+      expect(item.trackUrl).toBe("https://open.spotify.com/track/x");
+      expect(item.trackName).toBe("My Song");
+      expect(item.artist).toBe("My Artist");
+      expect(item.album).toBe("My Album");
+      expect(item.albumCoverUrl).toBe("https://example.com/cover.jpg");
+      expect(item.playCount).toBe(7);
+      expect(item.lastPlayedAt).toBe(9_000);
+    });
+
+    it("handles null trackUrl group (trackName+artist composite fallback)", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
+        {
+          trackUrl: null,
+          trackName: "Null URL Track",
+          artist: "Some Artist",
+          album: null,
+          albumCoverUrl: null,
+          _count: { trackUrl: 3 },
+          _max: { playedAt: BigInt(5_000) },
+        },
+      ] as never);
+
+      const result = await repo.getTopTracks(10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].trackUrl).toBeNull();
+      expect(result[0].trackName).toBe("Null URL Track");
+      expect(result[0].playCount).toBe(3);
+    });
+
+    it("respects the limit parameter", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+
+      await repo.getTopTracks(5);
+
+      const call = vi.mocked(prisma.playHistory.groupBy).mock.calls[0][0] as { take?: number };
+      expect(call.take).toBe(5);
+    });
+  });
+
+  // ── getTopArtists ─────────────────────────────────────────────────────────
+
+  describe("getTopArtists", () => {
+    it("returns empty array when no rows exist (S-08 / REQ-LH-016)", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+
+      const result = await repo.getTopArtists(10);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns artists ordered by playCount desc with lastPlayedAt tiebreaker", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
+        {
+          artist: "Artist A",
+          _count: { artist: 10 },
+          _max: { playedAt: BigInt(3000) },
+          _countDistinct: undefined,
+        },
+        {
+          artist: "Artist B",
+          _count: { artist: 4 },
+          _max: { playedAt: BigInt(1000) },
+          _countDistinct: undefined,
+        },
+      ] as never);
+
+      const result = await repo.getTopArtists(10);
+
+      expect(result[0].artist).toBe("Artist A");
+      expect(result[0].playCount).toBe(10);
+      expect(result[1].artist).toBe("Artist B");
+      expect(result[1].playCount).toBe(4);
+    });
+
+    it("maps TopArtistItem shape correctly (REQ-LH-015)", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
+        {
+          artist: "Cool Band",
+          _count: { artist: 6 },
+          _max: { playedAt: BigInt(7_000) },
+        },
+      ] as never);
+
+      const [item] = await repo.getTopArtists(10);
+
+      expect(item.artist).toBe("Cool Band");
+      expect(item.playCount).toBe(6);
+      expect(typeof item.lastPlayedAt).toBe("number");
+      expect(item.lastPlayedAt).toBe(7_000);
+    });
+
+    it("respects the limit parameter", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+
+      await repo.getTopArtists(3);
+
+      const call = vi.mocked(prisma.playHistory.groupBy).mock.calls[0][0] as { take?: number };
+      expect(call.take).toBe(3);
+    });
+  });
+
+  // ── getRecentPlays ────────────────────────────────────────────────────────
+
+  describe("getRecentPlays", () => {
+    it("returns empty array when no rows exist (REQ-LH-020)", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([] as never);
+
+      const result = await repo.getRecentPlays(20);
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns entries ordered by playedAt desc (most recent first)", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([
+        {
+          id: "r1",
+          trackId: "t1",
+          trackUrl: "https://open.spotify.com/track/a",
+          trackName: "Recent Track",
+          artist: "Artist A",
+          album: null,
+          albumCoverUrl: null,
+          durationMs: null,
+          playedAt: BigInt(2000),
+          createdAt: BigInt(0),
+        },
+        {
+          id: "r2",
+          trackId: null,
+          trackUrl: null,
+          trackName: "Older Track",
+          artist: "Artist B",
+          album: "Album B",
+          albumCoverUrl: null,
+          durationMs: 120_000,
+          playedAt: BigInt(1000),
+          createdAt: BigInt(0),
+        },
+      ] as never);
+
+      const result = await repo.getRecentPlays(20);
+
+      expect(result[0].trackName).toBe("Recent Track");
+      expect(result[0].playedAt).toBe(2000);
+      expect(result[1].trackName).toBe("Older Track");
+      expect(result[1].playedAt).toBe(1000);
+    });
+
+    it("maps BigInt playedAt to Number at the JSON boundary", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([
+        {
+          id: "r1",
+          trackId: null,
+          trackUrl: null,
+          trackName: "A Track",
+          artist: "Artist",
+          album: null,
+          albumCoverUrl: null,
+          durationMs: null,
+          playedAt: BigInt(1_700_000_000_000),
+          createdAt: BigInt(0),
+        },
+      ] as never);
+
+      const [item] = await repo.getRecentPlays(20);
+
+      expect(typeof item.playedAt).toBe("number");
+      expect(item.playedAt).toBe(1_700_000_000_000);
+    });
+
+    it("maps RecentPlayItem shape correctly (REQ-LH-019)", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([
+        {
+          id: "r1",
+          trackId: "t-123",
+          trackUrl: "https://open.spotify.com/track/x",
+          trackName: "Shape Test",
+          artist: "Shape Artist",
+          album: "Shape Album",
+          albumCoverUrl: "https://example.com/img.jpg",
+          durationMs: 200_000,
+          playedAt: BigInt(5_000),
+          createdAt: BigInt(0),
+        },
+      ] as never);
+
+      const [item] = await repo.getRecentPlays(20);
+
+      expect(item.trackId).toBe("t-123");
+      expect(item.trackUrl).toBe("https://open.spotify.com/track/x");
+      expect(item.trackName).toBe("Shape Test");
+      expect(item.artist).toBe("Shape Artist");
+      expect(item.album).toBe("Shape Album");
+      expect(item.playedAt).toBe(5_000);
+    });
+
+    it("respects the limit parameter", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([] as never);
+
+      await repo.getRecentPlays(15);
+
+      const call = vi.mocked(prisma.playHistory.findMany).mock.calls[0][0] as { take?: number };
+      expect(call.take).toBe(15);
+    });
+
+    it("passes orderBy playedAt desc to Prisma", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockResolvedValue([] as never);
+
+      await repo.getRecentPlays(20);
+
+      const call = vi.mocked(prisma.playHistory.findMany).mock.calls[0][0] as {
+        orderBy?: unknown;
+      };
+      expect(call.orderBy).toEqual({ playedAt: "desc" });
+    });
+  });
+
+  // ── Prisma error mapping ──────────────────────────────────────────────────
+
+  describe("error mapping", () => {
+    it("maps groupBy Prisma failure to AppError for getTopTracks", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockRejectedValue(new Error("DB failure"));
+
+      await expect(repo.getTopTracks(10)).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("maps groupBy Prisma failure to AppError for getTopArtists", async () => {
+      vi.mocked(prisma.playHistory.groupBy).mockRejectedValue(new Error("DB failure"));
+
+      await expect(repo.getTopArtists(10)).rejects.toBeInstanceOf(AppError);
+    });
+
+    it("maps findMany Prisma failure to AppError for getRecentPlays", async () => {
+      vi.mocked(prisma.playHistory.findMany).mockRejectedValue(new Error("DB failure"));
+
+      await expect(repo.getRecentPlays(20)).rejects.toBeInstanceOf(AppError);
+    });
+  });
+});

--- a/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
+++ b/apps/backend/src/infrastructure/database/__tests__/prisma-play-history-aggregation.repository.test.ts
@@ -17,7 +17,7 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
   let repo: PrismaPlayHistoryRepository;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     repo = new PrismaPlayHistoryRepository();
   });
 
@@ -154,8 +154,15 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
   // ── getTopArtists ─────────────────────────────────────────────────────────
 
   describe("getTopArtists", () => {
+    /**
+     * getTopArtists uses two groupBy calls:
+     *  call 0: groupBy(['artist']) → playCount + lastPlayedAt
+     *  call 1: groupBy(['artist','trackName']) → distinct track count per artist
+     */
+
     it("returns empty array when no rows exist (S-08 / REQ-LH-016)", async () => {
-      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+      // First groupBy (play counts) returns empty → early return, second groupBy is never called
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValueOnce([] as never);
 
       const result = await repo.getTopArtists(10);
 
@@ -163,18 +170,24 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
     });
 
     it("returns artists ordered by playCount desc with lastPlayedAt tiebreaker", async () => {
-      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
-        {
-          artist: "Artist A",
-          _count: { id: 10 },
-          _max: { playedAt: BigInt(3000) },
-        },
-        {
-          artist: "Artist B",
-          _count: { id: 4 },
-          _max: { playedAt: BigInt(1000) },
-        },
-      ] as never);
+      vi.mocked(prisma.playHistory.groupBy)
+        .mockResolvedValueOnce([
+          {
+            artist: "Artist A",
+            _count: { id: 10 },
+            _max: { playedAt: BigInt(3000) },
+          },
+          {
+            artist: "Artist B",
+            _count: { id: 4 },
+            _max: { playedAt: BigInt(1000) },
+          },
+        ] as never)
+        .mockResolvedValueOnce([
+          { artist: "Artist A", trackName: "Song 1", _count: { id: 1 } },
+          { artist: "Artist A", trackName: "Song 2", _count: { id: 1 } },
+          { artist: "Artist B", trackName: "Song X", _count: { id: 1 } },
+        ] as never);
 
       const result = await repo.getTopArtists(10);
 
@@ -183,21 +196,27 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       expect(result[1].artist).toBe("Artist B");
       expect(result[1].playCount).toBe(4);
 
-      // Fix F: assert the exact orderBy argument passed to Prisma so a broken sort still fails
+      // Fix F: assert the exact orderBy argument passed to the first Prisma groupBy call
       const call = vi.mocked(prisma.playHistory.groupBy).mock.calls[0][0] as {
         orderBy?: unknown;
       };
       expect(call.orderBy).toEqual([{ _count: { id: "desc" } }, { _max: { playedAt: "desc" } }]);
     });
 
-    it("maps TopArtistItem shape correctly (REQ-LH-015)", async () => {
-      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([
-        {
-          artist: "Cool Band",
-          _count: { id: 6 },
-          _max: { playedAt: BigInt(7_000) },
-        },
-      ] as never);
+    it("maps TopArtistItem shape correctly including trackCount (REQ-LH-015)", async () => {
+      vi.mocked(prisma.playHistory.groupBy)
+        .mockResolvedValueOnce([
+          {
+            artist: "Cool Band",
+            _count: { id: 6 },
+            _max: { playedAt: BigInt(7_000) },
+          },
+        ] as never)
+        .mockResolvedValueOnce([
+          { artist: "Cool Band", trackName: "Hit A", _count: { id: 1 } },
+          { artist: "Cool Band", trackName: "Hit B", _count: { id: 1 } },
+          { artist: "Cool Band", trackName: "Hit C", _count: { id: 1 } },
+        ] as never);
 
       const [item] = await repo.getTopArtists(10);
 
@@ -205,10 +224,51 @@ describe("PrismaPlayHistoryRepository — aggregation", () => {
       expect(item.playCount).toBe(6);
       expect(typeof item.lastPlayedAt).toBe("number");
       expect(item.lastPlayedAt).toBe(7_000);
+      expect(item.trackCount).toBe(3);
+    });
+
+    it("counts distinct tracks per artist: repeated plays of same track count as 1 (REQ-LH-015)", async () => {
+      // Artist A: plays [Track X, Track X, Track Y] → playCount=3, trackCount=2
+      vi.mocked(prisma.playHistory.groupBy)
+        .mockResolvedValueOnce([
+          {
+            artist: "Artist A",
+            _count: { id: 3 },
+            _max: { playedAt: BigInt(5_000) },
+          },
+        ] as never)
+        .mockResolvedValueOnce([
+          // groupBy(['artist','trackName']) collapses repeated plays into one row per (artist, trackName)
+          { artist: "Artist A", trackName: "Track X", _count: { id: 2 } },
+          { artist: "Artist A", trackName: "Track Y", _count: { id: 1 } },
+        ] as never);
+
+      const [item] = await repo.getTopArtists(10);
+
+      expect(item.playCount).toBe(3);
+      expect(item.trackCount).toBe(2);
+    });
+
+    it("sets trackCount=0 when artist has no rows in the track-groupBy result", async () => {
+      vi.mocked(prisma.playHistory.groupBy)
+        .mockResolvedValueOnce([
+          {
+            artist: "Ghost Artist",
+            _count: { id: 1 },
+            _max: { playedAt: BigInt(1_000) },
+          },
+        ] as never)
+        .mockResolvedValueOnce([] as never);
+
+      const [item] = await repo.getTopArtists(10);
+
+      expect(item.artist).toBe("Ghost Artist");
+      expect(item.trackCount).toBe(0);
     });
 
     it("respects the limit parameter", async () => {
-      vi.mocked(prisma.playHistory.groupBy).mockResolvedValue([] as never);
+      // First groupBy returns empty → early return; the take assertion still works on call[0]
+      vi.mocked(prisma.playHistory.groupBy).mockResolvedValueOnce([] as never);
 
       await repo.getTopArtists(3);
 

--- a/apps/backend/src/infrastructure/database/prisma-history.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-history.repository.ts
@@ -1,4 +1,11 @@
-import type { DownloadHistoryItem, ITrack, RecordPlayInput } from "@spotiarr/shared";
+import type {
+  DownloadHistoryItem,
+  ITrack,
+  RecordPlayInput,
+  TopTrackItem,
+  TopArtistItem,
+  RecentPlayItem,
+} from "@spotiarr/shared";
 import type { HistoryRepository } from "@/domain/repositories/history.repository";
 import { prisma } from "../setup/prisma";
 import { PrismaPlayHistoryRepository } from "./prisma-play-history.repository";
@@ -60,5 +67,17 @@ export class PrismaHistoryRepository implements HistoryRepository {
 
   async recordPlay(input: RecordPlayInput): Promise<void> {
     return this.playHistoryRepo.recordPlay(input);
+  }
+
+  async getTopTracks(limit: number): Promise<TopTrackItem[]> {
+    return this.playHistoryRepo.getTopTracks(limit);
+  }
+
+  async getTopArtists(limit: number): Promise<TopArtistItem[]> {
+    return this.playHistoryRepo.getTopArtists(limit);
+  }
+
+  async getRecentPlays(limit: number): Promise<RecentPlayItem[]> {
+    return this.playHistoryRepo.getRecentPlays(limit);
   }
 }

--- a/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
@@ -81,7 +81,8 @@ export class PrismaPlayHistoryRepository {
 
   async getTopArtists(limit: number): Promise<TopArtistItem[]> {
     try {
-      const rows = await prisma.playHistory.groupBy({
+      // First groupBy: play count + lastPlayedAt per artist (ordered, limited)
+      const playRows = await prisma.playHistory.groupBy({
         by: ["artist"],
         _count: { id: true },
         _max: { playedAt: true },
@@ -89,9 +90,28 @@ export class PrismaPlayHistoryRepository {
         take: limit,
       });
 
-      return rows.map((row) => ({
+      if (playRows.length === 0) return [];
+
+      // Second groupBy: distinct (artist, trackName) pairs to compute trackCount per artist.
+      // Prisma groupBy cannot COUNT(DISTINCT trackName) in a single call, so we run a
+      // second pass grouped by ['artist','trackName'] and count rows per artist in code.
+      const artistNames = playRows.map((r) => r.artist);
+      const trackRows = await prisma.playHistory.groupBy({
+        by: ["artist", "trackName"],
+        where: { artist: { in: artistNames } },
+        _count: { id: true },
+      });
+
+      // Build a lookup: artist → number of distinct trackName values
+      const trackCountByArtist = new Map<string, number>();
+      for (const row of trackRows) {
+        trackCountByArtist.set(row.artist, (trackCountByArtist.get(row.artist) ?? 0) + 1);
+      }
+
+      return playRows.map((row) => ({
         artist: row.artist,
         playCount: row._count.id,
+        trackCount: trackCountByArtist.get(row.artist) ?? 0,
         lastPlayedAt: Number(row._max.playedAt ?? 0),
       }));
     } catch (_error) {

--- a/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
@@ -1,4 +1,9 @@
-import type { RecordPlayInput } from "@spotiarr/shared";
+import type {
+  RecordPlayInput,
+  TopTrackItem,
+  TopArtistItem,
+  RecentPlayItem,
+} from "@spotiarr/shared";
 import { z, ZodError } from "zod";
 import { AppError } from "@/domain/errors/app-error";
 import { prisma } from "../setup/prisma";
@@ -47,6 +52,70 @@ export class PrismaPlayHistoryRepository {
       });
     } catch (_error) {
       throw new AppError(500, "internal_server_error", "Failed to record play event");
+    }
+  }
+
+  async getTopTracks(limit: number): Promise<TopTrackItem[]> {
+    try {
+      const rows = await prisma.playHistory.groupBy({
+        by: ["trackUrl", "trackName", "artist", "album", "albumCoverUrl"],
+        _count: { trackUrl: true },
+        _max: { playedAt: true },
+        orderBy: [{ _count: { trackUrl: "desc" } }, { _max: { playedAt: "desc" } }],
+        take: limit,
+      });
+
+      return rows.map((row) => ({
+        trackUrl: row.trackUrl,
+        trackName: row.trackName,
+        artist: row.artist,
+        album: row.album,
+        albumCoverUrl: row.albumCoverUrl,
+        playCount: row._count.trackUrl,
+        lastPlayedAt: Number(row._max.playedAt ?? 0),
+      }));
+    } catch (_error) {
+      throw new AppError(500, "internal_server_error", "Failed to retrieve top tracks");
+    }
+  }
+
+  async getTopArtists(limit: number): Promise<TopArtistItem[]> {
+    try {
+      const rows = await prisma.playHistory.groupBy({
+        by: ["artist"],
+        _count: { artist: true },
+        _max: { playedAt: true },
+        orderBy: [{ _count: { artist: "desc" } }, { _max: { playedAt: "desc" } }],
+        take: limit,
+      });
+
+      return rows.map((row) => ({
+        artist: row.artist,
+        playCount: row._count.artist,
+        lastPlayedAt: Number(row._max.playedAt ?? 0),
+      }));
+    } catch (_error) {
+      throw new AppError(500, "internal_server_error", "Failed to retrieve top artists");
+    }
+  }
+
+  async getRecentPlays(limit: number): Promise<RecentPlayItem[]> {
+    try {
+      const rows = await prisma.playHistory.findMany({
+        orderBy: { playedAt: "desc" },
+        take: limit,
+      });
+
+      return rows.map((row) => ({
+        trackId: row.trackId,
+        trackUrl: row.trackUrl,
+        trackName: row.trackName,
+        artist: row.artist,
+        album: row.album,
+        playedAt: Number(row.playedAt),
+      }));
+    } catch (_error) {
+      throw new AppError(500, "internal_server_error", "Failed to retrieve recent plays");
     }
   }
 }

--- a/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
+++ b/apps/backend/src/infrastructure/database/prisma-play-history.repository.ts
@@ -58,10 +58,10 @@ export class PrismaPlayHistoryRepository {
   async getTopTracks(limit: number): Promise<TopTrackItem[]> {
     try {
       const rows = await prisma.playHistory.groupBy({
-        by: ["trackUrl", "trackName", "artist", "album", "albumCoverUrl"],
-        _count: { trackUrl: true },
-        _max: { playedAt: true },
-        orderBy: [{ _count: { trackUrl: "desc" } }, { _max: { playedAt: "desc" } }],
+        by: ["trackUrl", "trackName", "artist"],
+        _count: { id: true },
+        _max: { playedAt: true, album: true, albumCoverUrl: true },
+        orderBy: [{ _count: { id: "desc" } }, { _max: { playedAt: "desc" } }],
         take: limit,
       });
 
@@ -69,9 +69,9 @@ export class PrismaPlayHistoryRepository {
         trackUrl: row.trackUrl,
         trackName: row.trackName,
         artist: row.artist,
-        album: row.album,
-        albumCoverUrl: row.albumCoverUrl,
-        playCount: row._count.trackUrl,
+        album: row._max.album,
+        albumCoverUrl: row._max.albumCoverUrl,
+        playCount: row._count.id,
         lastPlayedAt: Number(row._max.playedAt ?? 0),
       }));
     } catch (_error) {
@@ -83,15 +83,15 @@ export class PrismaPlayHistoryRepository {
     try {
       const rows = await prisma.playHistory.groupBy({
         by: ["artist"],
-        _count: { artist: true },
+        _count: { id: true },
         _max: { playedAt: true },
-        orderBy: [{ _count: { artist: "desc" } }, { _max: { playedAt: "desc" } }],
+        orderBy: [{ _count: { id: "desc" } }, { _max: { playedAt: "desc" } }],
         take: limit,
       });
 
       return rows.map((row) => ({
         artist: row.artist,
-        playCount: row._count.artist,
+        playCount: row._count.id,
         lastPlayedAt: Number(row._max.playedAt ?? 0),
       }));
     } catch (_error) {

--- a/apps/backend/src/presentation/controllers/history.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/history.controller.test.ts
@@ -7,8 +7,8 @@ function mockRes(): Response {
   return { json: vi.fn(), status: vi.fn().mockReturnThis() } as unknown as Response;
 }
 
-function mockReq(body: unknown = {}): Request {
-  return { body } as unknown as Request;
+function mockReq(body: unknown = {}, query: Record<string, string> = {}): Request {
+  return { body, query } as unknown as Request;
 }
 
 function makeUseCases(downloads: unknown[] = [], tracks: unknown[] = []): HistoryUseCases {
@@ -16,6 +16,9 @@ function makeUseCases(downloads: unknown[] = [], tracks: unknown[] = []): Histor
     getRecentDownloads: vi.fn().mockResolvedValue(downloads),
     getRecentTracks: vi.fn().mockResolvedValue(tracks),
     recordPlay: vi.fn().mockResolvedValue(undefined),
+    getTopTracks: vi.fn().mockResolvedValue([]),
+    getTopArtists: vi.fn().mockResolvedValue([]),
+    getRecentPlays: vi.fn().mockResolvedValue([]),
   } as unknown as HistoryUseCases;
 }
 
@@ -91,6 +94,108 @@ describe("HistoryController", () => {
       expect(useCases.recordPlay).toHaveBeenCalledWith(playBody);
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith({ data: null });
+    });
+  });
+
+  describe("getTopTracks", () => {
+    it("responds with 200 and { data: items } from use case", async () => {
+      const items = [{ trackName: "Song A", playCount: 5, artist: "Artist A" }];
+      vi.mocked(useCases.getTopTracks).mockResolvedValue(items as never);
+
+      const res = mockRes();
+      await controller.getTopTracks(mockReq({}, { limit: "10" }) as never, res);
+
+      expect(useCases.getTopTracks).toHaveBeenCalledOnce();
+      expect(res.json).toHaveBeenCalledWith({ data: items });
+    });
+
+    it("responds with { data: [] } for empty history (S-08)", async () => {
+      const res = mockRes();
+      await controller.getTopTracks(mockReq({}, {}) as never, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+
+    it("passes the parsed limit to the use case", async () => {
+      const res = mockRes();
+      await controller.getTopTracks(mockReq({}, { limit: "20" }) as never, res);
+
+      expect(useCases.getTopTracks).toHaveBeenCalledWith(20);
+    });
+
+    it("uses no argument (undefined) when limit param is missing, letting use case apply default", async () => {
+      const res = mockRes();
+      await controller.getTopTracks(mockReq({}, {}) as never, res);
+
+      expect(useCases.getTopTracks).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("getTopArtists", () => {
+    it("responds with 200 and { data: items } from use case", async () => {
+      const items = [{ artist: "Artist A", playCount: 8 }];
+      vi.mocked(useCases.getTopArtists).mockResolvedValue(items as never);
+
+      const res = mockRes();
+      await controller.getTopArtists(mockReq({}, { limit: "10" }) as never, res);
+
+      expect(useCases.getTopArtists).toHaveBeenCalledOnce();
+      expect(res.json).toHaveBeenCalledWith({ data: items });
+    });
+
+    it("responds with { data: [] } for empty history (REQ-LH-016)", async () => {
+      const res = mockRes();
+      await controller.getTopArtists(mockReq({}, {}) as never, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+
+    it("passes the parsed limit to the use case", async () => {
+      const res = mockRes();
+      await controller.getTopArtists(mockReq({}, { limit: "15" }) as never, res);
+
+      expect(useCases.getTopArtists).toHaveBeenCalledWith(15);
+    });
+
+    it("uses no argument (undefined) when limit param is missing", async () => {
+      const res = mockRes();
+      await controller.getTopArtists(mockReq({}, {}) as never, res);
+
+      expect(useCases.getTopArtists).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("getRecentPlays", () => {
+    it("responds with 200 and { data: items } from use case", async () => {
+      const items = [{ trackName: "Song B", playedAt: 1_700_000_000_000 }];
+      vi.mocked(useCases.getRecentPlays).mockResolvedValue(items as never);
+
+      const res = mockRes();
+      await controller.getRecentPlays(mockReq({}, { limit: "20" }) as never, res);
+
+      expect(useCases.getRecentPlays).toHaveBeenCalledOnce();
+      expect(res.json).toHaveBeenCalledWith({ data: items });
+    });
+
+    it("responds with { data: [] } for empty history (REQ-LH-020)", async () => {
+      const res = mockRes();
+      await controller.getRecentPlays(mockReq({}, {}) as never, res);
+
+      expect(res.json).toHaveBeenCalledWith({ data: [] });
+    });
+
+    it("passes the parsed limit to the use case", async () => {
+      const res = mockRes();
+      await controller.getRecentPlays(mockReq({}, { limit: "50" }) as never, res);
+
+      expect(useCases.getRecentPlays).toHaveBeenCalledWith(50);
+    });
+
+    it("uses no argument (undefined) when limit param is missing", async () => {
+      const res = mockRes();
+      await controller.getRecentPlays(mockReq({}, {}) as never, res);
+
+      expect(useCases.getRecentPlays).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/apps/backend/src/presentation/controllers/history.controller.test.ts
+++ b/apps/backend/src/presentation/controllers/history.controller.test.ts
@@ -103,7 +103,7 @@ describe("HistoryController", () => {
       vi.mocked(useCases.getTopTracks).mockResolvedValue(items as never);
 
       const res = mockRes();
-      await controller.getTopTracks(mockReq({}, { limit: "10" }) as never, res);
+      await controller.getTopTracks(mockReq({}, { limit: 10 } as never) as never, res);
 
       expect(useCases.getTopTracks).toHaveBeenCalledOnce();
       expect(res.json).toHaveBeenCalledWith({ data: items });
@@ -116,9 +116,10 @@ describe("HistoryController", () => {
       expect(res.json).toHaveBeenCalledWith({ data: [] });
     });
 
-    it("passes the parsed limit to the use case", async () => {
+    it("passes the coerced limit number to the use case", async () => {
       const res = mockRes();
-      await controller.getTopTracks(mockReq({}, { limit: "20" }) as never, res);
+      // Middleware coerces the query string to a number before the controller runs
+      await controller.getTopTracks(mockReq({}, { limit: 20 } as never) as never, res);
 
       expect(useCases.getTopTracks).toHaveBeenCalledWith(20);
     });
@@ -137,7 +138,7 @@ describe("HistoryController", () => {
       vi.mocked(useCases.getTopArtists).mockResolvedValue(items as never);
 
       const res = mockRes();
-      await controller.getTopArtists(mockReq({}, { limit: "10" }) as never, res);
+      await controller.getTopArtists(mockReq({}, { limit: 10 } as never) as never, res);
 
       expect(useCases.getTopArtists).toHaveBeenCalledOnce();
       expect(res.json).toHaveBeenCalledWith({ data: items });
@@ -150,9 +151,10 @@ describe("HistoryController", () => {
       expect(res.json).toHaveBeenCalledWith({ data: [] });
     });
 
-    it("passes the parsed limit to the use case", async () => {
+    it("passes the coerced limit number to the use case", async () => {
       const res = mockRes();
-      await controller.getTopArtists(mockReq({}, { limit: "15" }) as never, res);
+      // Middleware coerces the query string to a number before the controller runs
+      await controller.getTopArtists(mockReq({}, { limit: 15 } as never) as never, res);
 
       expect(useCases.getTopArtists).toHaveBeenCalledWith(15);
     });
@@ -171,7 +173,7 @@ describe("HistoryController", () => {
       vi.mocked(useCases.getRecentPlays).mockResolvedValue(items as never);
 
       const res = mockRes();
-      await controller.getRecentPlays(mockReq({}, { limit: "20" }) as never, res);
+      await controller.getRecentPlays(mockReq({}, { limit: 20 } as never) as never, res);
 
       expect(useCases.getRecentPlays).toHaveBeenCalledOnce();
       expect(res.json).toHaveBeenCalledWith({ data: items });
@@ -184,9 +186,10 @@ describe("HistoryController", () => {
       expect(res.json).toHaveBeenCalledWith({ data: [] });
     });
 
-    it("passes the parsed limit to the use case", async () => {
+    it("passes the coerced limit number to the use case", async () => {
       const res = mockRes();
-      await controller.getRecentPlays(mockReq({}, { limit: "50" }) as never, res);
+      // Middleware coerces the query string to a number before the controller runs
+      await controller.getRecentPlays(mockReq({}, { limit: 50 } as never) as never, res);
 
       expect(useCases.getRecentPlays).toHaveBeenCalledWith(50);
     });

--- a/apps/backend/src/presentation/controllers/history.controller.ts
+++ b/apps/backend/src/presentation/controllers/history.controller.ts
@@ -19,4 +19,25 @@ export class HistoryController {
     await this.historyUseCases.recordPlay(req.body);
     res.status(201).json({ data: null });
   };
+
+  getTopTracks = async (req: Request, res: Response) => {
+    const limitRaw = req.query.limit as string | undefined;
+    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const items = await this.historyUseCases.getTopTracks(limit);
+    res.json({ data: items });
+  };
+
+  getTopArtists = async (req: Request, res: Response) => {
+    const limitRaw = req.query.limit as string | undefined;
+    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const items = await this.historyUseCases.getTopArtists(limit);
+    res.json({ data: items });
+  };
+
+  getRecentPlays = async (req: Request, res: Response) => {
+    const limitRaw = req.query.limit as string | undefined;
+    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const items = await this.historyUseCases.getRecentPlays(limit);
+    res.json({ data: items });
+  };
 }

--- a/apps/backend/src/presentation/controllers/history.controller.ts
+++ b/apps/backend/src/presentation/controllers/history.controller.ts
@@ -21,22 +21,19 @@ export class HistoryController {
   };
 
   getTopTracks = async (req: Request, res: Response) => {
-    const limitRaw = req.query.limit as string | undefined;
-    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const limit = req.query.limit as number | undefined;
     const items = await this.historyUseCases.getTopTracks(limit);
     res.json({ data: items });
   };
 
   getTopArtists = async (req: Request, res: Response) => {
-    const limitRaw = req.query.limit as string | undefined;
-    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const limit = req.query.limit as number | undefined;
     const items = await this.historyUseCases.getTopArtists(limit);
     res.json({ data: items });
   };
 
   getRecentPlays = async (req: Request, res: Response) => {
-    const limitRaw = req.query.limit as string | undefined;
-    const limit = limitRaw !== undefined ? parseInt(limitRaw, 10) : undefined;
+    const limit = req.query.limit as number | undefined;
     const items = await this.historyUseCases.getRecentPlays(limit);
     res.json({ data: items });
   };

--- a/apps/backend/src/presentation/middleware/validate.ts
+++ b/apps/backend/src/presentation/middleware/validate.ts
@@ -12,6 +12,14 @@ export const validate =
       });
       if (parsed && typeof parsed === "object") {
         if ("body" in parsed && parsed.body !== undefined) req.body = parsed.body;
+        if ("query" in parsed && parsed.query !== undefined) {
+          const coercedQuery = parsed.query as Record<string, unknown>;
+          Object.defineProperty(req, "query", {
+            value: coercedQuery,
+            writable: true,
+            configurable: true,
+          });
+        }
       }
       next();
     } catch (error) {

--- a/apps/backend/src/presentation/routes/history.routes.test.ts
+++ b/apps/backend/src/presentation/routes/history.routes.test.ts
@@ -14,6 +14,9 @@ function makeUseCases(overrides: Partial<HistoryUseCases> = {}): HistoryUseCases
     getRecentDownloads: vi.fn().mockResolvedValue([]),
     getRecentTracks: vi.fn().mockResolvedValue([]),
     recordPlay: vi.fn().mockResolvedValue(undefined),
+    getTopTracks: vi.fn().mockResolvedValue([]),
+    getTopArtists: vi.fn().mockResolvedValue([]),
+    getRecentPlays: vi.fn().mockResolvedValue([]),
     ...overrides,
   } as unknown as HistoryUseCases;
 }
@@ -169,5 +172,100 @@ describe("POST /history/plays", () => {
 
     expect(res.status).toBe(201);
     expect(useCases.recordPlay).toHaveBeenCalledOnce();
+  });
+});
+
+describe("GET /history/top-tracks — limit validation (Fix D+E)", () => {
+  let useCases: HistoryUseCases;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    useCases = makeUseCases();
+    baseUrl = await startServer(buildApp(useCases));
+  });
+
+  it("returns 400 when limit is non-numeric (?limit=abc)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-tracks?limit=abc`);
+    expect(res.status).toBe(400);
+    expect(useCases.getTopTracks).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when limit is zero (?limit=0)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-tracks?limit=0`);
+    expect(res.status).toBe(400);
+    expect(useCases.getTopTracks).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when limit is negative (?limit=-5)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-tracks?limit=-5`);
+    expect(res.status).toBe(400);
+    expect(useCases.getTopTracks).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and passes coerced number when limit is valid (?limit=10)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-tracks?limit=10`);
+    expect(res.status).toBe(200);
+    expect(useCases.getTopTracks).toHaveBeenCalledWith(10);
+  });
+
+  it("passes limit above the cap to use case, which applies clamping (Fix E)", async () => {
+    // The schema does NOT reject large limits — the use case clamps silently
+    const res = await fetch(`${baseUrl}/history/top-tracks?limit=9999`);
+    expect(res.status).toBe(200);
+    // use case receives 9999 and internally clamps to MAX_TOP_TRACKS (50)
+    expect(useCases.getTopTracks).toHaveBeenCalledWith(9999);
+  });
+
+  it("returns 200 with no limit param (use case applies default)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-tracks`);
+    expect(res.status).toBe(200);
+    expect(useCases.getTopTracks).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe("GET /history/top-artists — limit validation (Fix D+E)", () => {
+  let useCases: HistoryUseCases;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    useCases = makeUseCases();
+    baseUrl = await startServer(buildApp(useCases));
+  });
+
+  it("returns 400 when limit is non-numeric (?limit=abc)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-artists?limit=abc`);
+    expect(res.status).toBe(400);
+    expect(useCases.getTopArtists).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and passes coerced number when limit is valid (?limit=5)", async () => {
+    const res = await fetch(`${baseUrl}/history/top-artists?limit=5`);
+    expect(res.status).toBe(200);
+    expect(useCases.getTopArtists).toHaveBeenCalledWith(5);
+  });
+});
+
+describe("GET /history/recent-plays — limit validation (Fix D+E)", () => {
+  let useCases: HistoryUseCases;
+  let baseUrl: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    useCases = makeUseCases();
+    baseUrl = await startServer(buildApp(useCases));
+  });
+
+  it("returns 400 when limit is non-numeric (?limit=abc)", async () => {
+    const res = await fetch(`${baseUrl}/history/recent-plays?limit=abc`);
+    expect(res.status).toBe(400);
+    expect(useCases.getRecentPlays).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and passes coerced number when limit is valid (?limit=20)", async () => {
+    const res = await fetch(`${baseUrl}/history/recent-plays?limit=20`);
+    expect(res.status).toBe(200);
+    expect(useCases.getRecentPlays).toHaveBeenCalledWith(20);
   });
 });

--- a/apps/backend/src/presentation/routes/history.routes.ts
+++ b/apps/backend/src/presentation/routes/history.routes.ts
@@ -2,7 +2,7 @@ import { Router, type Router as ExpressRouter } from "express";
 import type { Container } from "../../container";
 import { asyncHandler } from "../middleware/async-handler";
 import { validate } from "../middleware/validate";
-import { recordPlaySchema } from "./schemas/history.schema";
+import { historyLimitQuerySchema, recordPlaySchema } from "./schemas/history.schema";
 
 export function createHistoryRoutes(container: Container): ExpressRouter {
   const router: ExpressRouter = Router();
@@ -16,6 +16,27 @@ export function createHistoryRoutes(container: Container): ExpressRouter {
 
   // POST /api/history/plays - Record a play event
   router.post("/plays", validate(recordPlaySchema), asyncHandler(historyController.recordPlay));
+
+  // GET /api/history/top-tracks - Top tracks by play count
+  router.get(
+    "/top-tracks",
+    validate(historyLimitQuerySchema),
+    asyncHandler(historyController.getTopTracks),
+  );
+
+  // GET /api/history/top-artists - Top artists by play count
+  router.get(
+    "/top-artists",
+    validate(historyLimitQuerySchema),
+    asyncHandler(historyController.getTopArtists),
+  );
+
+  // GET /api/history/recent-plays - Most recent play events
+  router.get(
+    "/recent-plays",
+    validate(historyLimitQuerySchema),
+    asyncHandler(historyController.getRecentPlays),
+  );
 
   return router;
 }

--- a/apps/backend/src/presentation/routes/schemas/history.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/history.schema.ts
@@ -14,3 +14,15 @@ export const recordPlaySchema = z.object({
 });
 
 export type RecordPlayBody = z.infer<typeof recordPlaySchema>["body"];
+
+export const historyLimitQuerySchema = z.object({
+  query: z.object({
+    limit: z
+      .string()
+      .optional()
+      .transform((v) => (v !== undefined ? parseInt(v, 10) : undefined))
+      .pipe(z.number().int().positive().max(1000).optional()),
+  }),
+});
+
+export type HistoryLimitQuery = z.infer<typeof historyLimitQuerySchema>["query"];

--- a/apps/backend/src/presentation/routes/schemas/history.schema.ts
+++ b/apps/backend/src/presentation/routes/schemas/history.schema.ts
@@ -17,11 +17,7 @@ export type RecordPlayBody = z.infer<typeof recordPlaySchema>["body"];
 
 export const historyLimitQuerySchema = z.object({
   query: z.object({
-    limit: z
-      .string()
-      .optional()
-      .transform((v) => (v !== undefined ? parseInt(v, 10) : undefined))
-      .pipe(z.number().int().positive().max(1000).optional()),
+    limit: z.coerce.number().int().positive().optional(),
   }),
 });
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -272,6 +272,7 @@ export interface TopTrackItem {
 export interface TopArtistItem {
   artist: string;
   playCount: number;
+  trackCount: number;
   lastPlayedAt: number;
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -259,6 +259,31 @@ export interface RecordPlayInput {
   playedAt: number;
 }
 
+export interface TopTrackItem {
+  trackUrl: string | null;
+  trackName: string;
+  artist: string;
+  album: string | null;
+  albumCoverUrl: string | null;
+  playCount: number;
+  lastPlayedAt: number;
+}
+
+export interface TopArtistItem {
+  artist: string;
+  playCount: number;
+  lastPlayedAt: number;
+}
+
+export interface RecentPlayItem {
+  trackId: string | null;
+  trackUrl: string | null;
+  trackName: string;
+  artist: string;
+  album: string | null;
+  playedAt: number;
+}
+
 export interface DownloadHistoryItem {
   id: string;
   playlistId: string | null;


### PR DESCRIPTION
## Slice 2/5 — Backend aggregation (listening history)

Part of #205. Chained PR; targets the previous slice branch `feature/lh-backend-data-layer` (feature-branch-chain). Merge order: after PR-1 (#266).

### What
Read side over the append-only `PlayHistory` table.

- Shared DTOs: `TopTrackItem`, `TopArtistItem`, `RecentPlayItem`.
- `HistoryRepository` extended with `getTopTracks` / `getTopArtists` / `getRecentPlays`.
- `PrismaPlayHistoryRepository` aggregation via Prisma `groupBy` + `findMany`:
  - top tracks grouped by `['trackUrl','trackName','artist']` (so a track keeps one group even if its denormalized cover/album varies; null `trackUrl` falls back to name+artist), `album`/`albumCoverUrl` surfaced via `_max`.
  - play count from `_count.id` (NOT NULL) so null-url plays are counted.
  - deterministic ordering: count desc → `_max.playedAt` desc tiebreaker.
  - recent plays ordered by `playedAt` desc.
- `HistoryUseCases` query methods with limit clamping (defaults 10/10/20, max 50/50/100) — clamping is the single source of truth (per spec REQ-LH-010/014/018).
- 3 GET routes (`/api/history/top-tracks`, `/top-artists`, `/recent-plays`), Zod-coerced `limit` query param (`?limit=abc` → 400). Inherits `SPOTIARR_TOKEN` auth.
- Empty history → empty arrays.

### Review fixes folded in (commit 6ca06c3)
- Removed `album`/`albumCoverUrl` from `groupBy.by` (was splitting counts).
- `_count` by `id` not nullable `trackUrl` (was zero-counting null-url groups).
- Fixed limit coercion at the `validate` middleware: Express `req.query` is a getter that re-parses per access, so the Zod-coerced value was being discarded — now shadowed via `Object.defineProperty`. This also makes coerced query params reliable for all routes.
- Rewrote the faked-green null-trackUrl test to reflect real `_count.id` behavior; ordering tests now assert the exact `orderBy` argument.

### Tests
Strict TDD. Gates: lint exit 0, `test:run` **1925 passed / 0 failed**, build exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
