### PR TITLE
feat(player): prefetch next track audio (Slice 1 — gym)

### DIFF
--- a/apps/backend/src/application/ports/library-audio.port.ts
+++ b/apps/backend/src/application/ports/library-audio.port.ts
@@ -5,7 +5,7 @@ export type AudioRejectReason = "outside-root" | "bad-extension" | "not-found" |
 export type AudioByteRange = { start: number; end: number };
 
 export type ResolveAudioResult =
-  | { kind: "ok"; absolutePath: string; contentType: string; sizeBytes: number }
+  | { kind: "ok"; absolutePath: string; contentType: string; sizeBytes: number; mtimeMs: number }
   | { kind: "reject"; reason: AudioRejectReason };
 
 export interface LibraryAudioPort {

--- a/apps/backend/src/infrastructure/services/library-audio.service.test.ts
+++ b/apps/backend/src/infrastructure/services/library-audio.service.test.ts
@@ -50,6 +50,7 @@ describe("FileSystemLibraryAudioService", () => {
       absolutePath: await fs.realpath(trackPath),
       contentType: "audio/mpeg",
       sizeBytes: 10,
+      mtimeMs: expect.any(Number),
     });
   });
 

--- a/apps/backend/src/infrastructure/services/library-audio.service.ts
+++ b/apps/backend/src/infrastructure/services/library-audio.service.ts
@@ -75,6 +75,7 @@ export class FileSystemLibraryAudioService implements LibraryAudioPort {
       absolutePath: candidateRealPath,
       contentType: AUDIO_CONTENT_TYPES[extension],
       sizeBytes: stat.size,
+      mtimeMs: stat.mtimeMs,
     };
   }
 

--- a/apps/backend/src/presentation/controllers/library.controller.ts
+++ b/apps/backend/src/presentation/controllers/library.controller.ts
@@ -193,6 +193,8 @@ export class LibraryController {
 
       res.setHeader("Accept-Ranges", "bytes");
       res.setHeader("Content-Type", result.contentType);
+      res.setHeader("Cache-Control", "private, max-age=31536000, immutable");
+      res.setHeader("Last-Modified", new Date(result.mtimeMs).toUTCString());
 
       if (range.kind === "full") {
         res.setHeader("Content-Length", result.sizeBytes.toString());

--- a/apps/backend/src/presentation/routes/library.routes.test.ts
+++ b/apps/backend/src/presentation/routes/library.routes.test.ts
@@ -463,6 +463,70 @@ describe("GET /audio integration", () => {
     });
   });
 
+  it("responds with Cache-Control: private, max-age=31536000, immutable on 200", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-cache-200-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "audio-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
+  });
+
+  it("responds with Last-Modified on 200", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-lm-200-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "audio-content");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`);
+
+    expect(response.status).toBe(200);
+    const lastModified = response.headers.get("last-modified");
+    expect(lastModified).toBeTruthy();
+    expect(isNaN(Date.parse(lastModified!))).toBe(false);
+  });
+
+  it("responds with Cache-Control: private, max-age=31536000, immutable on 206", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-cache-206-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=0-1023" },
+    });
+
+    expect(response.status).toBe(206);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=31536000, immutable");
+  });
+
+  it("responds with Last-Modified on 206", async () => {
+    const downloadsRoot = await makeTempDir("lib-audio-lm-206-");
+    const filePath = path.join(downloadsRoot, "Artist", "song.mp3");
+
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "abcdef");
+
+    const baseUrl = await startTestServer(downloadsRoot);
+    const response = await fetch(`${baseUrl}/audio?path=${encodeURIComponent(filePath)}`, {
+      headers: { Range: "bytes=0-2" },
+    });
+
+    expect(response.status).toBe(206);
+    const lastModified = response.headers.get("last-modified");
+    expect(lastModified).toBeTruthy();
+    expect(isNaN(Date.parse(lastModified!))).toBe(false);
+  });
+
   it("returns 404 for unsupported extension", async () => {
     const downloadsRoot = await makeTempDir("lib-audio-route-root-");
     const filePath = path.join(downloadsRoot, "Artist", "cover.jpg");

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.test.tsx
@@ -145,17 +145,21 @@ describe("render guard", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Single audio element
+// Audio elements
 // ---------------------------------------------------------------------------
 
 describe("audio element", () => {
-  it("renders exactly one hidden audio element", () => {
+  it("renders main player audio and hidden warmer audio element", () => {
     usePlayerStore.getState().playQueue([makeItem("a")], 0);
     const { container } = render(<GlobalPlayerBar />);
 
     const audioEls = container.querySelectorAll("audio");
-    expect(audioEls).toHaveLength(1);
-    expect(audioEls[0]?.getAttribute("aria-label")).toBe("Audio player");
+    expect(audioEls).toHaveLength(2);
+    const mainAudio = container.querySelector("audio[aria-label='Audio player']");
+    expect(mainAudio).not.toBeNull();
+    const warmerAudio = container.querySelector("audio[aria-hidden='true']");
+    expect(warmerAudio).not.toBeNull();
+    expect(warmerAudio?.getAttribute("preload")).toBe("auto");
   });
 });
 

--- a/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
+++ b/apps/frontend/src/components/organisms/GlobalPlayerBar.tsx
@@ -9,6 +9,7 @@ import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useRecordPlayMutation } from "@/hooks/mutations/useRecordPlayMutation";
+import { useAudioPrefetch } from "@/hooks/useAudioPrefetch";
 import { useFocusReturnOnClose } from "@/hooks/useFocusReturnOnClose";
 import { useGlobalPlayerShortcuts } from "@/hooks/useGlobalPlayerShortcuts";
 import { useMediaSession } from "@/hooks/useMediaSession";
@@ -96,6 +97,7 @@ const TrackMeta: FC<{ item: QueueItem; onNavigate: (path: string) => void }> = (
 
 export const GlobalPlayerBar: FC = () => {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const warmerRef = useRef<HTMLAudioElement | null>(null);
   const [audioEl, setAudioEl] = useState<HTMLAudioElement | null>(null);
   const registerAudioEl = useCallback((el: HTMLAudioElement | null) => {
     audioRef.current = el;
@@ -171,6 +173,7 @@ export const GlobalPlayerBar: FC = () => {
   useGlobalPlayerShortcuts();
   useFocusReturnOnClose(isQueuePanelOpen, triggerRef);
   useFocusReturnOnClose(isNowPlayingOpen, nowPlayingTriggerRef);
+  useAudioPrefetch(warmerRef);
 
   useEffect(() => {
     const el = audioRef.current;
@@ -327,6 +330,7 @@ export const GlobalPlayerBar: FC = () => {
         preload="metadata"
         className="hidden"
       />
+      <audio ref={warmerRef} preload="auto" className="hidden" aria-hidden="true" />
       <QueueSidePanel />
       <NowPlayingFullscreen />
 

--- a/apps/frontend/src/hooks/useAudioPrefetch.test.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.test.ts
@@ -122,11 +122,59 @@ describe("computeNextAudioUrls", () => {
     const result = computeNextAudioUrls({ queue: [], currentIndex: null, ...DEFAULT_STATE }, 3);
     expect(result).toEqual([]);
   });
-});
 
-// ---------------------------------------------------------------------------
-// useAudioPrefetch hook tests
-// ---------------------------------------------------------------------------
+  it("repeatMode=all non-shuffle 2-track: returns the other track (wrap bug)", () => {
+    const queue = makeQueue(2);
+    const result = computeNextAudioUrls(
+      {
+        queue,
+        currentIndex: 0,
+        shuffleMode: false,
+        shuffleOrder: [],
+        shuffleOrderIndex: -1,
+        repeatMode: "all",
+      },
+      1,
+    );
+    expect(result).toEqual([queue[1]!.audioUrl]);
+  });
+
+  it("repeatMode=all shuffle 2-track: returns the other track (wrap bug)", () => {
+    const queue = makeQueue(2);
+    const result = computeNextAudioUrls(
+      {
+        queue,
+        currentIndex: 0,
+        shuffleMode: true,
+        shuffleOrder: [0, 1],
+        shuffleOrderIndex: 0,
+        repeatMode: "all",
+      },
+      1,
+    );
+    expect(result).toEqual([queue[1]!.audioUrl]);
+  });
+
+  it("repeatMode=all: wrap that lands on currentUrl is skipped, next valid takes its place", () => {
+    const queue = makeQueue(3);
+    const customQueue = [...queue];
+    customQueue[0] = { ...customQueue[0]!, audioUrl: "http://localhost/same.mp3" };
+    customQueue[2] = { ...customQueue[2]!, audioUrl: "http://localhost/same.mp3" };
+    const result = computeNextAudioUrls(
+      {
+        queue: customQueue,
+        currentIndex: 2,
+        shuffleMode: false,
+        shuffleOrder: [],
+        shuffleOrderIndex: -1,
+        repeatMode: "all",
+      },
+      2,
+    );
+    expect(result).toEqual([customQueue[1]!.audioUrl]);
+    expect(result).not.toContain("http://localhost/same.mp3");
+  });
+});
 
 function makeWarmerRef(el: HTMLAudioElement) {
   return { current: el } as React.RefObject<HTMLAudioElement | null>;
@@ -234,5 +282,45 @@ describe("useAudioPrefetch hook", () => {
     });
 
     expect(el.play).not.toHaveBeenCalled();
+  });
+
+  it("count 3→0: clears warmer.src instead of leaving old buffer active", () => {
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+    expect(el.src).toBe(queue[1]!.audioUrl);
+
+    act(() => {
+      usePreferencesStore.setState({ audioPrefetchCount: 0 });
+    });
+
+    expect(el.src).toBe("");
+  });
+
+  it("count 3→0→3: re-warms after being re-enabled", () => {
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+    expect(el.src).toBe(queue[1]!.audioUrl);
+
+    act(() => {
+      usePreferencesStore.setState({ audioPrefetchCount: 0 });
+    });
+    expect(el.src).toBe("");
+
+    act(() => {
+      usePreferencesStore.setState({ audioPrefetchCount: 3 });
+    });
+
+    expect(el.src).toBe(queue[1]!.audioUrl);
+    expect(el.load).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/frontend/src/hooks/useAudioPrefetch.test.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.test.ts
@@ -1,0 +1,238 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { usePreferencesStore } from "@/store/usePreferencesStore";
+import { computeNextAudioUrls, useAudioPrefetch } from "./useAudioPrefetch";
+
+function makeQueue(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `track-${i}`,
+    name: `Track ${i}`,
+    artist: "Artist",
+    audioUrl: `http://localhost/api/library/audio?path=/track-${i}.mp3`,
+  }));
+}
+
+const DEFAULT_STATE = {
+  shuffleMode: false,
+  shuffleOrder: [] as number[],
+  shuffleOrderIndex: -1,
+  repeatMode: "off" as const,
+};
+
+describe("computeNextAudioUrls", () => {
+  it("non-shuffle: returns next N urls from currentIndex+1", () => {
+    const queue = makeQueue(6);
+    const result = computeNextAudioUrls({ queue, currentIndex: 1, ...DEFAULT_STATE }, 3);
+    expect(result).toEqual([queue[2]!.audioUrl, queue[3]!.audioUrl, queue[4]!.audioUrl]);
+  });
+
+  it("non-shuffle: at last index returns []", () => {
+    const queue = makeQueue(4);
+    const result = computeNextAudioUrls({ queue, currentIndex: 3, ...DEFAULT_STATE }, 3);
+    expect(result).toEqual([]);
+  });
+
+  it("non-shuffle: fewer than N remaining clamps to available", () => {
+    const queue = makeQueue(5);
+    const result = computeNextAudioUrls({ queue, currentIndex: 3, ...DEFAULT_STATE }, 3);
+    expect(result).toEqual([queue[4]!.audioUrl]);
+  });
+
+  it("N=0 returns []", () => {
+    const queue = makeQueue(6);
+    const result = computeNextAudioUrls({ queue, currentIndex: 1, ...DEFAULT_STATE }, 0);
+    expect(result).toEqual([]);
+  });
+
+  it("N > remaining clamps without error", () => {
+    const queue = makeQueue(3);
+    const result = computeNextAudioUrls({ queue, currentIndex: 1, ...DEFAULT_STATE }, 10);
+    expect(result).toEqual([queue[2]!.audioUrl]);
+  });
+
+  it("dedup: current track url is not included in output", () => {
+    const queue = makeQueue(4);
+    const customQueue = [...queue];
+    customQueue[2] = { ...customQueue[2]!, audioUrl: customQueue[1]!.audioUrl };
+    const result = computeNextAudioUrls(
+      { queue: customQueue, currentIndex: 1, ...DEFAULT_STATE },
+      3,
+    );
+    expect(result).not.toContain(customQueue[1]!.audioUrl);
+  });
+
+  it("shuffle mode: maps via shuffleOrder indices correctly", () => {
+    const queue = makeQueue(5);
+    const result = computeNextAudioUrls(
+      {
+        queue,
+        currentIndex: 0,
+        shuffleMode: true,
+        shuffleOrder: [2, 0, 4, 1, 3],
+        shuffleOrderIndex: 1,
+        repeatMode: "off",
+      },
+      2,
+    );
+    // Next 2 in shuffle order after index 1: shuffleOrder[2]=4, shuffleOrder[3]=1
+    expect(result).toEqual([queue[4]!.audioUrl, queue[1]!.audioUrl]);
+  });
+
+  it("repeatMode=all non-shuffle: wraps modulo queue.length", () => {
+    const queue = makeQueue(4);
+    const result = computeNextAudioUrls(
+      {
+        queue,
+        currentIndex: 2,
+        shuffleMode: false,
+        shuffleOrder: [],
+        shuffleOrderIndex: -1,
+        repeatMode: "all",
+      },
+      3,
+    );
+    // currentIndex=2, next: 3, 0, 1
+    expect(result).toEqual([queue[3]!.audioUrl, queue[0]!.audioUrl, queue[1]!.audioUrl]);
+  });
+
+  it("repeatMode=one: returns []", () => {
+    const queue = makeQueue(5);
+    const result = computeNextAudioUrls(
+      {
+        queue,
+        currentIndex: 2,
+        shuffleMode: false,
+        shuffleOrder: [],
+        shuffleOrderIndex: -1,
+        repeatMode: "one",
+      },
+      3,
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("currentIndex=null returns []", () => {
+    const queue = makeQueue(4);
+    const result = computeNextAudioUrls({ queue, currentIndex: null, ...DEFAULT_STATE }, 3);
+    expect(result).toEqual([]);
+  });
+
+  it("empty queue returns []", () => {
+    const result = computeNextAudioUrls({ queue: [], currentIndex: null, ...DEFAULT_STATE }, 3);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAudioPrefetch hook tests
+// ---------------------------------------------------------------------------
+
+function makeWarmerRef(el: HTMLAudioElement) {
+  return { current: el } as React.RefObject<HTMLAudioElement | null>;
+}
+
+function makeMockAudioElement() {
+  return {
+    src: "",
+    load: vi.fn(),
+    play: vi.fn(),
+  } as unknown as HTMLAudioElement;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  usePlayerStore.setState({
+    queue: [],
+    currentIndex: null,
+    shuffleMode: false,
+    shuffleOrder: [],
+    shuffleOrderIndex: -1,
+    repeatMode: "off",
+  });
+  usePreferencesStore.setState({ audioPrefetchCount: 3 });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useAudioPrefetch hook", () => {
+  it("when audioPrefetchCount <= 0, hook does not set src on warmer", () => {
+    usePreferencesStore.setState({ audioPrefetchCount: 0 });
+    const queue = makeQueue(3);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+
+    expect(el.src).toBe("");
+    expect(el.load).not.toHaveBeenCalled();
+  });
+
+  it("sets warmer.src to the next track url on mount", () => {
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+
+    expect(el.src).toBe(queue[1]!.audioUrl);
+    expect(el.load).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls load() when next URL changes on queue/currentIndex update", () => {
+    const queue = makeQueue(5);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+    expect(el.load).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      usePlayerStore.setState({ currentIndex: 2 });
+    });
+
+    expect(el.src).toBe(queue[3]!.audioUrl);
+    expect(el.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears warmer.src when there are no following tracks", () => {
+    const queue = makeQueue(3);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+    expect(el.src).toBe(queue[1]!.audioUrl);
+
+    act(() => {
+      usePlayerStore.setState({ currentIndex: 2 });
+    });
+
+    expect(el.src).toBe("");
+  });
+
+  it("warmer never calls play()", () => {
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+
+    const el = makeMockAudioElement();
+    const warmerRef = makeWarmerRef(el);
+
+    renderHook(() => useAudioPrefetch(warmerRef));
+
+    act(() => {
+      usePlayerStore.setState({ currentIndex: 1 });
+    });
+
+    expect(el.play).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useAudioPrefetch.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.ts
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useRef } from "react";
+import type { QueueItem } from "@/store/usePlayerStore";
+import { usePlayerStore } from "@/store/usePlayerStore";
+import { usePreferencesStore } from "@/store/usePreferencesStore";
+
+type RepeatMode = "off" | "all" | "one";
+
+interface PrefetchState {
+  queue: QueueItem[];
+  currentIndex: number | null;
+  shuffleMode: boolean;
+  shuffleOrder: number[];
+  shuffleOrderIndex: number;
+  repeatMode: RepeatMode;
+}
+
+export function computeNextAudioUrls(state: PrefetchState, n: number): string[] {
+  const { queue, currentIndex, shuffleMode, shuffleOrder, shuffleOrderIndex, repeatMode } = state;
+
+  if (n <= 0 || currentIndex === null || queue.length === 0) return [];
+
+  if (repeatMode === "one") return [];
+
+  const currentUrl = queue[currentIndex]?.audioUrl;
+  const results: string[] = [];
+
+  if (shuffleMode) {
+    for (let i = 1; i <= n; i++) {
+      const orderIdx = shuffleOrderIndex + i;
+      if (repeatMode === "all") {
+        const wrappedOrderIdx = orderIdx % shuffleOrder.length;
+        const queueIdx = shuffleOrder[wrappedOrderIdx];
+        if (queueIdx === undefined) break;
+        const url = queue[queueIdx]?.audioUrl;
+        if (url && url !== currentUrl) results.push(url);
+      } else {
+        if (orderIdx >= shuffleOrder.length) break;
+        const queueIdx = shuffleOrder[orderIdx];
+        if (queueIdx === undefined) break;
+        const url = queue[queueIdx]?.audioUrl;
+        if (url && url !== currentUrl) results.push(url);
+      }
+    }
+    return results;
+  }
+
+  for (let i = 1; i <= n; i++) {
+    let nextIdx = currentIndex + i;
+    if (nextIdx >= queue.length) {
+      if (repeatMode === "all") {
+        nextIdx = nextIdx % queue.length;
+      } else {
+        break;
+      }
+    }
+    const url = queue[nextIdx]?.audioUrl;
+    if (url && url !== currentUrl) results.push(url);
+  }
+
+  return results;
+}
+
+export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | null>): void {
+  const queue = usePlayerStore((s) => s.queue);
+  const currentIndex = usePlayerStore((s) => s.currentIndex);
+  const shuffleMode = usePlayerStore((s) => s.shuffleMode);
+  const shuffleOrder = usePlayerStore((s) => s.shuffleOrder);
+  const shuffleOrderIndex = usePlayerStore((s) => s.shuffleOrderIndex);
+  const repeatMode = usePlayerStore((s) => s.repeatMode);
+  const audioPrefetchCount = usePreferencesStore((s) => s.audioPrefetchCount);
+
+  const nextUrl = useMemo(
+    () =>
+      computeNextAudioUrls(
+        { queue, currentIndex, shuffleMode, shuffleOrder, shuffleOrderIndex, repeatMode },
+        audioPrefetchCount,
+      )[0] ?? null,
+    [
+      queue,
+      currentIndex,
+      shuffleMode,
+      shuffleOrder,
+      shuffleOrderIndex,
+      repeatMode,
+      audioPrefetchCount,
+    ],
+  );
+
+  const prevUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const el = warmerRef.current;
+    if (!el) return;
+
+    if (audioPrefetchCount <= 0) {
+      return;
+    }
+
+    if (nextUrl === prevUrlRef.current) return;
+    prevUrlRef.current = nextUrl;
+
+    if (!nextUrl) {
+      el.src = "";
+      return;
+    }
+
+    el.src = nextUrl;
+    el.load();
+  }, [nextUrl, audioPrefetchCount, warmerRef]);
+}

--- a/apps/frontend/src/hooks/useAudioPrefetch.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.ts
@@ -93,6 +93,8 @@ export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | n
     if (!el) return;
 
     if (audioPrefetchCount <= 0) {
+      el.src = "";
+      prevUrlRef.current = null;
       return;
     }
 
@@ -106,5 +108,5 @@ export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | n
 
     el.src = nextUrl;
     el.load();
-  }, [nextUrl, audioPrefetchCount, warmerRef]);
+  }, [nextUrl, audioPrefetchCount]);
 }

--- a/apps/frontend/src/store/usePreferencesStore.test.ts
+++ b/apps/frontend/src/store/usePreferencesStore.test.ts
@@ -94,3 +94,44 @@ describe("persist — state updates are reflected after setState", () => {
     expect(persistApi.getOptions().name).toBe("spotiarr-preferences");
   });
 });
+
+// ---------------------------------------------------------------------------
+// audioPrefetchCount
+// ---------------------------------------------------------------------------
+
+describe("audioPrefetchCount", () => {
+  it("defaults to 3", () => {
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(3);
+  });
+
+  it("setAudioPrefetchCount updates the value", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(1);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(1);
+  });
+
+  it("setAudioPrefetchCount(-1) clamps to 0", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(-1);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(0);
+  });
+
+  it("setAudioPrefetchCount(11) clamps to 10", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(11);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(10);
+  });
+
+  it("setAudioPrefetchCount(0) sets to 0 (lower bound inclusive)", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(0);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(0);
+  });
+
+  it("setAudioPrefetchCount(10) sets to 10 (upper bound inclusive)", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(10);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(10);
+  });
+
+  it("value is persisted under spotiarr-preferences key", () => {
+    usePreferencesStore.getState().setAudioPrefetchCount(5);
+    expect(usePreferencesStore.getState().audioPrefetchCount).toBe(5);
+    expect(usePreferencesStore.persist.getOptions().name).toBe("spotiarr-preferences");
+  });
+});

--- a/apps/frontend/src/store/usePreferencesStore.test.ts
+++ b/apps/frontend/src/store/usePreferencesStore.test.ts
@@ -95,10 +95,6 @@ describe("persist — state updates are reflected after setState", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// audioPrefetchCount
-// ---------------------------------------------------------------------------
-
 describe("audioPrefetchCount", () => {
   it("defaults to 3", () => {
     expect(usePreferencesStore.getState().audioPrefetchCount).toBe(3);

--- a/apps/frontend/src/store/usePreferencesStore.ts
+++ b/apps/frontend/src/store/usePreferencesStore.ts
@@ -5,6 +5,8 @@ interface PreferencesState {
   isSidebarCollapsed: boolean;
   toggleSidebar: () => void;
   setSidebarCollapsed: (isCollapsed: boolean) => void;
+  audioPrefetchCount: number;
+  setAudioPrefetchCount: (n: number) => void;
 }
 
 export const usePreferencesStore = create<PreferencesState>()(
@@ -13,9 +15,12 @@ export const usePreferencesStore = create<PreferencesState>()(
       isSidebarCollapsed: false,
       toggleSidebar: () => set((state) => ({ isSidebarCollapsed: !state.isSidebarCollapsed })),
       setSidebarCollapsed: (isCollapsed: boolean) => set({ isSidebarCollapsed: isCollapsed }),
+      audioPrefetchCount: 3,
+      setAudioPrefetchCount: (n: number) =>
+        set({ audioPrefetchCount: Math.min(10, Math.max(0, n)) }),
     }),
     {
-      name: "spotiarr-preferences", // unique name for localStorage key
+      name: "spotiarr-preferences",
     },
   ),
 );


### PR DESCRIPTION
## Why

Two distinct playback problems reported while using Spotiarr on the go:
1. **Slow buffer at the gym** (network present but unstable) — track transitions stall.
2. **Playback stops in the metro** (no connectivity).

This is **Slice 1 of 2** (chained, `feature-branch-chain`). It targets the **gym / slow-network** case. Slice 2 (offline Service Worker caching, HTTPS-gated) lands in a follow-up PR onto this branch.

## What

- **Backend:** `Cache-Control: private, max-age=31536000, immutable` + `Last-Modified` on `streamAudio` (both 200 and 206 branches) so the browser HTTP cache reuses audio bytes. `private` is intentional — audio is gated by a same-origin session cookie.
- **Frontend:** prefetch the **immediate-next** queued track via a hidden `<audio preload="auto">` warmer element in `GlobalPlayerBar`. The warmer only sets `.src`/`.load()` — it **never** calls `.play()` (autoplay + E2E determinism safe).
- **`audioPrefetchCount` preference** (default 3, clamped 0–10, persisted). In Slice 1 it gates the warmer on/off; Slice 2 consumes the full N for offline caching.
- `computeNextAudioUrls` pure helper handles shuffle, repeat-all wrap, repeat-one, clamping and current-URL dedup.

### Design note (reviewed)
Slice 1 deliberately warms only **track[+1]** via the element. Running N=3 concurrent `<audio>` warmers would contend for bandwidth on exactly the slow networks this targets. Full N=3 read-ahead is realized in Slice 2 via sequential Cache-API fetches.

## Testing

- Backend: 1970/1970 green (incl. new header integration tests on 200 + 206).
- Frontend: 1585/1585 green — `computeNextAudioUrls` branch coverage, hook warm/clear behavior, runtime disable/re-enable, never-`.play()` assertion.
- Build clean.

A fresh-context review flagged a runtime-disable buffering gap (warmer kept buffering after count→0) — fixed with regression tests.