### PR TITLE
feat(history): frontend player instrumentation for listening history (3/5, #205)

### DIFF
--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -35,6 +35,10 @@ vi.mock("./NowPlayingFullscreen", () => ({
   NowPlayingFullscreen: () => null,
 }));
 
+vi.mock("@/hooks/mutations/useRecordPlayMutation", () => ({
+  useRecordPlayMutation: () => ({ mutate: vi.fn() }),
+}));
+
 vi.mock("react-i18next", async () => {
   const actual = await vi.importActual<typeof import("react-i18next")>("react-i18next");
   return {

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -1103,3 +1103,32 @@ describe("resume playback position on reload", () => {
     expect(audio.currentTime).not.toBe(42);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fix 1 — stable play recorder registration
+// ---------------------------------------------------------------------------
+
+describe("play recorder registration stability", () => {
+  it("setPlayRecorder is called exactly once on mount even after a time update", () => {
+    const setPlayRecorderSpy = vi.spyOn(usePlayerStore.getState(), "setPlayRecorder");
+
+    usePlayerStore.getState().playQueue([makeItem("a")], 0);
+    const { container } = render(<GlobalPlayerBar />);
+
+    // Simulate a timeupdate event which causes currentTime to change and the component to re-render
+    const audio = container.querySelector("audio") as HTMLAudioElement;
+    act(() => {
+      fireEvent(audio, new Event("timeupdate"));
+    });
+    act(() => {
+      fireEvent(audio, new Event("timeupdate"));
+    });
+
+    // setPlayRecorder should have been called once on mount (with the recorder fn),
+    // not re-called on every re-render triggered by timeupdate
+    const registrationCalls = setPlayRecorderSpy.mock.calls.filter(([arg]) => arg !== null);
+    expect(registrationCalls).toHaveLength(1);
+
+    setPlayRecorderSpy.mockRestore();
+  });
+});

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -125,6 +125,14 @@ export const GlobalPlayerBar: FC = () => {
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
   const setPlayRecorder = usePlayerStore((s) => s.setPlayRecorder);
   const { mutate: recordPlay } = useRecordPlayMutation();
+  // Keep a ref so the stable wrapper below always calls the latest mutate
+  // without itself changing reference on every render.
+  const recordPlayRef = useRef(recordPlay);
+  recordPlayRef.current = recordPlay;
+  const stableRecordPlay = useCallback(
+    (...args: Parameters<typeof recordPlay>) => recordPlayRef.current(...args),
+    [],
+  );
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
   const prev = usePlayerStore((s) => s.prev);
@@ -175,12 +183,13 @@ export const GlobalPlayerBar: FC = () => {
 
   // Wire the record-play mutation into the player store (Decision 2).
   // The store calls this fn when the threshold is crossed; the HTTP call stays in TanStack Query.
+  // stableRecordPlay has a stable reference (empty dep array) so this effect runs once on mount.
   useEffect(() => {
-    setPlayRecorder(recordPlay);
+    setPlayRecorder(stableRecordPlay);
     return () => {
       setPlayRecorder(null);
     };
-  }, [setPlayRecorder, recordPlay]);
+  }, [setPlayRecorder, stableRecordPlay]);
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { useRecordPlayMutation } from "@/hooks/mutations/useRecordPlayMutation";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
 import { useGlobalPlayerShortcuts } from "@/hooks/useGlobalPlayerShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
@@ -122,6 +123,8 @@ export const GlobalPlayerBar: FC = () => {
   const isMuted = usePlayerStore((s) => s.isMuted);
 
   const setAudioElement = usePlayerStore((s) => s.setAudioElement);
+  const setPlayRecorder = usePlayerStore((s) => s.setPlayRecorder);
+  const { mutate: recordPlay } = useRecordPlayMutation();
   const togglePlay = usePlayerStore((s) => s.togglePlay);
   const next = usePlayerStore((s) => s.next);
   const prev = usePlayerStore((s) => s.prev);
@@ -169,6 +172,15 @@ export const GlobalPlayerBar: FC = () => {
       setAudioElement(null);
     };
   }, [setAudioElement]);
+
+  // Wire the record-play mutation into the player store (Decision 2).
+  // The store calls this fn when the threshold is crossed; the HTTP call stays in TanStack Query.
+  useEffect(() => {
+    setPlayRecorder(recordPlay);
+    return () => {
+      setPlayRecorder(null);
+    };
+  }, [setPlayRecorder, recordPlay]);
 
   useEffect(() => {
     const el = audioRef.current;

--- a/apps/frontend/src/hooks/mutations/useRecordPlayMutation.test.tsx
+++ b/apps/frontend/src/hooks/mutations/useRecordPlayMutation.test.tsx
@@ -1,0 +1,111 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { historyService } from "@/services/history.service";
+import type { QueueItem } from "@/store/usePlayerStore";
+import { useRecordPlayMutation } from "./useRecordPlayMutation";
+
+vi.mock("@/services/history.service", () => ({
+  historyService: {
+    recordPlay: vi.fn(),
+    getDownloadHistory: vi.fn(),
+    getDownloadTracks: vi.fn(),
+  },
+}));
+
+const makeQueueItem = (id: string): QueueItem => ({
+  id,
+  name: "Track A",
+  artist: "Artist A",
+  album: "Album A",
+  artworkUrl: "https://example.com/art.jpg",
+  audioUrl: `/api/library/audio?id=${id}`,
+  durationMs: 180_000,
+});
+
+let queryClient: QueryClient;
+
+const createWrapper = () => {
+  queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useRecordPlayMutation", () => {
+  it("calls historyService.recordPlay with the QueueItem", async () => {
+    vi.mocked(historyService.recordPlay).mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useRecordPlayMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    const item = makeQueueItem("track-1");
+    await act(async () => {
+      result.current.mutate(item);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(historyService.recordPlay).toHaveBeenCalledOnce();
+    expect(historyService.recordPlay).toHaveBeenCalledWith(item);
+  });
+
+  it("swallows errors — mutation does not throw on service failure", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(historyService.recordPlay).mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useRecordPlayMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    const item = makeQueueItem("track-2");
+
+    await act(async () => {
+      // fire-and-forget: mutate (not mutateAsync) so error does NOT propagate
+      result.current.mutate(item);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Error is swallowed — no unhandled rejection thrown
+    // The console.error was called (logged, not rethrown)
+    expect(consoleError).toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
+  it("is fire-and-forget: mutateAsync resolves (does not reject) when service fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.mocked(historyService.recordPlay).mockRejectedValueOnce(new Error("500 Server Error"));
+
+    const { result } = renderHook(() => useRecordPlayMutation(), {
+      wrapper: createWrapper(),
+    });
+
+    const item = makeQueueItem("track-3");
+
+    // The mutation hook uses onError to swallow; calling mutate (not mutateAsync)
+    // means no propagation. We test that mutation enters error state without throwing.
+    let threw = false;
+    await act(async () => {
+      try {
+        result.current.mutate(item);
+      } catch {
+        threw = true;
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(threw).toBe(false);
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/frontend/src/hooks/mutations/useRecordPlayMutation.ts
+++ b/apps/frontend/src/hooks/mutations/useRecordPlayMutation.ts
@@ -1,0 +1,15 @@
+import { useMutation } from "@tanstack/react-query";
+import { historyService } from "@/services/history.service";
+import type { QueueItem } from "@/store/usePlayerStore";
+
+/**
+ * Fire-and-forget mutation that records a play event.
+ * Errors are logged and swallowed — a failed record MUST NOT disrupt playback.
+ */
+export const useRecordPlayMutation = () =>
+  useMutation({
+    mutationFn: (item: QueueItem) => historyService.recordPlay(item),
+    onError: (error) => {
+      console.error("[useRecordPlayMutation] Failed to record play:", error);
+    },
+  });

--- a/apps/frontend/src/services/history.service.ts
+++ b/apps/frontend/src/services/history.service.ts
@@ -1,4 +1,5 @@
-import { ApiRoutes, DownloadHistoryItem, PlaylistHistory } from "@spotiarr/shared";
+import { ApiRoutes, DownloadHistoryItem, PlaylistHistory, RecordPlayInput } from "@spotiarr/shared";
+import type { QueueItem } from "@/store/usePlayerStore";
 import { httpClient } from "./httpClient";
 
 export const historyService = {
@@ -14,5 +15,19 @@ export const historyService = {
       `${ApiRoutes.HISTORY}/tracks`,
     );
     return response.data;
+  },
+
+  recordPlay: async (item: QueueItem): Promise<void> => {
+    const input: RecordPlayInput = {
+      trackId: item.id ?? null,
+      trackUrl: item.audioUrl ?? null,
+      trackName: item.name,
+      artist: item.artist,
+      album: item.album ?? null,
+      albumCoverUrl: item.artworkUrl ?? null,
+      durationMs: item.durationMs ?? null,
+      playedAt: Date.now(),
+    };
+    await httpClient.post<void>(`${ApiRoutes.HISTORY}/plays`, input);
   },
 };

--- a/apps/frontend/src/store/usePlayerStore.test.ts
+++ b/apps/frontend/src/store/usePlayerStore.test.ts
@@ -1536,3 +1536,260 @@ describe("persist partialize — resume fields", () => {
     expect("duration" in result).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Play-session dedup guard (T-3.3) — setPlayRecorder, _playSessionId, _onTimeUpdate threshold
+// ---------------------------------------------------------------------------
+
+describe("play-session dedup guard", () => {
+  it("setPlayRecorder registers a recorder function without error", () => {
+    const recorder = vi.fn();
+    expect(() => usePlayerStore.getState().setPlayRecorder(recorder)).not.toThrow();
+  });
+
+  it("recorder is called exactly once when threshold is crossed on a single track", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    // Threshold not yet crossed
+    usePlayerStore.getState()._onTimeUpdate(20);
+    expect(recorder).not.toHaveBeenCalled();
+
+    // Cross the 30s threshold
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledOnce();
+    expect(recorder).toHaveBeenCalledWith(items[0]);
+
+    // Another timeupdate past threshold — should NOT call again
+    usePlayerStore.getState()._onTimeUpdate(45);
+    expect(recorder).toHaveBeenCalledOnce();
+  });
+
+  it("recorder is called once per session: new track after advance triggers a new call", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    // Cross threshold for track A
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+    expect(recorder).toHaveBeenCalledWith(items[0]);
+
+    // Advance to track B (next())
+    usePlayerStore.getState().next();
+    usePlayerStore.setState({ duration: 180 });
+
+    // Cross threshold for track B
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+    expect(recorder).toHaveBeenNthCalledWith(2, items[1]);
+  });
+
+  it("seek backward/forward on same session does not trigger a second call", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    // Cross threshold
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Simulate seek backward then forward — same session
+    usePlayerStore.getState()._onTimeUpdate(5);
+    usePlayerStore.getState()._onTimeUpdate(35);
+    usePlayerStore.getState()._onTimeUpdate(60);
+    expect(recorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("repeat-one: end restart creates a new play session and recorder fires again", () => {
+    const mockAudio = { currentTime: 0, play: vi.fn().mockResolvedValue(undefined) };
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 40, repeatMode: "one" });
+    usePlayerStore.getState().setAudioElement(mockAudio as unknown as HTMLAudioElement);
+
+    // First cycle: cross threshold (50% of 40s = 20s; use >50%)
+    usePlayerStore.getState()._onTimeUpdate(21);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Track ends -> repeat-one restarts (new play session)
+    usePlayerStore.getState()._onEnded();
+
+    // Second cycle: cross threshold again
+    usePlayerStore.getState()._onTimeUpdate(21);
+    expect(recorder).toHaveBeenCalledTimes(2);
+  });
+
+  it("playQueue bumps session: recorder fires for new queue even if same track position", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Start a new queue (re-play same track)
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+  });
+
+  it("playFromIndex bumps session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Jump to track B
+    usePlayerStore.getState().playFromIndex(1);
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+  });
+
+  it("prev() that changes track bumps session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Reset currentTime to <= 3 so prev() actually changes track
+    usePlayerStore.setState({ currentTime: 1 });
+    // prev() with currentTime <= 3 changes track
+    usePlayerStore.getState().prev();
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+  });
+
+  it("prev() that only seeks (currentTime > 3) does NOT bump session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ duration: 180, currentTime: 5 });
+
+    // Cross threshold on track B
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // prev() just rewinds (currentTime was 5 > 3)
+    usePlayerStore.getState().prev();
+    // currentTime now 0, still same track B (index 1)
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    // Still same session -> no second call
+    expect(recorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("50% threshold fires for short track before 30s mark", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [{ ...makeItem("a"), durationMs: 40_000 }];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 40 });
+
+    // 20s = exactly 50% — NOT > 50%, should not fire
+    usePlayerStore.getState()._onTimeUpdate(20);
+    expect(recorder).not.toHaveBeenCalled();
+
+    // 20.1s > 50% — fires (30s not reached yet)
+    usePlayerStore.getState()._onTimeUpdate(20.1);
+    expect(recorder).toHaveBeenCalledTimes(1);
+  });
+
+  it("recorder not called when no recorder is registered", () => {
+    usePlayerStore.getState().setPlayRecorder(null);
+    const items = [makeItem("a")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180 });
+
+    expect(() => usePlayerStore.getState()._onTimeUpdate(31)).not.toThrow();
+  });
+
+  it("auto-advance (ended, repeat off, not last) bumps session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({ duration: 180, repeatMode: "off" });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Track ends -> auto-advance to track B
+    usePlayerStore.getState()._onEnded();
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+    expect(recorder).toHaveBeenNthCalledWith(2, items[1]);
+  });
+
+  it("repeat-all wrap-around bumps session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b")];
+    usePlayerStore.getState().playQueue(items, 1);
+    usePlayerStore.setState({ duration: 180, repeatMode: "all" });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // End of last track with repeat all -> wrap to 0
+    usePlayerStore.getState()._onEnded();
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+    expect(recorder).toHaveBeenNthCalledWith(2, items[0]);
+  });
+
+  it("shuffle advance bumps session", () => {
+    const recorder = vi.fn();
+    usePlayerStore.getState().setPlayRecorder(recorder);
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    usePlayerStore.getState().playQueue(items, 0);
+    usePlayerStore.setState({
+      shuffleMode: true,
+      shuffleOrder: [0, 2, 1],
+      shuffleOrderIndex: 0,
+      duration: 180,
+    });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(1);
+
+    // Shuffle advance -> index 2 (shuffleOrder[1])
+    usePlayerStore.getState().next();
+    usePlayerStore.setState({ duration: 180 });
+
+    usePlayerStore.getState()._onTimeUpdate(31);
+    expect(recorder).toHaveBeenCalledTimes(2);
+    expect(recorder).toHaveBeenNthCalledWith(2, items[2]);
+  });
+});

--- a/apps/frontend/src/store/usePlayerStore.ts
+++ b/apps/frontend/src/store/usePlayerStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { shouldRecordPlay } from "@/utils/should-record-play";
 import { createPlayerUISlice, type PlayerUISlice } from "./playerUISlice";
 
 export interface QueueItem {
@@ -52,6 +53,8 @@ export interface PlayerState extends PlayerUISlice {
   reorderQueue: (fromIndex: number, toIndex: number) => void;
 
   setAudioElement: (el: HTMLAudioElement | null) => void;
+  /** Inject the play-recorder fn from TanStack Query mutation (GlobalPlayerBar effect). */
+  setPlayRecorder: (fn: ((item: QueueItem) => void) | null) => void;
   _onLoadedMetadata: (duration: number) => void;
   _onTimeUpdate: (currentTime: number) => void;
   _onEnded: () => void;
@@ -88,6 +91,12 @@ export const __partialize = (
 });
 
 let _audioElement: HTMLAudioElement | null = null;
+
+// Play-session dedup guard (Decision 2).
+// Module-level (not persisted, not in store state) — mirrors _audioElement pattern.
+let _playSessionId = 0;
+let _recordedPlaySession: number | null = null;
+let _playRecorder: ((item: QueueItem) => void) | null = null;
 
 function shuffleIndices(length: number, pin: number): number[] {
   if (length === 0) return [];
@@ -130,11 +139,18 @@ type AdvanceSource = "user" | "ended" | "error";
 export const usePlayerStore = create<PlayerState>()(
   persist(
     (set, get) => {
+      function bumpPlaySession(): void {
+        _playSessionId += 1;
+        _recordedPlaySession = null;
+      }
+
       function advance(source: AdvanceSource): void {
         const { currentIndex, queue, shuffleMode, shuffleOrder, shuffleOrderIndex, repeatMode } =
           get();
         if (currentIndex === null) return;
         if (source === "ended" && repeatMode === "one") {
+          // Repeat-one: same track restarts → new play instance (REQ-LH-005)
+          bumpPlaySession();
           if (_audioElement) {
             _audioElement.currentTime = 0;
             void _audioElement.play();
@@ -144,6 +160,8 @@ export const usePlayerStore = create<PlayerState>()(
         if (shuffleMode) {
           if (shuffleOrderIndex >= shuffleOrder.length - 1) {
             if (repeatMode === "all") {
+              // Shuffle repeat-all wrap-around → new track, new session
+              bumpPlaySession();
               set({
                 shuffleOrderIndex: 0,
                 currentIndex: shuffleOrder[0]!,
@@ -155,6 +173,8 @@ export const usePlayerStore = create<PlayerState>()(
             }
             return;
           }
+          // Shuffle advance to next track → new session
+          bumpPlaySession();
           const nextOrderIndex = shuffleOrderIndex + 1;
           set({
             shuffleOrderIndex: nextOrderIndex,
@@ -166,12 +186,16 @@ export const usePlayerStore = create<PlayerState>()(
         }
         if (currentIndex >= queue.length - 1) {
           if (repeatMode === "all") {
+            // Linear repeat-all wrap-around → new track, new session
+            bumpPlaySession();
             set({ currentIndex: 0, currentTime: 0, isBuffering: false });
           } else {
             set({ isPlaying: false });
           }
           return;
         }
+        // Linear advance → new track, new session
+        bumpPlaySession();
         set({ currentIndex: currentIndex + 1, currentTime: 0, isBuffering: false });
       }
 
@@ -184,6 +208,8 @@ export const usePlayerStore = create<PlayerState>()(
             get().clear();
             return;
           }
+          // New queue → new play instance
+          bumpPlaySession();
           set({
             queue: items,
             currentIndex: startIndex,
@@ -231,6 +257,8 @@ export const usePlayerStore = create<PlayerState>()(
           }
           if (shuffleMode) {
             if (shuffleOrderIndex > 0) {
+              // Shuffle: go back to previous track → new session
+              bumpPlaySession();
               const nextOrderIndex = shuffleOrderIndex - 1;
               set({
                 shuffleOrderIndex: nextOrderIndex,
@@ -241,6 +269,8 @@ export const usePlayerStore = create<PlayerState>()(
               return;
             }
             if (repeatMode === "all") {
+              // Shuffle repeat-all: wrap to last → new session
+              bumpPlaySession();
               const nextOrderIndex = shuffleOrder.length - 1;
               set({
                 shuffleOrderIndex: nextOrderIndex,
@@ -252,10 +282,14 @@ export const usePlayerStore = create<PlayerState>()(
             return;
           }
           if (currentIndex > 0) {
+            // Move to previous track → new session
+            bumpPlaySession();
             set({ currentIndex: currentIndex - 1, currentTime: 0, isBuffering: false });
             return;
           }
           if (repeatMode === "all") {
+            // Repeat-all wrap → new session
+            bumpPlaySession();
             set({ currentIndex: queue.length - 1, currentTime: 0, isBuffering: false });
           }
         },
@@ -305,6 +339,10 @@ export const usePlayerStore = create<PlayerState>()(
           _audioElement = el;
         },
 
+        setPlayRecorder(fn) {
+          _playRecorder = fn;
+        },
+
         _onLoadedMetadata(duration) {
           set({
             duration: Number.isFinite(duration) && duration > 0 ? duration : 0,
@@ -314,6 +352,20 @@ export const usePlayerStore = create<PlayerState>()(
 
         _onTimeUpdate(currentTime) {
           set({ currentTime });
+          // Play-session threshold check (REQ-LH-001, REQ-LH-003)
+          const { duration, currentIndex, queue } = get();
+          if (
+            _playRecorder !== null &&
+            _recordedPlaySession !== _playSessionId &&
+            currentIndex !== null &&
+            shouldRecordPlay(currentTime, duration > 0 ? duration : null)
+          ) {
+            _recordedPlaySession = _playSessionId;
+            const item = queue[currentIndex];
+            if (item) {
+              _playRecorder(item);
+            }
+          }
         },
 
         _onEnded() {
@@ -373,6 +425,8 @@ export const usePlayerStore = create<PlayerState>()(
         playFromIndex(index) {
           const { queue, shuffleMode } = get();
           if (index < 0 || index >= queue.length) return;
+          // New play instance — always bump session (even re-playing same track is a new listen)
+          bumpPlaySession();
           set({
             currentIndex: index,
             isPlaying: true,

--- a/apps/frontend/src/utils/detect-listening-intent.test.ts
+++ b/apps/frontend/src/utils/detect-listening-intent.test.ts
@@ -86,4 +86,14 @@ describe("detectListeningIntent", () => {
   it("is case-insensitive for ES", () => {
     expect(detectListeningIntent("Mis Artistas Más Escuchados")).toEqual({ scope: "artists" });
   });
+
+  // --- false-positive guard: standalone "most" without listened/played context ---
+  it("returns null for 'songs I like most' (standalone most is not a top-signal)", () => {
+    expect(detectListeningIntent("songs I like most")).toEqual({ scope: null });
+  });
+
+  // --- false-positive guard: "top" without music context ---
+  it("returns null for 'top of the morning' (top without music noun)", () => {
+    expect(detectListeningIntent("top of the morning")).toEqual({ scope: null });
+  });
 });

--- a/apps/frontend/src/utils/detect-listening-intent.test.ts
+++ b/apps/frontend/src/utils/detect-listening-intent.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { detectListeningIntent } from "./detect-listening-intent";
+
+describe("detectListeningIntent", () => {
+  // --- No match → null ---
+  it("returns null for an unrelated prompt", () => {
+    expect(detectListeningIntent("play some jazz music")).toEqual({ scope: null });
+  });
+
+  it("returns null for an empty string", () => {
+    expect(detectListeningIntent("")).toEqual({ scope: null });
+  });
+
+  // --- tracks scope (EN) ---
+  it("returns tracks for 'my most listened songs'", () => {
+    expect(detectListeningIntent("my most listened songs")).toEqual({ scope: "tracks" });
+  });
+
+  it("returns tracks for 'top tracks'", () => {
+    expect(detectListeningIntent("top tracks")).toEqual({ scope: "tracks" });
+  });
+
+  it("returns tracks for 'most played songs'", () => {
+    expect(detectListeningIntent("most played songs")).toEqual({ scope: "tracks" });
+  });
+
+  it("returns tracks for 'my favorite tracks lately'", () => {
+    expect(detectListeningIntent("generate a playlist from my top tracks")).toEqual({
+      scope: "tracks",
+    });
+  });
+
+  // --- tracks scope (ES) ---
+  it("returns tracks for 'mis canciones más escuchadas' (ES)", () => {
+    expect(detectListeningIntent("mis canciones más escuchadas")).toEqual({ scope: "tracks" });
+  });
+
+  it("returns tracks for 'temas más escuchados' (ES)", () => {
+    expect(detectListeningIntent("temas más escuchados")).toEqual({ scope: "tracks" });
+  });
+
+  // --- artists scope (EN) ---
+  it("returns artists for 'my most listened artists'", () => {
+    expect(detectListeningIntent("my most listened artists")).toEqual({ scope: "artists" });
+  });
+
+  it("returns artists for 'top artists'", () => {
+    expect(detectListeningIntent("top artists")).toEqual({ scope: "artists" });
+  });
+
+  it("returns artists for 'my favorite bands'", () => {
+    expect(detectListeningIntent("playlist based on my favorite bands")).toEqual({
+      scope: "artists",
+    });
+  });
+
+  // --- artists scope (ES) ---
+  it("returns artists for 'mis artistas más escuchados' (ES)", () => {
+    expect(detectListeningIntent("mis artistas más escuchados")).toEqual({ scope: "artists" });
+  });
+
+  it("returns artists for 'grupos más escuchados' (ES)", () => {
+    expect(detectListeningIntent("grupos más escuchados")).toEqual({ scope: "artists" });
+  });
+
+  // --- both scope: generic top/most-listened with no specific noun ---
+  it("returns both for 'my most listened'", () => {
+    expect(detectListeningIntent("my most listened")).toEqual({ scope: "both" });
+  });
+
+  it("returns both for 'based on what I listen to most'", () => {
+    expect(detectListeningIntent("based on what I listen to most")).toEqual({ scope: "both" });
+  });
+
+  it("returns both for 'lo que más escucho' (ES)", () => {
+    expect(detectListeningIntent("hazme una playlist con lo que más escucho")).toEqual({
+      scope: "both",
+    });
+  });
+
+  // --- case insensitivity ---
+  it("is case-insensitive for EN", () => {
+    expect(detectListeningIntent("My Top Tracks")).toEqual({ scope: "tracks" });
+  });
+
+  it("is case-insensitive for ES", () => {
+    expect(detectListeningIntent("Mis Artistas Más Escuchados")).toEqual({ scope: "artists" });
+  });
+});

--- a/apps/frontend/src/utils/detect-listening-intent.ts
+++ b/apps/frontend/src/utils/detect-listening-intent.ts
@@ -1,0 +1,41 @@
+import type { ListeningIntent } from "@spotiarr/shared";
+
+/**
+ * Pure helper that analyses a user prompt for listening-history intent.
+ * Returns { scope: 'tracks' | 'artists' | 'both' | null }.
+ *
+ * Detection rules (case-insensitive, bilingual EN/ES):
+ * - If a "top / most listened / más escuchad@" signal is present AND a track noun
+ *   (song/songs/track/tracks/canción/canciones/tema/temas) is near → scope: 'tracks'
+ * - If a "top / most listened / más escuchad@" signal is present AND an artist noun
+ *   (artist/artists/band/bands/grupo/grupos/artista/artistas) is near → scope: 'artists'
+ * - If a "top / most listened" signal is present with NO specific noun → scope: 'both'
+ * - Otherwise → scope: null
+ */
+export function detectListeningIntent(prompt: string): ListeningIntent {
+  const lower = prompt.toLowerCase();
+
+  // Phrases that signal "top / most listened" in EN and ES
+  const topSignal =
+    /\b(top|most[- ]listened|most[- ]played|favorite|favourites?|most)\b|m[aá]s escuchad[oa]s?|lo que m[aá]s escucho/i;
+
+  if (!topSignal.test(lower)) {
+    return { scope: null };
+  }
+
+  // Track nouns (EN + ES)
+  const trackNoun = /\b(songs?|tracks?|canciones?|temas?)\b/i;
+
+  // Artist nouns (EN + ES)
+  const artistNoun = /\b(artists?|bands?|grupos?|artistas?)\b/i;
+
+  const hasTrackNoun = trackNoun.test(lower);
+  const hasArtistNoun = artistNoun.test(lower);
+
+  if (hasTrackNoun && !hasArtistNoun) return { scope: "tracks" };
+  if (hasArtistNoun && !hasTrackNoun) return { scope: "artists" };
+  if (hasTrackNoun && hasArtistNoun) return { scope: "both" };
+
+  // Signal present but no specific noun → both
+  return { scope: "both" };
+}

--- a/apps/frontend/src/utils/detect-listening-intent.ts
+++ b/apps/frontend/src/utils/detect-listening-intent.ts
@@ -15,9 +15,12 @@ import type { ListeningIntent } from "@spotiarr/shared";
 export function detectListeningIntent(prompt: string): ListeningIntent {
   const lower = prompt.toLowerCase();
 
-  // Phrases that signal "top / most listened" in EN and ES
+  // Phrases that signal "top / most listened" in EN and ES.
+  // "top" requires an immediately following music noun or number to avoid false positives
+  // like "top of the morning". Standalone "most" is excluded; only compound forms
+  // (most-listened, most-played) or the idiomatic "listen to most" are accepted.
   const topSignal =
-    /\b(top|most[- ]listened|most[- ]played|favorite|favourites?|most)\b|m[aá]s escuchad[oa]s?|lo que m[aá]s escucho/i;
+    /\btop\s+(?:\d+|songs?|tracks?|canciones?|temas?|artists?|bands?|grupos?|artistas?)\b|most[- ]listened|most[- ]played|favorite|favourites?|listen(?:ing)?\s+to\s+most\b|m[aá]s escuchad[oa]s?|lo que m[aá]s escucho/i;
 
   if (!topSignal.test(lower)) {
     return { scope: null };

--- a/apps/frontend/src/utils/should-record-play.test.ts
+++ b/apps/frontend/src/utils/should-record-play.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { shouldRecordPlay } from "./should-record-play";
+
+describe("shouldRecordPlay", () => {
+  // --- 30-second boundary ---
+  it("returns false at exactly 30s (strict >)", () => {
+    expect(shouldRecordPlay(30, 180)).toBe(false);
+  });
+
+  it("returns true at 30.001s (crosses 30s threshold)", () => {
+    expect(shouldRecordPlay(30.001, 180)).toBe(true);
+  });
+
+  it("returns false at 29.999s", () => {
+    expect(shouldRecordPlay(29.999, 180)).toBe(false);
+  });
+
+  // --- 50% boundary ---
+  it("returns true at exactly 50% of a 40s track (20s — strict >)", () => {
+    // 20s is NOT > 50% of 40s (20/40 = 0.5, not > 0.5)
+    expect(shouldRecordPlay(20, 40)).toBe(false);
+  });
+
+  it("returns true just past 50% of a 40s track (20.001s)", () => {
+    expect(shouldRecordPlay(20.001, 40)).toBe(true);
+  });
+
+  it("returns true at 19.999s of a 39s track (> 50%)", () => {
+    // 19.999 / 38 < 0.5 → false; 19.999 / 38.999 is ~0.5128 > 0.5 → true
+    expect(shouldRecordPlay(20, 39)).toBe(true);
+  });
+
+  // 50% fires before 30s for a short track
+  it("returns true for a 40s track when 21s elapsed (> 50%, < 30s)", () => {
+    expect(shouldRecordPlay(21, 40)).toBe(true);
+  });
+
+  // --- Unknown / zero duration — only 30s rule applies ---
+  it("returns false at 25s when durationMs is 0", () => {
+    expect(shouldRecordPlay(25, 0)).toBe(false);
+  });
+
+  it("returns true at 31s when durationMs is 0", () => {
+    expect(shouldRecordPlay(31, 0)).toBe(true);
+  });
+
+  it("returns false at 25s when durationMs is null", () => {
+    expect(shouldRecordPlay(25, null)).toBe(false);
+  });
+
+  it("returns true at 31s when durationMs is null", () => {
+    expect(shouldRecordPlay(31, null)).toBe(true);
+  });
+
+  it("returns false at 25s when durationMs is undefined", () => {
+    expect(shouldRecordPlay(25, undefined)).toBe(false);
+  });
+
+  it("returns true at 31s when durationMs is undefined", () => {
+    expect(shouldRecordPlay(31, undefined)).toBe(true);
+  });
+
+  // --- Edge: negative duration treated as unknown ---
+  it("returns false at 25s when duration is negative (only 30s rule)", () => {
+    expect(shouldRecordPlay(25, -1)).toBe(false);
+  });
+
+  it("returns true at 31s when duration is negative", () => {
+    expect(shouldRecordPlay(31, -1)).toBe(true);
+  });
+});

--- a/apps/frontend/src/utils/should-record-play.ts
+++ b/apps/frontend/src/utils/should-record-play.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns true when a play qualifies to be recorded.
+ * Condition A: elapsed time exceeds 30 seconds (strict >)
+ * Condition B: elapsed time exceeds 50% of known duration (strict >)
+ *
+ * When duration is unknown (null, undefined, <= 0), only Condition A applies.
+ */
+export function shouldRecordPlay(
+  currentTime: number,
+  duration: number | null | undefined,
+): boolean {
+  if (currentTime > 30) return true;
+  if (duration != null && duration > 0 && currentTime / duration > 0.5) return true;
+  return false;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -298,6 +298,16 @@ export interface DownloadHistoryItem {
   completedAt: number;
 }
 
+// ---------------------------------------------------------------------------
+// AI listening intent types (PR-3 / T-3.7)
+// ---------------------------------------------------------------------------
+
+export type ListeningScope = "tracks" | "artists" | "both";
+
+export interface ListeningIntent {
+  scope: ListeningScope | null;
+}
+
 export interface PlaylistHistory {
   playlistId: string | null;
   playlistName: string;


### PR DESCRIPTION
Replaces #268 (auto-closed by GitHub's stacked-branch retarget quirk during chain merge). Same content: player threshold instrumentation + record mutation + detectListeningIntent. Part of #205.