### PR TITLE
feat(player): offline audio caching via service worker (Slice 2 — metro)

### DIFF
--- a/apps/frontend/src/hooks/useAudioPrefetch.test.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.test.ts
@@ -324,3 +324,169 @@ describe("useAudioPrefetch hook", () => {
     expect(el.load).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("useAudioPrefetch — Cache-API fetch path (Slice 2)", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    Object.defineProperty(window, "isSecureContext", {
+      value: true,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, "onLine", { value: true, configurable: true, writable: true });
+    if (!("serviceWorker" in navigator)) {
+      Object.defineProperty(navigator, "serviceWorker", {
+        value: {},
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "isSecureContext", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("no fetch when isSecureContext is false", () => {
+    Object.defineProperty(window, "isSecureContext", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 3 });
+
+    const el = makeMockAudioElement();
+    renderHook(() => useAudioPrefetch({ current: el }));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("no fetch when navigator.onLine is false", async () => {
+    Object.defineProperty(navigator, "onLine", {
+      value: false,
+      configurable: true,
+      writable: true,
+    });
+
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 3 });
+
+    const el = makeMockAudioElement();
+    renderHook(() => useAudioPrefetch({ current: el }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches next N urls sequentially with credentials:include when secure and online", async () => {
+    const queue = makeQueue(5);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 3 });
+
+    const el = makeMockAudioElement();
+    renderHook(() => useAudioPrefetch({ current: el }));
+
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+    expect(fetchSpy).toHaveBeenNthCalledWith(1, queue[1]!.audioUrl, {
+      credentials: "include",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(2, queue[2]!.audioUrl, {
+      credentials: "include",
+    });
+    expect(fetchSpy).toHaveBeenNthCalledWith(3, queue[3]!.audioUrl, {
+      credentials: "include",
+    });
+  });
+
+  it("fetch does not include Range header", async () => {
+    const queue = makeQueue(3);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 2 });
+
+    const el = makeMockAudioElement();
+    renderHook(() => useAudioPrefetch({ current: el }));
+
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const calls = fetchSpy.mock.calls as [string, RequestInit][];
+    for (const [, opts] of calls) {
+      const headers = opts?.headers as Record<string, string> | undefined;
+      expect(headers?.["Range"]).toBeUndefined();
+      expect(headers?.["range"]).toBeUndefined();
+    }
+  });
+
+  it("QuotaExceededError is swallowed — no unhandled rejection", async () => {
+    const err = new DOMException("QuotaExceededError");
+    fetchSpy.mockRejectedValueOnce(err);
+
+    const queue = makeQueue(3);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 1 });
+
+    const el = makeMockAudioElement();
+
+    await expect(
+      act(async () => {
+        renderHook(() => useAudioPrefetch({ current: el }));
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("network error is swallowed — no unhandled rejection", async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+
+    const queue = makeQueue(3);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 1 });
+
+    const el = makeMockAudioElement();
+
+    await expect(
+      act(async () => {
+        renderHook(() => useAudioPrefetch({ current: el }));
+        for (let i = 0; i < 10; i++) await Promise.resolve();
+      }),
+    ).resolves.not.toThrow();
+  });
+
+  it("N=0 in secure context: no fetch", async () => {
+    const queue = makeQueue(4);
+    usePlayerStore.setState({ queue, currentIndex: 0 });
+    usePreferencesStore.setState({ audioPrefetchCount: 0 });
+
+    const el = makeMockAudioElement();
+    renderHook(() => useAudioPrefetch({ current: el }));
+
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/hooks/useAudioPrefetch.ts
+++ b/apps/frontend/src/hooks/useAudioPrefetch.ts
@@ -60,6 +60,16 @@ export function computeNextAudioUrls(state: PrefetchState, n: number): string[] 
   return results;
 }
 
+async function prefetchIntoCache(urls: string[]): Promise<void> {
+  for (const url of urls) {
+    try {
+      await fetch(url, { credentials: "include" });
+    } catch {
+      // Quota exhaustion and network errors are silent no-ops.
+    }
+  }
+}
+
 export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | null>): void {
   const queue = usePlayerStore((s) => s.queue);
   const currentIndex = usePlayerStore((s) => s.currentIndex);
@@ -69,12 +79,12 @@ export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | n
   const repeatMode = usePlayerStore((s) => s.repeatMode);
   const audioPrefetchCount = usePreferencesStore((s) => s.audioPrefetchCount);
 
-  const nextUrl = useMemo(
+  const nextUrls = useMemo(
     () =>
       computeNextAudioUrls(
         { queue, currentIndex, shuffleMode, shuffleOrder, shuffleOrderIndex, repeatMode },
         audioPrefetchCount,
-      )[0] ?? null,
+      ),
     [
       queue,
       currentIndex,
@@ -86,8 +96,12 @@ export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | n
     ],
   );
 
+  const nextUrl = nextUrls[0] ?? null;
+
   const prevUrlRef = useRef<string | null>(null);
 
+  // Slice 1: warm the immediate-next track via hidden <audio> element (works over plain HTTP).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const el = warmerRef.current;
     if (!el) return;
@@ -109,4 +123,14 @@ export function useAudioPrefetch(warmerRef: React.RefObject<HTMLAudioElement | n
     el.src = nextUrl;
     el.load();
   }, [nextUrl, audioPrefetchCount]);
+
+  // Slice 2: sequentially fetch the next N tracks into the SW Cache API (HTTPS / secure context only).
+  // Inert when not secure, offline, or N=0. The SW CacheFirst rule serves them offline.
+  useEffect(() => {
+    if (!window.isSecureContext || !("serviceWorker" in navigator)) return;
+    if (!navigator.onLine) return;
+    if (audioPrefetchCount <= 0 || nextUrls.length === 0) return;
+
+    void prefetchIntoCache(nextUrls);
+  }, [nextUrls, audioPrefetchCount]);
 }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -43,10 +43,7 @@ export default defineConfig(({ mode }) => {
           navigateFallbackDenylist: [/^\/api/],
           runtimeCaching: [
             {
-              // Audio files only — must precede the /api NetworkOnly catch-all (Workbox first-match).
-              // maxEntries is fixed at build time (N+1 default: audioPrefetchCount=3 → 4 entries).
-              // Serving full 200 bodies (no Range) lets the SW cache offline playback without
-              // synthetic-206 slicing. The NetworkOnly rule at index 1 keeps SSE/status/downloads live.
+              // Must precede the /api NetworkOnly catch-all below (Workbox is first-match).
               urlPattern: ({ url }) => url.pathname === "/api/library/audio",
               handler: "CacheFirst",
               options: {

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -43,6 +43,20 @@ export default defineConfig(({ mode }) => {
           navigateFallbackDenylist: [/^\/api/],
           runtimeCaching: [
             {
+              // Audio files only — must precede the /api NetworkOnly catch-all (Workbox first-match).
+              // maxEntries is fixed at build time (N+1 default: audioPrefetchCount=3 → 4 entries).
+              // Serving full 200 bodies (no Range) lets the SW cache offline playback without
+              // synthetic-206 slicing. The NetworkOnly rule at index 1 keeps SSE/status/downloads live.
+              urlPattern: ({ url }) => url.pathname === "/api/library/audio",
+              handler: "CacheFirst",
+              options: {
+                cacheName: "spotiarr-audio",
+                matchOptions: { ignoreVary: true },
+                cacheableResponse: { statuses: [200] },
+                expiration: { maxEntries: 4, purgeOnQuotaError: true },
+              },
+            },
+            {
               urlPattern: ({ url }) => url.pathname.startsWith("/api"),
               handler: "NetworkOnly",
             },

--- a/skills/spotiarr-docker/SKILL.md
+++ b/skills/spotiarr-docker/SKILL.md
@@ -66,6 +66,17 @@ SPOTIARR_CORS_ORIGIN=             # comma-separated CORS origin allowlist; omit 
                                   # Wildcard "*" is rejected. Only needed for a separate-origin client.
 ```
 
+## Offline Audio Caching (Slice 2 — HTTPS required)
+
+The Service Worker audio cache (`spotiarr-audio`, CacheFirst strategy) requires a **secure context** (HTTPS or localhost). On plain HTTP the feature is automatically inert — online playback is unaffected, but tracks are not cached for offline use.
+
+To enable offline caching in production, terminate TLS at the reverse proxy before the container:
+
+- **Traefik** (bundled in `compose.yml`): configure the `websecure` entrypoint + a `CertificateResolver` (Let's Encrypt or manual cert). Set `SPOTIFY_REDIRECT_URI` to your `https://` domain.
+- Any other reverse proxy (Nginx, Caddy, etc.) works the same way — just ensure the browser sees HTTPS.
+
+Plain HTTP self-hosted installs continue to work online; they simply receive no offline benefit.
+
 ## Update Flow
 
 ```bash


### PR DESCRIPTION
## Why

**Slice 2 of 2** (chained onto Slice 1 #275). Targets the **metro / no-connectivity** case: playback stops dead with no network. Slice 1 fixed the gym/slow-network case; this adds true offline playback.

> Chain: this PR targets `feature/playback-prefetch-gym` (Slice 1). Only the tracker `feature/playback-prefetch-offline` merges to `main`.

## What

- **Workbox `CacheFirst` rule** (`vite.config.ts`) scoped to exactly `/api/library/audio`, **prepended before** the `/api` NetworkOnly catch-all (Workbox is first-match) so SSE/status/downloads stay network-only. Cache key includes the `?path=` query → each track cached independently. `statuses: [200]`, `maxEntries: 4` (N+1), `purgeOnQuotaError`.
- **Cache-fetch path** in `useAudioPrefetch`: sequentially `fetch(url, { credentials: "include" })` the next N tracks (no Range header → 200, cacheable) so the SW stores them. Runs **only** when `window.isSecureContext && "serviceWorker" in navigator && navigator.onLine`. Inert otherwise.
- **Graceful offline miss:** existing `usePlayerStore._onError` skip-on-error handles an uncached track offline — no infinite spinner, no new offline UI (product decision: no offline-status UI in MVP).
- **Errors swallowed:** quota/network errors never break online playback.

## ⚠️ Prerequisite

Offline caching requires a **secure context (HTTPS)** — Service Workers don't run over plain HTTP (except `localhost`). On a plain-HTTP self-hosted deploy the feature is **inert** and the app works normally online. Documented in the `spotiarr-docker` skill. Configure a TLS reverse proxy (Traefik) to enable it.

## Testing

- Frontend: 1592/1592 green (7 new TDD tests: secure-context gating, onLine guard, no-Range, sequential N fetches, quota swallow, N=0 no-op).
- Build clean — `dist/sw.js` generated.
- Offline SW path is **not** E2E-automatable (needs a real secure context + registered SW) — covered by the manual QA checklist below.

### Known limitation
`maxEntries` is fixed at build time (Workbox config is static). Changing `audioPrefetchCount` at runtime does not resize the cache budget until the next build. Accepted per design (ADR-10).

## Manual QA — Offline Audio Caching

- [ ] **HTTPS + SW registers**: serve behind TLS (or `localhost`); DevTools → Application → Service Workers shows "Activated and running".
- [ ] **Cache populated**: play a track; DevTools → Cache Storage → `spotiarr-audio` has a 200 entry.
- [ ] **Offline cached track plays**: throttle to Offline; cached track plays to completion, no spinner/error.
- [ ] **Offline uncached track fails gracefully**: offline, play an uncached track → skips/errors cleanly, no infinite spinner, no unhandled console error.
- [ ] **Quota exhaustion silent**: trigger caching under quota pressure → no unhandled rejection, online playback continues.
- [ ] **Plain HTTP inert**: serve over plain HTTP → audio plays online, no SW/cache console error, no `spotiarr-audio` bucket created.